### PR TITLE
Fix MISRA violations

### DIFF
--- a/misra/check_misra_github.sh
+++ b/misra/check_misra_github.sh
@@ -10,7 +10,7 @@ if [ -f ./results.txt ]; then
 fi
 
 for i in speeduino/speeduino/*.ino; do
-	$cppcheck_bin --dump --max-configs=1 --inline-suppr --suppressions-list=speeduino/misra/suppressions.txt --suppress=syntaxError:speeduino/speeduino/src/PID_v1/PID_v1.h --include=${i%.*}.h -DCORE_AVR=1 -D__AVR_ATmega2560__=1 $i > /dev/null
+	$cppcheck_bin --dump --max-configs=1 --inline-suppr --suppressions-list=speeduino/misra/suppressions.txt --language=c++ --include=${i%.*}.h -DCORE_AVR=1 -D__AVR_ATmega2560__=1 $i > /dev/null
 done
 
 mv speeduino/speeduino/*.dump ./

--- a/misra/check_misra_github.sh
+++ b/misra/check_misra_github.sh
@@ -19,10 +19,10 @@ rm ./utils.*.dump
 python $cppcheck_misra --rule-texts=speeduino/misra/misra_2012_text.txt *.dump 2> results.txt
 #rm *.dump
 
-cat results.txt
+sort results.txt | uniq
 # wc -l results.txt
 
-errors=`wc -l < results.txt | tr -d ' '`
+errors=`sort results.txt | uniq | wc -l`
 echo $errors MISRA violations
 
 if [ $errors -gt 0 ]; then

--- a/misra/misra_2012_text.txt
+++ b/misra/misra_2012_text.txt
@@ -114,7 +114,7 @@ No text specified
 Rule 11.2
 No text specified
 Rule 11.3
-No text specified
+A cast shall not be performed between a pointer to object type and a pointer to a different object type
 Rule 11.4
 Advisory - Object pointers should not be treated as or converted to integers
 Rule 11.5
@@ -186,7 +186,7 @@ No text specified
 Rule 17.1
 No text specified
 Rule 17.2
-No text specified
+Functions shall not call themselves, either directly or indirectly
 Rule 17.3
 No text specified
 Rule 17.4
@@ -196,7 +196,7 @@ No text specified
 Rule 17.6
 No text specified
 Rule 17.7
-No text specified
+The value returned by a function having non-void return type shall be used
 Rule 17.8
 Advisory - An argument to a function should be treated as read-only
 Rule 18.1
@@ -206,7 +206,7 @@ No text specified
 Rule 18.3
 No text specified
 Rule 18.4
-No text specified
+Advisory - The +, -, += and -= operators should not be applied to an expression of pointer type
 Rule 18.5
 No text specified
 Rule 18.6

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -18,7 +18,7 @@
   uint16_t freeRam();
 
   #if defined(TIMER5_MICROS)
-    //#define micros() (((timer5_overflow_count << 16) + TCNT5) * 4) //Fast version of micros() that uses the 4uS tick of timer5. See timers.ino for the overflow ISR of timer5
+    /*#define micros() (((timer5_overflow_count << 16) + TCNT5) * 4) */ //Fast version of micros() that uses the 4uS tick of timer5. See timers.ino for the overflow ISR of timer5
     #define millis() (ms_counter) //Replaces the standard millis() function with this macro. It is both faster and more accurate. See timers.ino for its counter increment.
     static inline unsigned long micros_safe(); //A version of micros() that is interrupt safe
   #else
@@ -34,7 +34,7 @@
 ***********************************************************************************************************
 * Schedules
 */
-  //Refer to http://svn.savannah.nongnu.org/viewvc/trunk/avr-libc/include/avr/iomxx0_1.h?root=avr-libc&view=markup
+  //Refer to svn.savannah.nongnu.org/viewvc/trunk/avr-libc/include/avr/iomxx0_1.h?root=avr-libc&view=markup
   #define FUEL1_COUNTER TCNT3
   #define FUEL2_COUNTER TCNT3
   #define FUEL3_COUNTER TCNT3
@@ -94,9 +94,9 @@
   #define IGN1_TIMER_ENABLE() TIFR5 |= (1<<OCF5A); TIMSK5 |= (1 << OCIE5A) //Turn on the A compare unit (ie turn on the interrupt)
   #define IGN2_TIMER_ENABLE() TIFR5 |= (1<<OCF5B); TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
   #define IGN3_TIMER_ENABLE() TIFR5 |= (1<<OCF5C); TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
