### PR TITLE
r command bug fixes and further multiprocessor can and serial3 support

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -722,6 +722,10 @@ page = 10
     defaultValue = boostMinDuty,0
     defaultValue = boostMaxDuty,100
     defaultValue = sparkDur,    1.0
+	defaultValue = speeduino_tsCanId, 0
+	defaultValue = true_address, 0
+	defaultValue = realtime_base_address, 0
+	defaultValue = obd_address, 0
 
     ;Default pins
     defaultValue = fanPin,      0

--- a/speeduino/cancomms.h
+++ b/speeduino/cancomms.h
@@ -3,7 +3,7 @@
 //These are the page numbers that the Tuner Studio serial protocol uses to transverse the different map and config pages.
 #define veMapPage    1
 
-
+uint8_t currentcanCommand;
 uint8_t currentCanPage = 1;//Not the same as the speeduino config page numbers
 uint8_t nCanretry = 0;      //no of retrys
 uint8_t cancmdfail = 0;     //command fail yes/no 
@@ -14,6 +14,5 @@ uint8_t Glow, Ghigh;
   
 void canCommand();//This is the heart of the Command Line Interpeter.  All that needed to be done was to make it human readable.
 void sendCancommand(uint8_t cmdtype , uint16_t canadddress, uint8_t candata1, uint8_t candata2, uint16_t paramgroup);
-void testCanComm();
 
 #endif // CANCOMMS_H

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -15,11 +15,18 @@ sendcancommand is called when a comman d is to be sent via serial3 to the Can in
 //#include "globals.h"
 //#include "storage.h"
 
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
-
 void canCommand()
 {
-  switch (Serial3.read())
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)  
+  currentcanCommand = Serial3.read();
+#elif defined(CORE_STM32)
+  currentcanCommand = Serial2.read();
+#elif defined(CORE_TEENSY)
+  currentcanCommand = Serial2.read();
+#else return;  
+#endif  
+
+  switch (currentcanCommand)
   {
     case 'A': // sends the bytes of realtime values
         sendValues(0, packetSize,3); //send values to serial3
@@ -27,14 +34,32 @@ void canCommand()
 
     case 'G': // this is the reply command sent by the Can interface
         //uint8_t Gdata;
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)       
         while (Serial3.available() == 0) { }
         cancmdfail = Serial3.read();
+#elif defined(CORE_STM32)
+        while (Serial2.available() == 0) { }
+        cancmdfail = Serial2.read();
+#elif defined(CORE_TEENSY)
+        while (Serial2.available() == 0) { }
+        cancmdfail = Serial2.read();
+#else return;        
+#endif
         if (cancmdfail != 0)
         {
           for (byte Gx = 0; Gx < 8; Gx++) //read all 8 bytes of data
             {
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)             
               while (Serial3.available() == 0) { }
               Gdata[Gx] = Serial3.read();
+#elif defined(CORE_STM32)
+              while (Serial2.available() == 0) { }
+              Gdata[Gx] = Serial2.read();
+#elif defined(CORE_TEENSY)
+              while (Serial2.available() == 0) { }
+              Gdata[Gx] = Serial2.read();
+#else return;              
+#endif
             }
 
           Glow = Gdata[(configPage10.caninput_param_start_byte[currentStatus.current_caninchannel])];
@@ -68,61 +93,129 @@ void canCommand()
 
     case 'L':
         uint8_t Llength;
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
         while (Serial3.available() == 0) { }
         canlisten = Serial3.read();
+#elif defined(CORE_STM32)
+        while (Serial2.available() == 0) { }
+        canlisten = Serial2.read();
+#elif defined(CORE_TEENSY)
+        while (Serial2.available() == 0) { }
+        canlisten = Serial2.read();
+#else return;        
+#endif
         if (canlisten == 0)
          {
           //command request failed and/or data/device was not available
           break;
          }
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)         
        while (Serial3.available() == 0) { }
        Llength= Serial3.read();              // next the number of bytes expected value
+#elif defined(CORE_STM32)
+       while (Serial2.available() == 0) { }
+       Llength= Serial2.read();              // next the number of bytes expected value
+#elif defined(CORE_TEENSY)       
+       while (Serial2.available() == 0) { }
+       Llength= Serial2.read();              // next the number of bytes expected value
+#else return;       
+#endif
          for (uint8_t Lcount = 0; Lcount <Llength ;Lcount++)
                 {
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)                  
                   while (Serial3.available() == 0){}
                   // receive all x bytes into "Lbuffer"
                   Lbuffer[Lcount] = Serial3.read();
+#elif defined(CORE_STM32)
+                  while (Serial2.available() == 0){}
+                  // receive all x bytes into "Lbuffer"
+                  Lbuffer[Lcount] = Serial2.read();
+#elif defined(CORE_TEENSY)
+                  while (Serial2.available() == 0){}
+                  // receive all x bytes into "Lbuffer"
+                  Lbuffer[Lcount] = Serial2.read();
+#else return;                  
+#endif
                 }
        break;
        
     case 'r': //New format for the optimised OutputChannels
-     // cmdPending = true;
       byte cmd;
