### PR TITLE
All ignition and fuel timers run at same speed

### DIFF
--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -37,7 +37,7 @@
   #define FUEL2_COUNTER TCNT3
   #define FUEL3_COUNTER TCNT3
   #define FUEL4_COUNTER TCNT4
-  #define FUEL5_COUNTER TCNT1
+  #define FUEL5_COUNTER TCNT4
   #define FUEL6_COUNTER TCNT4 //Replaces ignition 4
   #define FUEL7_COUNTER TCNT5 //Replaces ignition 3
   #define FUEL8_COUNTER TCNT5 //Replaces ignition 2
@@ -46,7 +46,7 @@
   #define IGN2_COUNTER  TCNT5
   #define IGN3_COUNTER  TCNT5
   #define IGN4_COUNTER  TCNT4
-  #define IGN5_COUNTER  TCNT1
+  #define IGN5_COUNTER  TCNT4
   #define IGN6_COUNTER  TCNT4 //Replaces injector 4
   #define IGN7_COUNTER  TCNT3 //Replaces injector 3
   #define IGN8_COUNTER  TCNT3 //Replaces injector 2
@@ -55,7 +55,7 @@
   #define FUEL2_COMPARE OCR3B
   #define FUEL3_COMPARE OCR3C
   #define FUEL4_COMPARE OCR4B
-  #define FUEL5_COMPARE OCR1C //Shared with FUEL1
+  #define FUEL5_COMPARE OCR4C //Shared with FUEL1
   #define FUEL6_COMPARE OCR4A //Replaces ignition4
   #define FUEL7_COMPARE OCR5C //Replaces ignition3
   #define FUEL8_COMPARE OCR5B //Replaces ignition2
@@ -64,7 +64,7 @@
   #define IGN2_COMPARE  OCR5B
   #define IGN3_COMPARE  OCR5C
   #define IGN4_COMPARE  OCR4A
-  #define IGN5_COMPARE  OCR1C
+  #define IGN5_COMPARE  OCR4C
   #define IGN6_COMPARE  OCR4B //Replaces injector 4
   #define IGN7_COMPARE  OCR3C //Replaces injector 3
   #define IGN8_COMPARE  OCR3B //Replaces injector 2
@@ -73,7 +73,7 @@
   #define FUEL2_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Turn on the B compare unit (ie turn on the interrupt)
   #define FUEL3_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Turn on the C compare unit (ie turn on the interrupt)
   #define FUEL4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Turn on the B compare unit (ie turn on the interrupt)
-  #define FUEL5_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C) //
+  #define FUEL5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //
   #define FUEL6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //
   #define FUEL7_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //
   #define FUEL8_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //
@@ -82,7 +82,7 @@
   #define FUEL2_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B); //Turn off this output compare unit
   #define FUEL3_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C); //Turn off this output compare unit
   #define FUEL4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B); //Turn off this output compare unit
-  #define FUEL5_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C); //
+  #define FUEL5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C); //
   #define FUEL6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A); //
   #define FUEL7_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C); //
   #define FUEL8_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B); //
@@ -96,7 +96,7 @@
   //#define IGN2_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
   //#define IGN3_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
   #define IGN4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //Turn on the A compare unit (ie turn on the interrupt)
-  #define IGN5_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C) //Turn on the A compare unit (ie turn on the interrupt)
+  #define IGN5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //Turn on the A compare unit (ie turn on the interrupt)
   #define IGN6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Replaces injector 4
   #define IGN7_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3C) //Replaces injector 3
   #define IGN8_TIMER_ENABLE() TIMSK3 |= (1 << OCIE3B) //Replaces injector 2
@@ -105,16 +105,16 @@
   #define IGN2_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5B) //Turn off this output compare unit
   #define IGN3_TIMER_DISABLE() TIMSK5 &= ~(1 << OCIE5C) //Turn off this output compare unit
   #define IGN4_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4A) //Turn off this output compare unit
-  #define IGN5_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C) //Turn off this output compare unit
+  #define IGN5_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C) //Turn off this output compare unit
   #define IGN6_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4B) //Replaces injector 4
   #define IGN7_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3C) //Replaces injector 3
   #define IGN8_TIMER_DISABLE() TIMSK3 &= ~(1 << OCIE3B) //Replaces injector 2
 
   #define MAX_TIMER_PERIOD 262140UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 4, as each timer tick is 4uS)