-  //#define IGN1_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5A) //Turn on the B compare unit (ie turn on the interrupt)
-  //#define IGN2_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) //Turn on the B compare unit (ie turn on the interrupt)
-  //#define IGN3_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) //Turn on the C compare unit (ie turn on the interrupt)
+  /*#define IGN1_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5A) */ //Turn on the B compare unit (ie turn on the interrupt)
+  /*#define IGN2_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5B) */ //Turn on the B compare unit (ie turn on the interrupt)
+  /*#define IGN3_TIMER_ENABLE() TIMSK5 |= (1 << OCIE5C) */ //Turn on the C compare unit (ie turn on the interrupt)
   #define IGN4_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4A) //Turn on the A compare unit (ie turn on the interrupt)
   #define IGN5_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4C) //Turn on the A compare unit (ie turn on the interrupt)
   #define IGN6_TIMER_ENABLE() TIMSK4 |= (1 << OCIE4B) //Replaces injector 4

--- a/speeduino/board_stm32_generic.h
+++ b/speeduino/board_stm32_generic.h
@@ -130,7 +130,7 @@
         #define IGN7_COMPARE (TIM4)->CCR3
         #define IGN8_COMPARE (TIM4)->CCR4
     #endif
-    //https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/754bc2969921f1ef262bd69e7faca80b19db7524/STM32F1/system/libmaple/include/libmaple/timer.h#L444
+    //github.com/rogerclarkmelbourne/Arduino_STM32/blob/754bc2969921f1ef262bd69e7faca80b19db7524/STM32F1/system/libmaple/include/libmaple/timer.h#L444
     #define FUEL1_TIMER_ENABLE() (TIM2)->CCER |= TIM_CCER_CC1E
     #define FUEL2_TIMER_ENABLE() (TIM2)->CCER |= TIM_CCER_CC2E
     #define FUEL3_TIMER_ENABLE() (TIM2)->CCER |= TIM_CCER_CC3E
@@ -214,7 +214,7 @@
         #define IGN7_COMPARE (TIMER4->regs).gen->CCR3
         #define IGN8_COMPARE (TIMER4->regs).gen->CCR4
     #endif
-    //https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/754bc2969921f1ef262bd69e7faca80b19db7524/STM32F1/system/libmaple/include/libmaple/timer.h#L444
+    //github.com/rogerclarkmelbourne/Arduino_STM32/blob/754bc2969921f1ef262bd69e7faca80b19db7524/STM32F1/system/libmaple/include/libmaple/timer.h#L444
     #define FUEL1_TIMER_ENABLE() (TIMER2->regs).gen->CCER |= TIMER_CCER_CC1E
     #define FUEL2_TIMER_ENABLE() (TIMER2->regs).gen->CCER |= TIMER_CCER_CC2E
     #define FUEL3_TIMER_ENABLE() (TIMER2->regs).gen->CCER |= TIMER_CCER_CC3E

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -23,7 +23,7 @@
 ***********************************************************************************************************
 * Schedules
 */
-  //http://shawnhymel.com/661/learning-the-teensy-lc-interrupt-service-routines/
+  //shawnhymel.com/661/learning-the-teensy-lc-interrupt-service-routines/
   #define FUEL1_COUNTER FTM0_CNT
   #define FUEL2_COUNTER FTM0_CNT
   #define FUEL3_COUNTER FTM0_CNT

--- a/speeduino/board_teensy40.h
+++ b/speeduino/board_teensy40.h
@@ -23,7 +23,7 @@
 ***********************************************************************************************************
 * Schedules
 */
-  //http://shawnhymel.com/661/learning-the-teensy-lc-interrupt-service-routines/
+  //shawnhymel.com/661/learning-the-teensy-lc-interrupt-service-routines/
   #define FUEL1_COUNTER TMR1_CNTR0
   #define FUEL2_COUNTER TMR1_CNTR0
   #define FUEL3_COUNTER TMR1_CNTR1

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -1126,7 +1126,7 @@ void sendPageASCII()
       Serial.println((const __FlashStringHelper *)&pageTitles[27]);//27 is the index to the first char in the second sting in pageTitles
       // The following loop displays in human readable form of all byte values in config page 1 up to but not including the first array.
       // incrementing void pointers is cumbersome. Thus we have "pnt_configPage = (byte *)pnt_configPage + 1"
