### PR TITLE
Schedules made simple

### DIFF
--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -37,7 +37,7 @@
   #define FUEL2_COUNTER TCNT3
   #define FUEL3_COUNTER TCNT3
   #define FUEL4_COUNTER TCNT4
-  #define FUEL5_COUNTER TCNT1
+  #define FUEL5_COUNTER TCNT4
   #define FUEL6_COUNTER TCNT4 //Replaces ignition 4
   #define FUEL7_COUNTER TCNT5 //Replaces ignition 3
   #define FUEL8_COUNTER TCNT5 //Replaces ignition 2
@@ -46,7 +46,7 @@
   #define IGN2_COUNTER  TCNT5
   #define IGN3_COUNTER  TCNT5
   #define IGN4_COUNTER  TCNT4
-  #define IGN5_COUNTER  TCNT1
+  #define IGN5_COUNTER  TCNT4
   #define IGN6_COUNTER  TCNT4 //Replaces injector 4
   #define IGN7_COUNTER  TCNT3 //Replaces injector 3
   #define IGN8_COUNTER  TCNT3 //Replaces injector 2
@@ -55,7 +55,7 @@
   #define FUEL2_COMPARE OCR3B
   #define FUEL3_COMPARE OCR3C
   #define FUEL4_COMPARE OCR4B
-  #define FUEL5_COMPARE OCR1C //Shared with FUEL1
+  #define FUEL5_COMPARE OCR4C //Shared with FUEL1
   #define FUEL6_COMPARE OCR4A //Replaces ignition4
   #define FUEL7_COMPARE OCR5C //Replaces ignition3
   #define FUEL8_COMPARE OCR5B //Replaces ignition2
@@ -64,7 +64,7 @@
   #define IGN2_COMPARE  OCR5B
   #define IGN3_COMPARE  OCR5C
   #define IGN4_COMPARE  OCR4A
-  #define IGN5_COMPARE  OCR1C
+  #define IGN5_COMPARE  OCR4C
   #define IGN6_COMPARE  OCR4B //Replaces injector 4
   #define IGN7_COMPARE  OCR3C //Replaces injector 3
   #define IGN8_COMPARE  OCR3B //Replaces injector 2

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -69,46 +69,43 @@
   #define IGN7_COMPARE  OCR3C //Replaces injector 3
   #define IGN8_COMPARE  OCR3B //Replaces injector 2
 
-  #define FUEL1_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3A) //Turn on the A compare unit (ie turn on the interrupt)
-  #define FUEL2_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Turn on the B compare unit (ie turn on the interrupt)
-  #define FUEL3_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Turn on the C compare unit (ie turn on the interrupt)
-  #define FUEL4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Turn on the B compare unit (ie turn on the interrupt)
-  #define FUEL5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //
-  #define FUEL6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //
-  #define FUEL7_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //
-  #define FUEL8_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //
+  #define FUEL1_TIMER_ENABLE TIMSK3
+  #define FUEL2_TIMER_ENABLE TIMSK3
+  #define FUEL3_TIMER_ENABLE TIMSK3
+  #define FUEL4_TIMER_ENABLE TIMSK4
+  #define FUEL5_TIMER_ENABLE TIMSK4
+  #define FUEL6_TIMER_ENABLE TIMSK4
+  #define FUEL7_TIMER_ENABLE TIMSK5
+  #define FUEL8_TIMER_ENABLE TIMSK5
 
-  #define FUEL1_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3A); //Turn off this output compare unit
-  #define FUEL2_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B); //Turn off this output compare unit
-  #define FUEL3_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C); //Turn off this output compare unit
-  #define FUEL4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B); //Turn off this output compare unit
-  #define FUEL5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C); //
-  #define FUEL6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A); //
-  #define FUEL7_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C); //
-  #define FUEL8_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B); //
+  #define FUEL1_ENABLE_BITMASK (1 << OCIE3A) //Turn off this output compare unit
+  #define FUEL2_ENABLE_BITMASK (1 << OCIE3B) //Turn off this output compare unit
+  #define FUEL3_ENABLE_BITMASK (1 << OCIE3C) //Turn off this output compare unit
+  #define FUEL4_ENABLE_BITMASK (1 << OCIE4B) //Turn off this output compare unit
+  #define FUEL5_ENABLE_BITMASK (1 << OCIE4C) //
+  #define FUEL6_ENABLE_BITMASK (1 << OCIE4A) //
+  #define FUEL7_ENABLE_BITMASK (1 << OCIE5C) //
+  #define FUEL8_ENABLE_BITMASK (1 << OCIE5B) //
 
   //These have the TIFR5 bits set to 1 to clear the interrupt flag. This prevents a false interrupt being called the first time the channel is enabled.
   //I'm not sure why these are necessary as these should all be reset upon initialisation, but they do for the problem when added here
-  #define IGN1_TIMER_ENABLE() TIFR5 |= (1<<OCF5A); TIMSK5 |= (1 << OCIE5A) //Turn on the A compare unit (ie turn on the interrupt)
-  #define IGN2_TIMER_ENABLE() TIFR5 |= (1<<OCF5B); TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
-  #define IGN3_TIMER_ENABLE() TIFR5 |= (1<<OCF5C); TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
-  //#define IGN1_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5A) //Turn on the B compare unit (ie turn on the interrupt)
-  //#define IGN2_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
-  //#define IGN3_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
-  #define IGN4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //Turn on the A compare unit (ie turn on the interrupt)
-  #define IGN5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //Turn on the A compare unit (ie turn on the interrupt)
-  #define IGN6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Replaces injector 4
-  #define IGN7_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Replaces injector 3
-  #define IGN8_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Replaces injector 2
+  #define IGN1_TIMER_ENABLE TIMSK5
+  #define IGN2_TIMER_ENABLE TIMSK5
+  #define IGN3_TIMER_ENABLE TIMSK5
+  #define IGN4_TIMER_ENABLE TIMSK4
+  #define IGN5_TIMER_ENABLE TIMSK4
+  #define IGN6_TIMER_ENABLE TIMSK4
+  #define IGN7_TIMER_ENABLE TIMSK3
+  #define IGN8_TIMER_ENABLE TIMSK3
 
-  #define IGN1_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5A) //Turn off this output compare unit
-  #define IGN2_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B) //Turn off this output compare unit
-  #define IGN3_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C) //Turn off this output compare unit
-  #define IGN4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A) //Turn off this output compare unit
-  #define IGN5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C) //Turn off this output compare unit
-  #define IGN6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B) //Replaces injector 4
-  #define IGN7_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C) //Replaces injector 3
-  #define IGN8_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B) //Replaces injector 2
+  #define IGN1_ENABLE_BITMASK (1 << OCIE5A) //Turn off this output compare unit
+  #define IGN2_ENABLE_BITMASK (1 << OCIE5B) //Turn off this output compare unit
+  #define IGN3_ENABLE_BITMASK (1 << OCIE5C) //Turn off this output compare unit
+  #define IGN4_ENABLE_BITMASK (1 << OCIE4A) //Turn off this output compare unit
+  #define IGN5_ENABLE_BITMASK (1 << OCIE4C) //Turn off this output compare unit
+  #define IGN6_ENABLE_BITMASK (1 << OCIE4B) //Replaces injector 4
+  #define IGN7_ENABLE_BITMASK (1 << OCIE3C) //Replaces injector 3
+  #define IGN8_ENABLE_BITMASK (1 << OCIE3B) //Replaces injector 2
 
   #define MAX_TIMER_PERIOD 262140UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 4, as each timer tick is 4uS)
   // #define MAX_TIMER_PERIOD_SLOW 1048560UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 16, as each timer tick is 16uS)

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -73,7 +73,7 @@
   #define FUEL2_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Turn on the B compare unit (ie turn on the interrupt)
   #define FUEL3_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Turn on the C compare unit (ie turn on the interrupt)
   #define FUEL4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Turn on the B compare unit (ie turn on the interrupt)
-  #define FUEL5_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C) //
+  #define FUEL5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //
   #define FUEL6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //
   #define FUEL7_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //
   #define FUEL8_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //
@@ -82,7 +82,7 @@
   #define FUEL2_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B); //Turn off this output compare unit
   #define FUEL3_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C); //Turn off this output compare unit
   #define FUEL4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B); //Turn off this output compare unit
-  #define FUEL5_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C); //
+  #define FUEL5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C); //
   #define FUEL6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A); //
   #define FUEL7_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C); //
   #define FUEL8_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B); //
@@ -96,7 +96,7 @@
   //#define IGN2_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
   //#define IGN3_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
   #define IGN4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //Turn on the A compare unit (ie turn on the interrupt)
-  #define IGN5_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C) //Turn on the A compare unit (ie turn on the interrupt)
+  #define IGN5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //Turn on the A compare unit (ie turn on the interrupt)
   #define IGN6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Replaces injector 4
   #define IGN7_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Replaces injector 3
   #define IGN8_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Replaces injector 2
@@ -105,16 +105,16 @@
   #define IGN2_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B) //Turn off this output compare unit
   #define IGN3_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C) //Turn off this output compare unit
   #define IGN4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A) //Turn off this output compare unit
-  #define IGN5_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C) //Turn off this output compare unit
+  #define IGN5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C) //Turn off this output compare unit
   #define IGN6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B) //Replaces injector 4
   #define IGN7_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C) //Replaces injector 3
   #define IGN8_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B) //Replaces injector 2
 
   #define MAX_TIMER_PERIOD 262140UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 4, as each timer tick is 4uS)
-  #define MAX_TIMER_PERIOD_SLOW 1048560UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 16, as each timer tick is 16uS)
+  // #define MAX_TIMER_PERIOD_SLOW 1048560UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 16, as each timer tick is 16uS)
   #define uS_TO_TIMER_COMPARE(uS1) ((uS1) >> 2) //Converts a given number of uS into the required number of timer ticks until that time has passed
   //This is a hack until I make all the AVR timers run at the same speed
-  #define uS_TO_TIMER_COMPARE_SLOW(uS1) ((uS1) >> 4)
+  // #define uS_TO_TIMER_COMPARE_SLOW(uS1) ((uS1) >> 4)
 
 /*
 ***********************************************************************************************************
@@ -134,11 +134,11 @@
 ***********************************************************************************************************
 * Idle
 */
-  #define IDLE_COUNTER TCNT4
-  #define IDLE_COMPARE OCR4C
+  #define IDLE_COUNTER TCNT1
+  #define IDLE_COMPARE OCR1C
 
-  #define IDLE_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C)
-  #define IDLE_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C)
+  #define IDLE_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C)
+  #define IDLE_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C)
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -35,9 +35,8 @@ void initBoard()
     TIMSK2 = 0x01;          //Timer2 Set Overflow Interrupt enabled.
     TCCR2A = 0x00;          //Timer2 Control Reg A: Wave Gen Mode normal
     /* Now configure the prescaler to CPU clock divided by 128 = 125Khz */
-    TCCR2B |= (1<<CS22)  | (1<<CS20); // Set bits
-    TCCR2B &= ~(1<<CS21);             // Clear bit. Shouldn't be needed as initial value is 0 anyway, but best to play it safe
-    TIFR2 = (1 << OCF2A) | (1<<OCF2B) | (1<<TOV2); //Clear the compare flag bits and overflow flag bit
+    TCCR2B = (1<<CS22)  | (1<<CS20); // Set bits
+    TIFR2  = (1 << OCF2A) | (1<<OCF2B) | (1<<TOV2); //Clear the compare flag bits and overflow flag bit
 
     //Enable the watchdog timer for 2 second resets (Good reference: www.tushev.org/articles/arduino/5/arduino-and-watchdog-timer)
     //Boooooooooo WDT is currently broken on Mega 2560 bootloaders :(
@@ -52,15 +51,15 @@ void initBoard()
     TCCR3B = 0x00;          //Disable Timer3 while we set it up
     TCNT3  = 0;             //Reset Timer Count
     TCCR3A = 0x00;          //Timer3 Control Reg A: Wave Gen Mode normal
-    TCCR3B = (1 << CS12);   //Same as: 0x03. Timer3 Control Reg B: Timer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
-    TIFR3 = (1 << OCF3A) | (1<<OCF3B) | (1<<OCF3C) | (1<<TOV3) | (1<<ICF3); //Clear the compare flags, overflow flag and external input flag bits
+    TCCR3B = (1 << CS11) | (1 << CS10);   //Same as: 0x03. Timer3 Control Reg B: Timer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TIFR3  = (1 << OCF3A) | (1<<OCF3B) | (1<<OCF3C) | (1<<TOV3) | (1<<ICF3); //Clear the compare flags, overflow flag and external input flag bits
 
     //Ignition Schedules, which uses timer 5. This is also used by the fast version of micros(). If the speed of this timer is changed from 4uS ticks, that MUST be changed as well. See globals.h and timers.ino
     TCCR5B = 0x00;          //Disable Timer5 while we set it up
     TCNT5  = 0;             //Reset Timer Count
     TCCR5A = 0x00;          //Timer5 Control Reg A: Wave Gen Mode normal
     TCCR5B = (1 << CS11) | (1 << CS10); //Timer5 Control Reg B: Timer Prescaler set to 64. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
-    TIFR5 = (1 << OCF5A) | (1<<OCF5B) | (1<<OCF5C) | (1<<TOV5) | (1<<ICF5); //Clear the compare flags, overflow flag and external input flag bits
+    TIFR5  = (1 << OCF5A) | (1<<OCF5B) | (1<<OCF5C) | (1<<TOV5) | (1<<ICF5); //Clear the compare flags, overflow flag and external input flag bits
     
     #if defined(TIMER5_MICROS)
       TIMSK5 |= (1 << TOIE5); //Enable the timer5 overflow interrupt (See timers.ino for ISR)
@@ -71,8 +70,8 @@ void initBoard()
     TCCR4B = 0x00;          //Disable Timer4 while we set it up
     TCNT4  = 0;             //Reset Timer Count
     TCCR4A = 0x00;          //Timer4 Control Reg A: Wave Gen Mode normal
-    TCCR4B = (1 << CS12);   //Timer4 Control Reg B: aka Divisor = 256 = 122.5HzTimer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
-    TIFR4 = (1 << OCF4A) | (1<<OCF4B) | (1<<OCF4C) | (1<<TOV4) | (1<<ICF4); //Clear the compare flags, overflow flag and external input flag bits
+    TCCR4B = (1 << CS11) | (1 << CS10);   //Timer4 Control Reg B: aka Divisor = 256 = 122.5HzTimer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TIFR4  = (1 << OCF4A) | (1<<OCF4B) | (1<<OCF4C) | (1<<TOV4) | (1<<ICF4); //Clear the compare flags, overflow flag and external input flag bits
 
 }
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -232,8 +232,8 @@ If it's the correct tooth, but the schedule is not yet started, calculate and an
     } \
     else if ( (currentTooth == ignition4EndTooth) ) \
     { \
-      if( (ignitionSchedule4.Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE_SLOW( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); } \
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE_SLOW( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; } \
+      if( (ignitionSchedule4.Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); } \
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; } \
     } \
   } \
 }

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -215,24 +215,24 @@ If it's the correct tooth, but the schedule is not yet started, calculate and an
   { \
     if ( (currentTooth == ignition1EndTooth) ) \
     { \
-      if( (ignitionSchedule1.Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); } \
+      if( (ignitionSchedule1.Status == Schedule::RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); } \
       else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule1.endScheduleSetByDecoder = true; } \
     } \
   \
     else if ( (currentTooth == ignition2EndTooth) ) \
     { \
-      if( (ignitionSchedule2.Status == RUNNING) ) { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); } \
+      if( (ignitionSchedule2.Status == Schedule::RUNNING) ) { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); } \
       else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule2.endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule2.endScheduleSetByDecoder = true; } \
     } \
   \
     else if ( (currentTooth == ignition3EndTooth) ) \
     { \
-      if( (ignitionSchedule3.Status == RUNNING) ) { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); } \
+      if( (ignitionSchedule3.Status == Schedule::RUNNING) ) { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); } \
       else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule3.endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule3.endScheduleSetByDecoder = true; } \
     } \
     else if ( (currentTooth == ignition4EndTooth) ) \
     { \
-      if( (ignitionSchedule4.Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); } \
+      if( (ignitionSchedule4.Status == Schedule::RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); } \
       else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; } \
     } \
   } \
@@ -341,8 +341,8 @@ void triggerPri_missingTooth()
        //ignition1EndTooth = 11;
        //ignition1EndAngle = 0;
         int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