-  #define MAX_TIMER_PERIOD_SLOW 1048560UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 16, as each timer tick is 16uS)
+  #define MAX_TIMER_PERIOD_SLOW 262140UL //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 16, as each timer tick is 16uS)
   #define uS_TO_TIMER_COMPARE(uS1) ((uS1) >> 2) //Converts a given number of uS into the required number of timer ticks until that time has passed
   //This is a hack until I make all the AVR timers run at the same speed
-  #define uS_TO_TIMER_COMPARE_SLOW(uS1) ((uS1) >> 4)
+  #define uS_TO_TIMER_COMPARE_SLOW(uS1) ((uS1) >> 2)
 
 /*
 ***********************************************************************************************************
@@ -134,11 +134,11 @@
 ***********************************************************************************************************
 * Idle
 */
-  #define IDLE_COUNTER TCNT4
-  #define IDLE_COMPARE OCR4C
+  #define IDLE_COUNTER TCNT1
+  #define IDLE_COMPARE OCR1C
 
-  #define IDLE_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C)
-  #define IDLE_TIMER_DISABLE() TIMSK4 &= ~(1 << OCIE4C)
+  #define IDLE_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C)
+  #define IDLE_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C)
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -4,11 +4,17 @@
 #include "auxiliaries.h"
 
 // Prescaler values for timers 1-3-4-5. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
