### PR TITLE
Invert TPS toggle option

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -741,8 +741,9 @@ page = 10
         flexFuelAdj         = array,  U08,      57, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
         flexAdvBins         = array,  U08,      63, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
         flexAdvAdj          = array,  U08,      69, [6], "Deg",  1.0,       0.0,   0.0,     250.0,    0
+        invertTPS           = bits,   U08,      75, [0:0],     "No","Yes"
 
-        unused11_75_191     = array,  U08,      75,[116],"RPM",  100.0,      0.0,  100,     25500,    0
+        unused11_76_191     = array,  U08,      76,[115],"RPM",  100.0,      0.0,  100,     25500,    0
 
 ;-------------------------------------------------------------------------------
 
@@ -829,6 +830,7 @@ page = 10
     defaultValue = VVTasOnOff,  0
     defaultValue = stagingEnabled, 0
     defaultValue = lnchCtrlTPS, 0
+    defaultValue = invertTPS, 0
     defaultValue = resetControl, 0
     defaultValue = bootloaderCaps, 0
 	 ; defaultValue = obd_address, 0
@@ -1010,6 +1012,7 @@ menuDialog = main
 	fanHyster   = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"
 
 	taeTime     = "The duration of the acceleration enrichment"
+    invertTPS   = "You set this if your tpsMin to tpsMax range is in reverse of what's standardly used."
 
 	iacChannels = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
 	iacStepTime = "Pause time between each step. Values that are too low can cause the motor to behave erratically or not at all"
@@ -1228,6 +1231,10 @@ menuDialog = main
       field = "Taper Start RPM",        taeTaperMin
       field = "Taper End RPM",          taeTaperMax
 
+    dialog = accelEnrichments_south_south
+        field = "TPS is inverted", invertTPS                    {}, { !invertTPS }
+        field = "#TPS is inverted", invertTPS                   {}, { invertTPS }
+
     dialog = accelEnrichments_south, "Decelleration Fuel Cutoff (DFCO)"
       field = "Enabled", dfcoEnabled
       field = "TPS Threshold", dfcoTPSThresh,                     { dfcoEnabled }
@@ -1247,7 +1254,8 @@ menuDialog = main
         panel = accelEnrichments_north, North
         panel = accelEnrichments_north_south, Center
         panel = accelEnrichments_center, Center
-        panel = accelEnrichments_south, South
+        panel = accelEnrichments_south, Center
+        panel = accelEnrichments_south_south, South
 
     dialog = veTableDialog_north, ""
         panel = veTable1Tbl

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -729,8 +729,10 @@ struct config10 {
   uint8_t flexAdvBins[6];
   uint8_t flexAdvAdj[6];    //Additional advance (in degrees) @ current ethanol (typically 0 @ 0%, 10-20 @ 100%)
                             //And another three corn rows die.
+  uint8_t invertTPS : 1; //For backwards throttle position sensors
+  uint8_t unused11_75 : 7;
 
-  byte unused11_75_191[117];
+  byte unused11_76_191[116];
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -199,6 +199,10 @@ void readTPS()
     analogRead(pinTPS);
     byte tempTPS = fastMap1023toX(analogRead(pinTPS), 255); //Get the current raw TPS ADC value and map it into a byte
   #endif
+  if ((bool)configPage10.invertTPS)
+  {
+     tempTPS = ~(byte)tempTPS; //For those who have tpsMin and tpsMax at opposite ends.
+  }
   currentStatus.tpsADC = ADC_FILTER(tempTPS, ADCFILTER_TPS, currentStatus.tpsADC);
   //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).
   byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted


### PR DESCRIPTION
The vast majority of us physically swap the wires and/or terminals on our throttle position sensor to get the signal range moving in the right direction.  For the rest, there is this option which does it for you programmaticaly.