-       //if ( (toothCurrentCount == ignition1EndTooth) && (ignitionSchedule1.Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); }
-       //if ( (toothCurrentCount == ignition1EndTooth) && (ignitionSchedule1.Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( 9048 ); }
+       //if ( (toothCurrentCount == ignition1EndTooth) && (ignitionSchedule1.Status == Schedule::RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); }
+       //if ( (toothCurrentCount == ignition1EndTooth) && (ignitionSchedule1.Status == Schedule::RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( 9048 ); }
        //else { if (toothCurrentCount == ignition1EndTooth) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( 9048 ); } }
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) )
         {

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -834,10 +834,10 @@ void initialiseAll()
     unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     if(primingValue > 0)
     {
-      setFuelSchedule1(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-      setFuelSchedule2(100, (primingValue * 100 * 5));
-      setFuelSchedule3(100, (primingValue * 100 * 5));
-      setFuelSchedule4(100, (primingValue * 100 * 5));
+      fuelSchedule1.setSchedule(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
+      fuelSchedule2.setSchedule(100, (primingValue * 100 * 5));
+      fuelSchedule3.setSchedule(100, (primingValue * 100 * 5));
+      fuelSchedule4.setSchedule(100, (primingValue * 100 * 5));
     }
 
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -834,10 +834,10 @@ void initialiseAll()
     unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     if(primingValue > 0)
     {
-      fuelSchedule1.setSchedule(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-      fuelSchedule2.setSchedule(100, (primingValue * 100 * 5));
-      fuelSchedule3.setSchedule(100, (primingValue * 100 * 5));
-      fuelSchedule4.setSchedule(100, (primingValue * 100 * 5));
+      fuelSchedule1.setSchedule(openInjector1, 100, (primingValue * 100 * 5), closeInjector1); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
+      fuelSchedule2.setSchedule(openInjector2, 100, (primingValue * 100 * 5), closeInjector2);
+      fuelSchedule3.setSchedule(openInjector3, 100, (primingValue * 100 * 5), closeInjector3);
+      fuelSchedule4.setSchedule(openInjector4, 100, (primingValue * 100 * 5), closeInjector4);
     }
 
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -669,36 +669,37 @@ void initialiseAll()
     {
       if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX = 720; }
     }
+
     
 
     switch(configPage4.sparkMode)
     {
     case IGN_MODE_WASTED:
         //Wasted Spark (Normal mode)
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
+        ignitionSchedule1.StartCallback = beginCoil1Charge;
+        ignitionSchedule1.EndCallback = endCoil1Charge;
+        ignitionSchedule2.StartCallback = beginCoil2Charge;
+        ignitionSchedule2.EndCallback = endCoil2Charge;
+        ignitionSchedule3.StartCallback = beginCoil3Charge;
+        ignitionSchedule3.EndCallback = endCoil3Charge;
+        ignitionSchedule4.StartCallback = beginCoil4Charge;
+        ignitionSchedule4.EndCallback = endCoil4Charge;
+        ignitionSchedule5.StartCallback = beginCoil5Charge;
+        ignitionSchedule5.EndCallback = endCoil5Charge;
         break;
 
     case IGN_MODE_SINGLE:
         //Single channel mode. All ignition pulses are on channel 1
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil1Charge;
-        ign2EndFunction = endCoil1Charge;
-        ign3StartFunction = beginCoil1Charge;
-        ign3EndFunction = endCoil1Charge;
-        ign4StartFunction = beginCoil1Charge;
-        ign4EndFunction = endCoil1Charge;
-        ign5StartFunction = beginCoil1Charge;
-        ign5EndFunction = endCoil1Charge;
+        ignitionSchedule1.StartCallback = beginCoil1Charge;
+        ignitionSchedule1.EndCallback = endCoil1Charge;
+        ignitionSchedule2.StartCallback = beginCoil1Charge;
+        ignitionSchedule2.EndCallback = endCoil1Charge;
+        ignitionSchedule3.StartCallback = beginCoil1Charge;
+        ignitionSchedule3.EndCallback = endCoil1Charge;
+        ignitionSchedule4.StartCallback = beginCoil1Charge;
+        ignitionSchedule4.EndCallback = endCoil1Charge;
+        ignitionSchedule5.StartCallback = beginCoil1Charge;
+        ignitionSchedule5.EndCallback = endCoil1Charge;
         break;
 
     case IGN_MODE_WASTEDCOP:
@@ -706,80 +707,80 @@ void initialiseAll()
         //This is not a valid mode for >4 cylinders
         if( configPage2.nCylinders <= 4 )
         {
-          ign1StartFunction = beginCoil1and3Charge;
-          ign1EndFunction = endCoil1and3Charge;
-          ign2StartFunction = beginCoil2and4Charge;
-          ign2EndFunction = endCoil2and4Charge;
+          ignitionSchedule1.StartCallback = beginCoil1and3Charge;
+          ignitionSchedule1.EndCallback = endCoil1and3Charge;
+          ignitionSchedule2.StartCallback = beginCoil2and4Charge;
+          ignitionSchedule2.EndCallback = endCoil2and4Charge;
 
-          ign3StartFunction = nullCallback;
-          ign3EndFunction = nullCallback;
-          ign4StartFunction = nullCallback;
-          ign4EndFunction = nullCallback;
+          ignitionSchedule3.StartCallback = nullCallback;
+          ignitionSchedule3.EndCallback = nullCallback;
+          ignitionSchedule4.StartCallback = nullCallback;
+          ignitionSchedule4.EndCallback = nullCallback;
         }
         else
         {
           //If the person has inadvertantly selected this when running more than 4 cylinders, just use standard Wasted spark mode
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil2Charge;
-          ign2EndFunction = endCoil2Charge;
-          ign3StartFunction = beginCoil3Charge;
-          ign3EndFunction = endCoil3Charge;
-          ign4StartFunction = beginCoil4Charge;
-          ign4EndFunction = endCoil4Charge;
-          ign5StartFunction = beginCoil5Charge;
-          ign5EndFunction = endCoil5Charge;
+          ignitionSchedule1.StartCallback = beginCoil1Charge;
+          ignitionSchedule1.EndCallback = endCoil1Charge;
+          ignitionSchedule2.StartCallback = beginCoil2Charge;
+          ignitionSchedule2.EndCallback = endCoil2Charge;
+          ignitionSchedule3.StartCallback = beginCoil3Charge;
+          ignitionSchedule3.EndCallback = endCoil3Charge;
+          ignitionSchedule4.StartCallback = beginCoil4Charge;
+          ignitionSchedule4.EndCallback = endCoil4Charge;
+          ignitionSchedule5.StartCallback = beginCoil5Charge;
+          ignitionSchedule5.EndCallback = endCoil5Charge;
         }
         break;
 
     case IGN_MODE_SEQUENTIAL:
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
-        ign6StartFunction = beginCoil6Charge;
-        ign6EndFunction = endCoil6Charge;
-        ign7StartFunction = beginCoil7Charge;
-        ign7EndFunction = endCoil7Charge;
-        ign8StartFunction = beginCoil8Charge;
-        ign8EndFunction = endCoil8Charge;
+        ignitionSchedule1.StartCallback = beginCoil1Charge;
+        ignitionSchedule1.EndCallback = endCoil1Charge;
+        ignitionSchedule2.StartCallback = beginCoil2Charge;
+        ignitionSchedule2.EndCallback = endCoil2Charge;
+        ignitionSchedule3.StartCallback = beginCoil3Charge;
+        ignitionSchedule3.EndCallback = endCoil3Charge;
+        ignitionSchedule4.StartCallback = beginCoil4Charge;
+        ignitionSchedule4.EndCallback = endCoil4Charge;
+        ignitionSchedule5.StartCallback = beginCoil5Charge;
+        ignitionSchedule5.EndCallback = endCoil5Charge;
+        ignitionSchedule6.StartCallback = beginCoil6Charge;
+        ignitionSchedule6.EndCallback = endCoil6Charge;
+        ignitionSchedule7.StartCallback = beginCoil7Charge;
+        ignitionSchedule7.EndCallback = endCoil7Charge;
+        ignitionSchedule8.StartCallback = beginCoil8Charge;
+        ignitionSchedule8.EndCallback = endCoil8Charge;
         break;
 
     case IGN_MODE_ROTARY:
         if(configPage10.rotaryType == ROTARY_IGN_FC)
         {
           //Ignition channel 1 is a wasted spark signal for leading signal on both rotors
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil1Charge;
-          ign2EndFunction = endCoil1Charge;
+          ignitionSchedule1.StartCallback = beginCoil1Charge;
+          ignitionSchedule1.EndCallback = endCoil1Charge;
+          ignitionSchedule2.StartCallback = beginCoil1Charge;
+          ignitionSchedule2.EndCallback = endCoil1Charge;
 
-          ign3StartFunction = beginTrailingCoilCharge;
-          ign3EndFunction = endTrailingCoilCharge1;
-          ign4StartFunction = beginTrailingCoilCharge;
-          ign4EndFunction = endTrailingCoilCharge2;
+          ignitionSchedule3.StartCallback = beginTrailingCoilCharge;
+          ignitionSchedule3.EndCallback = endTrailingCoilCharge1;
+          ignitionSchedule4.StartCallback = beginTrailingCoilCharge;
+          ignitionSchedule4.EndCallback = endTrailingCoilCharge2;
         }
         else if(configPage10.rotaryType == ROTARY_IGN_FD)
         {
           //Ignition channel 1 is a wasted spark signal for leading signal on both rotors
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil1Charge;
-          ign2EndFunction = endCoil1Charge;
+          ignitionSchedule1.StartCallback = beginCoil1Charge;
+          ignitionSchedule1.EndCallback = endCoil1Charge;
+          ignitionSchedule2.StartCallback = beginCoil1Charge;
+          ignitionSchedule2.EndCallback = endCoil1Charge;
 
           //Trailing coils have their own channel each
           //IGN2 = front rotor trailing spark
-          ign3StartFunction = beginCoil2Charge;
-          ign3EndFunction = endCoil2Charge;
+          ignitionSchedule3.StartCallback = beginCoil2Charge;
+          ignitionSchedule3.EndCallback = endCoil2Charge;
           //IGN3 = rear rotor trailing spark
-          ign4StartFunction = beginCoil3Charge;
-          ign4EndFunction = endCoil3Charge;
+          ignitionSchedule4.StartCallback = beginCoil3Charge;
+          ignitionSchedule4.EndCallback = endCoil3Charge;
 
           //IGN4 not used
         }
@@ -788,17 +789,17 @@ void initialiseAll()
           //RX8 outputs are simply 1 coil and 1 output per plug
 
           //IGN1 is front rotor, leading spark
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
+          ignitionSchedule1.StartCallback = beginCoil1Charge;
+          ignitionSchedule1.EndCallback = endCoil1Charge;
           //IGN2 is rear rotor, leading spark
-          ign2StartFunction = beginCoil2Charge;
-          ign2EndFunction = endCoil2Charge;
+          ignitionSchedule2.StartCallback = beginCoil2Charge;
+          ignitionSchedule2.EndCallback = endCoil2Charge;
           //IGN3 = front rotor trailing spark
-          ign3StartFunction = beginCoil3Charge;
-          ign3EndFunction = endCoil3Charge;
+          ignitionSchedule3.StartCallback = beginCoil3Charge;
+          ignitionSchedule3.EndCallback = endCoil3Charge;
           //IGN4 = rear rotor trailing spark
-          ign4StartFunction = beginCoil4Charge;
-          ign4EndFunction = endCoil4Charge;
+          ignitionSchedule4.StartCallback = beginCoil4Charge;
+          ignitionSchedule4.EndCallback = endCoil4Charge;
         }
         break;
 
@@ -806,16 +807,16 @@ void initialiseAll()
 
     default:
         //Wasted spark (Shouldn't ever happen anyway)
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
+        ignitionSchedule1.StartCallback = beginCoil1Charge;
+        ignitionSchedule1.EndCallback = endCoil1Charge;
+        ignitionSchedule2.StartCallback = beginCoil2Charge;
+        ignitionSchedule2.EndCallback = endCoil2Charge;
+        ignitionSchedule3.StartCallback = beginCoil3Charge;
+        ignitionSchedule3.EndCallback = endCoil3Charge;
+        ignitionSchedule4.StartCallback = beginCoil4Charge;
+        ignitionSchedule4.EndCallback = endCoil4Charge;
+        ignitionSchedule5.StartCallback = beginCoil5Charge;
+        ignitionSchedule5.EndCallback = endCoil5Charge;
         break;
     }
 
@@ -834,10 +835,10 @@ void initialiseAll()
     unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     if(primingValue > 0)
     {
-      fuelSchedule1.setSchedule(openInjector1, 100, (primingValue * 100 * 5), closeInjector1); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-      fuelSchedule2.setSchedule(openInjector2, 100, (primingValue * 100 * 5), closeInjector2);
-      fuelSchedule3.setSchedule(openInjector3, 100, (primingValue * 100 * 5), closeInjector3);
-      fuelSchedule4.setSchedule(openInjector4, 100, (primingValue * 100 * 5), closeInjector4);
+      fuelSchedule1.setSchedule(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
+      fuelSchedule2.setSchedule(100, (primingValue * 100 * 5));
+      fuelSchedule3.setSchedule(100, (primingValue * 100 * 5));
+      fuelSchedule4.setSchedule(100, (primingValue * 100 * 5));
     }
 
 

--- a/speeduino/scheduledIO.h
+++ b/speeduino/scheduledIO.h
@@ -60,10 +60,10 @@ void closeInjector7() {*inj7_pin_port &= ~(inj7_pin_mask);}
 void openInjector8() {*inj8_pin_port |= (inj8_pin_mask);}
 void closeInjector8() {*inj8_pin_port &= ~(inj8_pin_mask);}
 
-void openInjector1andMaybe4() {openInjector1(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) openInjector4();}
-void closeInjector1andMaybe4() {closeInjector1(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) closeInjector4();}
-void openInjector2andMaybe3() {openInjector2(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) openInjector3();}
-void closeInjector2andMaybe3() {closeInjector2(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) closeInjector3();}
+void openInjector1and4() {openInjector1(); openInjector4();}
+void closeInjector1and4() {closeInjector1(); closeInjector4();}
+void openInjector2and3() {openInjector2(); openInjector3();}
+void closeInjector2and3() {closeInjector2(); closeInjector3();}
 
 //5 cylinder support doubles up injector 3 as being closese to inj 5 (Crank angle)
 void openInjector3and5() {openInjector3(); openInjector5();}

--- a/speeduino/scheduledIO.h
+++ b/speeduino/scheduledIO.h
@@ -1,6 +1,8 @@
 #ifndef SCHEDULEDIO_H
 #define SCHEDULEDIO_H
 
+#include "globals.h"
+
 //If coil inverse is on, set the output low, else set it high
 //#define beginCoil1Charge() { configPage4.IgInv == 1 ? *ign1_pin_port &= ~(ign1_pin_mask); : *ign1_pin_port |= (ign1_pin_mask); } TACH_PULSE_LOW();
 
@@ -40,32 +42,32 @@ void beginCoil2and4Charge();
 void endCoil2and4Charge();
 
 
-#define openInjector1() *inj1_pin_port |= (inj1_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ1)
-#define closeInjector1() *inj1_pin_port &= ~(inj1_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ1)
-#define openInjector2() *inj2_pin_port |= (inj2_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ2)
-#define closeInjector2() *inj2_pin_port &= ~(inj2_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ2)
-#define openInjector3() *inj3_pin_port |= (inj3_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ3)
-#define closeInjector3() *inj3_pin_port &= ~(inj3_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ3)
-#define openInjector4() *inj4_pin_port |= (inj4_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ4)
-#define closeInjector4() *inj4_pin_port &= ~(inj4_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ4)
-#define openInjector5() *inj5_pin_port |= (inj5_pin_mask)
-#define closeInjector5() *inj5_pin_port &= ~(inj5_pin_mask)
+void openInjector1() {*inj1_pin_port |= (inj1_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ1);}
+void closeInjector1() {*inj1_pin_port &= ~(inj1_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ1);}
+void openInjector2() {*inj2_pin_port |= (inj2_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ2);}
+void closeInjector2() {*inj2_pin_port &= ~(inj2_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ2);}
+void openInjector3() {*inj3_pin_port |= (inj3_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ3);}
+void closeInjector3() {*inj3_pin_port &= ~(inj3_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ3);}
+void openInjector4() {*inj4_pin_port |= (inj4_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ4);}
+void closeInjector4() {*inj4_pin_port &= ~(inj4_pin_mask);  BIT_CLEAR(currentStatus.status1, BIT_STATUS1_INJ4);}
+void openInjector5() {*inj5_pin_port |= (inj5_pin_mask);}
+void closeInjector5() {*inj5_pin_port &= ~(inj5_pin_mask);}
 //Dynamic functions below
-#define openInjector6() *inj6_pin_port |= (inj6_pin_mask);
-#define closeInjector6() *inj6_pin_port &= ~(inj6_pin_mask);
-#define openInjector7() *inj7_pin_port |= (inj7_pin_mask);
-#define closeInjector7() *inj7_pin_port &= ~(inj7_pin_mask);
-#define openInjector8() *inj8_pin_port |= (inj8_pin_mask);
-#define closeInjector8() *inj8_pin_port &= ~(inj8_pin_mask);
+void openInjector6() {*inj6_pin_port |= (inj6_pin_mask);}
+void closeInjector6() {*inj6_pin_port &= ~(inj6_pin_mask);}
+void openInjector7() {*inj7_pin_port |= (inj7_pin_mask);}
+void closeInjector7() {*inj7_pin_port &= ~(inj7_pin_mask);}
+void openInjector8() {*inj8_pin_port |= (inj8_pin_mask);}
+void closeInjector8() {*inj8_pin_port &= ~(inj8_pin_mask);}
 
-#define openInjector1and4() openInjector1(); openInjector4()
-#define closeInjector1and4() closeInjector1(); closeInjector4()
-#define openInjector2and3() openInjector2(); openInjector3()
-#define closeInjector2and3() closeInjector2(); closeInjector3()
+void openInjector1andMaybe4() {openInjector1(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) openInjector4();}
+void closeInjector1andMaybe4() {closeInjector1(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) closeInjector4();}
+void openInjector2andMaybe3() {openInjector2(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) openInjector3();}
+void closeInjector2andMaybe3() {closeInjector2(); if (configPage2.injLayout == INJ_SEMISEQUENTIAL) closeInjector3();}
 
 //5 cylinder support doubles up injector 3 as being closese to inj 5 (Crank angle)
-#define openInjector3and5() openInjector3(); openInjector5()
-#define closeInjector3and5() closeInjector3(); closeInjector5()
+void openInjector3and5() {openInjector3(); openInjector5();}
+void closeInjector3and5() {closeInjector3(); closeInjector5();}
 
 #define coil1Low() (*ign1_pin_port &= ~(ign1_pin_mask))
 #define coil1High() (*ign1_pin_port |= (ign1_pin_mask))

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -76,8 +76,6 @@ static inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute
 #endif
 #endif
 
-
-
 class Schedule {
 
 #if defined(CORE_AVR)

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -90,37 +90,35 @@ public:
   enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The 3 statuses that a schedule can have
 
   volatile unsigned long duration;
-  volatile ScheduleStatus Status;
-  volatile byte schedulesSet; //A counter of how many times the schedule has been set
-  void (*StartCallback)(); //Start Callback function for schedule
-  void (*EndCallback)(); //Start Callback function for schedule
+  volatile ScheduleStatus Status = OFF;
+  volatile byte schedulesSet = 0; //A counter of how many times the schedule has been set
+  void (*StartCallback)() = nullptr;//Start Callback function for schedule
+  void (*EndCallback)() = nullptr; //Start Callback function for schedule
   volatile unsigned long startTime; /**< The system time (in uS) that the schedule started, used by the overdwell protection in timers.ino */
   volatile uint16_t startCompare; //The counter value of the timer when this will start
   volatile uint16_t endCompare;
 
   unsigned int nextStartCompare;
-  unsigned int nextEndCompare;
+  unsigned int nextDuration;
   volatile bool hasNextSchedule = false;
   volatile bool endScheduleSetByDecoder = false;
 
-  volatile DataRegister& counter;
-  volatile DataRegister& compare;
-  volatile EnableRegister& enableRegister;
-  const EnableRegister enableBitMask;
+  struct {
+    volatile DataRegister& counter;
+    volatile DataRegister& compare;
+    volatile EnableRegister& enableRegister;
+    const EnableRegister enableBitMask;
+  } timer;
 
 public:
   Schedule(volatile DataRegister& _counter, volatile DataRegister& _compare, volatile EnableRegister& _enable, const EnableRegister _bitMask)
-      : Status(OFF), schedulesSet(0), counter(_counter), compare(_compare), enableRegister(_enable), enableBitMask(_bitMask)
+      : timer({_counter, _compare, _enable, _bitMask})
   {
-
+    // Nothing else to do here
   }
-  void enable() { enableRegister |= enableBitMask; }
-  void disable() { enableRegister &= ~enableBitMask; }
+  void enable() { timer.enableRegister |= timer.enableBitMask; }
+  void disable() { timer.enableRegister &= ~timer.enableBitMask; }
   void setSchedule(void (*_startCallback)(), uint32_t _timeout, uint32_t _duration, void(*_endCallBack)());
-  void setSchedule(uint32_t _timeout, uint32_t _duration)
-  {
-    setSchedule(nullptr, _timeout, _duration, nullptr);
-  }
   void interrupt();
 };
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -29,23 +29,6 @@ See page 136 of the processors datasheet: http://www.atmel.com/Images/doc2549.pd
 #define IGNITION_REFRESH_THRESHOLD  30 //Time in uS that the refresh functions will check to ensure there is enough time before changing the end compare
 
 void initialiseSchedulers();
-// void setFuelSchedule1(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule2(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule3(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule4(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)()); //Schedule 5 remains a special case for now due to the way it's implemented 
-// //void setFuelSchedule5(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule6(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule7(unsigned long timeout, unsigned long duration);
-// void setFuelSchedule8(unsigned long timeout, unsigned long duration);
-// void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-// void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 
 static inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((always_inline));
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -118,7 +118,7 @@ public:
   }
   void enable() { timer.enableRegister |= timer.enableBitMask; }
   void disable() { timer.enableRegister &= ~timer.enableBitMask; }
-  void setSchedule(void (*_startCallback)(), uint32_t _timeout, uint32_t _duration, void(*_endCallBack)());
+  void setSchedule(uint32_t _timeout, uint32_t _duration);
   void interrupt();
 };
 

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -11,98 +11,96 @@ A full copy of the license may be found in the projects root directory
 
 void initialiseSchedulers()
 {
-    nullSchedule.Status = OFF;
+    // fuelSchedule1.Status = Schedule::OFF;
+    // fuelSchedule2.Status = Schedule::OFF;
+    // fuelSchedule3.Status = Schedule::OFF;
+    // fuelSchedule4.Status = Schedule::OFF;
+    // fuelSchedule5.Status = Schedule::OFF;
+    // fuelSchedule6.Status = Schedule::OFF;
+    // fuelSchedule7.Status = Schedule::OFF;
+    // fuelSchedule8.Status = Schedule::OFF;
 
-    fuelSchedule1.Status = OFF;
-    fuelSchedule2.Status = OFF;
-    fuelSchedule3.Status = OFF;
-    fuelSchedule4.Status = OFF;
-    fuelSchedule5.Status = OFF;
-    fuelSchedule6.Status = OFF;
-    fuelSchedule7.Status = OFF;
-    fuelSchedule8.Status = OFF;
+    // fuelSchedule1.schedulesSet = 0;
+    // fuelSchedule2.schedulesSet = 0;
+    // fuelSchedule3.schedulesSet = 0;
+    // fuelSchedule4.schedulesSet = 0;
+    // fuelSchedule5.schedulesSet = 0;
+    // fuelSchedule6.schedulesSet = 0;
+    // fuelSchedule7.schedulesSet = 0;
+    // fuelSchedule8.schedulesSet = 0;
 
-    fuelSchedule1.schedulesSet = 0;
-    fuelSchedule2.schedulesSet = 0;
-    fuelSchedule3.schedulesSet = 0;
-    fuelSchedule4.schedulesSet = 0;
-    fuelSchedule5.schedulesSet = 0;
-    fuelSchedule6.schedulesSet = 0;
-    fuelSchedule7.schedulesSet = 0;
-    fuelSchedule8.schedulesSet = 0;
+    // fuelSchedule1.counter = &FUEL1_COUNTER;
+    // fuelSchedule1.compare = &FUEL1_COMPARE;
+    // fuelSchedule2.counter = &FUEL2_COUNTER;
+    // fuelSchedule2.compare = &FUEL2_COMPARE;
+    // fuelSchedule3.counter = &FUEL3_COUNTER;
+    // fuelSchedule3.compare = &FUEL3_COMPARE;
+    // fuelSchedule4.counter = &FUEL4_COUNTER;
+    // fuelSchedule4.compare = &FUEL4_COMPARE;
+    // #if (INJ_CHANNELS >= 5)
+    // fuelSchedule5.counter = &FUEL5_COUNTER;
+    // fuelSchedule5.compare = &FUEL5_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 6)
+    // fuelSchedule6.counter = &FUEL6_COUNTER;
+    // fuelSchedule6.compare = &FUEL6_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 7)
+    // fuelSchedule7.counter = &FUEL7_COUNTER;
+    // fuelSchedule7.compare = &FUEL7_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 8)
+    // fuelSchedule8.counter = &FUEL8_COUNTER;
+    // fuelSchedule8.compare = &FUEL8_COMPARE;
+    // #endif
 
-    fuelSchedule1.counter = &FUEL1_COUNTER;
-    fuelSchedule1.compare = &FUEL1_COMPARE;
-    fuelSchedule2.counter = &FUEL2_COUNTER;
-    fuelSchedule2.compare = &FUEL2_COMPARE;
-    fuelSchedule3.counter = &FUEL3_COUNTER;
-    fuelSchedule3.compare = &FUEL3_COMPARE;
-    fuelSchedule4.counter = &FUEL4_COUNTER;
-    fuelSchedule4.compare = &FUEL4_COMPARE;
-    #if (INJ_CHANNELS >= 5)
-    fuelSchedule5.counter = &FUEL5_COUNTER;
-    fuelSchedule5.compare = &FUEL5_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 6)
-    fuelSchedule6.counter = &FUEL6_COUNTER;
-    fuelSchedule6.compare = &FUEL6_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 7)
-    fuelSchedule7.counter = &FUEL7_COUNTER;
-    fuelSchedule7.compare = &FUEL7_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 8)
-    fuelSchedule8.counter = &FUEL8_COUNTER;
-    fuelSchedule8.compare = &FUEL8_COMPARE;
-    #endif
+    // ignitionSchedule1.Status = Schedule::OFF;
+    // ignitionSchedule2.Status = Schedule::OFF;
+    // ignitionSchedule3.Status = Schedule::OFF;
+    // ignitionSchedule4.Status = Schedule::OFF;
+    // ignitionSchedule5.Status = Schedule::OFF;
+    // ignitionSchedule6.Status = Schedule::OFF;
+    // ignitionSchedule7.Status = Schedule::OFF;
+    // ignitionSchedule8.Status = Schedule::OFF;
 