-const uint8_t TIMER_PRESCALER_1 =    ((0<<CS12)|(0<<CS11)|(1<<CS10));
-const uint8_t TIMER_PRESCALER_8 =    ((0<<CS12)|(1<<CS11)|(0<<CS10));
-const uint8_t TIMER_PRESCALER_64 =   ((0<<CS12)|(1<<CS11)|(1<<CS10));
-const uint8_t TIMER_PRESCALER_256 =  ((1<<CS12)|(0<<CS11)|(0<<CS10));
-const uint8_t TIMER_PRESCALER_1024 = ((1<<CS12)|(0<<CS11)|(1<<CS10));
+#define TIMER_PRESCALER_OFF  ((0<<CS12)|(0<<CS11)|(0<<CS10))
+#define TIMER_PRESCALER_1    ((0<<CS12)|(0<<CS11)|(1<<CS10))
+#define TIMER_PRESCALER_8    ((0<<CS12)|(1<<CS11)|(0<<CS10))
+#define TIMER_PRESCALER_64   ((0<<CS12)|(1<<CS11)|(1<<CS10))
+#define TIMER_PRESCALER_256  ((1<<CS12)|(0<<CS11)|(0<<CS10))
+#define TIMER_PRESCALER_1024 ((1<<CS12)|(0<<CS11)|(1<<CS10))
+
+#define TIMER_MODE_NORMAL    ((0<<WGM01)|(0<<WGM00))
+#define TIMER_MODE_PWM       ((0<<WGM01)|(1<<WGM00))
+#define TIMER_MODE_CTC       ((1<<WGM01)|(0<<WGM00))
+#define TIMER_MODE_FASTPWM   ((1<<WGM01)|(1<<WGM00))
 
 void initBoard()
 {
@@ -23,9 +29,9 @@ void initBoard()
     * Auxilliaries
     */
     //PWM used by the Boost and VVT outputs. C Channel is used by ign5
-    TCCR1B = 0x00;          //Disbale Timer1 while we set it up
-    TCNT1  = 0;             //Reset Timer Count
-    TCCR1A = 0x00;          //Timer1 Control Reg A: Wave Gen Mode normal (Simply counts up from 0 to 65535 (16-bit int)
+    TCCR1B = TIMER_PRESCALER_OFF;   //Disbale Timer1 while we set it up
+    TCNT1  = 0;                     //Reset Timer Count
+    TCCR1A = TIMER_MODE_NORMAL;     //Timer1 Control Reg A: Wave Gen Mode normal (Simply counts up from 0 to 65535 (16-bit int)
     TCCR1B = TIMER_PRESCALER_256;   //Timer1 Control Reg B: Timer Prescaler set to 256. 1 tick = 16uS.
     TIFR1 = (1 << OCF1A) | (1<<OCF1B) | (1<<OCF1C) | (1<<TOV1) | (1<<ICF1); //Clear the compare flags, overflow flag and external input flag bits
 
@@ -38,10 +44,10 @@ void initBoard()
     * Timers
     */
     //Configure Timer2 for our low-freq interrupt code.
-    TCCR2B = 0x00;          //Disbale Timer2 while we set it up
-    TCNT2  = 131;           //Preload timer2 with 131 cycles, leaving 125 till overflow. As the timer runs at 125Khz, this causes overflow to occur at 1Khz = 1ms
-    TIMSK2 = 0x01;          //Timer2 Set Overflow Interrupt enabled.
-    TCCR2A = 0x00;          //Timer2 Control Reg A: Wave Gen Mode normal
+    TCCR2B = TIMER_PRESCALER_OFF;   //Disbale Timer2 while we set it up
+    TCNT2  = 131;                   //Preload timer2 with 131 cycles, leaving 125 till overflow. As the timer runs at 125Khz, this causes overflow to occur at 1Khz = 1ms
+    TIMSK2 = (1<<TOIE2);            //Timer2 Set Overflow Interrupt enabled.
+    TCCR2A = TIMER_MODE_NORMAL;     //Timer2 Control Reg A: Wave Gen Mode normal
     /* Now configure the prescaler to CPU clock divided by 128 = 125Khz */
     TCCR2B = (1<<CS22)  | (1<<CS20); // Set bits. This timer uses different prescaler values, thus we cannot use the defines above.
     TIFR2 = (1 << OCF2A) | (1<<OCF2B) | (1<<TOV2); //Clear the compare flag bits and overflow flag bit
@@ -56,17 +62,17 @@ void initBoard()
     * */
     //Much help in this from www.arduinomega.blogspot.com.au/2011/05/timer2-and-overflow-interrupt-lets-get.html
     //Fuel Schedules, which uses timer 3
-    TCCR3B = 0x00;          //Disable Timer3 while we set it up
-    TCNT3  = 0;             //Reset Timer Count
-    TCCR3A = 0x00;          //Timer3 Control Reg A: Wave Gen Mode normal
-    TCCR3B = TIMER_PRESCALER_64;   //Timer3 Control Reg B: Timer Prescaler set to 64.
+    TCCR3B = TIMER_PRESCALER_OFF;   //Disable Timer3 while we set it up
+    TCNT3  = 0;                     //Reset Timer Count
+    TCCR3A = TIMER_MODE_NORMAL;     //Timer3 Control Reg A: Wave Gen Mode normal
+    TCCR3B = TIMER_PRESCALER_64;    //Timer3 Control Reg B: Timer Prescaler set to 64.
     TIFR3 = (1 << OCF3A) | (1<<OCF3B) | (1<<OCF3C) | (1<<TOV3) | (1<<ICF3); //Clear the compare flags, overflow flag and external input flag bits
 
     //Ignition Schedules, which uses timer 5. This is also used by the fast version of micros(). If the speed of this timer is changed from 4uS ticks, that MUST be changed as well. See globals.h and timers.ino
-    TCCR5B = 0x00;          //Disable Timer5 while we set it up
-    TCNT5  = 0;             //Reset Timer Count
-    TCCR5A = 0x00;          //Timer5 Control Reg A: Wave Gen Mode normal
-    TCCR5B = TIMER_PRESCALER_64; //Timer5 Control Reg B: Timer Prescaler set to 64.
+    TCCR5B = TIMER_PRESCALER_OFF;   //Disable Timer5 while we set it up
+    TCNT5  = 0;                     //Reset Timer Count
+    TCCR5A = TIMER_MODE_NORMAL;     //Timer5 Control Reg A: Wave Gen Mode normal
+    TCCR5B = TIMER_PRESCALER_64;    //Timer5 Control Reg B: Timer Prescaler set to 64.
     TIFR5 = (1 << OCF5A) | (1<<OCF5B) | (1<<OCF5C) | (1<<TOV5) | (1<<ICF5); //Clear the compare flags, overflow flag and external input flag bits
     
     #if defined(TIMER5_MICROS)
@@ -75,10 +81,10 @@ void initBoard()
     #endif
 
     //The remaining Schedules (Fuel schedule 4 and ignition schedules 4 and 5) use Timer4
-    TCCR4B = 0x00;          //Disable Timer4 while we set it up
-    TCNT4  = 0;             //Reset Timer Count
-    TCCR4A = 0x00;          //Timer4 Control Reg A: Wave Gen Mode normal
-    TCCR4B = TIMER_PRESCALER_64;   //Timer4 Control Reg B: Timer Prescaler set to 64.
+    TCCR4B = TIMER_PRESCALER_OFF;   //Disable Timer4 while we set it up
+    TCNT4  = 0;                     //Reset Timer Count
+    TCCR4A = TIMER_MODE_NORMAL;     //Timer4 Control Reg A: Wave Gen Mode normal
+    TCCR4B = TIMER_PRESCALER_64;    //Timer4 Control Reg B: Timer Prescaler set to 64.
     TIFR4 = (1 << OCF4A) | (1<<OCF4B) | (1<<OCF4C) | (1<<TOV4) | (1<<ICF4); //Clear the compare flags, overflow flag and external input flag bits
 
 }