-      for (pnt_configPage = &configPage2; pnt_configPage < &configPage2.wueValues[0]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
+      for (pnt_configPage = (byte *)&configPage2; pnt_configPage < &configPage2.wueValues[0]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
       for (byte x = 10; x; x--)// The x between the ';' has the same representation as the "x != 0" test or comparision
       {
         Serial.print(configPage2.wueValues[10 - x]);// This displays the values horizantially on the screen
@@ -1204,7 +1204,7 @@ void sendPageASCII()
       //currentTitleIndex = 91;
       //To Display Values from Config Page 3
       Serial.println((const __FlashStringHelper *)&pageTitles[91]);//special typecasting to enable suroutine that the F macro uses
-      for (pnt_configPage = &configPage6; pnt_configPage < &configPage6.voltageCorrectionBins[0]; pnt_configPage = (byte *)pnt_configPage + 1)
+      for (pnt_configPage = (byte *)&configPage6; pnt_configPage < &configPage6.voltageCorrectionBins[0]; pnt_configPage = (byte *)pnt_configPage + 1)
       {
         Serial.println(*((byte *)pnt_configPage));// Displaying byte values of config page 3 up to but not including the first array
       }

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -9,7 +9,7 @@
 
 //#define fastDegreesToUS(targetDegrees) ((targetDegrees) * (unsigned long)timePerDegree)
 #define fastDegreesToUS(targetDegrees) (((targetDegrees) * (unsigned long)timePerDegreex16) >> 4)
-//#define fastTimeToAngle(time) (((unsigned long)time * degreesPeruSx2048) / 2048) //Divide by 2048 will be converted at compile time to bitshift
+/*#define fastTimeToAngle(time) (((unsigned long)time * degreesPeruSx2048) / 2048) */ //Divide by 2048 will be converted at compile time to bitshift
 #define fastTimeToAngle(time) (((unsigned long)(time) * degreesPeruSx32768) / 32768) //Divide by 32768 will be converted at compile time to bitshift
 
 #define ignitionLimits(angle) ( (((int16_t)(angle)) >= CRANK_ANGLE_MAX_IGN) ? ((angle) - CRANK_ANGLE_MAX_IGN) : ( ((int16_t)(angle) < 0) ? ((angle) + CRANK_ANGLE_MAX_IGN) : (angle)) )

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1040,7 +1040,7 @@ byte pinFlex; //Pin with the flex sensor attached
 byte pinBaro; //Pin that an external barometric pressure sensor is attached to (If used)
 byte pinResetControl; // Output pin used control resetting the Arduino
 
-// global variables // from speeduino.ino
+/* global variables */ // from speeduino.ino
 extern struct statuses currentStatus; // from speeduino.ino
 extern struct table3D fuelTable; //16x16 fuel map
 extern struct table3D fuelTable2; //16x16 fuel map

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -259,7 +259,9 @@ void idleControl()
 
           //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
           if (idleStepper.targetIdleStep > configPage9.iacMaxSteps * 3)
-             idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;             
+          {
+            idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
+          }
 
           doStep();
         }
@@ -275,9 +277,11 @@ void idleControl()
             iacStepTime = configPage6.iacStepTime * 1000;
             iacCoolTime = configPage9.iacCoolTime * 1000;
 
-          //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
-          if (idleStepper.targetIdleStep > configPage9.iacMaxSteps * 3)
-             idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;             
+            //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
+            if (idleStepper.targetIdleStep > configPage9.iacMaxSteps * 3)
+            {
+              idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
+            }
           }
           doStep();
         }
@@ -308,7 +312,9 @@ void idleControl()
 
         //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
         if (idleStepper.targetIdleStep > configPage9.iacMaxSteps * 3)
-           idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;             
+        {
+          idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
+        }
 
         doStep();
         currentStatus.idleLoad = idleStepper.curIdleStep >> 1; //Current step count (Divided by 2 for byte)
@@ -458,7 +464,9 @@ static inline void disableIdle()
 
         //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
         if (idleStepper.targetIdleStep > configPage9.iacMaxSteps * 3)
-           idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;             
+        {
+          idleStepper.targetIdleStep = configPage9.iacMaxSteps * 3;
+        }
     }
   }
   BIT_CLEAR(currentStatus.spark, BIT_SPARK_IDLE); //Turn the idle control flag off

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1026,82 +1026,82 @@ void setPinMapping(byte boardID)
         //******************************************
         //******** PORTA CONNECTIONS *************** 
         //******************************************
-        // = PA0 //Wakeup ADC123
+        /* = PA0 */ //Wakeup ADC123
         pinTPS = PA1; //ADC123
         pinMAP = PA2; //ADC123
         pinIAT = PA3; //ADC123
         pinCLT = PA4; //ADC12
         pinO2 = PA5; //ADC12
-        // = PA6; //ADC12 LED_BUILTIN_1
+        /* = PA6; */ //ADC12 LED_BUILTIN_1
         pinFuelPump = PA7; //ADC12 LED_BUILTIN_2
         pinIdle1 = PA8; //