-    ignitionSchedule1.Status = OFF;
-    ignitionSchedule2.Status = OFF;
-    ignitionSchedule3.Status = OFF;
-    ignitionSchedule4.Status = OFF;
-    ignitionSchedule5.Status = OFF;
-    ignitionSchedule6.Status = OFF;
-    ignitionSchedule7.Status = OFF;
-    ignitionSchedule8.Status = OFF;
+    ignitionSchedule1.enable();
+    ignitionSchedule2.enable();
+    ignitionSchedule3.enable();
+    ignitionSchedule4.enable();
 
-    IGN1_TIMER_ENABLE();
-    IGN2_TIMER_ENABLE();
-    IGN3_TIMER_ENABLE();
-    IGN4_TIMER_ENABLE();
+    // ignitionSchedule1.schedulesSet = 0;
+    // ignitionSchedule2.schedulesSet = 0;
+    // ignitionSchedule3.schedulesSet = 0;
+    // ignitionSchedule4.schedulesSet = 0;
+    // ignitionSchedule5.schedulesSet = 0;
+    // ignitionSchedule6.schedulesSet = 0;
+    // ignitionSchedule7.schedulesSet = 0;
+    // ignitionSchedule8.schedulesSet = 0;
 
-    ignitionSchedule1.schedulesSet = 0;
-    ignitionSchedule2.schedulesSet = 0;
-    ignitionSchedule3.schedulesSet = 0;
-    ignitionSchedule4.schedulesSet = 0;
-    ignitionSchedule5.schedulesSet = 0;
-    ignitionSchedule6.schedulesSet = 0;
-    ignitionSchedule7.schedulesSet = 0;
-    ignitionSchedule8.schedulesSet = 0;
-
-    ignitionSchedule1.counter = &IGN1_COUNTER;
-    ignitionSchedule1.compare = &IGN1_COMPARE;
-    ignitionSchedule2.counter = &IGN2_COUNTER;
-    ignitionSchedule2.compare = &IGN2_COMPARE;
-    ignitionSchedule3.counter = &IGN3_COUNTER;
-    ignitionSchedule3.compare = &IGN3_COMPARE;
-    ignitionSchedule4.counter = &IGN4_COUNTER;
-    ignitionSchedule4.compare = &IGN4_COMPARE;
-    #if (INJ_CHANNELS >= 5)
-    ignitionSchedule5.counter = &IGN5_COUNTER;
-    ignitionSchedule5.compare = &IGN5_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 6)
-    ignitionSchedule6.counter = &IGN6_COUNTER;
-    ignitionSchedule6.compare = &IGN6_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 7)
-    ignitionSchedule7.counter = &IGN7_COUNTER;
-    ignitionSchedule7.compare = &IGN7_COMPARE;
-    #endif
-    #if (INJ_CHANNELS >= 8)
-    ignitionSchedule8.counter = &IGN8_COUNTER;
-    ignitionSchedule8.compare = &IGN8_COMPARE;
-    #endif
+    // ignitionSchedule1.counter = &IGN1_COUNTER;
+    // ignitionSchedule1.compare = &IGN1_COMPARE;
+    // ignitionSchedule2.counter = &IGN2_COUNTER;
+    // ignitionSchedule2.compare = &IGN2_COMPARE;
+    // ignitionSchedule3.counter = &IGN3_COUNTER;
+    // ignitionSchedule3.compare = &IGN3_COMPARE;
+    // ignitionSchedule4.counter = &IGN4_COUNTER;
+    // ignitionSchedule4.compare = &IGN4_COMPARE;
+    // #if (INJ_CHANNELS >= 5)
+    // ignitionSchedule5.counter = &IGN5_COUNTER;
+    // ignitionSchedule5.compare = &IGN5_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 6)
+    // ignitionSchedule6.counter = &IGN6_COUNTER;
+    // ignitionSchedule6.compare = &IGN6_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 7)
+    // ignitionSchedule7.counter = &IGN7_COUNTER;
+    // ignitionSchedule7.compare = &IGN7_COMPARE;
+    // #endif
+    // #if (INJ_CHANNELS >= 8)
+    // ignitionSchedule8.counter = &IGN8_COUNTER;
+    // ignitionSchedule8.compare = &IGN8_COMPARE;
+    // #endif
 
 }
 
@@ -117,376 +115,44 @@ endCallback: This function is called once the duration time has been reached
 */
 
 //Experimental new generic function