@@ -114,5 +120,18 @@ static inline unsigned long micros_safe()
   return newMicros;
 } 
 #endif //TIMER5_MICROS
+
+// Those are not needed anymore
+#undef TIMER_PRESCALER_OFF
+#undef TIMER_PRESCALER_1
+#undef TIMER_PRESCALER_8
+#undef TIMER_PRESCALER_64
+#undef TIMER_PRESCALER_256
+#undef TIMER_PRESCALER_1024
+
+#undef TIMER_MODE_NORMAL
+#undef TIMER_MODE_PWM
+#undef TIMER_MODE_CTC
+#undef TIMER_MODE_FASTPWM
 
 #endif //CORE_AVR

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -121,17 +121,4 @@ static inline unsigned long micros_safe()
 } 
 #endif //TIMER5_MICROS
 
-// Those are not needed anymore
-#undef TIMER_PRESCALER_OFF
-#undef TIMER_PRESCALER_1
-#undef TIMER_PRESCALER_8
-#undef TIMER_PRESCALER_64
-#undef TIMER_PRESCALER_256
-#undef TIMER_PRESCALER_1024
-
-#undef TIMER_MODE_NORMAL
-#undef TIMER_MODE_PWM
-#undef TIMER_MODE_CTC
-#undef TIMER_MODE_FASTPWM
-
 #endif //CORE_AVR

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -52,7 +52,7 @@ void initBoard()
     TCCR3B = 0x00;          //Disable Timer3 while we set it up
     TCNT3  = 0;             //Reset Timer Count
     TCCR3A = 0x00;          //Timer3 Control Reg A: Wave Gen Mode normal
-    TCCR3B = (1 << CS12);   //Same as: 0x03. Timer3 Control Reg B: Timer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR3B = (1 << CS11) | (1 << CS10);   //Same as: 0x03. Timer3 Control Reg B: Timer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
     TIFR3 = (1 << OCF3A) | (1<<OCF3B) | (1<<OCF3C) | (1<<TOV3) | (1<<ICF3); //Clear the compare flags, overflow flag and external input flag bits
 
     //Ignition Schedules, which uses timer 5. This is also used by the fast version of micros(). If the speed of this timer is changed from 4uS ticks, that MUST be changed as well. See globals.h and timers.ino
@@ -71,7 +71,7 @@ void initBoard()
     TCCR4B = 0x00;          //Disable Timer4 while we set it up
     TCNT4  = 0;             //Reset Timer Count
     TCCR4A = 0x00;          //Timer4 Control Reg A: Wave Gen Mode normal
