### PR TITLE
Idle stepper direction changing

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -547,6 +547,7 @@ page = 6
         fanPWMBins = array, U08,      124, [4],        "F",        1.8,    -22.23,    -40,    215,      0
     #endif
 
+
 ;--------------------------------------------------
 ;Boost and vvt maps (Page 7)
 ;--------------------------------------------------
@@ -852,7 +853,9 @@ page = 9
         ;unused10_150        = scalar, U08,    150,       "",       1, 0, 0, 255, 0
         ;unused10_151        = scalar, U08,    151,       "",       1, 0, 0, 255, 0
         ;unused10_152        = scalar, U08,    152,       "",       1, 0, 0, 255, 0
-        unused10_153        = scalar, U08,    153,       "",       1, 0, 0, 255, 0
+        ;unused10_153        = scalar, U08,    153,       "",       1, 0, 0, 255, 0
+        iacStepperInv  = bits,   U08,     153, [0:0], "No",        "Yes"
+
         unused10_154        = scalar, U08,    154,       "",       1, 0, 0, 255, 0
         unused10_155        = scalar, U08,    155,       "",       1, 0, 0, 255, 0
 		unused10_156        = scalar, U08,    156,       "",       1, 0, 0, 255, 0
@@ -1714,6 +1717,7 @@ menuDialog = main
         field = "Step time (ms)",       iacStepTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Home steps",           iacStepHome,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Minimum Steps",		iacStepHyster,			{ iacAlgorithm == 4 || iacAlgorithm == 5 }
+        field = "Stepper Inverted", iacStepperInv,       { iacAlgorithm == 4 || iacAlgorithm == 5 }
 
     dialog = pwm_idle, "PWM Idle"
         field = "Number of outputs",    iacChannels,            { iacAlgorithm == 2 || iacAlgorithm == 3 }
@@ -1801,7 +1805,7 @@ menuDialog = main
         field = "Cranking advance Angle",       CrankAng
         field = "Spark Outputs triggers",        IgInv
         field = ""
-        field = "Enabled Fixed/Locked timing",  fixAngEnable                 
+        field = "Enabled Fixed/Locked timing",  fixAngEnable
         field = "Fixed Angle",                  FixAng,         { fixAngEnable }
         field = "#Note: During cranking the fixed/locked timing angle is overriden by the Cranking advance angle value above"
         field = ""
@@ -1895,8 +1899,8 @@ menuDialog = main
         field = "Nitrous is armed when pin is", n2o_pin_polarity,{ n2o_enable > 0 }
         field = "Minimum CLT",                  n2o_minCLT,     { n2o_enable > 0 }
         field = "Minimum TPS",                  n2o_minTPS,     { n2o_enable > 0 }
-        field = "Maximum MAP",                  n2o_maxMAP,     { n2o_enable > 0 }    
-        field = "Leanest AFR",                  n2o_maxAFR,     { n2o_enable > 0 }    
+        field = "Maximum MAP",                  n2o_maxMAP,     { n2o_enable > 0 }
+        field = "Leanest AFR",                  n2o_maxAFR,     { n2o_enable > 0 }
 
     dialog = NitrousControl,                "Nitrous"
         panel = NitrousMain,                North

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -726,8 +726,9 @@ struct config9 {
   uint16_t obd_address;             //speeduino OBD diagnostic address
   uint8_t Auxinpina[16];            //analog  pin number when internal aux in use
   uint8_t Auxinpinb[16];            // digital pin number when internal aux in use
-  
-  byte unused10_152;
+
+  byte iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
+
   byte unused10_153;
   byte unused10_154;
   byte unused10_155;

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -23,6 +23,8 @@ struct StepperIdle
   int targetIdleStep; //What the targetted step is
   volatile StepperStatus stepperStatus;
   volatile unsigned long stepStartTime; //The time the curren
+  byte lessAirDirection;
+  byte moreAirDirection;
 };
 
 #if defined(CORE_AVR)


### PR DESCRIPTION
I'd be grateful if this change could be integrated back into the mainline. It adds an "Inverted Y/N" setting to invert the direction of the stepper motor for situations where it is wired the opposite way around such that the forward direction in the software results in it being physically driven backwards, and vice versa.

I've tested it with open loop stepper mode on my vehicle.

I think I may even have seen an enhancement request for it some time in the past (#132 )