### PR TITLE
Fix minor mistakes in pages definition

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -220,15 +220,15 @@ page = 1
 
       ; Display (Options for what the display is showing)
       display       = bits,   U08,      21, [0:2],  "Unused", "Adafruit 128x32", "Generic 128x32", "Adafruit 128x64", "Generic 128x64", "INVALID", "INVALID", "INVALID"
-      display1      = bits    U08,      21, [3:5],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
-      display2      = bits    U08,      21, [6:7],  "O2", "Voltage", "CPU", "Mem"
+      display1      = bits,   U08,      21, [3:5],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
+      display2      = bits,   U08,      21, [6:7],  "O2", "Voltage", "CPU", "Mem"
 
-      display3      = bits    U08,      22, [0:2],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
-      display4      = bits    U08,      22, [3:4],  "O2", "Voltage", "CPU", "Mem"
-      display5      = bits    U08,      22, [5:7],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
+      display3      = bits,   U08,      22, [0:2],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
+      display4      = bits,   U08,      22, [3:4],  "O2", "Voltage", "CPU", "Mem"
+      display5      = bits,   U08,      22, [5:7],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
 
-      displayB1     = bits    U08,      23, [0:3],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
-      displayB2     = bits    U08,      23, [4:7],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
+      displayB1     = bits,   U08,      23, [0:3],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
+      displayB2     = bits,   U08,      23, [4:7],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
 
       reqFuel       = scalar, U08,      24,        "ms",        0.1,       0.0,   0.0,    25.5,      1
       divider       = scalar, U08,      25,        "",          1.0,       0.0
@@ -313,7 +313,7 @@ page = 1
       primeBins     = array,  U08,       87, [4],  "F", 1.8,    -22.23,    -40,    215,      0
 #endif
 
-      unused2-91    = array,  U08,      91, [36],   "%",        1.0,       0.0,   0.0,     255,      0
+      unused2-91    = array,  U08,      91, [37],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -426,11 +426,11 @@ page = 4
     #if CELSIUS
         cltAdvBins   = array,  U08,     71, [ 6],   "C",      1.0,    -40,  -40,   102.0,      0
     #else
-        cltAdvBins   = array,  U08,     77, [ 6],   "F",      1.8,    -22.23,  -40,   215.0,      0 ; No -40 degree offset here
+        cltAdvBins   = array,  U08,     71, [ 6],   "F",      1.8,    -22.23,  -40,   215.0,      0 ; No -40 degree offset here
     #endif
         cltAdvValues = array,  S08,     77, [ 6],   "deg",    0.1,     0.0,  -12.7,   12.7,      1
 
-        unused4-64   = array,  U08,     83, [44],   "%",      1.0,       0.0,   0.0,     255,      0
+        unused4-64   = array,  U08,     83, [45],   "%",      1.0,       0.0,   0.0,     255,      0
 ;--------------------------------------------------
 
 ;Start AFR page
@@ -861,66 +861,12 @@ page = 9
         Auxin13pinb       = bits,	 U08,	  150, 		[0:5],  $DIGITAL_PIN
 		Auxin14pinb       = bits,	 U08,	  151, 		[0:5],  $DIGITAL_PIN
         Auxin15pinb       = bits,	 U08,	  152, 		[0:5],  $DIGITAL_PIN
-        
-		;unused10_137        = scalar, U08,    137,       "",       1, 0, 0, 255, 0
-        ;unused10_138        = scalar, U08,    138,       "",       1, 0, 0, 255, 0
-        ;unused10_139        = scalar, U08,    139,       "",       1, 0, 0, 255, 0
-        ;unused10_140        = scalar, U08,    140,       "",       1, 0, 0, 255, 0
-        ;unused10_141        = scalar, U08,    141,       "",       1, 0, 0, 255, 0
-		;unused10_142        = scalar, U08,    142,       "",       1, 0, 0, 255, 0
-        ;unused10_143        = scalar, U08,    143,       "",       1, 0, 0, 255, 0
-        ;unused10_144        = scalar, U08,    144,       "",       1, 0, 0, 255, 0
-        ;unused10_145        = scalar, U08,    145,       "",       1, 0, 0, 255, 0
-        ;unused10_146        = scalar, U08,    146,       "",       1, 0, 0, 255, 0
-        ;unused10_147        = scalar, U08,    147,       "",       1, 0, 0, 255, 0
-        ;unused10_148        = scalar, U08,    148,       "",       1, 0, 0, 255, 0
-		;unused10_149        = scalar, U08,    149,       "",       1, 0, 0, 255, 0
-        ;unused10_150        = scalar, U08,    150,       "",       1, 0, 0, 255, 0
-        ;unused10_151        = scalar, U08,    151,       "",       1, 0, 0, 255, 0
-        ;unused10_152        = scalar, U08,    152,       "",       1, 0, 0, 255, 0
-        ;unused10_153        = scalar, U08,    153,       "",       1, 0, 0, 255, 0
-        iacStepperInv  = bits,   U08,     153, [0:0], "No",        "Yes"
-        iacCoolTime  = bits , U08,      153, [1:3],      "0", "1", "2", "3", "4", "5", "6","INVALID"
 