-      if (Serial.available() < 6) { return; }
-      Serial.read(); //Read the $tsCanId
-      cmd = Serial.read();
-
+      byte tsCanId_sent;
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3      
+      if (Serial3.available() < 6) { return; }
+      tsCanId_sent = Serial3.read(); //Read the $tsCanId
+      cmd = Serial3.read();
+#elif defined(CORE_STM32)
+      if (Serial2.available() < 6) { return; }
+      tsCanId_sent = Serial2.read(); //Read the $tsCanId
+      cmd = Serial2.read();
+#elif defined(CORE_TEENSY)
+      if (Serial2.available() < 6) { return; }
+      tsCanId_sent = Serial2.read(); //Read the $tsCanId
+      cmd = Serial2.read();
+#else return;      
+#endif
       uint16_t offset, length;
       if(cmd == 0x30) //Send output channels command 0x30 is 48dec
       {
         byte tmp;
-        tmp = Serial.read();
-        offset = word(Serial.read(), tmp);
-        tmp = Serial.read();
-        length = word(Serial.read(), tmp);
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3
+        tmp = Serial3.read();
+        offset = word(Serial3.read(), tmp);
+        tmp = Serial3.read();
+        length = word(Serial3.read(), tmp);
+#elif defined(CORE_STM32)
+        tmp = Serial2.read();
+        offset = word(Serial2.read(), tmp);
+        tmp = Serial2.read();
+        length = word(Serial2.read(), tmp);
+#elif defined(CORE_TEENSY)
+        tmp = Serial2.read();
+        offset = word(Serial2.read(), tmp);
+        tmp = Serial2.read();
+        length = word(Serial2.read(), tmp);
+#else return;        
+#endif        
         sendValues(offset, length, 3);
       }
       else
       {
         //No other r/ commands should be called
       }
-      cmdPending = false;
       break;
       
     case 'S': // send code version
        for (unsigned int sig = 0; sig < sizeof(displaySignature) - 1; sig++){
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3        
            Serial3.write(displaySignature[sig]);
+#elif defined(CORE_STM32) 
+          Serial2.write(displaySignature[sig]);
+#elif defined(CORE_TEENSY)
+          Serial2.write(displaySignature[sig]);
+#else return;
+#endif          
        }
        //Serial3.print("speeduino 201609-dev");
        break;
 
     case 'Q': // send code version
        for (unsigned int revn = 0; revn < sizeof( TSfirmwareVersion) - 1; revn++){
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3
            Serial3.write( TSfirmwareVersion[revn]);
+#elif defined(CORE_STM32) 
+           Serial2.write( TSfirmwareVersion[revn]);          
+#elif defined(CORE_TEENSY)
+           Serial2.write( TSfirmwareVersion[revn]);
+#else return;
+#endif           
        }
        //Serial3.print("speeduino 201609-dev");
        break;
 
+    case 'Z': //dev use
+       break;
+       
     default:
        break;
   }
@@ -134,32 +227,65 @@ void sendCancommand(uint8_t cmdtype, uint16_t canaddress, uint8_t candata1, uint
     switch (cmdtype)
     {
       case 0:
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3       
         Serial3.print("G");
         Serial3.write(canaddress);  //tscanid of speeduino device
         Serial3.write(candata1);    // table id
         Serial3.write(candata2);    //table memory offset
+#elif defined(CORE_STM32)
+        Serial2.print("G");
+        Serial2.write(canaddress);  //tscanid of speeduino device
+        Serial2.write(candata1);    // table id
+        Serial2.write(candata2);    //table memory offset
+#elif defined(CORE_TEENSY)
+        Serial2.print("G");
+        Serial2.write(canaddress);  //tscanid of speeduino device
+        Serial2.write(candata1);    // table id
+        Serial2.write(candata2);    //table memory offset
+#else return;
+#endif        
      break;
 
      case 1:                      //send request to listen for a can message
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3 
         Serial3.print("L");
         Serial3.write(canaddress);  //11 bit canaddress of device to listen for
+#elif defined(CORE_STM32)
+        Serial2.print("L");
+        Serial2.write(canaddress);  //11 bit canaddress of device to listen for
+#elif defined(CORE_TEENSY)        
+        Serial2.print("L");
+        Serial2.write(canaddress);  //11 bit canaddress of device to listen for
+
+#else return;
+#endif
      break;
 
      case 2:
-        Serial3.print("R");
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3     
+        Serial3.print("R");                         //send "R" to request data from the parmagroup whos value is sent next
         Serial3.write( lowByte(paramgroup) );       //send lsb first
         Serial3.write( lowByte(paramgroup >> 8) );
+#elif defined(CORE_STM32)
+        Serial2.print("R");                         //send "R" to request data from the parmagroup whos value is sent next
+        Serial2.write( lowByte(paramgroup) );       //send lsb first
+        Serial2.write( lowByte(paramgroup >> 8) );
+#elif defined(CORE_TEENSY)
+        Serial2.print("R");                         //send "R" to request data from the parmagroup whos value is sent next
+        Serial2.write( lowByte(paramgroup) );       //send lsb first
+        Serial2.write( lowByte(paramgroup >> 8) );
+#else return;
+#endif
      break;
 
      case 3:
         //send to truecan send routine
+#if defined(CORE_STM32)
+
+#elif defined(CORE_TEENSY)
+#else return;
+#endif
      break;
     }
 }
 
-#else
-//Dummy functions for those that can't do Serial3
-void canCommand() { return; }
-void sendCancommand(uint8_t cmdtype, uint16_t canaddress, uint8_t candata1, uint8_t candata2, uint16_t paramgroup) { return; }
-
-#endif


### PR DESCRIPTION
This version is based from the can-serial3 branch which was updated from josh's master on 07/05/2017

Before change it compiled at 
bytes of 63,444 flash(24%) and 4137 bytes of ram(50%) used
upon pr submission this changed to
bytes of 63,558 flash(25%) and 4156 bytes of ram(50%) used

changes to ini due to lack of defaults for can addresses
added more specific teensy and stm32 can related work for secondary serial
bugs with new r command fixed in conjunction with sample programs for direct access to serial3
sample programs to be found 
https://github.com/Autohome2/Speeduino-can-interface/tree/master/Serial%20test%20programs%20and%20samples/sample

%20programs/get_realtime_example_r