-        // = PA9 //TXD1
-        // = PA10 //RXD1
-        // = PA11 //(DO NOT USE FOR SPEEDUINO) USB
-        // = PA12 //(DO NOT USE FOR SPEEDUINO) USB 
-        // = PA13 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA14 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA15 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
+        /* = PA9 */ //TXD1
+        /* = PA10 */ //RXD1
+        /* = PA11 */ //(DO NOT USE FOR SPEEDUINO) USB
+        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB 
+        /* = PA13 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA14 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA15 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
         //******** PORTB CONNECTIONS *************** 
         //******************************************
-        // = PB0; (DO NOT USE FOR SPEEDUINO)//ADC123 //SPI FLASH CHIP CS pin
+        /* = PB0; */ //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        // = PB2; //(DO NOT USE FOR SPEEDUINO) BOOT1 
-        // = PB3; //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
-        // = PB4; //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
-        // = PB5; //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
-        // = PB6; //NRF_CE
-        // = PB7; //NRF_CS
-        // = PB8; //NRF_IRQ
+        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        /* = PB3; */ //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
+        /* = PB4; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
+        /* = PB5; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
+        /* = PB6; */ //NRF_CE
+        /* = PB7; */ //NRF_CS
+        /* = PB8; */ //NRF_IRQ
         pinIdle2 = PB9; //
-        // = PB10; //TXD3
-        // = PB11; //RXD3
+        /* = PB10; */ //TXD3
+        /* = PB11; */ //RXD3
         pinBoost = PB12; //
-        // = PB13; //SPI2_SCK
-        // = PB14; //SPI2_MISO
-        // = PB15; //SPI2_MOSI
+        /* = PB13; */ //SPI2_SCK
+        /* = PB14; */ //SPI2_MISO
+        /* = PB15; */ //SPI2_MOSI
 
         //******************************************
         //******** PORTC CONNECTIONS *************** 
         //******************************************
-        // = PC0; //ADC123 
+        /* = PC0; */ //ADC123 
         pinBat = PC1; //ADC123
-        // = PC2; //ADC123
-        // = PC3; //ADC123
-        // = PC4; //ADC12
-        // = PC5; //ADC12
+        /* = PC2; */ //ADC123
+        /* = PC3; */ //ADC123
+        /* = PC4; */ //ADC12
+        /* = PC5; */ //ADC12
         pinVVT_1 = PC6; //
         pinDisplayReset = PC7; //
-        // = PC8; //(DO NOT USE FOR SPEEDUINO) //SDIO_D0
-        // = PC9; //(DO NOT USE FOR SPEEDUINO) //SDIO_D1
-        // = PC10; //(DO NOT USE FOR SPEEDUINO) //SDIO_D2
-        // = PC11; //(DO NOT USE FOR SPEEDUINO) //SDIO_D3
-        // = PC12; //(DO NOT USE FOR SPEEDUINO) //SDIO_SCK
+        /* = PC8; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D0
+        /* = PC9; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D1
+        /* = PC10; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D2
+        /* = PC11; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D3
+        /* = PC12; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_SCK
         pinTachOut = PC13; //
-        // = PC14; //(DO NOT USE FOR SPEEDUINO) //OSC32_IN
-        // = PC15; //(DO NOT USE FOR SPEEDUINO) //OSC32_OUT
+        /* = PC14; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_IN
+        /* = PC15; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
         //******** PORTD CONNECTIONS *************** 
         //******************************************
-        // = PD0; //CANRX
-        // = PD1; //CANTX
-        // = PD2; //(DO NOT USE FOR SPEEDUINO) //SDIO_CMD
+        /* = PD0; */ //CANRX
+        /* = PD1; */ //CANTX
+        /* = PD2; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_CMD
         pinCoil1 = PD3; //
         pinCoil2 = PD4; //
-        // = PD5;//TXD2
-        // = PD6; //RXD2
+        /* = PD5;*/ //TXD2
+        /* = PD6; */ //RXD2
         pinCoil3 = PD7; //
         pinCoil4 = PD8; //
         pinCoil5 = PD9;//
         pinFan = PD10; //
-        // = PD11; //
-        // = PD12; //
-        // = PD13; //
-        // = PD14; //
-        // = PD15; //
+        /* = PD11; */ //
+        /* = PD12; */ //
+        /* = PD13; */ //
+        /* = PD14; */ //
+        /* = PD15; */ //
 
         //******************************************
         //******** PORTE CONNECTIONS *************** 
@@ -1109,8 +1109,8 @@ void setPinMapping(byte boardID)
         pinStepperDir = PE0; //
         pinStepperStep = PE1; //
         pinStepperEnable = PE2; //
-        // = PE3; //ONBOARD KEY1
-        // = PE4; //ONBOARD KEY2
+        /* = PE3; */ //ONBOARD KEY1
+        /* = PE4; */ //ONBOARD KEY2
         pinFlex = PE5; //
         pinTrigger = PE6; //
         pinInjector1 = PE7; //
@@ -1120,8 +1120,8 @@ void setPinMapping(byte boardID)
         pinInjector5 = PE11; //
         pinInjector6 = PE12; //
         pinTrigger2 = PE13; //
-        // = PE14; //
-        // = PE15; //
+        /* = PE14; */ //
+        /* = PE15; */ //
       #elif defined(CORE_STM32)
         //blue pill wiki.stm32duino.com/index.php?title=Blue_Pill
         //Maple mini wiki.stm32duino.com/index.php?title=Maple_Mini
