### PR TITLE
Fix second revolution check for MAP minimum

### DIFF
--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -232,7 +232,7 @@ static inline void readMAP()
       //Minimum reading in a cycle
       if (currentStatus.RPM > 0 ) //If the engine isn't running, fall back to instantaneous reads
       {
-        if( (MAPcurRev == currentStatus.startRevolutions) || (MAPcurRev == (currentStatus.startRevolutions+1)) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
+        if( (MAPcurRev == currentStatus.startRevolutions) || ((MAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
         {
           #if defined(ANALOG_ISR_MAP)
             tempReading = AnChannel[pinMAP-A0];


### PR DESCRIPTION
Second revolution is never picked up with MAP Sample Method Set to cycle minimum as  the +1 on the second check is in the wrong place. This causes issues with a single cylinder engine as there is only one MAP pulse every two cycles, but is sampled every cycle causing the MAP to fluctuate between two values