### PR TITLE
Fix for TS rom burn break

### DIFF
--- a/comms.ino
+++ b/comms.ino
@@ -45,7 +45,7 @@ void command()
       if (currentPage >= '0') {//This converts the ascii number char into binary
         currentPage -= '0';
       }
-      if (currentPage == veMapPage || currentPage == ignMapPage || currentPage == afrMapPage) { // Detecting if the current page is a table/map
+      if (currentPage == veMapPage || currentPage == ignMapPage || currentPage == afrMapPage || currentPage == boostvvtPage) {// Detecting if the current page is a table/map
         isMap = true;
       }
       else {
@@ -78,7 +78,7 @@ void command()
       int offset;
       while (Serial.available() == 0) { }
 
-      if (isMap)
+      if (isMap && currentPage != boostvvtPage)
       {
         byte offset1, offset2;
         offset1 = Serial.read();


### PR DESCRIPTION
This is a fix that's been tested for the issue with the boost and vvt tables not burning to the rom correctly