-void setFuelSchedule(struct Schedule *targetSchedule, unsigned long timeout, unsigned long duration)
+void Schedule::setSchedule(void (*_startCallback)(), uint32_t _timeout, uint32_t _duration, void(*_endCallback)())
 {
-  if(targetSchedule->Status != RUNNING) //Check that we're not already part way through a schedule
+  if(Status != Schedule::RUNNING) //Check that we're not already part way through a schedule
   {
-    //Callbacks no longer used, but retained for now:
-    //fuelSchedule1.StartCallback = startCallback;
-    //fuelSchedule1.EndCallback = endCallback;
-    targetSchedule->duration = duration;
+    StartCallback = _startCallback;
+    EndCallback = _endCallback;
+    duration = _duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >16x (Each tick represents 16uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
+    if (_timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >16x (Each tick represents 16uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(_timeout); } //Normal case
 
     //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
     noInterrupts();
-    targetSchedule->startCompare = *targetSchedule->counter + timeout_timer_compare;
-    targetSchedule->endCompare = targetSchedule->startCompare + uS_TO_TIMER_COMPARE(duration);
-    targetSchedule->Status = PENDING; //Turn this schedule on
-    targetSchedule->schedulesSet++; //Increment the number of times this schedule has been set
+    startCompare = counter + timeout_timer_compare;
+    endCompare = startCompare + uS_TO_TIMER_COMPARE(_duration);
+    Status = Schedule::PENDING; //Turn this schedule on
+    schedulesSet++; //Increment the number of times this schedule has been set
 
-    *targetSchedule->compare = targetSchedule->startCompare;
+    compare = startCompare;
     interrupts();
-    FUEL1_TIMER_ENABLE();
+    enable();
   }
   else
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    targetSchedule->nextStartCompare = *targetSchedule->counter + uS_TO_TIMER_COMPARE(timeout);
-    targetSchedule->nextEndCompare = targetSchedule->nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    targetSchedule->hasNextSchedule = true;
+    nextStartCompare = counter + uS_TO_TIMER_COMPARE(_timeout);
+    nextEndCompare = nextStartCompare + uS_TO_TIMER_COMPARE(_duration);
+    hasNextSchedule = true;
   }
 }
 
-
-//void setFuelSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule1(unsigned long timeout, unsigned long duration)
-{
-  //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD)
-  {
-    if(fuelSchedule1.Status != RUNNING) //Check that we're not already part way through a schedule
-    {
-      //Callbacks no longer used, but retained for now:
-      //fuelSchedule1.StartCallback = startCallback;
-      //fuelSchedule1.EndCallback = endCallback;
-      fuelSchedule1.duration = duration;
-
-      //Need to check that the timeout doesn't exceed the overflow
-      uint16_t timeout_timer_compare;
-      if ((timeout+duration) > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1 - duration) ); } // If the timeout is >16x (Each tick represents 16uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-      //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-      noInterrupts();
-      fuelSchedule1.startCompare = FUEL1_COUNTER + timeout_timer_compare;
-      fuelSchedule1.endCompare = fuelSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration);
-      fuelSchedule1.Status = PENDING; //Turn this schedule on
-      fuelSchedule1.schedulesSet++; //Increment the number of times this schedule has been set
-      //Schedule 1 shares a timer with schedule 5
-      //if(channel5InjEnabled) { FUEL1_COMPARE = setQueue(timer3Aqueue, &fuelSchedule1, &fuelSchedule5, FUEL1_COUNTER); }
-      //else { timer3Aqueue[0] = &fuelSchedule1; timer3Aqueue[1] = &fuelSchedule1; timer3Aqueue[2] = &fuelSchedule1; timer3Aqueue[3] = &fuelSchedule1; FUEL1_COMPARE = fuelSchedule1.startCompare; }
-      //timer3Aqueue[0] = &fuelSchedule1; timer3Aqueue[1] = &fuelSchedule1; timer3Aqueue[2] = &fuelSchedule1; timer3Aqueue[3] = &fuelSchedule1;
-      FUEL1_COMPARE = fuelSchedule1.startCompare;
-      interrupts();
-      FUEL1_TIMER_ENABLE();
-    }
-    else
-    {
-      //If the schedule is already running, we can set the next schedule so it is ready to go
-      //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      noInterrupts();
-      fuelSchedule1.nextStartCompare = FUEL1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      fuelSchedule1.nextEndCompare = fuelSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      fuelSchedule1.duration = duration;
-      fuelSchedule1.hasNextSchedule = true;
-      interrupts();
-    } //Schedule is RUNNING
-  } //Timeout less than threshold
-}
-
-void setFuelSchedule2(unsigned long timeout, unsigned long duration)
-{
-  //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD)
-  {
-    if(fuelSchedule2.Status != RUNNING) //Check that we're not already part way through a schedule
-    {
-      //Callbacks no longer used, but retained for now:
-      //fuelSchedule2.StartCallback = startCallback;
-      //fuelSchedule2.EndCallback = endCallback;
-      fuelSchedule2.duration = duration;
-
-      //Need to check that the timeout doesn't exceed the overflow
-      uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-      //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-      noInterrupts();
-      fuelSchedule2.startCompare = FUEL2_COUNTER + timeout_timer_compare;
-      fuelSchedule2.endCompare = fuelSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration);
-      FUEL2_COMPARE = fuelSchedule2.startCompare; //Use the B compare unit of timer 3
-      fuelSchedule2.Status = PENDING; //Turn this schedule on
-      fuelSchedule2.schedulesSet++; //Increment the number of times this schedule has been set
-      interrupts();
-      FUEL2_TIMER_ENABLE();
-    }
-    else
-    {
-      //If the schedule is already running, we can set the next schedule so it is ready to go
-      //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule2.nextStartCompare = FUEL2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      fuelSchedule2.nextEndCompare = fuelSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      fuelSchedule2.hasNextSchedule = true;
-    }
-  }
-}
-//void setFuelSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule3(unsigned long timeout, unsigned long duration)
-{
-  //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD)
-  {
-    if(fuelSchedule3.Status != RUNNING)//Check that we're not already part way through a schedule
-    {
-      //Callbacks no longer used, but retained for now:
-      //fuelSchedule3.StartCallback = startCallback;
-      //fuelSchedule3.EndCallback = endCallback;
-      fuelSchedule3.duration = duration;
-
-      //Need to check that the timeout doesn't exceed the overflow
-      uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-      //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-      noInterrupts();
-      fuelSchedule3.startCompare = FUEL3_COUNTER + timeout_timer_compare;
-      fuelSchedule3.endCompare = fuelSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration);
-      FUEL3_COMPARE = fuelSchedule3.startCompare; //Use the C copmare unit of timer 3
-      fuelSchedule3.Status = PENDING; //Turn this schedule on
-      fuelSchedule3.schedulesSet++; //Increment the number of times this schedule has been set
-      interrupts();
-      FUEL3_TIMER_ENABLE();
-    }
-    else
-    {
-      //If the schedule is already running, we can set the next schedule so it is ready to go
-      //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule3.nextStartCompare = FUEL3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      fuelSchedule3.nextEndCompare = fuelSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      fuelSchedule3.hasNextSchedule = true;
-    }
-  }
-}
-//void setFuelSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses timer 4 compare B
-{
-  //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD)
-  {
-    if(fuelSchedule4.Status != RUNNING) //Check that we're not already part way through a schedule
-    {
-      //Callbacks no longer used, but retained for now:
-      //fuelSchedule4.StartCallback = startCallback;
-      //fuelSchedule4.EndCallback = endCallback;
-      fuelSchedule4.duration = duration;
-
-      //Need to check that the timeout doesn't exceed the overflow
-      uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-      //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-      noInterrupts();
-      fuelSchedule4.startCompare = FUEL4_COUNTER + timeout_timer_compare;
-      fuelSchedule4.endCompare = fuelSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration);
-      FUEL4_COMPARE = fuelSchedule4.startCompare; //Use the C copmare unit of timer 3
-      fuelSchedule4.Status = PENDING; //Turn this schedule on
-      fuelSchedule4.schedulesSet++; //Increment the number of times this schedule has been set
-      interrupts();
-      FUEL4_TIMER_ENABLE();
-    }
-    else
-    {
-      //If the schedule is already running, we can set the next schedule so it is ready to go
-      //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule4.nextStartCompare = FUEL4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      fuelSchedule4.nextEndCompare = fuelSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      fuelSchedule4.hasNextSchedule = true;
-    }
-  }
-}
-
-#if INJ_CHANNELS >= 5
-void setFuelSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(fuelSchedule5.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    fuelSchedule5.StartCallback = startCallback; //Name the start callback function
-    fuelSchedule5.EndCallback = endCallback; //Name the end callback function
-    fuelSchedule5.duration = duration;
-
-    /*
-     * The following must be enclosed in the noIntterupts block to avoid contention caused if the relevant interrupts fires before the state is fully set
-     */
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
-    noInterrupts();
-    fuelSchedule5.startCompare = TCNT3 + (timeout >> 4); //As above, but with bit shift instead of / 16
-    fuelSchedule5.endCompare = fuelSchedule5.startCompare + (duration >> 4);
-    fuelSchedule5.Status = PENDING; //Turn this schedule on
-    fuelSchedule5.schedulesSet++; //Increment the number of times this schedule has been set
-    OCR3A = setQueue(timer3Aqueue, &fuelSchedule1, &fuelSchedule5, TCNT3); //Schedule 1 shares a timer with schedule 5
-    interrupts();
-    TIMSK3 |= (1 << OCIE3A); //Turn on the A compare unit (ie turn on the interrupt)
-#endif
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule5.nextStartCompare = FUEL5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    fuelSchedule5.nextEndCompare = fuelSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    fuelSchedule5.hasNextSchedule = true;
-  }
-}
-#endif
-
-#if INJ_CHANNELS >= 6
-//This uses timer
-void setFuelSchedule6(unsigned long timeout, unsigned long duration)
-{
-  if(fuelSchedule6.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    //Callbacks no longer used, but retained for now:
-    //fuelSchedule4.StartCallback = startCallback;
-    //fuelSchedule4.EndCallback = endCallback;
-    fuelSchedule6.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-    noInterrupts();
-    fuelSchedule6.startCompare = FUEL6_COUNTER + timeout_timer_compare;
-    fuelSchedule6.endCompare = fuelSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration);
-    FUEL6_COMPARE = fuelSchedule6.startCompare; //Use the C copmare unit of timer 3
-    fuelSchedule6.Status = PENDING; //Turn this schedule on
-    fuelSchedule6.schedulesSet++; //Increment the number of times this schedule has been set
-    interrupts();
-    FUEL6_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule6.nextStartCompare = FUEL6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    fuelSchedule6.nextEndCompare = fuelSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    fuelSchedule6.hasNextSchedule = true;
-  }
-}
-#endif
-
-#if INJ_CHANNELS >= 7
-//This uses timer
-void setFuelSchedule7(unsigned long timeout, unsigned long duration)
-{
-  if(fuelSchedule7.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    //Callbacks no longer used, but retained for now:
-    //fuelSchedule4.StartCallback = startCallback;
-    //fuelSchedule4.EndCallback = endCallback;
-    fuelSchedule7.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-    noInterrupts();
-    fuelSchedule7.startCompare = FUEL7_COUNTER + timeout_timer_compare;
-    fuelSchedule7.endCompare = fuelSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration);
-    FUEL7_COMPARE = fuelSchedule7.startCompare; //Use the C copmare unit of timer 3
-    fuelSchedule7.Status = PENDING; //Turn this schedule on
-    fuelSchedule7.schedulesSet++; //Increment the number of times this schedule has been set
-    interrupts();
-    FUEL7_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule7.nextStartCompare = FUEL7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    fuelSchedule7.nextEndCompare = fuelSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    fuelSchedule7.hasNextSchedule = true;
-  }
-}
-#endif
-
-#if INJ_CHANNELS >= 8
-//This uses timer
-void setFuelSchedule8(unsigned long timeout, unsigned long duration)
-{
-  if(fuelSchedule8.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    //Callbacks no longer used, but retained for now:
-    //fuelSchedule4.StartCallback = startCallback;
-    //fuelSchedule4.EndCallback = endCallback;
-    fuelSchedule8.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
-    noInterrupts();
-    fuelSchedule8.startCompare = FUEL8_COUNTER + timeout_timer_compare;
-    fuelSchedule8.endCompare = fuelSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration);
-    FUEL8_COMPARE = fuelSchedule8.startCompare; //Use the C copmare unit of timer 3
-    fuelSchedule8.Status = PENDING; //Turn this schedule on
-    fuelSchedule8.schedulesSet++; //Increment the number of times this schedule has been set
-    interrupts();
-    FUEL8_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule8.nextStartCompare = FUEL8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    fuelSchedule8.nextEndCompare = fuelSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    fuelSchedule8.hasNextSchedule = true;
-  }
-}
-#endif
-
-//Ignition schedulers use Timer 5
-void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule1.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    ignitionSchedule1.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule1.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule1.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    //timeout -= (micros() - lastCrankAngleCalc);
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN1_COMPARE = ignitionSchedule1.startCompare;
-    ignitionSchedule1.Status = PENDING; //Turn this schedule on
-    ignitionSchedule1.schedulesSet++;
-    interrupts();
-    IGN1_TIMER_ENABLE();
-  }
-}
 
 static inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
 {
-  if( (ignitionSchedule1.Status == RUNNING) && (timeToEnd < ignitionSchedule1.duration) )
+  if( (ignitionSchedule1.Status == Schedule::RUNNING) && (timeToEnd < ignitionSchedule1.duration) )
   //Must have the threshold check here otherwise it can cause a condition where the compare fires twice, once after the other, both for the end
   //if( (timeToEnd < ignitionSchedule1.duration) && (timeToEnd > IGNITION_REFRESH_THRESHOLD) )
   {
@@ -494,214 +160,6 @@ static inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
     ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeToEnd);
     IGN1_COMPARE = ignitionSchedule1.endCompare;
     interrupts();
-  }
-}
-
-void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule2.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-    ignitionSchedule2.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule2.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule2.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN2_COMPARE = ignitionSchedule2.startCompare;
-    ignitionSchedule2.Status = PENDING; //Turn this schedule on
-    ignitionSchedule2.schedulesSet++;
-    interrupts();
-    IGN2_TIMER_ENABLE();
-  }
-}
-void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule3.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule3.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule3.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule3.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN3_COMPARE = ignitionSchedule3.startCompare;
-    ignitionSchedule3.Status = PENDING; //Turn this schedule on
-    ignitionSchedule3.schedulesSet++;
-    interrupts();
-    IGN3_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    ignitionSchedule3.hasNextSchedule = true;
-  }
-}
-void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule4.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule4.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule4.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule4.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN4_COMPARE = ignitionSchedule4.startCompare;
-    ignitionSchedule4.Status = PENDING; //Turn this schedule on
-    ignitionSchedule4.schedulesSet++;
-    interrupts();
-    IGN4_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    ignitionSchedule4.hasNextSchedule = true;
-  }
-}
-void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule5.Status != RUNNING)//Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule5.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule5.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule5.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN5_COMPARE = ignitionSchedule5.startCompare;
-    ignitionSchedule5.Status = PENDING; //Turn this schedule on
-    ignitionSchedule5.schedulesSet++;
-    interrupts();
-    IGN5_TIMER_ENABLE();
-  }
-}
-void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule6.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule6.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule6.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule6.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN6_COMPARE = ignitionSchedule6.startCompare;
-    ignitionSchedule6.Status = PENDING; //Turn this schedule on
-    ignitionSchedule6.schedulesSet++;
-    interrupts();
-    IGN6_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    ignitionSchedule6.hasNextSchedule = true;
-  }
-}
-void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule7.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule7.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule7.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule7.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule7.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN7_COMPARE = ignitionSchedule7.startCompare;
-    ignitionSchedule7.Status = PENDING; //Turn this schedule on
-    ignitionSchedule7.schedulesSet++;
-    interrupts();
-    IGN7_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    ignitionSchedule7.hasNextSchedule = true;
-  }
-}
-void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-{
-  if(ignitionSchedule8.Status != RUNNING) //Check that we're not already part way through a schedule
-  {
-
-    ignitionSchedule8.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule8.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule8.duration = duration;
-
-    //Need to check that the timeout doesn't exceed the overflow
-    uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
-
-    noInterrupts();
-    ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN8_COMPARE = ignitionSchedule8.startCompare;
-    ignitionSchedule8.Status = PENDING; //Turn this schedule on
-    ignitionSchedule8.schedulesSet++;
-    interrupts();
-    IGN8_TIMER_ENABLE();
-  }
-  else
-  {
-    //If the schedule is already running, we can set the next schedule so it is ready to go
-    //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-    ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    ignitionSchedule8.hasNextSchedule = true;
   }
 }
 
@@ -716,20 +174,20 @@ ISR(TIMER3_COMPA_vect) //fuelSchedules 1 and 5
 static inline void fuelSchedule1Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (fuelSchedule1.Status == PENDING) //Check to see if this schedule is turn on
+    if (fuelSchedule1.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       //To use timer queue, change fuelShedule1 to timer3Aqueue[0];
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector1and4(); }
       else { openInjector1(); }
-      fuelSchedule1.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      fuelSchedule1.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       FUEL1_COMPARE = FUEL1_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule1.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (fuelSchedule1.Status == RUNNING)
+    else if (fuelSchedule1.Status == Schedule::RUNNING)
     {
        //timer3Aqueue[0]->EndCallback();
        if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { closeInjector1and4(); }
        else { closeInjector1(); }
-       fuelSchedule1.Status = OFF; //Turn off the schedule
+       fuelSchedule1.Status = Schedule::OFF; //Turn off the schedule
        fuelSchedule1.schedulesSet = 0;
        //FUEL1_COMPARE = fuelSchedule1.endCompare;
 
@@ -738,13 +196,13 @@ static inline void fuelSchedule1Interrupt() //Most ARM chips can simply call a f
        {
          FUEL1_COMPARE = fuelSchedule1.nextStartCompare;
          fuelSchedule1.endCompare = fuelSchedule1.nextEndCompare;
-         fuelSchedule1.Status = PENDING;
+         fuelSchedule1.Status = Schedule::PENDING;
          fuelSchedule1.schedulesSet = 1;
          fuelSchedule1.hasNextSchedule = false;
        }
-       else { FUEL1_TIMER_DISABLE(); }
+       else { fuelSchedule1.disable(); }
     }
-    else if (fuelSchedule1.Status == OFF) { FUEL1_TIMER_DISABLE(); } //Safety check. Turn off this output compare unit and return without performing any action
+    else if (fuelSchedule1.Status == Schedule::OFF) { fuelSchedule1.disable(); } //Safety check. Turn off this output compare unit and return without performing any action
   }
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) //AVR chips use the ISR for this
@@ -753,20 +211,20 @@ ISR(TIMER3_COMPB_vect) //fuelSchedule2
 static inline void fuelSchedule2Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (fuelSchedule2.Status == PENDING) //Check to see if this schedule is turn on
+    if (fuelSchedule2.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       //fuelSchedule2.StartCallback();
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector2and3(); }
       else { openInjector2(); }