-    TCCR4B = (1 << CS12);   //Timer4 Control Reg B: aka Divisor = 256 = 122.5HzTimer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR4B = (1 << CS11) | (1 << CS10);   //Timer4 Control Reg B: aka Divisor = 256 = 122.5HzTimer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
     TIFR4 = (1 << OCF4A) | (1<<OCF4B) | (1<<OCF4C) | (1<<TOV4) | (1<<ICF4); //Clear the compare flags, overflow flag and external input flag bits
 
 }

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -31,6 +31,7 @@ void initBoard()
 
     boost_pwm_max_count = 1000000L / (16 * configPage6.boostFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow freqneucies up to 511Hz
     vvt_pwm_max_count = 1000000L / (16 * configPage6.vvtFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle
+    // put idle_pwm_max_count calculation here?
 
     /*
     ***********************************************************************************************************
@@ -73,7 +74,7 @@ void initBoard()
       TIMSK0 &= ~_BV(TOIE0); // disable timer0 overflow interrupt
     #endif
 
-    //The remaining Schedules (Schedules 4 for fuel and ignition) use Timer4
+    //The remaining Schedules (Fuel schedule 4 and ignition schedules 4 and 5) use Timer4
     TCCR4B = 0x00;          //Disable Timer4 while we set it up
     TCNT4  = 0;             //Reset Timer Count
     TCCR4A = 0x00;          //Timer4 Control Reg A: Wave Gen Mode normal

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -3,6 +3,13 @@
 #include "globals.h"
 #include "auxiliaries.h"
 
+// Prescaler values for timers 1-3-4-5. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+const uint8_t TIMER_PRESCALER_1 =    ((0<<CS12)|(0<<CS11)|(1<<CS10));
+const uint8_t TIMER_PRESCALER_8 =    ((0<<CS12)|(1<<CS11)|(0<<CS10));
+const uint8_t TIMER_PRESCALER_64 =   ((0<<CS12)|(1<<CS11)|(1<<CS10));
+const uint8_t TIMER_PRESCALER_256 =  ((1<<CS12)|(0<<CS11)|(0<<CS10));
+const uint8_t TIMER_PRESCALER_1024 = ((1<<CS12)|(0<<CS11)|(1<<CS10));
+
 void initBoard()
 {
     /*
@@ -19,7 +26,7 @@ void initBoard()
     TCCR1B = 0x00;          //Disbale Timer1 while we set it up
     TCNT1  = 0;             //Reset Timer Count
     TCCR1A = 0x00;          //Timer1 Control Reg A: Wave Gen Mode normal (Simply counts up from 0 to 65535 (16-bit int)
-    TCCR1B = (1 << CS12);   //Timer1 Control Reg B: Timer Prescaler set to 256. 1 tick = 16uS. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR1B = TIMER_PRESCALER_256;   //Timer1 Control Reg B: Timer Prescaler set to 256. 1 tick = 16uS.
     TIFR1 = (1 << OCF1A) | (1<<OCF1B) | (1<<OCF1C) | (1<<TOV1) | (1<<ICF1); //Clear the compare flags, overflow flag and external input flag bits
 
     boost_pwm_max_count = 1000000L / (16 * configPage6.boostFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow freqneucies up to 511Hz
@@ -35,8 +42,7 @@ void initBoard()
     TIMSK2 = 0x01;          //Timer2 Set Overflow Interrupt enabled.
     TCCR2A = 0x00;          //Timer2 Control Reg A: Wave Gen Mode normal
     /* Now configure the prescaler to CPU clock divided by 128 = 125Khz */
-    TCCR2B |= (1<<CS22)  | (1<<CS20); // Set bits
-    TCCR2B &= ~(1<<CS21);             // Clear bit. Shouldn't be needed as initial value is 0 anyway, but best to play it safe
+    TCCR2B = (1<<CS22)  | (1<<CS20); // Set bits. This timer uses different prescaler values, thus we cannot use the defines above.
     TIFR2 = (1 << OCF2A) | (1<<OCF2B) | (1<<TOV2); //Clear the compare flag bits and overflow flag bit
 
     //Enable the watchdog timer for 2 second resets (Good reference: www.tushev.org/articles/arduino/5/arduino-and-watchdog-timer)
@@ -52,14 +58,14 @@ void initBoard()
     TCCR3B = 0x00;          //Disable Timer3 while we set it up
     TCNT3  = 0;             //Reset Timer Count
     TCCR3A = 0x00;          //Timer3 Control Reg A: Wave Gen Mode normal
-    TCCR3B = (1 << CS11) | (1 << CS10);   //Same as: 0x03. Timer3 Control Reg B: Timer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR3B = TIMER_PRESCALER_64;   //Timer3 Control Reg B: Timer Prescaler set to 64.
     TIFR3 = (1 << OCF3A) | (1<<OCF3B) | (1<<OCF3C) | (1<<TOV3) | (1<<ICF3); //Clear the compare flags, overflow flag and external input flag bits
 
     //Ignition Schedules, which uses timer 5. This is also used by the fast version of micros(). If the speed of this timer is changed from 4uS ticks, that MUST be changed as well. See globals.h and timers.ino
     TCCR5B = 0x00;          //Disable Timer5 while we set it up
     TCNT5  = 0;             //Reset Timer Count
     TCCR5A = 0x00;          //Timer5 Control Reg A: Wave Gen Mode normal
-    TCCR5B = (1 << CS11) | (1 << CS10); //Timer5 Control Reg B: Timer Prescaler set to 64. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR5B = TIMER_PRESCALER_64; //Timer5 Control Reg B: Timer Prescaler set to 64.
     TIFR5 = (1 << OCF5A) | (1<<OCF5B) | (1<<OCF5C) | (1<<TOV5) | (1<<ICF5); //Clear the compare flags, overflow flag and external input flag bits
     
     #if defined(TIMER5_MICROS)
@@ -71,7 +77,7 @@ void initBoard()
     TCCR4B = 0x00;          //Disable Timer4 while we set it up
     TCNT4  = 0;             //Reset Timer Count
     TCCR4A = 0x00;          //Timer4 Control Reg A: Wave Gen Mode normal
-    TCCR4B = (1 << CS11) | (1 << CS10);   //Timer4 Control Reg B: aka Divisor = 256 = 122.5HzTimer Prescaler set to 256. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
+    TCCR4B = TIMER_PRESCALER_64;   //Timer4 Control Reg B: Timer Prescaler set to 64.
     TIFR4 = (1 << OCF4A) | (1<<OCF4B) | (1<<OCF4C) | (1<<TOV4) | (1<<ICF4); //Clear the compare flags, overflow flag and external input flag bits
 
 }

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -463,7 +463,7 @@ static inline void enableIdle()
 }
 
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER4_COMPC_vect)
+ISR(TIMER1_COMPC_vect)
 #else
 static inline void idleInterrupt() //Most ARM chips can simply call a function
 #endif

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -854,7 +854,7 @@ static inline void fuelSchedule4Interrupt() //Most ARM chips can simply call a f
 
 #if (INJ_CHANNELS >= 5)
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER1_COMPC_vect) //fuelSchedule5
+ISR(TIMER4_COMPC_vect) //fuelSchedule5
 #else
 static inline void fuelSchedule5Interrupt() //Most ARM chips can simply call a function
 #endif
