### PR TITLE
fix bins in MX5 NA6 Base Tune

### DIFF
--- a/reference/Base Tunes/NA6 PNP base tune.msq
+++ b/reference/Base Tunes/NA6 PNP base tune.msq
@@ -628,9 +628,9 @@
       </constant>
 <constant cols="1" digits="0" name="iacCrankBins" rows="4" units="C">
          -40.0 
-         -40.0 
-         -40.0 
-         -40.0 
+         0.0 
+         40.0 
+         80.0 
       </constant>
 <constant name="iacAlgorithm">"None"</constant>
 <constant name="iacStepTime">"1"</constant>
@@ -647,9 +647,9 @@
 <constant digits="0" name="fanFreq" units="Hz">0.0</constant>
 <constant cols="1" digits="0" name="fanPWMBins" rows="4" units="C">
          -40.0 
-         -40.0 
-         -40.0 
-         -40.0 
+         0.0 
+         40.0 
+         80.0 
       </constant>
 </page>
 <page number="6" size="240">


### PR DESCRIPTION
fixing temperature bins makes possible to actually use these functions.
in the current state these points appear one over each other in Tunerstudio and you can't drag them properly.