@@ -1637,45 +1637,45 @@ void setPinMapping(byte boardID)
         //******************************************
         //******** PORTA CONNECTIONS *************** 
         //******************************************
-        // = PA0 //Wakeup ADC123
+        /* = PA0 */ //Wakeup ADC123
         pinInjector1 = PA1;
         pinInjector2 = PA2;
         pinInjector3 = PA3;
         pinInjector4 = PA4;
         
-        // = PA5; //ADC12
+        /* = PA5; */ //ADC12
         pinFuelPump = PA6; //ADC12 LED_BUILTIN_1
-        // = PA7; //ADC12 LED_BUILTIN_2
+        /* = PA7; */ //ADC12 LED_BUILTIN_2
         pinCoil3 = PA8;
-        // = PA9 //TXD1
-        // = PA10 //RXD1
-        // = PA11 //(DO NOT USE FOR SPEEDUINO) USB
-        // = PA12 //(DO NOT USE FOR SPEEDUINO) USB 
-        // = PA13 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA14 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA15 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
+        /* = PA9 */ //TXD1
+        /* = PA10 */ //RXD1
+        /* = PA11 */ //(DO NOT USE FOR SPEEDUINO) USB
+        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB 
+        /* = PA13 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA14 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA15 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
         //******** PORTB CONNECTIONS *************** 
         //******************************************
-        // = PB0; (DO NOT USE FOR SPEEDUINO)//ADC123 //SPI FLASH CHIP CS pin
+        /* = PB0; */ //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        // = PB2; //(DO NOT USE FOR SPEEDUINO) BOOT1 
-        // = PB3; //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
-        // = PB4; //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
-        // = PB5; //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
-        // = PB6; //NRF_CE
-        // = PB7; //NRF_CS
-        // = PB8; //NRF_IRQ
+        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        /* = PB3; */ //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
+        /* = PB4; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
+        /* = PB5; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
+        /* = PB6; */ //NRF_CE
+        /* = PB7; */ //NRF_CS
+        /* = PB8; */ //NRF_IRQ
         pinCoil2 = PB9; //
-        // = PB9; //
+        /* = PB9; */ //
         pinCoil4 = PB10; //TXD3
         pinIdle1 = PB11; //RXD3
         pinIdle2 = PB12; //
-        // pinBoost = PB12; //
-        // = PB13; //SPI2_SCK
-        // = PB14; //SPI2_MISO
-        // = PB15; //SPI2_MOSI
+        /* pinBoost = PB12; */ //
+        /* = PB13; */ //SPI2_SCK
+        /* = PB14; */ //SPI2_MISO
+        /* = PB15; */ //SPI2_MOSI
 
         //******************************************
         //******** PORTC CONNECTIONS *************** 
@@ -1685,60 +1685,60 @@ void setPinMapping(byte boardID)
         pinIAT = PC2; //ADC123
         pinCLT = PC3; //ADC123
         pinO2 = PC4; //ADC12
-        // = PC5; //ADC12
-        //pinVVT_1 = PC6; //
+        /* = PC5; */ //ADC12
+        /*pinVVT_1 = PC6; */ //
         pinBat = PC6; //
         pinDisplayReset = PC7; //
-        // = PC8; //(DO NOT USE FOR SPEEDUINO) //SDIO_D0
-        // = PC9; //(DO NOT USE FOR SPEEDUINO) //SDIO_D1
-        // = PC10; //(DO NOT USE FOR SPEEDUINO) //SDIO_D2
-        // = PC11; //(DO NOT USE FOR SPEEDUINO) //SDIO_D3
-        // = PC12; //(DO NOT USE FOR SPEEDUINO) //SDIO_SCK
+        /* = PC8; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D0
+        /* = PC9; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D1
+        /* = PC10; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D2
+        /* = PC11; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D3
+        /* = PC12; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_SCK
         pinTachOut = PC13; //
-        // = PC14; //(DO NOT USE FOR SPEEDUINO) //OSC32_IN
-        // = PC15; //(DO NOT USE FOR SPEEDUINO) //OSC32_OUT
+        /* = PC14; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_IN
+        /* = PC15; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
         //******** PORTD CONNECTIONS *************** 
         //******************************************
-        // = PD0; //CANRX
-        // = PD1; //CANTX
-        // = PD2; //(DO NOT USE FOR SPEEDUINO) //SDIO_CMD
-        // = PD3; //
-        // = PD4; //
+        /* = PD0; */ //CANRX
+        /* = PD1; */ //CANTX
+        /* = PD2; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_CMD
+        /* = PD3; */ //
+        /* = PD4; */ //
         pinFlex = PD4;
-        // = PD5;//TXD2
-        // = PD6; //RXD2
+        /* = PD5;*/ //TXD2
+        /* = PD6; */ //RXD2
         pinCoil1 = PD7; //
