### PR TITLE
fix confusing engine constants window

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -233,7 +233,7 @@ page = 1
       displayB2     = bits,   U08,      23, [4:7],  "RPM", "PW", "Advance", "VE", "GammaE", "TPS", "IAT", "CLT"
 
       reqFuel       = scalar, U08,      24,        "ms",        0.1,       0.0,   0.0,    25.5,      1
-      divider       = scalar, U08,      25,        "",          1.0,       0.0
+      divider       = scalar, U08,      25,        "",          1.0,       0.0,   1.0,    8.0,       0
       alternate     = bits,   U08,      26, [0:0], "Simultaneous", "Alternating"
       multiplyMAP   = bits,   U08,      26, [1:1], "No",       "Yes"
       includeAFR    = bits,   U08,      26, [2:2], "No",       "Yes"
@@ -1544,6 +1544,18 @@ menuDialog = main
 ; dialog which will be added.
 ; dialogs can be nested and can be mixed with fields
 
+    dialog = engine_constants_northwest, "Engine Constants"
+        field = "Required Fuel", reqFuel
+        field = "Control Alogrithm", ignAlgorithm
+        field = "Engine Stroke", twoStroke
+        field = "Number of Cylinders", nCylinders
+
+    dialog = engine_constants_southeast, "Injection Constants"
+        ;field = "Injector Port Type", injType ; Not actually used
+        field = "Number of Injectors", nInjectors
+        field = "Injector Staging", alternate
+        field = "Squirt per Engine Cyle", divider
+
     dialog = engine_constants_southwest, "Speeduino Board"
         field = "Stoichiometric ratio", stoich
         field = "Injector Layout",      injLayout,           { nCylinders <= 4 }
@@ -1551,16 +1563,18 @@ menuDialog = main
         field = "MAP Sample method",    mapSample
 
     dialog = engine_constants_west, ""
-        panel = std_injection, North
+        panel = engine_constants_northwest, North
         panel = engine_constants_southwest
 
     dialog = engine_constants_northeast, "Oddfire Angles"
+        field = "Engine Type",     engineType
         field = "Channel 2 angle", oddfire2,                { engineType == 1 }
         field = "Channel 3 angle", oddfire3,                { engineType == 1 && nCylinders >= 3 }
         field = "Channel 4 angle", oddfire4,                { engineType == 1 && nCylinders >= 4 }
 
     dialog = engine_constants_east, ""
-        panel = engine_constants_northeast, North
+        panel = engine_constants_southeast, North
+        panel = engine_constants_northeast, South, { nCylinders >= 1 && nCylinders <= 4 }
         field = ""
 
     dialog = engine_constants, "", border

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -271,11 +271,6 @@ void initialiseAll()
     initialiseTriggers();
 
     //End crank triger interrupt attachment
-    if(configPage2.strokes == FOUR_STROKE)
-    {
-      //Default is 1 squirt per revolution, so we halve the given req-fuel figure (Which would be over 2 revolutions)
-      req_fuel_uS = req_fuel_uS / 2; //The req_fuel calculation above gives the total required fuel (At VE 100%) in the full cycle. If we're doing more than 1 squirt per cycle then we need to split the amount accordingly. (Note that in a non-sequential 4-stroke setup you cannot have less than 2 squirts as you cannot determine the stroke to make the single squirt on)
-    }
 
     //Initial values for loop times
     previousLoopTime = 0;
@@ -283,10 +278,12 @@ void initialiseAll()
 
     mainLoopCount = 0;
 
-    currentStatus.nSquirts = configPage2.nCylinders / configPage2.divider; //The number of squirts being requested. This is manaully overriden below for sequential setups (Due to TS req_fuel calc limitations)
+    currentStatus.nSquirts = configPage2.divider; //The number of squirts being requested.
     if(currentStatus.nSquirts == 0) { currentStatus.nSquirts = 1; } //Safety check. Should never happen as TS will give an error, but leave incase tune is manually altered etc. 
     if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX_INJ = 720 / currentStatus.nSquirts; }
     else { CRANK_ANGLE_MAX_INJ = 360 / currentStatus.nSquirts; }
+
+    req_fuel_uS /= currentStatus.nSquirts;
 
     //Calculate the number of degrees between cylinders
     switch (configPage2.nCylinders) {
@@ -297,13 +294,6 @@ void initialiseAll()
 
         //Sequential ignition works identically on a 1 cylinder whether it's odd or even fire. 
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) ) { CRANK_ANGLE_MAX_IGN = 720; }
-
-        if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) )
-        {
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
-        }
 
         channel1InjEnabled = true;
 
