### PR TITLE
Add option to invert boost pwm.

### DIFF
--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -257,13 +257,21 @@ void boostDisable()
 {
   if (boost_pwm_state == true)
   {
+    #ifdef INVERTED_BOOST
     BOOST_PIN_LOW();  // Switch pin to low
+    #else
+    BOOST_PIN_HIGH();  // Switch pin high
+    #endif
     BOOST_TIMER_COMPARE = BOOST_TIMER_COUNTER + (boost_pwm_max_count - boost_pwm_cur_value);
     boost_pwm_state = false;
   }
   else
   {
+    #ifdef INVERTED_BOOST
     BOOST_PIN_HIGH();  // Switch pin high
+    #else
+    BOOST_PIN_LOW();  // Switch pin to low
+    #endif
     BOOST_TIMER_COMPARE = BOOST_TIMER_COUNTER + boost_pwm_target_value;
     boost_pwm_cur_value = boost_pwm_target_value;
     boost_pwm_state = true;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -42,6 +42,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <FlexCAN.h>
 #endif
 
+// #define INVERTED_BOOST // Uncomment this to invert boost output
+
 void setup()
 {
   initialiseAll();


### PR DESCRIPTION
Resolution for issue #200. I admit I spent way too long trying to figure out how the TunerStudio configuration works before finally giving up. So now, the option to toggle whether the PWM is inverted is a `#define` in `speeduino.ino`.