-        // = PD7; //
-        // = PD8; //
+        /* = PD7; */ //
+        /* = PD8; */ //
         pinCoil5 = PD9;//
-        // = PD10; //
-        // = PD11; //
-        // = PD12; //
+        /* = PD10; */ //
+        /* = PD11; */ //
+        /* = PD12; */ //
         pinTrigger = PD13; //
         pinTrigger2 = PD14; //
-        // = PD15; //
+        /* = PD15; */ //
 
         //******************************************
         //******** PORTE CONNECTIONS *************** 
         //******************************************
-        // = PE0; //
-        // = PE1; //
+        /* = PE0; */ //
+        /* = PE1; */ //
         pinStepperEnable = PE2; //
-        // = PE3; //ONBOARD KEY1
-        // = PE4; //ONBOARD KEY2
+        /* = PE3; */ //ONBOARD KEY1
+        /* = PE4; */ //ONBOARD KEY2
         pinStepperStep = PE5; //
         pinFan = PE6; //
         pinStepperDir = PE7; //
-        // = PE8; //
-        // = PE9; //
-        // = PE10; //
+        /* = PE8; */ //
+        /* = PE9; */ //
+        /* = PE10; */ //
         pinInjector5 = PE11; //
         pinInjector6 = PE12; //
-        // = PE13; //
-        // = PE14; //
-        // = PE15; //
+        /* = PE13; */ //
+        /* = PE14; */ //
+        /* = PE15; */ //
         
      #elif defined(CORE_STM32)
         //blue pill wiki.stm32duino.com/index.php?title=Blue_Pill
@@ -1786,45 +1786,45 @@ void setPinMapping(byte boardID)
         //******************************************
         //******** PORTA CONNECTIONS *************** 
         //******************************************
-        // = PA0 //Wakeup ADC123
+        /* = PA0 */ //Wakeup ADC123
         pinInjector1 = PA1;
         pinInjector2 = PA2;
         pinInjector3 = PA3;
         pinInjector4 = PA4;
         
         pinFuelPump = PA5; //ADC12
-        // = PA6; //ADC12 LED_BUILTIN_1
-        // = PA7; //ADC12 LED_BUILTIN_2
+        /* = PA6; */ //ADC12 LED_BUILTIN_1
+        /* = PA7; */ //ADC12 LED_BUILTIN_2
         pinCoil3 = PA8;
-        // = PA9 //TXD1
-        // = PA10 //RXD1
-        // = PA11 //(DO NOT USE FOR SPEEDUINO) USB
-        // = PA12 //(DO NOT USE FOR SPEEDUINO) USB 
-        // = PA13 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA14 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
-        // = PA15 //(DO NOT USE FOR SPEEDUINO) //NOT ON GPIO //DEBUG ST-LINK
+        /* = PA9 */ //TXD1
+        /* = PA10 */ //RXD1
+        /* = PA11 */ //(DO NOT USE FOR SPEEDUINO) USB
+        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB 
+        /* = PA13 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA14 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
+        /* = PA15 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
         //******** PORTB CONNECTIONS *************** 
         //******************************************
-        // = PB0; (DO NOT USE FOR SPEEDUINO)//ADC123 //SPI FLASH CHIP CS pin
+        /* = PB0; */ //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        // = PB2; //(DO NOT USE FOR SPEEDUINO) BOOT1 
-        // = PB3; //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
-        // = PB4; //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
-        // = PB5; //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
-        // = PB6; //NRF_CE
-        // = PB7; //NRF_CS
-        // = PB8; //NRF_IRQ
+        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        /* = PB3; */ //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
+        /* = PB4; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
+        /* = PB5; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
+        /* = PB6; */ //NRF_CE
+        /* = PB7; */ //NRF_CS
+        /* = PB8; */ //NRF_IRQ
         pinCoil2 = PB9; //
-        // = PB9; //
+        /* = PB9; */ //
         pinCoil4 = PB10; //TXD3
         pinIdle1 = PB11; //RXD3
         pinIdle2 = PB12; //
-        // pinBoost = PB12; //
-        // = PB13; //SPI2_SCK
-        // = PB14; //SPI2_MISO
-        // = PB15; //SPI2_MOSI
+        /* pinBoost = PB12; */ //
+        /* = PB13; */ //SPI2_SCK
+        /* = PB14; */ //SPI2_MISO
+        /* = PB15; */ //SPI2_MOSI
 
         //******************************************
         //******** PORTC CONNECTIONS *************** 
@@ -1834,60 +1834,60 @@ void setPinMapping(byte boardID)
         pinIAT = PC2; //ADC123
         pinCLT = PC3; //ADC123
         pinO2 = PC4; //ADC12
-        // = PC5; //ADC12
-        //pinVVT_1 = PC6; //
+        /* = PC5; */ //ADC12
+        /*pinVVT_1 = PC6; */ //
         pinBat = PC6; //
         pinDisplayReset = PC7; //
