### PR TITLE
Coolant based ASE %, ASE duration, priming pulse width and Coolant based ignition adjustment

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -207,9 +207,9 @@
 page = 1
       unused2-1     = scalar, S08,       0,         "kPa",      1.0,       0.0,   -127,    127,       0
       unused2-2     = scalar, U08,       1,         "kPa",      1.0,       0.0,   0.0,    255,       0
-      asePct        = scalar, U08,       2,         "%",        1.0,       0.0,   0.0,    95.0,      0
-      aseCount      = scalar, U08,       3,         "s",        1.0,       0.0,   0.0,    255,       0
-      wueRates      = array,  U08,       4, [10],   "%",        1.0,       0.0,   0.0,    255,      0
+      unused2-3     = scalar, U08,       2,         "%",        1.0,       0.0,   0.0,    95.0,      0 ;This used to be asePct
+      unused2-4     = scalar, U08,       3,         "s",        1.0,       0.0,   0.0,    255,       0 ;This used to be aseCount
+      wueRates      = array,  U08,       4, [10],   "%",        1.0,       0.0,   0.0,    255,       0
       crankingPct   = scalar, U08,      14,         "%",        1.0,       0.0,   0.0,    255,       0
       pinLayout     = bits,   U08,      15, [0:7],  "Speeduino v0.1", "Speeduino v0.2", "Speeduino v0.3", "Speeduino v0.4", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "NA6 MX5 PNP", "Turtana PCB", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Plazomat I/O 0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Daz V6 Shield 0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "NO2C", "UA4C", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "dvjcodec Teensy RevA", "dvjcodec Teensy RevB", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       tachoPin      = bits,   U08,      16, [0:5],  "Board Default", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
@@ -265,7 +265,7 @@ page = 1
       perToothIgn   = bits,   U08,      38, [6:6], "No", "Yes"
       dfcoEnabled   = bits,   U08,      38, [7:7], "Off",       "On"
 
-      primePulse    = scalar, U08,      39,        "ms",        0.1,       0.0,   0.0,     25.5,     1
+      unused2-39    = scalar, U08,      39,        "ms",        0.1,       0.0,   0.0,     25.5,     1 ;This used to be PrimePulse
       dutyLim       = scalar, U08,      40,        "%",         1.0,       0.0,   0.0,     95.0,     0
       flexFreqLow   = scalar, U08,      41,        "Hz",        1.0,       0.0,   0.0,     250.0,    0
       flexFreqHigh  = scalar, U08,      42,        "Hz",        1.0,       0.0,   0.0,     250.0,    0
@@ -300,7 +300,21 @@ page = 1
       fanWhenOff   = bits,   U08,     70, [0:0], "No",        "Yes" 
       unused_fan_bits = bits,  U08,    70,[1:7]
 
-      unused2-67    = array,  U08,      71, [56],   "%",        1.0,       0.0,   0.0,     255,      0
+      asePct        = array,  U08,       71, [4],    "%",        1.0,       0.0,     0,    255,       0
+      aseCount      = array,  U08,       75, [4],    "s", 		1.0,       0.0,     0.0,     255,    0 ; Values for the afterstart enrichment curve
+#if CELSIUS
+      aseBins       = array,  U08,       79, [4],  "C", 1.0,       -40,    -40,    215,      0
+#else
+      aseBins       = array,  U08,       79, [4],  "F", 1.8,    -22.23,    -40,    215,      0
+#endif
+      primePulse    = array,  U08,       83, [4],  "ms",        0.5,       0.0,   0.0,     127.5,     1
+#if CELSIUS
+      primeBins     = array,  U08,       87, [4],  "C", 1.0,       -40,    -40,    215,      0
+#else
+      primeBins     = array,  U08,       87, [4],  "F", 1.8,    -22.23,    -40,    215,      0
+#endif
+
+      unused2-91    = array,  U08,      91, [36],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -409,8 +423,17 @@ page = 4
         ADCFILTER_MAP   = scalar, U08,      69, "%",          1.0,  0.0,   0,     240,    0
         ADCFILTER_BARO  = scalar, U08,      70, "%",          1.0,  0.0,   0,     240,    0
 
