### PR TITLE
Secondary fan, A/C control, Zero Throttle TIming, misc Fan, DFCO and Idle mods

### DIFF
--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -18,18 +18,32 @@ void initialiseFan()
   currentStatus.fanOn = false;
 }
 
+void initialiseAC()
+{
+  digitalWrite(44, LOW); // initialize AC low
+  currentStatus.ACOn = false;
+}
+
 void fanControl()
 {
   if( configPage3.fanEnable == 1 )
   {
     int onTemp = (int)configPage3.fanSP - CALIBRATION_TEMPERATURE_OFFSET;
     int offTemp = onTemp - configPage3.fanHyster;
-
-    if ( (!currentStatus.fanOn) && (currentStatus.coolant >= onTemp) ) { digitalWrite(pinFan,fanHIGH); currentStatus.fanOn = true; }
-    if ( (currentStatus.fanOn) && (currentStatus.coolant <= offTemp) ) { digitalWrite(pinFan, fanLOW); currentStatus.fanOn = false; }
+    //fan1
+    if ( (!currentStatus.fanOn) && (currentStatus.coolant >= onTemp) && (currentStatus.RPM > 0) )  { digitalWrite(4,fanHIGH); currentStatus.fanOn = true; }
+    if ( ((currentStatus.fanOn) && (currentStatus.coolant <= offTemp)) || (currentStatus.RPM == 0) ) { digitalWrite(4, fanLOW); currentStatus.fanOn = false; }
+    //fan2
+    if ( ((currentStatus.fanOn) && (currentStatus.coolant >= onTemp+5) && (currentStatus.RPM > 0)) || (currentStatus.AcReq == true) ) { digitalWrite(46,fanHIGH); currentStatus.fanOn = true; }
+    if ( ((!currentStatus.fanOn) && (currentStatus.coolant <= offTemp+5) && (currentStatus.AcReq == false)) || (currentStatus.RPM == 0) ) { digitalWrite(46, fanLOW); currentStatus.fanOn = false; }
   }
 }
 
+void ACControl()
+{
+  if ((currentStatus.AcReq) && (currentStatus.TPS < 60) && (currentStatus.RPM > 600) && (currentStatus.RPM < 3600)){digitalWrite(44, HIGH); currentStatus.ACOn = true;}// turn on AC compressor
+  else{ digitalWrite(44, LOW); currentStatus.ACOn = false;} // shut down AC compressor
+}
 void initialiseAuxPWM()
 {
   #if defined(CORE_AVR)
@@ -206,3 +220,4 @@ void boostDisable()
     vvt_pwm_state = true;
   }
 }
+

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -28,6 +28,7 @@ static inline int8_t correctionIATretard(int8_t);
 static inline int8_t correctionSoftRevLimit(int8_t);
 static inline int8_t correctionSoftLaunch(int8_t);
 static inline int8_t correctionSoftFlatShift(int8_t);
+static inline int8_t correctionZeroThrottleTiming(int8_t);
 
 uint16_t correctionsDwell(uint16_t dwell);
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -268,6 +268,11 @@ struct statuses {
   byte afrTarget;
   byte idleDuty;
   bool fanOn; //Whether or not the fan is turned on
+  bool ACOn; //whether AC is on
+  bool AcReq; // AC request
+  bool highIdleReq; //raises idle in open loop to evade stalling
+  bool DFCOwait; // waits to enable DFCO
+  byte DFCOcounter = 0;// counts cycles till dfco
   volatile byte ethanolPct; //Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85.
   unsigned long TAEEndTime; //The target end time used whenever TAE is turned on
   volatile byte status1;

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -233,6 +233,7 @@ void idleControl()
         enableIdle();
         idle_pwm_target_value = percentage(currentStatus.idleDuty, idle_pwm_max_count);
         currentStatus.idleLoad = currentStatus.idleDuty >> 1;
+        if ((currentStatus.highIdleReq) && (currentStatus.idleLoad < 50)){ currentStatus.idleLoad = 50;}
         idleOn = true;
       }
       break;

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -37,12 +37,10 @@ uint16_t MAPcurRev; //Tracks which revolution we're sampling on
  */
 #define ADC_FILTER(input, alpha, prior) (((long)input * (256 - alpha) + ((long)prior * alpha))) >> 8
 