-      fuelSchedule2.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      fuelSchedule2.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       FUEL2_COMPARE = FUEL2_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule2.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (fuelSchedule2.Status == RUNNING)
+    else if (fuelSchedule2.Status == Schedule::RUNNING)
     {
        //fuelSchedule2.EndCallback();
        if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { closeInjector2and3(); }
        else { closeInjector2(); }
-       fuelSchedule2.Status = OFF; //Turn off the schedule
+       fuelSchedule2.Status = Schedule::OFF; //Turn off the schedule
        fuelSchedule2.schedulesSet = 0;
 
        //If there is a next schedule queued up, activate it
@@ -774,11 +232,11 @@ static inline void fuelSchedule2Interrupt() //Most ARM chips can simply call a f
        {
          FUEL2_COMPARE = fuelSchedule2.nextStartCompare;
          fuelSchedule2.endCompare = fuelSchedule2.nextEndCompare;
-         fuelSchedule2.Status = PENDING;
+         fuelSchedule2.Status = Schedule::PENDING;
          fuelSchedule2.schedulesSet = 1;
          fuelSchedule2.hasNextSchedule = false;
        }
-       else { FUEL2_TIMER_DISABLE(); }
+       else { fuelSchedule2.disable(); }
     }
   }
 
@@ -788,22 +246,22 @@ ISR(TIMER3_COMPC_vect) //fuelSchedule3
 static inline void fuelSchedule3Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (fuelSchedule3.Status == PENDING) //Check to see if this schedule is turn on
+    if (fuelSchedule3.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       //fuelSchedule3.StartCallback();
       //Hack for 5 cylinder
       if(channel5InjEnabled) { openInjector3and5(); }
       else { openInjector3(); }
-      fuelSchedule3.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      fuelSchedule3.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       FUEL3_COMPARE = FUEL3_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule3.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (fuelSchedule3.Status == RUNNING)
+    else if (fuelSchedule3.Status == Schedule::RUNNING)
     {
        //fuelSchedule3.EndCallback();
        //Hack for 5 cylinder
        if(channel5InjEnabled) { closeInjector3and5(); }
        else { closeInjector3and5(); }
-       fuelSchedule3.Status = OFF; //Turn off the schedule
+       fuelSchedule3.Status = Schedule::OFF; //Turn off the schedule
        fuelSchedule3.schedulesSet = 0;
 
        //If there is a next schedule queued up, activate it
@@ -811,11 +269,11 @@ static inline void fuelSchedule3Interrupt() //Most ARM chips can simply call a f
        {
          FUEL3_COMPARE = fuelSchedule3.nextStartCompare;
          fuelSchedule3.endCompare = fuelSchedule3.nextEndCompare;
-         fuelSchedule3.Status = PENDING;
+         fuelSchedule3.Status = Schedule::PENDING;
          fuelSchedule3.schedulesSet = 1;
          fuelSchedule3.hasNextSchedule = false;
        }
-       else { FUEL3_TIMER_DISABLE(); }
+       else { fuelSchedule3.disable(); }
     }
   }
 
@@ -825,18 +283,18 @@ ISR(TIMER4_COMPB_vect) //fuelSchedule4
 static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (fuelSchedule4.Status == PENDING) //Check to see if this schedule is turn on
+    if (fuelSchedule4.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       //fuelSchedule4.StartCallback();
       openInjector4();
-      fuelSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      fuelSchedule4.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       FUEL4_COMPARE = FUEL4_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (fuelSchedule4.Status == RUNNING)
+    else if (fuelSchedule4.Status == Schedule::RUNNING)
     {
        //fuelSchedule4.EndCallback();
        closeInjector4();
-       fuelSchedule4.Status = OFF; //Turn off the schedule
+       fuelSchedule4.Status = Schedule::OFF; //Turn off the schedule
        fuelSchedule4.schedulesSet = 0;
 
        //If there is a next schedule queued up, activate it
@@ -844,11 +302,11 @@ static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a f
        {
          FUEL4_COMPARE = fuelSchedule4.nextStartCompare;
          fuelSchedule4.endCompare = fuelSchedule4.nextEndCompare;
-         fuelSchedule4.Status = PENDING;
+         fuelSchedule4.Status = Schedule::PENDING;
          fuelSchedule4.schedulesSet = 1;
          fuelSchedule4.hasNextSchedule = false;
        }
-       else { FUEL4_TIMER_DISABLE(); }
+       else { fuelSchedule4.disable(); }
     }
   }
 
@@ -859,16 +317,16 @@ ISR(TIMER1_COMPC_vect) //fuelSchedule5
 static inline void fuelSchedule5Interrupt() //Most ARM chips can simply call a function
 #endif
 {
-  if (fuelSchedule5.Status == PENDING) //Check to see if this schedule is turn on
+  if (fuelSchedule5.Status == Schedule::PENDING) //Check to see if this schedule is turn on
   {
     openInjector5();
-    fuelSchedule5.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+    fuelSchedule5.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
     FUEL5_COMPARE = fuelSchedule5.endCompare;
   }
-  else if (fuelSchedule5.Status == RUNNING)
+  else if (fuelSchedule5.Status == Schedule::RUNNING)
   {
      closeInjector5();
-     fuelSchedule5.Status = OFF; //Turn off the schedule
+     fuelSchedule5.Status = Schedule::OFF; //Turn off the schedule
      fuelSchedule5.schedulesSet = 0;
 
      //If there is a next schedule queued up, activate it
@@ -876,11 +334,11 @@ static inline void fuelSchedule5Interrupt() //Most ARM chips can simply call a f
      {
        FUEL5_COMPARE = fuelSchedule5.nextStartCompare;
        fuelSchedule5.endCompare = fuelSchedule5.nextEndCompare;
-       fuelSchedule5.Status = PENDING;
+       fuelSchedule5.Status = Schedule::PENDING;
        fuelSchedule5.schedulesSet = 1;
        fuelSchedule5.hasNextSchedule = false;
      }
-     else { FUEL5_TIMER_DISABLE(); }
+     else { fuelSchedule5.disable(); }
   }
 }
 #endif
@@ -892,18 +350,18 @@ ISR(TIMER4_COMPA_vect) //fuelSchedule6
 static inline void fuelSchedule6Interrupt() //Most ARM chips can simply call a function
 #endif
 {
-  if (fuelSchedule6.Status == PENDING) //Check to see if this schedule is turn on
+  if (fuelSchedule6.Status == Schedule::PENDING) //Check to see if this schedule is turn on
   {
     //fuelSchedule4.StartCallback();
     openInjector6();
-    fuelSchedule6.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+    fuelSchedule6.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
     FUEL6_COMPARE = fuelSchedule6.endCompare;
   }
-  else if (fuelSchedule6.Status == RUNNING)
+  else if (fuelSchedule6.Status == Schedule::RUNNING)
   {
      //fuelSchedule4.EndCallback();
      closeInjector6();
-     fuelSchedule6.Status = OFF; //Turn off the schedule
+     fuelSchedule6.Status = Schedule::OFF; //Turn off the schedule
      fuelSchedule6.schedulesSet = 0;
 
      //If there is a next schedule queued up, activate it
@@ -911,11 +369,11 @@ static inline void fuelSchedule6Interrupt() //Most ARM chips can simply call a f
      {
        FUEL6_COMPARE = fuelSchedule6.nextStartCompare;
        fuelSchedule6.endCompare = fuelSchedule6.nextEndCompare;
-       fuelSchedule6.Status = PENDING;
+       fuelSchedule6.Status = Schedule::PENDING;
        fuelSchedule6.schedulesSet = 1;
        fuelSchedule6.hasNextSchedule = false;
      }
-     else { FUEL6_TIMER_DISABLE(); }
+     else { fuelSchedule6.disable(); }
   }
 }
 #endif
@@ -927,16 +385,16 @@ ISR(TIMER5_COMPC_vect) //fuelSchedule7
 static inline void fuelSchedule7Interrupt() //Most ARM chips can simply call a function
 #endif
 {
-  if (fuelSchedule7.Status == PENDING) //Check to see if this schedule is turn on
+  if (fuelSchedule7.Status == Schedule::PENDING) //Check to see if this schedule is turn on
   {
     openInjector7();
-    fuelSchedule7.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+    fuelSchedule7.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
     FUEL7_COMPARE = fuelSchedule7.endCompare;
   }
-  else if (fuelSchedule7.Status == RUNNING)
+  else if (fuelSchedule7.Status == Schedule::RUNNING)
   {
      closeInjector7();
-     fuelSchedule7.Status = OFF; //Turn off the schedule
+     fuelSchedule7.Status = Schedule::OFF; //Turn off the schedule
      fuelSchedule7.schedulesSet = 0;
 
      //If there is a next schedule queued up, activate it
@@ -944,11 +402,11 @@ static inline void fuelSchedule7Interrupt() //Most ARM chips can simply call a f
      {
        FUEL7_COMPARE = fuelSchedule7.nextStartCompare;
        fuelSchedule7.endCompare = fuelSchedule7.nextEndCompare;
-       fuelSchedule7.Status = PENDING;
+       fuelSchedule7.Status = Schedule::PENDING;
        fuelSchedule7.schedulesSet = 1;
        fuelSchedule7.hasNextSchedule = false;
      }
-     else { FUEL7_TIMER_DISABLE(); }
+     else { fuelSchedule7.disable(); }
   }
 }
 #endif
@@ -960,18 +418,18 @@ ISR(TIMER5_COMPB_vect) //fuelSchedule8
 static inline void fuelSchedule8Interrupt() //Most ARM chips can simply call a function
 #endif
 {
-  if (fuelSchedule8.Status == PENDING) //Check to see if this schedule is turn on
+  if (fuelSchedule8.Status == Schedule::PENDING) //Check to see if this schedule is turn on
   {
     //fuelSchedule4.StartCallback();
     openInjector8();
-    fuelSchedule8.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+    fuelSchedule8.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
     FUEL8_COMPARE = fuelSchedule8.endCompare;
   }
-  else if (fuelSchedule8.Status == RUNNING)
+  else if (fuelSchedule8.Status == Schedule::RUNNING)
   {
      //fuelSchedule4.EndCallback();
      closeInjector8();
-     fuelSchedule8.Status = OFF; //Turn off the schedule
+     fuelSchedule8.Status = Schedule::OFF; //Turn off the schedule
      fuelSchedule8.schedulesSet = 0;
 
      //If there is a next schedule queued up, activate it
@@ -979,11 +437,11 @@ static inline void fuelSchedule8Interrupt() //Most ARM chips can simply call a f
      {
        FUEL8_COMPARE = fuelSchedule8.nextStartCompare;
        fuelSchedule8.endCompare = fuelSchedule8.nextEndCompare;
-       fuelSchedule8.Status = PENDING;
+       fuelSchedule8.Status = Schedule::PENDING;
        fuelSchedule8.schedulesSet = 1;
        fuelSchedule8.hasNextSchedule = false;
      }
-     else { FUEL8_TIMER_DISABLE(); }
+     else { fuelSchedule8.disable(); }
   }
 }
 #endif
@@ -995,29 +453,29 @@ ISR(TIMER5_COMPA_vect) //ignitionSchedule1
 static inline void ignitionSchedule1Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule1.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule1.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule1.StartCallback();
-      ignitionSchedule1.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule1.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule1.startTime = micros();
       if(ignitionSchedule1.endScheduleSetByDecoder == true) { IGN1_COMPARE = ignitionSchedule1.endCompare; }
       else { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule1.duration); } //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule1.Status == RUNNING)
+    else if (ignitionSchedule1.Status == Schedule::RUNNING)
     {
       ignitionSchedule1.EndCallback();
       //   *ign1_pin_port &= ~(ign1_pin_mask);
-      ignitionSchedule1.Status = OFF; //Turn off the schedule
+      ignitionSchedule1.Status = Schedule::OFF; //Turn off the schedule
       ignitionSchedule1.schedulesSet = 0;
       ignitionSchedule1.hasNextSchedule = false;
       ignitionSchedule1.endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
-      IGN1_TIMER_DISABLE();
+      ignitionSchedule1.disable();
     }
-    else if (ignitionSchedule1.Status == OFF)
+    else if (ignitionSchedule1.Status == Schedule::OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
-      IGN1_TIMER_DISABLE();
+      ignitionSchedule1.disable();
     }
   }
 #endif
@@ -1029,27 +487,27 @@ ISR(TIMER5_COMPB_vect) //ignitionSchedule2
 static inline void ignitionSchedule2Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule2.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule2.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule2.StartCallback();
-      ignitionSchedule2.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule2.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule2.startTime = micros();
       if(ignitionSchedule2.endScheduleSetByDecoder == true) { IGN2_COMPARE = ignitionSchedule2.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
       else { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
-    else if (ignitionSchedule2.Status == RUNNING)
+    else if (ignitionSchedule2.Status == Schedule::RUNNING)
     {
-      ignitionSchedule2.Status = OFF; //Turn off the schedule
+      ignitionSchedule2.Status = Schedule::OFF; //Turn off the schedule
       ignitionSchedule2.EndCallback();
       ignitionSchedule2.schedulesSet = 0;
       ignitionSchedule2.endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
-      IGN2_TIMER_DISABLE();
+      ignitionSchedule2.disable();
     }
-    else if (ignitionSchedule2.Status == OFF)
+    else if (ignitionSchedule2.Status == Schedule::OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
-      IGN2_TIMER_DISABLE();
+      ignitionSchedule2.disable();
     }
   }
 #endif
@@ -1061,17 +519,17 @@ ISR(TIMER5_COMPC_vect) //ignitionSchedule3
 static inline void ignitionSchedule3Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule3.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule3.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule3.StartCallback();
-      ignitionSchedule3.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule3.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule3.startTime = micros();
       if(ignitionSchedule3.endScheduleSetByDecoder == true) { IGN3_COMPARE = ignitionSchedule3.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
       else { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
-    else if (ignitionSchedule3.Status == RUNNING)
+    else if (ignitionSchedule3.Status == Schedule::RUNNING)
     {
-       ignitionSchedule3.Status = OFF; //Turn off the schedule
+       ignitionSchedule3.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule3.EndCallback();
        ignitionSchedule3.schedulesSet = 0;
        ignitionSchedule3.endScheduleSetByDecoder = false;
@@ -1082,16 +540,16 @@ static inline void ignitionSchedule3Interrupt() //Most ARM chips can simply call
        {
          IGN3_COMPARE = ignitionSchedule3.nextStartCompare;
          ignitionSchedule3.endCompare = ignitionSchedule3.nextEndCompare;
-         ignitionSchedule3.Status = PENDING;
+         ignitionSchedule3.Status = Schedule::PENDING;
          ignitionSchedule3.schedulesSet = 1;
          ignitionSchedule3.hasNextSchedule = false;
        }
-       else { IGN3_TIMER_DISABLE(); }
+       else { ignitionSchedule3.disable(); }
     }
-    else if (ignitionSchedule3.Status == OFF)
+    else if (ignitionSchedule3.Status == Schedule::OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
-      IGN3_TIMER_DISABLE();
+      ignitionSchedule3.disable();
     }
   }
 #endif
@@ -1103,16 +561,16 @@ ISR(TIMER4_COMPA_vect) //ignitionSchedule4
 static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule4.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule4.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule4.StartCallback();
-      ignitionSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule4.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule4.startTime = micros();
       IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule4.Status == RUNNING)
+    else if (ignitionSchedule4.Status == Schedule::RUNNING)
     {
-       ignitionSchedule4.Status = OFF; //Turn off the schedule
+       ignitionSchedule4.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule4.EndCallback();
        ignitionSchedule4.schedulesSet = 0;
        ignitionSchedule4.endScheduleSetByDecoder = false;
@@ -1123,16 +581,16 @@ static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call
        {
          IGN4_COMPARE = ignitionSchedule4.nextStartCompare;
          ignitionSchedule4.endCompare = ignitionSchedule4.nextEndCompare;
-         ignitionSchedule4.Status = PENDING;
+         ignitionSchedule4.Status = Schedule::PENDING;
          ignitionSchedule4.schedulesSet = 1;
          ignitionSchedule4.hasNextSchedule = false;
        }
-       else { IGN4_TIMER_DISABLE(); }
+       else { ignitionSchedule4.disable(); }
     }
-    else if (ignitionSchedule4.Status == OFF)
+    else if (ignitionSchedule4.Status == Schedule::OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
-      IGN4_TIMER_DISABLE();
+      ignitionSchedule4.disable();
     }
   }
 #endif
@@ -1144,21 +602,21 @@ ISR(TIMER1_COMPC_vect) //ignitionSchedule5
 static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule5.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule5.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule5.StartCallback();
-      ignitionSchedule5.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule5.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule5.startTime = micros();
       IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule5.Status == RUNNING)
+    else if (ignitionSchedule5.Status == Schedule::RUNNING)
     {
-       ignitionSchedule5.Status = OFF; //Turn off the schedule
+       ignitionSchedule5.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule5.EndCallback();
        ignitionSchedule5.schedulesSet = 0;
        ignitionSchedule5.endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
-       IGN5_TIMER_DISABLE();
+       ignitionSchedule5.disable();
     }
   }
 #endif