-        unused10_154        = scalar, U08,    154,       "",       1, 0, 0, 255, 0
-        unused10_155        = scalar, U08,    155,       "",       1, 0, 0, 255, 0
-		unused10_156        = scalar, U08,    156,       "",       1, 0, 0, 255, 0
-        unused10_157        = scalar, U08,    157,       "",       1, 0, 0, 255, 0
-        unused10_158        = scalar, U08,    158,       "",       1, 0, 0, 255, 0
-        unused10_159        = scalar, U08,    159,       "",       1, 0, 0, 255, 0
-        unused10_160        = scalar, U08,    160,       "",       1, 0, 0, 255, 0
-        unused10_161        = scalar, U08,    161,       "",       1, 0, 0, 255, 0
-        unused10_162        = scalar, U08,    162,       "",       1, 0, 0, 255, 0		
-		unused10_163        = scalar, U08,    163,       "",       1, 0, 0, 255, 0
-        unused10_164        = scalar, U08,    164,       "",       1, 0, 0, 255, 0
-        unused10_165        = scalar, U08,    165,       "",       1, 0, 0, 255, 0
-        unused10_166        = scalar, U08,    166,       "",       1, 0, 0, 255, 0
-        unused10_167        = scalar, U08,    167,       "",       1, 0, 0, 255, 0
-        unused10_168        = scalar, U08,    168,       "",       1, 0, 0, 255, 0
-        unused10_169        = scalar, U08,    169,       "",       1, 0, 0, 255, 0
-		unused10_170        = scalar, U08,    170,       "",       1, 0, 0, 255, 0
-        unused10_171        = scalar, U08,    171,       "",       1, 0, 0, 255, 0
-        unused10_172        = scalar, U08,    172,       "",       1, 0, 0, 255, 0
-        unused10_173        = scalar, U08,    173,       "",       1, 0, 0, 255, 0
-        unused10_174        = scalar, U08,    174,       "",       1, 0, 0, 255, 0
-        unused10_175        = scalar, U08,    175,       "",       1, 0, 0, 255, 0
-        unused10_176        = scalar, U08,    176,       "",       1, 0, 0, 255, 0
-		unused10_177        = scalar, U08,    177,       "",       1, 0, 0, 255, 0
-        unused10_178        = scalar, U08,    178,       "",       1, 0, 0, 255, 0
-        unused10_179        = scalar, U08,    179,       "",       1, 0, 0, 255, 0
-        unused10_180        = scalar, U08,    180,       "",       1, 0, 0, 255, 0
-        unused10_181        = scalar, U08,    181,       "",       1, 0, 0, 255, 0
-        unused10_182        = scalar, U08,    182,       "",       1, 0, 0, 255, 0
-        unused10_183        = scalar, U08,    183,       "",       1, 0, 0, 255, 0
-		unused10_184        = scalar, U08,    184,       "",       1, 0, 0, 255, 0
-        unused10_185        = scalar, U08,    185,       "",       1, 0, 0, 255, 0
-        unused10_186        = scalar, U08,    186,       "",       1, 0, 0, 255, 0
-        unused10_187        = scalar, U08,    187,       "",       1, 0, 0, 255, 0
-        unused10_188        = scalar, U08,    188,       "",       1, 0, 0, 255, 0
-        unused10_189        = scalar, U08,    189,       "",       1, 0, 0, 255, 0
-        unused10_190        = scalar, U08,    190,       "",       1, 0, 0, 255, 0
-        blankfield          = bits,   U08,    191,      [0:0], "",""
-		;unused10_191        = scalar, U08,    191,       "",       1, 0, 0, 255, 0
+        iacStepperInv  = bits,   U08,   153, [0:0], "No",        "Yes"
+        iacCoolTime    = bits,   U08,   153, [1:3], "0", "1", "2", "3", "4", "5", "6","INVALID"
+        unused10_153   = bits,   U08,   153, [4:7], ""
+
+        unused10_154        = array, U08,    154, [38],       "",       1, 0, 0, 255, 0
 		
 page = 10
 #if CELSIUS

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -2,6 +2,7 @@
 #define GLOBALS_H
 #include <Arduino.h>
 #include "table.h"
+#include <assert.h>
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
   #define BOARD_DIGITAL_GPIO_PINS 54
@@ -993,5 +994,11 @@ volatile uint16_t ignitionCount; //The count of ignition events that have taken 
 extern byte cltCalibrationTable[CALIBRATION_TABLE_SIZE];
 extern byte iatCalibrationTable[CALIBRATION_TABLE_SIZE];
 extern byte o2CalibrationTable[CALIBRATION_TABLE_SIZE];
+
+static_assert(sizeof(struct config2) == 128, "configPage2 size is not 128");
+static_assert(sizeof(struct config4) == 128, "configPage4 size is not 128");
+static_assert(sizeof(struct config6) == 128, "configPage6 size is not 128");
+static_assert(sizeof(struct config9) == 192, "configPage9 size is not 192");
+static_assert(sizeof(struct config10) == 192, "configPage10 size is not 192");
 
 #endif // GLOBALS_H


### PR DESCRIPTION
Regarding #222.
Fixed speeduino page size in globals.h and speeduino.h
Sizes weren't the same between these two definitions.
Also, I added a check at compile time to help limit these errors in the future.