### PR TITLE
More stepper control changes for better starting and finer tuning

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -857,6 +857,7 @@ page = 9
         ;unused10_152        = scalar, U08,    152,       "",       1, 0, 0, 255, 0
         ;unused10_153        = scalar, U08,    153,       "",       1, 0, 0, 255, 0
         iacStepperInv  = bits,   U08,     153, [0:0], "No",        "Yes"
+        iacCoolTime  = bits , U08,      153, [1:3],      "0", "1", "2", "3", "4", "5", "6","INVALID"
 
         unused10_154        = scalar, U08,    154,       "",       1, 0, 0, 255, 0
         unused10_155        = scalar, U08,    155,       "",       1, 0, 0, 255, 0
@@ -1348,6 +1349,8 @@ menuDialog = main
 
 	iacChannels = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
 	iacStepTime = "Pause time between each step. Values that are too low can cause the motor to behave erratically or not at all"
+  iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
+  
     iacStepHome = "Homing steps to perform on startup. Must be greater than the fully open steps value"
 	iacStepHyster = "The minimum number of steps to move in any one go."
 	iacAlgorithm = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
@@ -1719,6 +1722,7 @@ menuDialog = main
 
     dialog = stepper_idle, "Stepper Idle"
         field = "Step time (ms)",       iacStepTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
+        field = "Cool time (ms)",       iacCoolTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Home steps",           iacStepHome,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Minimum Steps",		iacStepHyster,			{ iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Stepper Inverted", iacStepperInv,       { iacAlgorithm == 4 || iacAlgorithm == 5 }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -746,8 +746,8 @@ struct config9 {
   uint8_t Auxinpinb[16];            // digital pin number when internal aux in use
 
   byte iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
+  byte iacCoolTime : 3; // how long to wait for the stepper to cool between steps
 
-  byte unused10_153;
   byte unused10_154;
   byte unused10_155;
   byte unused10_156;

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -39,6 +39,7 @@ struct StepperIdle idleStepper;
 bool idleOn; //Simply tracks whether idle was on last time around
 byte idleInitComplete = 99; //TRacks which idle method was initialised. 99 is a method that will never exist
 unsigned int iacStepTime;
+unsigned int iacCoolTime;
 unsigned int completedHomeSteps;
 
 volatile PORT_TYPE *idle_pin_port;


### PR DESCRIPTION
I am still on a quest to get better idle stepper motor control, especially around engine start time as I have found the existing behaviour to be a kinda random.

I have in the past reported that the stepper motor seemed to move quite slowly or not at all sometimes, and whilst some of the fixes I have provided in the past have improved this situation greatly, I have some further changes that appear to make a significant difference, especially for engine starting.

Below is a description of my findings and the changes I have made. Most of the below is referring to open loop stepper control.

At key-on, the stepper homes as expected. Thereafter, with the engine stopped, the next thing it tries to do is to target the coolant based stepper position. Typically if the coolant is cold then the stepper needs to be opened quite a lot. As you know it does this via the idleControl() function. However, when the engine is stopped the system is also calling "disableIdle()" many times per second (about 8000/sec on my system). disableIdle() is constantly switching the stepper off so and stopping it from moving by setting the target to the current position.  So the two functions are still fighting against each other to control the stepper position.

The effect of this is that the stepper takes a relatively long time to move into its final position (by comparison with the step size in ms), and the actual timing is a bit random and depends on what else is going on, since the main stepper control code executes less frequently than the disableIdle code. If you play with the step times ranging from 1ms to 6ms there is no real effect seen and you can't get the step time anywhere near 1ms (even allowing for the length of the cooling step).

Note that for closed loop control there is a similar fight going on between the two functions; the PID algorithm just keeps on concluding it needs to be fully open when the engine is stopped, and disableIdle() keeps trying to stop it from opening. I do wonder if having the stepper fully open like this might make some cars harder to start, and therefore whether even when closed loop control is configured the cranking curve should still really be active but that's for another day.

I have proposed some changes to this stuff in the branch I have made a pull request for, which is branched from the February release. These are as follows:

* I have changed disableIdle() so that it does not continuously try and stop the stepper motor from moving when the engine is stopped when closed or open loop is configured.
* I have added a check to the running state of open loop idle control, so that it only executes the running state code if RPM is > 0. This stops the two functions fighting each other when the engine is stopped.
* For closed loop operation, disableIdle() no longer does anything with the stepper since the PID target is always active.
* For open loop operation, disableIdle() now targets the cranking stepper position, ready for the next engine start. The idea is if you turn off the engine but leave the key in the run position, it should be ready in the right spot for cranking, and similarly while you wait for the priming pulse to complete the stepper ought to have positioned itself at the right point for cranking. I have included the idleAdder code here but you could argue it isn't needed. This change is based on the understanding that the only call made to disableIdle() in open loop stepper operation is when the engine is stopped.

* My branch also contains a submission to separate out the stepper cooling time from the step time. There is a separate iacCoolTime setting and associated config. As part of this I have allowed for a zero ms cool down time and the code skips the cooling step completely if set as such.

The objective of adding the extra control for step cool time is that I want to be able to get the idle as smooth and responsive as possible (ultimately with closed loop) and this probably requires better response times from the stepper motor, so tuning to the minimum is a bit more granular and some motors may not even need a cooling step at all.

Sorry for the long winded post but I wanted to be clear about the background of these changes and justify as best I can why I think they are needed.  I'd be grateful if you could incorporate this into the master.