-        // = PC8; //(DO NOT USE FOR SPEEDUINO) //SDIO_D0
-        // = PC9; //(DO NOT USE FOR SPEEDUINO) //SDIO_D1
-        // = PC10; //(DO NOT USE FOR SPEEDUINO) //SDIO_D2
-        // = PC11; //(DO NOT USE FOR SPEEDUINO) //SDIO_D3
-        // = PC12; //(DO NOT USE FOR SPEEDUINO) //SDIO_SCK
+        /* = PC8; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D0
+        /* = PC9; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D1
+        /* = PC10; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D2
+        /* = PC11; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_D3
+        /* = PC12; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_SCK
         pinTachOut = PC13; //
-        // = PC14; //(DO NOT USE FOR SPEEDUINO) //OSC32_IN
-        // = PC15; //(DO NOT USE FOR SPEEDUINO) //OSC32_OUT
+        /* = PC14; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_IN
+        /* = PC15; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
         //******** PORTD CONNECTIONS *************** 
         //******************************************
-        // = PD0; //CANRX
-        // = PD1; //CANTX
-        // = PD2; //(DO NOT USE FOR SPEEDUINO) //SDIO_CMD
-        // = PD3; //
-        // = PD4; //
+        /* = PD0; */ //CANRX
+        /* = PD1; */ //CANTX
+        /* = PD2; */ //(DO NOT USE FOR SPEEDUINO) - SDIO_CMD
+        /* = PD3; */ //
+        /* = PD4; */ //
         pinFlex = PD4;
-        // = PD5;//TXD2
-        // = PD6; //RXD2
+        /* = PD5;*/ //TXD2
+        /* = PD6; */ //RXD2
         pinCoil1 = PD7; //
-        // = PD7; //
-        // = PD8; //
+        /* = PD7; */ //
+        /* = PD8; */ //
         pinCoil5 = PD9;//
-        // = PD10; //
-        // = PD11; //
-        // = PD12; //
+        /* = PD10; */ //
+        /* = PD11; */ //
+        /* = PD12; */ //
         pinTrigger = PD13; //
         pinTrigger2 = PD14; //
-        // = PD15; //
+        /* = PD15; */ //
 
         //******************************************
         //******** PORTE CONNECTIONS *************** 
         //******************************************
-        // = PE0; //
-        // = PE1; //
+        /* = PE0; */ //
+        /* = PE1; */ //
         pinStepperEnable = PE2; //
-        // = PE3; //ONBOARD KEY1
-        // = PE4; //ONBOARD KEY2
+        /* = PE3; */ //ONBOARD KEY1
+        /* = PE4; */ //ONBOARD KEY2
         pinStepperStep = PE5; //
         pinFan = PE6; //
         pinStepperDir = PE7; //
-        // = PE8; //
-        // = PE9; //
-        // = PE10; //
+        /* = PE8; */ //
+        /* = PE9; */ //
+        /* = PE10; */ //
         pinInjector5 = PE11; //
         pinInjector6 = PE12; //
-        // = PE13; //
-        // = PE14; //
-        // = PE15; //
+        /* = PE13; */ //
+        /* = PE14; */ //
+        /* = PE15; */ //
       #else
         #ifndef SMALL_FLASH_MODE //No support for bluepill here anyway
         //Pin mappings as per the v0.2 shield

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -11,7 +11,7 @@ unsigned long divu100(unsigned long);
 
 //This is a dedicated function that specifically handles the case of mapping 0-1023 values into a 0 to X range
 //This is a common case because it means converting from a standard 10-bit analog input to a byte or 10-bit analog into 0-511 (Eg the temperature readings)
-#if defined(_VARIANT_ARDUINO_STM32_) //libmaple //ST stm32duino core returns 0 - 1023 for analog read first use analogReadResolution(12); to make it 12 bit
+#if defined(_VARIANT_ARDUINO_STM32_) /*libmaple */ //ST stm32duino core returns 0 - 1023 for analog read first use analogReadResolution(12); to make it 12 bit
   #define fastMap1023toX(x, out_max) ( ((unsigned long)x * out_max) >> 12)
   //This is a new version that allows for out_min
   #define fastMap10Bit(x, out_min, out_max) ( ( ((unsigned long)x * (out_max-out_min)) >> 12 ) + out_min)

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -5,7 +5,7 @@ It functions by waiting for the overflow vectors from each of the timers in use 
 //Technical
 Currently I am prescaling the 16-bit timers to 256 for injection and 64 for ignition. This means that the counter increments every 16us (injection) / 4uS (ignition) and will overflow every 1048576uS
 Max Period = (Prescale)*(1/Frequency)*(2^17)