-        unused4-64      = array,  U08,      71, [56],   "%",        1.0,       0.0,   0.0,     255,      0
+;CLT (Coolant temp) timing Advance/Retard
+    #if CELSIUS
+        cltAdvBins   = array,  U08,     71, [ 6],   "C",      1.0,    -40,  -40,   102.0,      0
+    #else
+        cltAdvBins   = array,  U08,     77, [ 6],   "F",      1.8,    -22.23,  -40,   215.0,      0 ; No -40 degree offset here
+    #endif
+        cltAdvValues = array,  S08,     77, [ 6],   "deg",    0.1,     0.0,  -12.7,   12.7,      1
+
+        unused4-64   = array,  U08,     83, [44],   "%",      1.0,       0.0,   0.0,     255,      0
 ;--------------------------------------------------
+
 ;Start AFR page
 ;--------------------------------------------------
 page = 5
@@ -1242,12 +1265,16 @@ menuDialog = main
       subMenu = dwellSettings,          "Dwell settings"
       subMenu = dwell_correction_curve, "Dwell Compensation"
       subMenu = iat_retard_curve,       "IAT Retard"
+      subMenu = clt_advance_curve,      "Cold Advance"
       ;subMenu = knockSettings,          "Knock Settings"
       subMenu = rotary_ignition,        "Rotary Ignition",    { sparkMode == 4 }
 
    menu = "&Starting/Idle"
         subMenu = crankPW,              "Cranking Settings"
+        subMenu = primePW,              "Priming Pulsewidth"
         subMenu = warmup,               "Warmup Enrichment"
+        subMenu = ASE,                  "Afterstart Enrichment - Percentage"
+        subMenu = ASE_time,             "Afterstart Enrichment - Duration"
         subMenu = std_separator
         subMenu = idleSettings,         "Idle Control"
         subMenu = iacClosedLoop_curve,  "Idle - Closed loop targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 }
@@ -1398,6 +1425,10 @@ menuDialog = main
     hardCutType = "How hard cuts should be performed for rev/launch limits. Full cut will stop all ignition events, Rolling cut will step through all ignition outputs, only cutting 1 per revolution"
 
 	enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
+	
+    cltAdvValues = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timign when engine is too hot to prevent knock."
+    asePct = "Defines the fuel enrichment percentage after start. This is needed to keep engine running after start and it's usually about 5% when engine is hot to 50% when engine is cold.
+    aseCount = "Will set how long time the After Start Enrichment is applied in seconds. Usually this is second or two when engine is hot up to 10 or twenty on really cold engine.
 
 	;speeduino_tsCanId = "This is the TsCanId that the Speeduino ECU will respond to. This should match the main controller CAN ID in project properties if it is connected directy to TunerStudio, Otherwise the device ID if connected via CAN passthrough"
 	true_address = "This is the 11bit Can address of the Speeduino ECU "
@@ -1775,9 +1806,10 @@ menuDialog = main
     dialog = crankingOptions, "", yAxis
         field = "Cranking RPM (Max)", crankRPM
         field = "Flood Clear level", tpsflood
-        field = ""
         field = "Fuel pump prime duration", fpPrime
-        field = "Priming Pulsewidth", primePulse
+
+    dialog = primePW, "Priming Pulsewidth"
+        panel = priming_pw_curve
 
     dialog = crankPW, "Cranking Settings", yAxis
         topicHelp = "http://speeduino.com/wiki/index.php/Cranking"
@@ -1785,11 +1817,15 @@ menuDialog = main
         panel = crankingEnrichDialog, Center
         panel = crankingIgnOptions, South
 
+    dialog = ASE, "Afterstart Enrichment(ASE) - Percent Multiplier"
+        field = "Coolant axis is shared with ASE duration"
+        field = ""
+        panel = afterstart_enrichment_curve
 
-    dialog = aseSettings, "Afterstart Enrichment"
-        field = "Enrichment %", asePct
-        field = "Number of Sec to run", aseCount
-
+    dialog = ASE_time, "Afterstart Enrichment(ASE) - Number of seconds to run"
+        field = "Coolant axis is shared with ASE percentage"
+        field = ""
+        panel = afterstart_enrichment_time
 
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "http://speeduino.com/wiki/index.php/Decoders"
@@ -1807,7 +1843,7 @@ menuDialog = main
         field = "cranking before the injectors and coils are fired"
         field = "Trigger edge",                   TrigEdge      { TrigPattern != 4 } ;4G63 uses both edges
         field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 } ;Missing tooth, dual wheel and Miata 9905