@@ -1139,7 +1139,7 @@ static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call
 
 #if IGN_CHANNELS >= 5
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER1_COMPC_vect) //ignitionSchedule5
+ISR(TIMER4_COMPC_vect) //ignitionSchedule5
 #else
 static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call a function
 #endif
@@ -1165,7 +1165,7 @@ static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call
 
 #if IGN_CHANNELS >= 6
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER1_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
+ISR(TIMER4_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
 #else
 static inline void ignitionSchedule6Interrupt() //Most ARM chips can simply call a function
 #endif
@@ -1191,7 +1191,7 @@ static inline void ignitionSchedule6Interrupt() //Most ARM chips can simply call
 
 #if IGN_CHANNELS >= 7
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER1_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
+ISR(TIMER4_COMPC_vect) //ignitionSchedule6  NOT CORRECT!!!
 #else
 static inline void ignitionSchedule7Interrupt() //Most ARM chips can simply call a function
 #endif
@@ -1217,7 +1217,7 @@ static inline void ignitionSchedule7Interrupt() //Most ARM chips can simply call
 
 #if IGN_CHANNELS >= 8
 #if defined(CORE_AVR) //AVR chips use the ISR for this
-ISR(TIMER1_COMPC_vect) //ignitionSchedule8  NOT CORRECT!!!
+ISR(TIMER4_COMPC_vect) //ignitionSchedule8  NOT CORRECT!!!
 #else
 static inline void ignitionSchedule8Interrupt() //Most ARM chips can simply call a function
 #endif


### PR DESCRIPTION
Remove the need for slow versions of MAX_TIMER_PERIOD and uS_TO_TIMER_COMPARE() macros.
Enables the possibility to make the schedule code cleaner.