-static inline void instanteneousMAPReading() __attribute__((always_inline));
-static inline void readMAP() __attribute__((always_inline));
-void readTPS();
+void instanteneousMAPReading();
+void readMAP();
 void flexPulse();
-
-
+void readACReq();
 #if defined(ANALOG_ISR)
 //Analog ISR interrupt routine
 /*

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -48,7 +48,7 @@ void initialiseADC()
   MAPrunningValue = 0;
 }
 
-static inline void instanteneousMAPReading()
+void instanteneousMAPReading()
 {
   unsigned int tempReading;
   //Instantaneous MAP readings
@@ -71,7 +71,7 @@ static inline void instanteneousMAPReading()
 
 }
 
-static inline void readMAP()
+void readMAP()
 {
   unsigned int tempReading;
   //MAP Sampling system
@@ -119,7 +119,7 @@ static inline void readMAP()
             if(currentStatus.MAP < 0) { currentStatus.MAP = 0; } //Sanity check
           }
           else { instanteneousMAPReading(); }
-
+          
           MAPcurRev = currentStatus.startRevolutions; //Reset the current rev count
           MAPrunningValue = 0;
           MAPcount = 0;
@@ -270,3 +270,10 @@ void flexPulse()
  {
    ++flexCounter;
  }
+
+ void readACReq()
+ {
+  if ((digitalRead(26) == HIGH) && (digitalRead(28) == HIGH)) {currentStatus.AcReq = true;} //pin 26 is AC Request, pin 28 is a combined pressure/temp signal that is high when the A/C compressor can be activated
+  else {currentStatus.AcReq = false;}
+ }
+

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -230,12 +230,13 @@ void setup()
   closeInjector5();
 
   //Set the tacho output default state
-  digitalWrite(pinTachOut, HIGH);
+  digitalWrite(pinTachOut, LOW);
   //Perform all initialisations
   initialiseSchedulers();
   //initialiseDisplay();
   initialiseIdle();
   initialiseFan();
+  initialiseAC();
   initialiseAuxPWM();
   initialiseCorrections();
   initialiseADC();
@@ -805,18 +806,18 @@ void loop()
        readIAT();
        readO2();
        readBat();
-
+       readACReq();
        if(eepromWritesPending == true) { writeAllConfig(); } //Check for any outstanding EEPROM writes.
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) //ATmega2561 does not have Serial3
       //if Can interface is enabled then check for external data requests.
       if (configPage10.enable_candata_in)     //if external data input is enabled
-          {
+          {            
             if (configPage10.enable_canbus == 1)  // megas only support can via secondary serial
               {
                for (byte caninChan = 0; caninChan <16 ; caninChan++)
                   {
-                   currentStatus.current_caninchannel = caninChan;
+                   currentStatus.current_caninchannel = caninChan; 
                    //currentStatus.canin[14] = currentStatus.current_caninchannel;
                    currentStatus.canin[13]  = ((configPage10.caninput_source_can_address[currentStatus.current_caninchannel]&2047)+0x100);
                    if (BIT_CHECK(configPage10.caninput_sel,currentStatus.current_caninchannel))  //if current input channel bit is enabled
@@ -827,7 +828,7 @@ void loop()
                   }
               }
           }
-
+          
 #elif defined(CORE_STM32) || defined(CORE_TEENSY)
       //if serial3io is enabled then check for serial3 requests.
       if (configPage10.enable_candata_in)
@@ -839,11 +840,11 @@ void loop()
                   {
                     if (configPage10.enable_canbus == 1)  //can via secondary serial
                       {
-                        sendCancommand(2,0,currentStatus.current_caninchannel,0,((configPage10.caninput_source_can_address[currentStatus.current_caninchannel]&2047)+256));    //send an R command for data from paramgroup[currentStatus.current_caninchannel]
-                      }
+                        sendCancommand(2,0,currentStatus.current_caninchannel,0,((configPage10.caninput_source_can_address[currentStatus.current_caninchannel]&2047)+256));    //send an R command for data from paramgroup[currentStatus.current_caninchannel]                    
+                      }    
                else if (configPage10.enable_canbus == 2) // can via internal can module
-                      {
-                        sendCancommand(3,configPage10.speeduino_tsCanId,currentStatus.current_caninchannel,0,configPage10.caninput_source_can_address[currentStatus.current_caninchannel]);    //send via localcanbus the command for data from paramgroup[currentStatus.current_caninchannel]
+                      {                      
+                        sendCancommand(3,configPage10.speeduino_tsCanId,currentStatus.current_caninchannel,0,configPage10.caninput_source_can_address[currentStatus.current_caninchannel]);    //send via localcanbus the command for data from paramgroup[currentStatus.current_caninchannel]                       
                       }
                   }
               }
@@ -1339,13 +1340,11 @@ void loop()
                       ign1EndFunction
                       );
         }
-        /*
         if(ignition1EndAngle > crankAngle && configPage2.StgCycles == 0)
         {
           unsigned long uSToEnd = degreesToUS( (ignition1EndAngle - crankAngle) );
-          refreshIgnitionSchedule1( uSToEnd + fixedCrankingOverride );
+          //refreshIgnitionSchedule1( uSToEnd + fixedCrankingOverride );
         }
-        */
 
         tempCrankAngle = crankAngle - channel2IgnDegrees;
         if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -166,7 +166,7 @@ void oneMSInterval() //Most ARM chips can simply call a function
     {
        fanControl();            // Fucntion to turn the cooling fan on/off
     }