-		field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) }
+        field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) }
         field = "Trigger Filter",                 TrigFilter,   { TrigPattern != 13 }
         field = "Re-sync every cycle",            useResync,    { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05
 
@@ -2031,7 +2067,6 @@ menuDialog = main
         panel = warmup_curve
         field = "Final enrichment value must be 100%."
         field = ""
-        panel = aseSettings
 
     ;Fuel trim composite dialog
     dialog = inj_trim1TblTitle, "Channel #1"
@@ -2745,6 +2780,14 @@ cmdtestspk450dc = "E\x03\x0C"
             xBins = iatRetBins, iat
             yBins = iatRetRates
 
+; CLT based ignition timing retard
+        curve = clt_advance_curve, "Cold Advance"
+            columnLabel =   "Coolant Temp", "Advance"
+            xAxis = -40, 200, 5
+            yAxis = -12.7, 12.7, 5
+            xBins = cltAdvBins, coolant
+            yBins = cltAdvValues
+
 ; Curves for idle control
         ; Standard duty table for PWM valves
         curve = iacPwm_curve, "IAC PWM Duty"
@@ -2767,7 +2810,7 @@ cmdtestspk450dc = "E\x03\x0C"
             yBins = iacCrankDuty
 
         curve = iacStep_curve, "IAC Stepper Motor"
-        	columnLabel = "Coolant Temperature", "Motor"
+            columnLabel = "Coolant Temperature", "Motor"
         #if CELSIUS
             xAxis = -40, 215, 6
         #else
@@ -2778,7 +2821,7 @@ cmdtestspk450dc = "E\x03\x0C"
             yBins = iacOLStepVal
 
         curve = iacStepCrank_curve, "IAC Stepper Motor Cranking"
-        	columnLabel = "Coolant Temperature", "Motor"
+            columnLabel = "Coolant Temperature", "Motor"
             xAxis = -40, 120, 6
             yAxis = 0, 850, 4
             xBins = iacCrankBins, coolant
@@ -2820,6 +2863,33 @@ cmdtestspk450dc = "E\x03\x0C"
             xBins       = crankingEnrichBins, coolant
             yBins       = crankingEnrichValues
             ;gauge       = cltGau25
+
+; Priming Pulsewidth curve
+        curve = priming_pw_curve, "Priming Pulsewidth"
+            columnLabel = "Coolant", "PW"
+            xAxis       = -40, 110, 4
+            yAxis       =   0,  25.5, 4
+            xBins       = primeBins, coolant
+            yBins       = primePulse
+            gauge       = cltGauge
+
+; Afterstart Enrichment curve
+        curve = afterstart_enrichment_curve, "ASE - Enrichment %"
+            columnLabel = "Coolant", "Enrichment"
+            xAxis       = -40, 110, 4
+            yAxis       =   0,  200, 4
+            xBins       = aseBins, coolant
+            yBins       = asePct
+            gauge       = cltGauge
+
+; Afterstart Enrichment time
+        curve = afterstart_enrichment_time, "ASE - Duration"
+            columnLabel = "Coolant", "Time"
+            xAxis       = -40, 110, 4
+            yAxis       =   0,  20, 4
+            xBins       = aseBins, coolant
+            yBins       = aseCount
+            gauge       = cltGauge
 
 ; Warmup enrichment VEAL AFR adjustment curve (Not currently working)
         ;curve = warmup_afr_curve, "AFR Target Temperature Adustment"

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -25,6 +25,7 @@ static inline int8_t correctionFixedTiming(int8_t);
 static inline int8_t correctionCrankingFixedTiming(int8_t);
 static inline int8_t correctionFlexTiming(int8_t);
 static inline int8_t correctionIATretard(int8_t);
+static inline int8_t correctionCLTadvance(int8_t);
 static inline int8_t correctionSoftRevLimit(int8_t);
 static inline int8_t correctionNitrous(int8_t);
 static inline int8_t correctionSoftLaunch(int8_t);

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -138,10 +138,10 @@ static inline byte correctionASE()
   //Two checks are requiredL:
   //1) Is the negine run time less than the configured ase time
   //2) Make sure we're not still cranking
-  if ( (currentStatus.runSecs < configPage2.aseCount) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) )
+  if ( (currentStatus.runSecs < (table2D_getValue(&ASECountTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET))) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) )
   {
     BIT_SET(currentStatus.engine, BIT_ENGINE_ASE); //Mark ASE as active.
-    ASEValue = 100 + configPage2.asePct;
+    ASEValue = 100 + table2D_getValue(&ASETable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
   }
   else
   {
@@ -397,6 +397,7 @@ int8_t correctionsIgn(int8_t base_advance)
   int8_t advance;
   advance = correctionFlexTiming(base_advance);
   advance = correctionIATretard(advance);
+  advance = correctionCLTadvance(advance);
   advance = correctionSoftRevLimit(advance);
   advance = correctionNitrous(advance);
   advance = correctionSoftLaunch(advance);
@@ -445,6 +446,16 @@ static inline int8_t correctionIATretard(int8_t advance)
   else { ignIATValue = -OFFSET_IGNITION; }
 
   return ignIATValue;
+}
+
+static inline int8_t correctionCLTadvance(int8_t advance)
+{
+  byte ignCLTValue = advance;
+  //Adjust the advance based on CLT.
+  int8_t advanceCLTadjust = table2D_getValue(&CLTAdvanceTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
+  ignCLTValue = (advance + advanceCLTadjust/10);
+
+  return ignCLTValue;
 }
 
 static inline int8_t correctionSoftRevLimit(int8_t advance)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -245,11 +245,16 @@ struct table3D trim3Table; //6x6 Fuel trim 3 map
 struct table3D trim4Table; //6x6 Fuel trim 4 map
 struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
 struct table2D WUETable; //10 bin Warm Up Enrichment map (2D)
+struct table2D ASETable; //4 bin After Start Enrichment map (2D)
+struct table2D ASECountTable; //4 bin After Start duration map (2D)
+struct table2D PrimingPulseTable; //4 bin Priming pulsewidth map (2D)
 struct table2D crankingEnrichTable; //4 bin cranking Enrichment map (2D)
 struct table2D dwellVCorrectionTable; //6 bin dwell voltage correction (2D)
 struct table2D injectorVCorrectionTable; //6 bin injector voltage correction (2D)
 struct table2D IATDensityCorrectionTable; //9 bin inlet air temperature density correction (2D)
 struct table2D IATRetardTable; //6 bin ignition adjustment based on inlet air temperature  (2D)
+struct table2D IDLEAdvanceTable; //6 bin idle advance adjustment table based on RPM difference  (2D)
+struct table2D CLTAdvanceTable; //6 bin ignition adjustment based on coolant temperature  (2D)
 struct table2D rotarySplitTable; //8 bin ignition split curve for rotary leading/trailing  (2D)
 struct table2D flexFuelTable;  //6 bin flex fuel correction table for fuel adjustments (2D)
 struct table2D flexAdvTable;   //6 bin flex fuel correction table for timing advance (2D)
@@ -454,8 +459,8 @@ struct config2 {
 
   byte unused2_1;
   byte unused2_2;
-  byte asePct;  //Afterstart enrichment (%)
-  byte aseCount; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
+  byte unused2_3;  //Was ASE
+  byte unused2_4;  //Was ASECount
   byte wueValues[10]; //Warm up enrichment array (10 bytes)
   byte crankingPct; //Cranking enrichment
   byte pinMapping; // The board / ping mapping to be used
@@ -513,7 +518,7 @@ struct config2 {
   byte perToothIgn : 1;
   byte dfcoEnabled : 1; //Whether or not DFCO is turned on
 
-  byte primePulse;
+  byte unused2_39;  //Was primePulse
   byte dutyLim;
   byte flexFreqLow; //Lowest valid frequency reading from the flex sensor
   byte flexFreqHigh; //Highest valid frequency reading from the flex sensor
@@ -549,8 +554,12 @@ struct config2 {
 
   byte fanWhenOff : 1;      // Only run fan when engine is running
   byte fanUnused : 7;
-
-  byte unused1_70[57];
+  byte asePct[4];  //Afterstart enrichment (%)
+  byte aseCount[4]; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
+  byte aseBins[4]; //Afterstart enrichment temp axis
+  byte primePulse[4]; //Priming pulsewidth
+  byte primeBins[4]; //Priming temp axis
+  byte unused2_91[37];
 
 #if defined(CORE_AVR)
   };
@@ -623,8 +632,11 @@ struct config4 {
   byte ADCFILTER_BAT;
   byte ADCFILTER_MAP; //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
   byte ADCFILTER_BARO;
+  
+  byte cltAdvBins[6]; // Coolant Temp timing advance curve bins
+  byte cltAdvValues[6]; // Coolant timing advance curve values
 
-  byte unused2_64[57];
+  byte unused2_64[45];
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -814,12 +814,13 @@ void initialiseAll()
     interrupts();
     //Perform the priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
     readCLT(); // need to read coolant temp to make priming pulsewidth work correctly.
-    if((table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) > 0)
+    unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
+    if(primingValue > 0)
     {
-      setFuelSchedule1(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-      setFuelSchedule2(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
-      setFuelSchedule3(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
-      setFuelSchedule4(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
+      setFuelSchedule1(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
+      setFuelSchedule2(100, (primingValue * 100 * 5));
+      setFuelSchedule3(100, (primingValue * 100 * 5));
+      setFuelSchedule4(100, (primingValue * 100 * 5));
     }
 
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -815,7 +815,7 @@ void initialiseAll()
     //Perform the priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
     if((table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) > 0)
     {
-      setFuelSchedule1(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
+      setFuelSchedule1(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500)); //to acheive long enough priming pulses, the values in tuner studio are 0.5ms so those need to be multiplied by 500 to get uS value.
       setFuelSchedule2(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
       setFuelSchedule3(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
       setFuelSchedule4(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -813,12 +813,13 @@ void initialiseAll()
 
     interrupts();
     //Perform the priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
+    readCLT(); // need to read coolant temp to make priming pulsewidth work correctly.
     if((table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) > 0)
     {
-      setFuelSchedule1(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500)); //to acheive long enough priming pulses, the values in tuner studio are 0.5ms so those need to be multiplied by 500 to get uS value.
-      setFuelSchedule2(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
-      setFuelSchedule3(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
-      setFuelSchedule4(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
+      setFuelSchedule1(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
+      setFuelSchedule2(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
+      setFuelSchedule3(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
+      setFuelSchedule4(100, (unsigned long)5*(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 100));
     }
 
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -63,6 +63,19 @@ void initialiseAll()
     WUETable.xSize = 10;
     WUETable.values = configPage2.wueValues;
     WUETable.axisX = configPage4.wueBins;
+    ASETable.valueSize = SIZE_BYTE;
+    ASETable.xSize = 4;
+    ASETable.values = configPage2.asePct;
+    ASETable.axisX = configPage2.aseBins;
+    ASECountTable.valueSize = SIZE_BYTE;
+    ASECountTable.xSize = 4;
+    ASECountTable.values = configPage2.aseCount;
+    ASECountTable.axisX = configPage2.aseBins;
+    PrimingPulseTable.valueSize = SIZE_BYTE;
+    PrimingPulseTable.xSize = 4;
+    PrimingPulseTable.values = configPage2.primePulse;
+    PrimingPulseTable.axisX = configPage2.primeBins;
+    crankingEnrichTable.valueSize = SIZE_BYTE;
     crankingEnrichTable.valueSize = SIZE_BYTE;
     crankingEnrichTable.xSize = 4;
     crankingEnrichTable.values = configPage10.crankingEnrichValues;
@@ -84,6 +97,10 @@ void initialiseAll()
     IATRetardTable.xSize = 6;
     IATRetardTable.values = configPage4.iatRetValues;
     IATRetardTable.axisX = configPage4.iatRetBins;
+    CLTAdvanceTable.valueSize = SIZE_BYTE;
+    CLTAdvanceTable.xSize = 6;
+    CLTAdvanceTable.values = configPage4.cltAdvValues;
+    CLTAdvanceTable.axisX = configPage4.cltAdvBins;
     rotarySplitTable.valueSize = SIZE_BYTE;
     rotarySplitTable.xSize = 8;
     rotarySplitTable.values = configPage10.rotarySplitValues;
@@ -796,12 +813,12 @@ void initialiseAll()
 
     interrupts();
     //Perform the priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
-    if(configPage2.primePulse > 0)
+    if((table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) > 0)
     {
-      setFuelSchedule1(100, (unsigned long)(configPage2.primePulse * 100));
-      setFuelSchedule2(100, (unsigned long)(configPage2.primePulse * 100));
-      setFuelSchedule3(100, (unsigned long)(configPage2.primePulse * 100));
-      setFuelSchedule4(100, (unsigned long)(configPage2.primePulse * 100));
+      setFuelSchedule1(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
+      setFuelSchedule2(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
+      setFuelSchedule3(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
+      setFuelSchedule4(100, (unsigned long)(table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) * 500));
     }
 
 


### PR DESCRIPTION
Speeduino was lacking coolant based After Start Enrichment, After Start Enrichment duration and Priming pulse widths. Which are mandatory features when using car in cold environments. Also the ignition timing needs to be adjusted based on coolant temperature in cold environments to maintain engine performance also with cold engine. So that feature is also added as Cold Advance.