@@ -1170,21 +628,21 @@ ISR(TIMER1_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
 static inline void ignitionSchedule6Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule6.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule6.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule6.StartCallback();
-      ignitionSchedule6.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule6.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule6.startTime = micros();
       IGN6_COMPARE = IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule6.Status == RUNNING)
+    else if (ignitionSchedule6.Status == Schedule::RUNNING)
     {
-       ignitionSchedule6.Status = OFF; //Turn off the schedule
+       ignitionSchedule6.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule6.EndCallback();
        ignitionSchedule6.schedulesSet = 0;
        ignitionSchedule6.endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
-       IGN6_TIMER_DISABLE();
+       ignitionSchedule6.disable();
     }
   }
 #endif
@@ -1196,21 +654,21 @@ ISR(TIMER1_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
 static inline void ignitionSchedule7Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule7.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule7.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule7.StartCallback();
-      ignitionSchedule7.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule7.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule7.startTime = micros();
       IGN7_COMPARE = IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule7.Status == RUNNING)
+    else if (ignitionSchedule7.Status == Schedule::RUNNING)
     {
-       ignitionSchedule7.Status = OFF; //Turn off the schedule
+       ignitionSchedule7.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule7.EndCallback();
        ignitionSchedule7.schedulesSet = 0;
        ignitionSchedule7.endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
-       IGN7_TIMER_DISABLE();
+       ignitionSchedule7.disable();
     }
   }
 #endif
@@ -1222,21 +680,21 @@ ISR(TIMER1_COMPC_vect) //ignitionSchedule8  NOT CORRECT!!!
 static inline void ignitionSchedule8Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule8.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule8.Status == Schedule::PENDING) //Check to see if this schedule is turn on
     {
       ignitionSchedule8.StartCallback();
-      ignitionSchedule8.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule8.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule8.startTime = micros();
       IGN8_COMPARE = IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration); //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule8.Status == RUNNING)
+    else if (ignitionSchedule8.Status == Schedule::RUNNING)
     {
-       ignitionSchedule8.Status = OFF; //Turn off the schedule
+       ignitionSchedule8.Status = Schedule::OFF; //Turn off the schedule
        ignitionSchedule8.EndCallback();
        ignitionSchedule8.schedulesSet = 0;
        ignitionSchedule8.endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
-       IGN8_TIMER_DISABLE();
+       ignitionSchedule8.disable();
     }
   }
 #endif

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -104,7 +104,7 @@ static inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
   }
 }
 
-static inline void fuelScheduleInterrupt(Schedule& fuelSchedule)
+static inline __attribute__((always_inline)) void fuelScheduleInterrupt(Schedule& fuelSchedule)
 {
   switch(fuelSchedule.Status)
   {
@@ -138,7 +138,7 @@ static inline void fuelScheduleInterrupt(Schedule& fuelSchedule)
   }
 }
 