-
+    ACControl();
     //Check whether fuel pump priming is complete
     if(fpPrimed == false)
     {
@@ -215,7 +215,17 @@ void oneMSInterval() //Most ARM chips can simply call a function
       if (currentStatus.ethanolPct == 1) { currentStatus.ethanolPct = 0; }
 
     }
+    //high idle function
+    if ((currentStatus.TPS > 5) && (currentStatus.RPM > 950)){currentStatus.highIdleReq = true;} // increases idle value to evade stalling when coming down from high load
+     else {currentStatus.highIdleReq = false;}
 
+    //DFCO wait time
+    if ( ( currentStatus.RPM > ( configPage2.dfcoRPM * 10) ) && ( currentStatus.TPS < configPage2.dfcoTPSThresh ) ) 
+    {
+      currentStatus.DFCOcounter++;
+      if (currentStatus.DFCOcounter > 2 ) {currentStatus.DFCOwait = true;}
+    }
+    else {currentStatus.DFCOwait = false; currentStatus.DFCOcounter = 0;}
   }
 #if defined(CORE_AVR) //AVR chips use the ISR for this
     //Reset Timer2 to trigger in another ~1ms

--- a/speeduino/utils.ino
+++ b/speeduino/utils.ino
@@ -520,7 +520,9 @@ void setPinMapping(byte boardID)
   pinMode(pinIdle2, OUTPUT);
   pinMode(pinFuelPump, OUTPUT);
   pinMode(pinIgnBypass, OUTPUT);
-  pinMode(pinFan, OUTPUT);
+  pinMode(4, OUTPUT); // primary fan
+  pinMode(46, OUTPUT); // aux 
+  pinMode(44, OUTPUT); //ac control
   pinMode(pinStepperDir, OUTPUT);
   pinMode(pinStepperStep, OUTPUT);
   pinMode(pinStepperEnable, OUTPUT);
@@ -575,6 +577,8 @@ void setPinMapping(byte boardID)
       pinMode(pinCLT, INPUT);
       pinMode(pinBat, INPUT);
       pinMode(pinBaro, INPUT);
+      pinMode(26, INPUT); // pin input for AC
+      pinMode(28, INPUT); // pin input for AC temp and pressure check
     #endif
   #endif
   pinMode(pinTrigger, INPUT);


### PR DESCRIPTION
Added very rough implementations for secondary fan output, A/C control with requests and pressure input, and zero throttle timing correction tables. It also checks for RPM in the fan control methods, to shut fans off in the event of stalling or not keying off completely, counts for two seconds before allowing DFCO so there are no transient events between successive DFCO events, and has a "highIdleReq" which makes the idle valve stay at a given value for a second before going to the main table, to discourage stalling.
I do not know how to work with inis yet so everything is hardcoded to the firmware.