-(See http://playground.arduino.cc/code/timer1)
+(See playground.arduino.cc/code/timer1)
 This means that the precision of the scheduler is 16uS (+/- 8uS of target) for fuel and 4uS (+/- 2uS) for ignition
 
 /Features
@@ -16,7 +16,7 @@ Timer identification
 The Arduino timer3 is used for schedule 1
 The Arduino timer4 is used for schedule 2
 Both of these are 16-bit timers (ie count to 65536)
-See page 136 of the processors datasheet: http://www.atmel.com/Images/doc2549.pdf
+See page 136 of the processors datasheet: www.atmel.com/Images/doc2549.pdf
 
 256 prescale gives tick every 16uS
 256 prescale gives overflow every 1048576uS (This means maximum wait time is 1.0485 seconds)
@@ -181,10 +181,10 @@ static inline unsigned int setQueue(volatile Schedule *queue[], Schedule *schedu
 
   //Sort the queues. Both queues are kept in sync.
   //This implementes a sorting networking based on the Bose-Nelson sorting network
-  //See: http://pages.ripco.net/~jgamble/nw.html
+  //See: pages.ripco.net/~jgamble/nw.html
   #define SWAP(x,y) if(tmpQueue[y] < tmpQueue[x]) { unsigned int tmp = tmpQueue[x]; tmpQueue[x] = tmpQueue[y]; tmpQueue[y] = tmp; volatile Schedule *tmpS = queue[x]; queue[x] = queue[y]; queue[y] = tmpS; }
-  //SWAP(0, 1); //Likely not needed
-  //SWAP(2, 3); //Likely not needed
+  /*SWAP(0, 1); */ //Likely not needed
+  /*SWAP(2, 3); */ //Likely not needed
   SWAP(0, 2);
   SWAP(1, 3);
   SWAP(1, 2);

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -2,7 +2,7 @@
 This scheduler is designed to maintain 2 schedules for use by the fuel and ignition systems.
 It functions by waiting for the overflow vectors from each of the timers in use to overflow, which triggers an interrupt
 
-//Technical
+/Technical
 Currently I am prescaling the 16-bit timers to 256 for injection and 64 for ignition. This means that the counter increments every 16us (injection) / 4uS (ignition) and will overflow every 1048576uS
 Max Period = (Prescale)*(1/Frequency)*(2^17)
 (See playground.arduino.cc/code/timer1)

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -50,7 +50,7 @@ byte cltErrorCount = 0;
 
 /**
  * @brief Simple low pass IIR filter macro for the analog inputs
- * This is effectively implementing the smooth filter from http://playground.arduino.cc/Main/Smooth
+ * This is effectively implementing the smooth filter from playground.arduino.cc/Main/Smooth
  * But removes the use of floats and uses 8 bits of fixed precision.
  */
 #define ADC_FILTER(input, alpha, prior) (((long)input * (256 - alpha) + ((long)prior * alpha))) >> 8
@@ -79,7 +79,7 @@ ISR(ADC_vect)
   byte nChannel;
   int result = ADCL | (ADCH << 8);
 
-  //ADCSRA = 0x6E;  // ADC disabled by clearing bit 7(ADEN)
+  /*ADCSRA = 0x6E;  */ // ADC disabled by clearing bit 7(ADEN)
   //BIT_CLEAR(ADCSRA, ADIE);
 
   nChannel = ADMUX & 0x07;
@@ -102,7 +102,7 @@ ISR(ADC_vect)
   AnChannel[nChannel-1] = result;
 
   //BIT_SET(ADCSRA, ADIE);
-  //ADCSRA = 0xEE; // ADC Interrupt Flag enabled
+  /*ADCSRA = 0xEE; */ // ADC Interrupt Flag enabled
 }
 */
 ISR(ADC_vect)

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -10,7 +10,7 @@ We're implementing a lower frequency interrupt loop to perform calculations that
 //Technical
 Timer2 is only 8bit so we are setting the prescaler to 128 to get the most out of it. This means that the counter increments every 0.008ms and the overflow at 256 will be after 2.048ms
 Max Period = (Prescale)*(1/Frequency)*(2^8)
-(See http://arduinomega.blogspot.com.au/2011/05/timer2-and-overflow-interrupt-lets-get.html)
+(See arduinomega.blogspot.com.au/2011/05/timer2-and-overflow-interrupt-lets-get.html)
 
 We're after a 1ms interval so we'll need 131 intervals to reach this ( 1ms / 0.008ms per tick = 125).
 Hence we will preload the timer with 131 cycles to leave 125 until overflow (1ms).


### PR DESCRIPTION
In misra/check_misra_github.sh,
- I changed the language to C++, to remove the warning `Code 'classFastCRC7{' is invalid C code`
- I fixed the MISRA violation count, that reported some lines more than once.

In misra/misra_2012_text.txt,
- I added violation descriptions

In the other files, I fixed violations of types
- comments within comments 
- body of if/while must be enclosed by brackets
- incompatible pointer types