-static inline void ignitionScheduleInterrupt(Schedule& ignitionSchedule)
+static inline __attribute__((always_inline)) void ignitionScheduleInterrupt(Schedule& ignitionSchedule)
 {
   switch (ignitionSchedule.Status)
   {

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -11,97 +11,10 @@ A full copy of the license may be found in the projects root directory
 
 void initialiseSchedulers()
 {
-    // fuelSchedule1.Status = Schedule::OFF;
-    // fuelSchedule2.Status = Schedule::OFF;
-    // fuelSchedule3.Status = Schedule::OFF;
-    // fuelSchedule4.Status = Schedule::OFF;
-    // fuelSchedule5.Status = Schedule::OFF;
-    // fuelSchedule6.Status = Schedule::OFF;
-    // fuelSchedule7.Status = Schedule::OFF;
-    // fuelSchedule8.Status = Schedule::OFF;
-
-    // fuelSchedule1.schedulesSet = 0;
-    // fuelSchedule2.schedulesSet = 0;
-    // fuelSchedule3.schedulesSet = 0;
-    // fuelSchedule4.schedulesSet = 0;
-    // fuelSchedule5.schedulesSet = 0;
-    // fuelSchedule6.schedulesSet = 0;
-    // fuelSchedule7.schedulesSet = 0;
-    // fuelSchedule8.schedulesSet = 0;
-
-    // fuelSchedule1.counter = &FUEL1_COUNTER;
-    // fuelSchedule1.compare = &FUEL1_COMPARE;
-    // fuelSchedule2.counter = &FUEL2_COUNTER;
-    // fuelSchedule2.compare = &FUEL2_COMPARE;
-    // fuelSchedule3.counter = &FUEL3_COUNTER;
-    // fuelSchedule3.compare = &FUEL3_COMPARE;
-    // fuelSchedule4.counter = &FUEL4_COUNTER;
-    // fuelSchedule4.compare = &FUEL4_COMPARE;
-    // #if (INJ_CHANNELS >= 5)
-    // fuelSchedule5.counter = &FUEL5_COUNTER;
-    // fuelSchedule5.compare = &FUEL5_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 6)
-    // fuelSchedule6.counter = &FUEL6_COUNTER;
-    // fuelSchedule6.compare = &FUEL6_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 7)
-    // fuelSchedule7.counter = &FUEL7_COUNTER;
-    // fuelSchedule7.compare = &FUEL7_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 8)
-    // fuelSchedule8.counter = &FUEL8_COUNTER;
-    // fuelSchedule8.compare = &FUEL8_COMPARE;
-    // #endif
-
-    // ignitionSchedule1.Status = Schedule::OFF;
-    // ignitionSchedule2.Status = Schedule::OFF;
-    // ignitionSchedule3.Status = Schedule::OFF;
-    // ignitionSchedule4.Status = Schedule::OFF;
-    // ignitionSchedule5.Status = Schedule::OFF;
-    // ignitionSchedule6.Status = Schedule::OFF;
-    // ignitionSchedule7.Status = Schedule::OFF;
-    // ignitionSchedule8.Status = Schedule::OFF;
-
     ignitionSchedule1.enable();
     ignitionSchedule2.enable();
     ignitionSchedule3.enable();
     ignitionSchedule4.enable();
-
-    // ignitionSchedule1.schedulesSet = 0;
-    // ignitionSchedule2.schedulesSet = 0;
-    // ignitionSchedule3.schedulesSet = 0;
-    // ignitionSchedule4.schedulesSet = 0;
-    // ignitionSchedule5.schedulesSet = 0;
-    // ignitionSchedule6.schedulesSet = 0;
-    // ignitionSchedule7.schedulesSet = 0;
-    // ignitionSchedule8.schedulesSet = 0;
-
-    // ignitionSchedule1.counter = &IGN1_COUNTER;
-    // ignitionSchedule1.compare = &IGN1_COMPARE;
-    // ignitionSchedule2.counter = &IGN2_COUNTER;
-    // ignitionSchedule2.compare = &IGN2_COMPARE;
-    // ignitionSchedule3.counter = &IGN3_COUNTER;
-    // ignitionSchedule3.compare = &IGN3_COMPARE;
-    // ignitionSchedule4.counter = &IGN4_COUNTER;
-    // ignitionSchedule4.compare = &IGN4_COMPARE;
-    // #if (INJ_CHANNELS >= 5)
-    // ignitionSchedule5.counter = &IGN5_COUNTER;
-    // ignitionSchedule5.compare = &IGN5_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 6)
-    // ignitionSchedule6.counter = &IGN6_COUNTER;
-    // ignitionSchedule6.compare = &IGN6_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 7)
-    // ignitionSchedule7.counter = &IGN7_COUNTER;
-    // ignitionSchedule7.compare = &IGN7_COMPARE;
-    // #endif
-    // #if (INJ_CHANNELS >= 8)
-    // ignitionSchedule8.counter = &IGN8_COUNTER;
-    // ignitionSchedule8.compare = &IGN8_COMPARE;
-    // #endif
-
 }
 
 /*
@@ -157,8 +70,8 @@ static inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
   //if( (timeToEnd < ignitionSchedule1.duration) && (timeToEnd > IGNITION_REFRESH_THRESHOLD) )
   {
     noInterrupts();
-    ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeToEnd);
-    IGN1_COMPARE = ignitionSchedule1.endCompare;
+    ignitionSchedule1.endCompare = ignitionSchedule1.counter + uS_TO_TIMER_COMPARE(timeToEnd);
+    ignitionSchedule1.compare = ignitionSchedule1.endCompare;
     interrupts();
   }
 }
@@ -180,7 +93,7 @@ static inline void fuelSchedule1Interrupt() //Most ARM chips can simply call a f
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector1and4(); }
       else { openInjector1(); }
       fuelSchedule1.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL1_COMPARE = FUEL1_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule1.duration); //Doing this here prevents a potential overflow on restarts
+      fuelSchedule1.compare = fuelSchedule1.counter + uS_TO_TIMER_COMPARE(fuelSchedule1.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule1.Status == Schedule::RUNNING)
     {
@@ -194,7 +107,7 @@ static inline void fuelSchedule1Interrupt() //Most ARM chips can simply call a f
        //If there is a next schedule queued up, activate it
        if(fuelSchedule1.hasNextSchedule == true)
        {
-         FUEL1_COMPARE = fuelSchedule1.nextStartCompare;
+         fuelSchedule1.compare = fuelSchedule1.nextStartCompare;
          fuelSchedule1.endCompare = fuelSchedule1.nextEndCompare;
          fuelSchedule1.Status = Schedule::PENDING;
          fuelSchedule1.schedulesSet = 1;
@@ -217,7 +130,7 @@ static inline void fuelSchedule2Interrupt() //Most ARM chips can simply call a f
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector2and3(); }
       else { openInjector2(); }
       fuelSchedule2.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL2_COMPARE = FUEL2_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule2.duration); //Doing this here prevents a potential overflow on restarts
+      fuelSchedule2.compare = fuelSchedule2.counter + uS_TO_TIMER_COMPARE(fuelSchedule2.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule2.Status == Schedule::RUNNING)
     {
@@ -230,7 +143,7 @@ static inline void fuelSchedule2Interrupt() //Most ARM chips can simply call a f
        //If there is a next schedule queued up, activate it
        if(fuelSchedule2.hasNextSchedule == true)
        {
-         FUEL2_COMPARE = fuelSchedule2.nextStartCompare;
+         fuelSchedule2.compare = fuelSchedule2.nextStartCompare;
          fuelSchedule2.endCompare = fuelSchedule2.nextEndCompare;
          fuelSchedule2.Status = Schedule::PENDING;
          fuelSchedule2.schedulesSet = 1;
@@ -253,7 +166,7 @@ static inline void fuelSchedule3Interrupt() //Most ARM chips can simply call a f
       if(channel5InjEnabled) { openInjector3and5(); }
       else { openInjector3(); }
       fuelSchedule3.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL3_COMPARE = FUEL3_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule3.duration); //Doing this here prevents a potential overflow on restarts
+      fuelSchedule3.compare = fuelSchedule3.counter + uS_TO_TIMER_COMPARE(fuelSchedule3.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule3.Status == Schedule::RUNNING)
     {
@@ -267,7 +180,7 @@ static inline void fuelSchedule3Interrupt() //Most ARM chips can simply call a f
        //If there is a next schedule queued up, activate it
        if(fuelSchedule3.hasNextSchedule == true)
        {
-         FUEL3_COMPARE = fuelSchedule3.nextStartCompare;
+         fuelSchedule3.compare = fuelSchedule3.nextStartCompare;
          fuelSchedule3.endCompare = fuelSchedule3.nextEndCompare;
          fuelSchedule3.Status = Schedule::PENDING;
          fuelSchedule3.schedulesSet = 1;
@@ -288,7 +201,7 @@ static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a f
       //fuelSchedule4.StartCallback();
       openInjector4();
       fuelSchedule4.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL4_COMPARE = FUEL4_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule4.duration); //Doing this here prevents a potential overflow on restarts
+      fuelSchedule4.compare = fuelSchedule4.counter + uS_TO_TIMER_COMPARE(fuelSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule4.Status == Schedule::RUNNING)
     {
@@ -300,7 +213,7 @@ static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a f
        //If there is a next schedule queued up, activate it
        if(fuelSchedule4.hasNextSchedule == true)
        {
-         FUEL4_COMPARE = fuelSchedule4.nextStartCompare;
+         fuelSchedule4.compare = fuelSchedule4.nextStartCompare;
          fuelSchedule4.endCompare = fuelSchedule4.nextEndCompare;
          fuelSchedule4.Status = Schedule::PENDING;
          fuelSchedule4.schedulesSet = 1;
@@ -321,7 +234,7 @@ static inline void fuelSchedule5Interrupt() //Most ARM chips can simply call a f
   {
     openInjector5();
     fuelSchedule5.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-    FUEL5_COMPARE = fuelSchedule5.endCompare;
+    fuelSchedule5.compare = fuelSchedule5.endCompare;
   }
   else if (fuelSchedule5.Status == Schedule::RUNNING)
   {
@@ -332,7 +245,7 @@ static inline void fuelSchedule5Interrupt() //Most ARM chips can simply call a f
      //If there is a next schedule queued up, activate it
      if(fuelSchedule5.hasNextSchedule == true)
      {
-       FUEL5_COMPARE = fuelSchedule5.nextStartCompare;
+       fuelSchedule4.compare = fuelSchedule5.nextStartCompare;
        fuelSchedule5.endCompare = fuelSchedule5.nextEndCompare;
        fuelSchedule5.Status = Schedule::PENDING;
        fuelSchedule5.schedulesSet = 1;
@@ -355,7 +268,7 @@ static inline void fuelSchedule6Interrupt() //Most ARM chips can simply call a f
     //fuelSchedule4.StartCallback();
     openInjector6();
     fuelSchedule6.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-    FUEL6_COMPARE = fuelSchedule6.endCompare;
+    fuelSchedule6.compare = fuelSchedule6.endCompare;
   }
   else if (fuelSchedule6.Status == Schedule::RUNNING)
   {
@@ -367,7 +280,7 @@ static inline void fuelSchedule6Interrupt() //Most ARM chips can simply call a f
      //If there is a next schedule queued up, activate it
      if(fuelSchedule6.hasNextSchedule == true)
      {
-       FUEL6_COMPARE = fuelSchedule6.nextStartCompare;
+       fuelSchedule6.compare = fuelSchedule6.nextStartCompare;
        fuelSchedule6.endCompare = fuelSchedule6.nextEndCompare;
        fuelSchedule6.Status = Schedule::PENDING;
        fuelSchedule6.schedulesSet = 1;
@@ -389,7 +302,7 @@ static inline void fuelSchedule7Interrupt() //Most ARM chips can simply call a f
   {
     openInjector7();
     fuelSchedule7.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-    FUEL7_COMPARE = fuelSchedule7.endCompare;
+    fuelSchedule7.compare = fuelSchedule7.endCompare;
   }
   else if (fuelSchedule7.Status == Schedule::RUNNING)
   {
@@ -400,7 +313,7 @@ static inline void fuelSchedule7Interrupt() //Most ARM chips can simply call a f
      //If there is a next schedule queued up, activate it
      if(fuelSchedule7.hasNextSchedule == true)
      {
-       FUEL7_COMPARE = fuelSchedule7.nextStartCompare;
+       fuelSchedule7.compare = fuelSchedule7.nextStartCompare;
        fuelSchedule7.endCompare = fuelSchedule7.nextEndCompare;
        fuelSchedule7.Status = Schedule::PENDING;
        fuelSchedule7.schedulesSet = 1;
@@ -423,7 +336,7 @@ static inline void fuelSchedule8Interrupt() //Most ARM chips can simply call a f
     //fuelSchedule4.StartCallback();
     openInjector8();
     fuelSchedule8.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-    FUEL8_COMPARE = fuelSchedule8.endCompare;
+    fuelSchedule8.compare = fuelSchedule8.endCompare;
   }
   else if (fuelSchedule8.Status == Schedule::RUNNING)
   {
@@ -435,7 +348,7 @@ static inline void fuelSchedule8Interrupt() //Most ARM chips can simply call a f
      //If there is a next schedule queued up, activate it
      if(fuelSchedule8.hasNextSchedule == true)
      {
-       FUEL8_COMPARE = fuelSchedule8.nextStartCompare;
+       fuelSchedule8.compare = fuelSchedule8.nextStartCompare;
        fuelSchedule8.endCompare = fuelSchedule8.nextEndCompare;
        fuelSchedule8.Status = Schedule::PENDING;
        fuelSchedule8.schedulesSet = 1;
@@ -458,8 +371,8 @@ static inline void ignitionSchedule1Interrupt() //Most ARM chips can simply call
       ignitionSchedule1.StartCallback();
       ignitionSchedule1.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule1.startTime = micros();
-      if(ignitionSchedule1.endScheduleSetByDecoder == true) { IGN1_COMPARE = ignitionSchedule1.endCompare; }
-      else { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule1.duration); } //Doing this here prevents a potential overflow on restarts
+      if(ignitionSchedule1.endScheduleSetByDecoder == true) { ignitionSchedule1.compare = ignitionSchedule1.endCompare; }
+      else { ignitionSchedule1.compare = ignitionSchedule1.counter + uS_TO_TIMER_COMPARE(ignitionSchedule1.duration); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule1.Status == Schedule::RUNNING)
     {
@@ -492,8 +405,8 @@ static inline void ignitionSchedule2Interrupt() //Most ARM chips can simply call
       ignitionSchedule2.StartCallback();
       ignitionSchedule2.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule2.startTime = micros();
-      if(ignitionSchedule2.endScheduleSetByDecoder == true) { IGN2_COMPARE = ignitionSchedule2.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(ignitionSchedule2.endScheduleSetByDecoder == true) { ignitionSchedule2.compare = ignitionSchedule2.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { ignitionSchedule2.compare = ignitionSchedule2.counter + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
     else if (ignitionSchedule2.Status == Schedule::RUNNING)
     {
@@ -524,8 +437,8 @@ static inline void ignitionSchedule3Interrupt() //Most ARM chips can simply call
       ignitionSchedule3.StartCallback();
       ignitionSchedule3.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule3.startTime = micros();
-      if(ignitionSchedule3.endScheduleSetByDecoder == true) { IGN3_COMPARE = ignitionSchedule3.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(ignitionSchedule3.endScheduleSetByDecoder == true) { ignitionSchedule3.compare = ignitionSchedule3.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { ignitionSchedule3.compare = ignitionSchedule3.counter + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
     else if (ignitionSchedule3.Status == Schedule::RUNNING)
     {
@@ -538,7 +451,7 @@ static inline void ignitionSchedule3Interrupt() //Most ARM chips can simply call
        //If there is a next schedule queued up, activate it
        if(ignitionSchedule3.hasNextSchedule == true)
        {
-         IGN3_COMPARE = ignitionSchedule3.nextStartCompare;
+         ignitionSchedule3.compare = ignitionSchedule3.nextStartCompare;
          ignitionSchedule3.endCompare = ignitionSchedule3.nextEndCompare;
          ignitionSchedule3.Status = Schedule::PENDING;
          ignitionSchedule3.schedulesSet = 1;
@@ -566,7 +479,7 @@ static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call
       ignitionSchedule4.StartCallback();
       ignitionSchedule4.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule4.startTime = micros();
-      IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration); //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule4.compare = ignitionSchedule4.counter + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule4.Status == Schedule::RUNNING)
     {
@@ -579,7 +492,7 @@ static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call
        //If there is a next schedule queued up, activate it
        if(ignitionSchedule4.hasNextSchedule == true)
        {
-         IGN4_COMPARE = ignitionSchedule4.nextStartCompare;
+         ignitionSchedule4.compare = ignitionSchedule4.nextStartCompare;
          ignitionSchedule4.endCompare = ignitionSchedule4.nextEndCompare;
          ignitionSchedule4.Status = Schedule::PENDING;
          ignitionSchedule4.schedulesSet = 1;
@@ -607,7 +520,7 @@ static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call
       ignitionSchedule5.StartCallback();
       ignitionSchedule5.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule5.startTime = micros();
-      IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration); //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule5.compare = ignitionSchedule5.counter + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule5.Status == Schedule::RUNNING)
     {
@@ -633,7 +546,7 @@ static inline void ignitionSchedule6Interrupt() //Most ARM chips can simply call
       ignitionSchedule6.StartCallback();
       ignitionSchedule6.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule6.startTime = micros();
-      IGN6_COMPARE = IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration); //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule6.compare = ignitionSchedule6.counter + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule6.Status == Schedule::RUNNING)
     {
@@ -659,7 +572,7 @@ static inline void ignitionSchedule7Interrupt() //Most ARM chips can simply call
       ignitionSchedule7.StartCallback();
       ignitionSchedule7.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule7.startTime = micros();
-      IGN7_COMPARE = IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration); //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule7.compare = ignitionSchedule7.counter + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule7.Status == Schedule::RUNNING)
     {
@@ -685,7 +598,7 @@ static inline void ignitionSchedule8Interrupt() //Most ARM chips can simply call
       ignitionSchedule8.StartCallback();
       ignitionSchedule8.Status = Schedule::RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule8.startTime = micros();
-      IGN8_COMPARE = IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration); //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule8.compare = ignitionSchedule8.counter + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule8.Status == Schedule::RUNNING)
     {

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -157,7 +157,7 @@ void setFuelSchedule(struct Schedule *targetSchedule, unsigned long timeout, uns
 void setFuelSchedule1(unsigned long timeout, unsigned long duration)
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD_SLOW)
+  if(timeout < MAX_TIMER_PERIOD)
   {
     if(fuelSchedule1.Status != RUNNING) //Check that we're not already part way through a schedule
     {
@@ -168,13 +168,13 @@ void setFuelSchedule1(unsigned long timeout, unsigned long duration)
 
       //Need to check that the timeout doesn't exceed the overflow
       uint16_t timeout_timer_compare;
-      if ((timeout+duration) > MAX_TIMER_PERIOD_SLOW) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD_SLOW - 1 - duration) ); } // If the timeout is >16x (Each tick represents 16uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+      if ((timeout+duration) > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1 - duration) ); } // If the timeout is >16x (Each tick represents 16uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
       //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
       noInterrupts();
       fuelSchedule1.startCompare = FUEL1_COUNTER + timeout_timer_compare;
-      fuelSchedule1.endCompare = fuelSchedule1.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule1.endCompare = fuelSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration);
       fuelSchedule1.Status = PENDING; //Turn this schedule on
       fuelSchedule1.schedulesSet++; //Increment the number of times this schedule has been set
       //Schedule 1 shares a timer with schedule 5
@@ -190,8 +190,8 @@ void setFuelSchedule1(unsigned long timeout, unsigned long duration)
       //If the schedule is already running, we can set the next schedule so it is ready to go
       //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
       noInterrupts();
-      fuelSchedule1.nextStartCompare = FUEL1_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-      fuelSchedule1.nextEndCompare = fuelSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule1.nextStartCompare = FUEL1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      fuelSchedule1.nextEndCompare = fuelSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
       fuelSchedule1.duration = duration;
       fuelSchedule1.hasNextSchedule = true;
       interrupts();
@@ -202,7 +202,7 @@ void setFuelSchedule1(unsigned long timeout, unsigned long duration)
 void setFuelSchedule2(unsigned long timeout, unsigned long duration)
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD_SLOW)
+  if(timeout < MAX_TIMER_PERIOD)
   {
     if(fuelSchedule2.Status != RUNNING) //Check that we're not already part way through a schedule
     {
@@ -213,13 +213,13 @@ void setFuelSchedule2(unsigned long timeout, unsigned long duration)
 
       //Need to check that the timeout doesn't exceed the overflow
       uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD_SLOW) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
       //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
       noInterrupts();
       fuelSchedule2.startCompare = FUEL2_COUNTER + timeout_timer_compare;
-      fuelSchedule2.endCompare = fuelSchedule2.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule2.endCompare = fuelSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration);
       FUEL2_COMPARE = fuelSchedule2.startCompare; //Use the B compare unit of timer 3
       fuelSchedule2.Status = PENDING; //Turn this schedule on
       fuelSchedule2.schedulesSet++; //Increment the number of times this schedule has been set
@@ -230,8 +230,8 @@ void setFuelSchedule2(unsigned long timeout, unsigned long duration)
     {
       //If the schedule is already running, we can set the next schedule so it is ready to go
       //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule2.nextStartCompare = FUEL2_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-      fuelSchedule2.nextEndCompare = fuelSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule2.nextStartCompare = FUEL2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      fuelSchedule2.nextEndCompare = fuelSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
       fuelSchedule2.hasNextSchedule = true;
     }
   }
@@ -240,7 +240,7 @@ void setFuelSchedule2(unsigned long timeout, unsigned long duration)
 void setFuelSchedule3(unsigned long timeout, unsigned long duration)
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD_SLOW)
+  if(timeout < MAX_TIMER_PERIOD)
   {
     if(fuelSchedule3.Status != RUNNING)//Check that we're not already part way through a schedule
     {
@@ -251,13 +251,13 @@ void setFuelSchedule3(unsigned long timeout, unsigned long duration)
 
       //Need to check that the timeout doesn't exceed the overflow
       uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD_SLOW) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
       //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
       noInterrupts();
       fuelSchedule3.startCompare = FUEL3_COUNTER + timeout_timer_compare;
-      fuelSchedule3.endCompare = fuelSchedule3.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule3.endCompare = fuelSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration);
       FUEL3_COMPARE = fuelSchedule3.startCompare; //Use the C copmare unit of timer 3
       fuelSchedule3.Status = PENDING; //Turn this schedule on
       fuelSchedule3.schedulesSet++; //Increment the number of times this schedule has been set
@@ -268,8 +268,8 @@ void setFuelSchedule3(unsigned long timeout, unsigned long duration)
     {
       //If the schedule is already running, we can set the next schedule so it is ready to go
       //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule3.nextStartCompare = FUEL3_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-      fuelSchedule3.nextEndCompare = fuelSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule3.nextStartCompare = FUEL3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      fuelSchedule3.nextEndCompare = fuelSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
       fuelSchedule3.hasNextSchedule = true;
     }
   }
@@ -278,7 +278,7 @@ void setFuelSchedule3(unsigned long timeout, unsigned long duration)
 void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses timer 4 compare B
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
-  if(timeout < MAX_TIMER_PERIOD_SLOW)
+  if(timeout < MAX_TIMER_PERIOD)
   {
     if(fuelSchedule4.Status != RUNNING) //Check that we're not already part way through a schedule
     {
@@ -289,13 +289,13 @@ void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses time
 
       //Need to check that the timeout doesn't exceed the overflow
       uint16_t timeout_timer_compare;
-      if (timeout > MAX_TIMER_PERIOD_SLOW) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-      else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+      if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+      else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
       //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
       noInterrupts();
       fuelSchedule4.startCompare = FUEL4_COUNTER + timeout_timer_compare;
-      fuelSchedule4.endCompare = fuelSchedule4.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule4.endCompare = fuelSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration);
       FUEL4_COMPARE = fuelSchedule4.startCompare; //Use the C copmare unit of timer 3
       fuelSchedule4.Status = PENDING; //Turn this schedule on
       fuelSchedule4.schedulesSet++; //Increment the number of times this schedule has been set
@@ -306,8 +306,8 @@ void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses time
     {
       //If the schedule is already running, we can set the next schedule so it is ready to go
       //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-      fuelSchedule4.nextStartCompare = FUEL4_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-      fuelSchedule4.nextEndCompare = fuelSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+      fuelSchedule4.nextStartCompare = FUEL4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      fuelSchedule4.nextEndCompare = fuelSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
       fuelSchedule4.hasNextSchedule = true;
     }
   }
@@ -340,8 +340,8 @@ void setFuelSchedule5(void (*startCallback)(), unsigned long timeout, unsigned l
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule5.nextStartCompare = FUEL5_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    fuelSchedule5.nextEndCompare = fuelSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    fuelSchedule5.nextStartCompare = FUEL5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    fuelSchedule5.nextEndCompare = fuelSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     fuelSchedule5.hasNextSchedule = true;
   }
 }
@@ -360,13 +360,13 @@ void setFuelSchedule6(unsigned long timeout, unsigned long duration)
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD_SLOW) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     //The following must be enclosed in the noInterupts block to avoid contention caused if the relevant interrupt fires before the state is fully set
     noInterrupts();
     fuelSchedule6.startCompare = FUEL6_COUNTER + timeout_timer_compare;
-    fuelSchedule6.endCompare = fuelSchedule6.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    fuelSchedule6.endCompare = fuelSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration);
     FUEL6_COMPARE = fuelSchedule6.startCompare; //Use the C copmare unit of timer 3
     fuelSchedule6.Status = PENDING; //Turn this schedule on
     fuelSchedule6.schedulesSet++; //Increment the number of times this schedule has been set
@@ -377,8 +377,8 @@ void setFuelSchedule6(unsigned long timeout, unsigned long duration)
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    fuelSchedule6.nextStartCompare = FUEL6_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    fuelSchedule6.nextEndCompare = fuelSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    fuelSchedule6.nextStartCompare = FUEL6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    fuelSchedule6.nextEndCompare = fuelSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     fuelSchedule6.hasNextSchedule = true;
   }
 }
@@ -563,12 +563,12 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
     ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     IGN4_COMPARE = ignitionSchedule4.startCompare;
     ignitionSchedule4.Status = PENDING; //Turn this schedule on
     ignitionSchedule4.schedulesSet++;
@@ -579,8 +579,8 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     ignitionSchedule4.hasNextSchedule = true;
   }
 }
@@ -595,12 +595,12 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
     ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     IGN5_COMPARE = ignitionSchedule5.startCompare;
     ignitionSchedule5.Status = PENDING; //Turn this schedule on
     ignitionSchedule5.schedulesSet++;
@@ -619,12 +619,12 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
     ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     IGN6_COMPARE = ignitionSchedule6.startCompare;
     ignitionSchedule6.Status = PENDING; //Turn this schedule on
     ignitionSchedule6.schedulesSet++;
@@ -635,8 +635,8 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     ignitionSchedule6.hasNextSchedule = true;
   }
 }
@@ -651,12 +651,12 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
     ignitionSchedule7.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     IGN7_COMPARE = ignitionSchedule7.startCompare;
     ignitionSchedule7.Status = PENDING; //Turn this schedule on
     ignitionSchedule7.schedulesSet++;
@@ -667,8 +667,8 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     ignitionSchedule7.hasNextSchedule = true;
   }
 }
@@ -683,12 +683,12 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
-    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
-    else { timeout_timer_compare = uS_TO_TIMER_COMPARE_SLOW(timeout); } //Normal case
+    if (timeout > MAX_TIMER_PERIOD) { timeout_timer_compare = uS_TO_TIMER_COMPARE( (MAX_TIMER_PERIOD - 1) ); } // If the timeout is >4x (Each tick represents 4uS) the maximum allowed value of unsigned int (65535), the timer compare value will overflow when appliedcausing erratic behaviour such as erroneous sparking.
+    else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
     ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE_SLOW(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     IGN8_COMPARE = ignitionSchedule8.startCompare;
     ignitionSchedule8.Status = PENDING; //Turn this schedule on
     ignitionSchedule8.schedulesSet++;
@@ -699,8 +699,8 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
   {
     //If the schedule is already running, we can set the next schedule so it is ready to go
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
-    ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE_SLOW(timeout);
-    ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE_SLOW(duration);
+    ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+    ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
     ignitionSchedule8.hasNextSchedule = true;
   }
 }
@@ -722,7 +722,7 @@ static inline void fuelSchedule1Interrupt() //Most ARM chips can simply call a f
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector1and4(); }
       else { openInjector1(); }
       fuelSchedule1.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL1_COMPARE = FUEL1_COUNTER + uS_TO_TIMER_COMPARE_SLOW(fuelSchedule1.duration); //Doing this here prevents a potential overflow on restarts
+      FUEL1_COMPARE = FUEL1_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule1.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule1.Status == RUNNING)
     {
@@ -759,7 +759,7 @@ static inline void fuelSchedule2Interrupt() //Most ARM chips can simply call a f
       if (configPage2.injLayout == INJ_SEMISEQUENTIAL) { openInjector2and3(); }
       else { openInjector2(); }
       fuelSchedule2.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL2_COMPARE = FUEL2_COUNTER + uS_TO_TIMER_COMPARE_SLOW(fuelSchedule2.duration); //Doing this here prevents a potential overflow on restarts
+      FUEL2_COMPARE = FUEL2_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule2.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule2.Status == RUNNING)
     {
@@ -795,7 +795,7 @@ static inline void fuelSchedule3Interrupt() //Most ARM chips can simply call a f
       if(channel5InjEnabled) { openInjector3and5(); }
       else { openInjector3(); }
       fuelSchedule3.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL3_COMPARE = FUEL3_COUNTER + uS_TO_TIMER_COMPARE_SLOW(fuelSchedule3.duration); //Doing this here prevents a potential overflow on restarts
+      FUEL3_COMPARE = FUEL3_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule3.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule3.Status == RUNNING)
     {
@@ -830,7 +830,7 @@ static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a f
       //fuelSchedule4.StartCallback();
       openInjector4();
       fuelSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      FUEL4_COMPARE = FUEL4_COUNTER + uS_TO_TIMER_COMPARE_SLOW(fuelSchedule4.duration); //Doing this here prevents a potential overflow on restarts
+      FUEL4_COMPARE = FUEL4_COUNTER + uS_TO_TIMER_COMPARE(fuelSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (fuelSchedule4.Status == RUNNING)
     {
@@ -1108,7 +1108,7 @@ static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call
       ignitionSchedule4.StartCallback();
       ignitionSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule4.startTime = micros();
-      IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE_SLOW(ignitionSchedule4.duration); //Doing this here prevents a potential overflow on restarts
+      IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule4.Status == RUNNING)
     {
@@ -1149,7 +1149,7 @@ static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call
       ignitionSchedule5.StartCallback();
       ignitionSchedule5.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule5.startTime = micros();
-      IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE_SLOW(ignitionSchedule5.duration); //Doing this here prevents a potential overflow on restarts
+      IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration); //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule5.Status == RUNNING)
     {

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -79,26 +79,4 @@ uint16_t staged_req_fuel_mult_pri;
 uint16_t staged_req_fuel_mult_sec;
 ///@}
 
-/** @name IgnitionCallbacks
- * These are the function pointers that get called to begin and end the ignition coil charging. They are required for the various spark output modes
-*/
-///@{
-void (*ign1StartFunction)();
-void (*ign1EndFunction)();
-void (*ign2StartFunction)();
-void (*ign2EndFunction)();
-void (*ign3StartFunction)();
-void (*ign3EndFunction)();
-void (*ign4StartFunction)();
-void (*ign4EndFunction)();
-void (*ign5StartFunction)();
-void (*ign5EndFunction)();
-void (*ign6StartFunction)();
-void (*ign6EndFunction)();
-void (*ign7StartFunction)();
-void (*ign7EndFunction)();
-void (*ign8StartFunction)();
-void (*ign8EndFunction)();
-///@}
-
 #endif

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -741,10 +741,10 @@ void loop()
       {
         if(currentStatus.PW1 >= inj_opentime_uS)
         {
-          if ( (injector1StartAngle <= crankAngle) && (fuelSchedule1.Status == RUNNING) ) { injector1StartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (injector1StartAngle <= crankAngle) && (fuelSchedule1.Status == Schedule::RUNNING) ) { injector1StartAngle += CRANK_ANGLE_MAX_INJ; }
           if (injector1StartAngle > crankAngle)
           {
-            setFuelSchedule1(
+            fuelSchedule1.setSchedule(
                       ((injector1StartAngle - crankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW1
                       );
@@ -770,10 +770,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector2StartAngle - channel2InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule2.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule2.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule2(
+            fuelSchedule2.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW2
                       );
@@ -788,10 +788,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector3StartAngle - channel3InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule3.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule3.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule3(
+            fuelSchedule3.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW3
                       );
@@ -806,10 +806,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector4StartAngle - channel4InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule4.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule4.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule4(
+            fuelSchedule4.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW4
                       );
@@ -829,12 +829,12 @@ void loop()
           {
             //Note the hacky use of fuel schedule 3 below
             /*
-            setFuelSchedule3(openInjector3and5,
+            fuelSchedule3.setSchedule(openInjector3and5,
                       ((unsigned long)(tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW1,
                       closeInjector3and5
                     );*/
-            setFuelSchedule3(
+            fuelSchedule3.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW1
                       );
@@ -849,10 +849,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector6StartAngle - channel6InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule6.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule6.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule6(
+            fuelSchedule6.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW6
                       );
@@ -867,10 +867,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector7StartAngle - channel7InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule7.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule7.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule7(
+            fuelSchedule7.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW7
                       );
@@ -885,10 +885,10 @@ void loop()
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
           tempStartAngle = injector8StartAngle - channel8InjDegrees;
           if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
-          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule8.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
+          if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule8.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            setFuelSchedule8(
+            fuelSchedule8.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
                       (unsigned long)currentStatus.PW8
                       );
@@ -955,9 +955,9 @@ void loop()
 #if IGN_CHANNELS >= 1
         if ( (ignition1StartAngle > crankAngle) && (curRollingCut != 1) )
         {
-            if(ignitionSchedule1.Status != RUNNING)
+            if(ignitionSchedule1.Status != Schedule::RUNNING)
             {
-              setIgnitionSchedule1(ign1StartFunction,
+              ignitionSchedule1.setSchedule(ign1StartFunction,
                         //((unsigned long)(ignition1StartAngle - crankAngle) * (unsigned long)timePerDegree),
                         angleToTime((ignition1StartAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV),
                         currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
@@ -968,7 +968,7 @@ void loop()
 #endif
 
 #if defined(USE_IGN_REFRESH)
-        if( (ignitionSchedule1.Status == RUNNING) && (ignition1EndAngle > crankAngle) && (configPage4.StgCycles == 0) && (configPage2.perToothIgn != true) )
+        if( (ignitionSchedule1.Status == Schedule::RUNNING) && (ignition1EndAngle > crankAngle) && (configPage4.StgCycles == 0) && (configPage2.perToothIgn != true) )
         {
           unsigned long uSToEnd = 0;
 
@@ -1003,7 +1003,7 @@ void loop()
 
             if( (ignition2StartTime > 0) && (curRollingCut != 2) )
             {
-              setIgnitionSchedule2(ign2StartFunction,
+              ignitionSchedule2.setSchedule(ign2StartFunction,
                         ignition2StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
                         ign2EndFunction
@@ -1026,7 +1026,7 @@ void loop()
 
             if( (ignition3StartTime > 0) && (curRollingCut != 3) )
             {
-              setIgnitionSchedule3(ign3StartFunction,
+              ignitionSchedule3.setSchedule(ign3StartFunction,
                         ignition3StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
                         ign3EndFunction
@@ -1050,7 +1050,7 @@ void loop()
 
             if( (ignition4StartTime > 0) && (curRollingCut != 4) )
             {
-              setIgnitionSchedule4(ign4StartFunction,
+              ignitionSchedule4.setSchedule(ign4StartFunction,
                         ignition4StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
                         ign4EndFunction
@@ -1073,7 +1073,7 @@ void loop()
             else { ignition5StartTime = 0; }
 
             if( (ignition5StartTime > 0) && (curRollingCut != 5) ) {
-            setIgnitionSchedule5(ign5StartFunction,
+            ignitionSchedule5.setSchedule(ign5StartFunction,
                       ignition5StartTime,
                       currentStatus.dwell + fixedCrankingOverride,
                       ign5EndFunction
@@ -1094,7 +1094,7 @@ void loop()
 
             if( (ignition6StartTime > 0) && (curRollingCut != 2) )
             {
-              setIgnitionSchedule6(ign6StartFunction,
+              ignitionSchedule6.setSchedule(ign6StartFunction,
                         ignition6StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
                         ign6EndFunction

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -745,10 +745,10 @@ void loop()
           if ( (injector1StartAngle <= crankAngle) && (fuelSchedule1.Status == Schedule::RUNNING) ) { injector1StartAngle += CRANK_ANGLE_MAX_INJ; }
           if (injector1StartAngle > crankAngle)
           {
-            fuelSchedule1.setSchedule(openInjector1andMaybe4,
+            fuelSchedule1.setSchedule(
                       ((injector1StartAngle - crankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1,
-                      closeInjector1andMaybe4);
+                      (unsigned long)currentStatus.PW1
+                      );
           }
         }
 #endif
@@ -774,10 +774,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule2.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule2.setSchedule(openInjector2andMaybe3,
+            fuelSchedule2.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW2,
-                      closeInjector2andMaybe3);
+                      (unsigned long)currentStatus.PW2
+                      );
           }
         }
 #endif
@@ -792,10 +792,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule3.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule3.setSchedule(openInjector3,
+            fuelSchedule3.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW3,
-                      closeInjector3);
+                      (unsigned long)currentStatus.PW3
+                      );
           }
         }
 #endif
@@ -810,10 +810,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule4.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule4.setSchedule(openInjector4,
+            fuelSchedule4.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW4,
-                      closeInjector4);
+                      (unsigned long)currentStatus.PW4
+                      );
           }
         }
 #endif
@@ -829,10 +829,10 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             //Note the hacky use of fuel schedule 3 below
-            fuelSchedule3.setSchedule(openInjector3and5,
+            fuelSchedule3.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1,
-                      closeInjector3and5);
+                      (unsigned long)currentStatus.PW1
+                      );
           }
         }
 #endif
@@ -847,10 +847,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule6.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule6.setSchedule(openInjector6,
+            fuelSchedule6.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW6,
-                      closeInjector6);
+                      (unsigned long)currentStatus.PW6
+                      );
           }
         }
 #endif
@@ -865,10 +865,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule7.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule7.setSchedule(openInjector7,
+            fuelSchedule7.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW7,
-                      closeInjector7);
+                      (unsigned long)currentStatus.PW7
+                      );
           }
         }
 #endif
@@ -883,10 +883,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule8.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule8.setSchedule(openInjector8,
+            fuelSchedule8.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW8,
-                      closeInjector8);
+                      (unsigned long)currentStatus.PW8
+                      );
           }
         }
 #endif
@@ -952,11 +952,10 @@ void loop()
         {
             if(ignitionSchedule1.Status != Schedule::RUNNING)
             {
-              ignitionSchedule1.setSchedule(ign1StartFunction,
+              ignitionSchedule1.setSchedule(
                         //((unsigned long)(ignition1StartAngle - crankAngle) * (unsigned long)timePerDegree),
                         angleToTime((ignition1StartAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV),
-                        currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
-                        ign1EndFunction
+                        currentStatus.dwell + fixedCrankingOverride //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride
                         );
             }
         }
@@ -998,10 +997,9 @@ void loop()
 
             if( (ignition2StartTime > 0) && (curRollingCut != 2) )
             {
-              ignitionSchedule2.setSchedule(ign2StartFunction,
+              ignitionSchedule2.setSchedule(
                         ignition2StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign2EndFunction
+                        currentStatus.dwell + fixedCrankingOverride
                         );
             }
         }
@@ -1021,10 +1019,9 @@ void loop()
 
             if( (ignition3StartTime > 0) && (curRollingCut != 3) )
             {
-              ignitionSchedule3.setSchedule(ign3StartFunction,
+              ignitionSchedule3.setSchedule(
                         ignition3StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign3EndFunction
+                        currentStatus.dwell + fixedCrankingOverride
                         );
             }
         }
@@ -1045,10 +1042,9 @@ void loop()
 
             if( (ignition4StartTime > 0) && (curRollingCut != 4) )
             {
-              ignitionSchedule4.setSchedule(ign4StartFunction,
+              ignitionSchedule4.setSchedule(
                         ignition4StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign4EndFunction
+                        currentStatus.dwell + fixedCrankingOverride
                         );
             }
         }
@@ -1068,10 +1064,9 @@ void loop()
             else { ignition5StartTime = 0; }
 
             if( (ignition5StartTime > 0) && (curRollingCut != 5) ) {
-            ignitionSchedule5.setSchedule(ign5StartFunction,
+            ignitionSchedule5.setSchedule(
                       ignition5StartTime,
-                      currentStatus.dwell + fixedCrankingOverride,
-                      ign5EndFunction
+                      currentStatus.dwell + fixedCrankingOverride
                       );
             }
         }
@@ -1089,10 +1084,9 @@ void loop()
 
             if( (ignition6StartTime > 0) && (curRollingCut != 2) )
             {
-              ignitionSchedule6.setSchedule(ign6StartFunction,
+              ignitionSchedule6.setSchedule(
                         ignition6StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign6EndFunction
+                        currentStatus.dwell + fixedCrankingOverride
                         );
             }
         }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "decoders.h"
 #include "idle.h"
 #include "auxiliaries.h"
+#include "scheduledIO.h"
 #include "sensors.h"
 #include "storage.h"
 #include "crankMaths.h"
@@ -744,10 +745,10 @@ void loop()
           if ( (injector1StartAngle <= crankAngle) && (fuelSchedule1.Status == Schedule::RUNNING) ) { injector1StartAngle += CRANK_ANGLE_MAX_INJ; }
           if (injector1StartAngle > crankAngle)
           {
-            fuelSchedule1.setSchedule(
+            fuelSchedule1.setSchedule(openInjector1andMaybe4,
                       ((injector1StartAngle - crankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1
-                      );
+                      (unsigned long)currentStatus.PW1,
+                      closeInjector1andMaybe4);
           }
         }
 #endif
@@ -773,10 +774,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule2.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule2.setSchedule(
+            fuelSchedule2.setSchedule(openInjector2andMaybe3,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW2
-                      );
+                      (unsigned long)currentStatus.PW2,
+                      closeInjector2andMaybe3);
           }
         }
 #endif
@@ -791,10 +792,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule3.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule3.setSchedule(
+            fuelSchedule3.setSchedule(openInjector3,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW3
-                      );
+                      (unsigned long)currentStatus.PW3,
+                      closeInjector3);
           }
         }
 #endif
@@ -809,10 +810,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule4.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule4.setSchedule(
+            fuelSchedule4.setSchedule(openInjector4,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW4
-                      );
+                      (unsigned long)currentStatus.PW4,
+                      closeInjector4);
           }
         }
 #endif
@@ -828,16 +829,10 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             //Note the hacky use of fuel schedule 3 below
-            /*
             fuelSchedule3.setSchedule(openInjector3and5,
-                      ((unsigned long)(tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1,
-                      closeInjector3and5
-                    );*/
-            fuelSchedule3.setSchedule(
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1
-                      );
+                      (unsigned long)currentStatus.PW1,
+                      closeInjector3and5);
           }
         }
 #endif
@@ -852,10 +847,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule6.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule6.setSchedule(
+            fuelSchedule6.setSchedule(openInjector6,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW6
-                      );
+                      (unsigned long)currentStatus.PW6,
+                      closeInjector6);
           }
         }
 #endif
@@ -870,10 +865,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule7.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule7.setSchedule(
+            fuelSchedule7.setSchedule(openInjector7,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW7
-                      );
+                      (unsigned long)currentStatus.PW7,
+                      closeInjector7);
           }
         }
 #endif