@@ -325,12 +315,6 @@ void initialiseAll()
         //Sequential ignition works identically on a 2 cylinder whether it's odd or even fire (With the default being a 180 degree second cylinder). 
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) ) { CRANK_ANGLE_MAX_IGN = 720; }
 
-        if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) )
-        {
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
-        }
         //The below are true regardless of whether this is running sequential or not
         if (configPage2.engineType == EVEN_FIRE ) { channel2InjDegrees = 180; }
         else { channel2InjDegrees = configPage2.oddfire2; }
@@ -408,9 +392,6 @@ void initialiseAll()
           channel1InjDegrees = 0;
           channel2InjDegrees = 240;
           channel3InjDegrees = 480;
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
         }
 
         channel1InjEnabled = true;
@@ -473,10 +454,6 @@ void initialiseAll()
 
           channel3InjEnabled = true;
           channel4InjEnabled = true;
-
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
         }
 
         //Check if injector staging is enabled
@@ -526,9 +503,6 @@ void initialiseAll()
           channel3InjDegrees = 288;
           channel4InjDegrees = 432;
           channel5InjDegrees = 576;
-
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
         }
         if (!configPage2.injTiming) 
         { 
@@ -575,10 +549,6 @@ void initialiseAll()
           channel4InjEnabled = true;
           channel5InjEnabled = true;
           channel6InjEnabled = true;
-
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
         }
     #endif
 
@@ -626,10 +596,6 @@ void initialiseAll()
           channel6InjEnabled = true;
           channel7InjEnabled = true;
           channel8InjEnabled = true;
-
-          CRANK_ANGLE_MAX_INJ = 720;
-          currentStatus.nSquirts = 1;
-          req_fuel_uS = req_fuel_uS * 2;
         }
     #endif
 

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -10,7 +10,7 @@
 
 void doUpdates()
 {
-  #define CURRENT_DATA_VERSION    12
+  #define CURRENT_DATA_VERSION    13
 
   //May 2017 firmware introduced a -40 offset on the ignition table. Update that table to +40
   if(EEPROM.read(EEPROM_DATA_VERSION) == 2)
@@ -246,6 +246,33 @@ void doUpdates()
 
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 12);
+  }
+
+  if(EEPROM.read(EEPROM_DATA_VERSION) == 12)
+  {
+    //August 2019
+    // Req_fuel does not get computed by TS anymore
+
+    // The divider field now contains the raw nSquirt value
+    configPage2.divider = configPage2.nCylinders / configPage2.divider;
+
+    // Before, the nSquirt value was overwritten to 1 when four stroke and sequential injection was selected 
+    if (configPage2.strokes == FOUR_STROKE && configPage2.injLayout == INJ_SEQUENTIAL)
+    {
+      configPage2.divider = 1;
+    }
+
+    // Before, reqfuel was divided by the divider, now we store the raw value
+    configPage2.reqFuel *= configPage2.divider;
+
+    // Before, reqfuel was multiplied by 2 when alternating injection was selected. 
+    if (configPage2.strokes == FOUR_STROKE && configPage2.injLayout != INJ_SEQUENTIAL)
+    {
+      configPage2.reqFuel /= 2;
+    }
+
+    writeAllConfig();
+    EEPROM.write(EEPROM_DATA_VERSION, 13);
   }
 
   //Final check is always for 255 and 0 (Brand new arduino)


### PR DESCRIPTION
This is my take at fixing the confusing Engine Constants window in TS.

With this change, we get:
* Injector Layout: (not changed)
  * Paired: Each channel controls 2 injectors
  * Semi-Sequential: Each channel controls 1 injector, but they fire in pairs
  * Sequential: Each channel controls 1 injectors, and they are all independent.
* Squirts per Engine Cycle: it's the number of times each injector fires per cycle (360° for 2-stroke, 720° for 4-stroke), no matter the other settings, and every value from 1 to 8 is valid.
* Injector Staging:
  * Simultaneous: All injectors are fired at once every "squirt cycle" (engine cycle / squirts per engine cycle)
  * Alternating: All channels are fired in sequence over the "squirt cycle"
* Req Fuel: same as before, but the calculator utility is gone. We could check with the TS devs if we could extract it from the default panel

Here's a preview of the new look:
![engine_constants](https://user-images.githubusercontent.com/21108660/63199190-15109800-c04b-11e9-8af5-9623abf84f63.png)


The code implements the fixes, and comes with a fully functional update function.