### PR TITLE
Default RPM pointer

### DIFF
--- a/speeduino.ino
+++ b/speeduino.ino
@@ -201,6 +201,7 @@ void setup()
     default:
       trigger = triggerPri_missingTooth;
       getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth
       break;
   }
   if(configPage2.TrigEdge == 0)

--- a/speeduino.ino
+++ b/speeduino.ino
@@ -200,6 +200,7 @@ void setup()
       
     default:
       trigger = triggerPri_missingTooth;
+      getRPM = getRPM_missingTooth;
       break;
   }
   if(configPage2.TrigEdge == 0)


### PR DESCRIPTION
Default RPM mode configuration to allow tuner studio to be opened prior to being able to configure board set-up