@@ -888,10 +883,10 @@ void loop()
           if ( (tempStartAngle <= tempCrankAngle) && (fuelSchedule8.Status == Schedule::RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_INJ; }
           if ( tempStartAngle > tempCrankAngle )
           {
-            fuelSchedule8.setSchedule(
+            fuelSchedule8.setSchedule(openInjector8,
                       ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW8
-                      );
+                      (unsigned long)currentStatus.PW8,
+                      closeInjector8);
           }
         }
 #endif

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -56,11 +56,11 @@ void oneMSInterval() //Most ARM chips can simply call a function
   bool isCrankLocked = configPage4.ignCranklock && (currentStatus.RPM < currentStatus.crankRPM); //Dwell limiter is disabled during cranking on setups using the locked cranking timing. WE HAVE to do the RPM check here as relying on the engine cranking bit can be potentially too slow in updating
   //Check first whether each spark output is currently on. Only check it's dwell time if it is
 
-  if(ignitionSchedule1.Status == RUNNING) { if( (ignitionSchedule1.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil1Charge(); ignitionSchedule1.Status = OFF; } }
-  if(ignitionSchedule2.Status == RUNNING) { if( (ignitionSchedule2.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil2Charge(); ignitionSchedule2.Status = OFF; } }
-  if(ignitionSchedule3.Status == RUNNING) { if( (ignitionSchedule3.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil3Charge(); ignitionSchedule3.Status = OFF; } }
-  if(ignitionSchedule4.Status == RUNNING) { if( (ignitionSchedule4.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil4Charge(); ignitionSchedule4.Status = OFF; } }
-  if(ignitionSchedule5.Status == RUNNING) { if( (ignitionSchedule5.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil5Charge(); ignitionSchedule5.Status = OFF; } }
+  if(ignitionSchedule1.Status == Schedule::RUNNING) { if( (ignitionSchedule1.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil1Charge(); ignitionSchedule1.Status = Schedule::OFF; } }
+  if(ignitionSchedule2.Status == Schedule::RUNNING) { if( (ignitionSchedule2.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil2Charge(); ignitionSchedule2.Status = Schedule::OFF; } }
+  if(ignitionSchedule3.Status == Schedule::RUNNING) { if( (ignitionSchedule3.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil3Charge(); ignitionSchedule3.Status = Schedule::OFF; } }
+  if(ignitionSchedule4.Status == Schedule::RUNNING) { if( (ignitionSchedule4.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil4Charge(); ignitionSchedule4.Status = Schedule::OFF; } }
+  if(ignitionSchedule5.Status == Schedule::RUNNING) { if( (ignitionSchedule5.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { endCoil5Charge(); ignitionSchedule5.Status = Schedule::OFF; } }
 
   //Tacho output check
   //Tacho is flagged as being ready for a pulse by the ignition outputs. 


### PR DESCRIPTION
I noticed that there was a lot of code duplication in the schedule control.
This is my attempt at making everything simpler.

For that, I first made all the schedules run on timers that are prescaled the same.
Then I made the Schedule struct a class, with a constructor and all.
I made functions with every part of code that was duplicated.
Lastly, the schedules callbacks are now set in initialiseAll, then are left alone.

This new code was tested with an oscilloscope in various engine configuration (2-3-4 cylinders, paired and sequential injection) and is working exactly as before.