### PR TITLE
improve table2D_getValue() function speed

### DIFF
--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -263,14 +263,13 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
     else
     {
       //If we're not in the same bin, loop through to find where we are
-      xMinValue = table2D_getAxisValue(fromTable, fromTable->xSize-1); // init xMinValue so it has the good value 3 lines below.
-      for (int x = fromTable->xSize-1; x >= 0; x--)
+      xMaxValue = table2D_getAxisValue(fromTable, fromTable->xSize-1); // init xMaxValue in preparation for loop.
+      for (int x = fromTable->xSize-1; x > 0; x--)
       {
-        xMaxValue = xMinValue; // we moved one cell below, the last Min is now the Max
         xMinValue = table2D_getAxisValue(fromTable, x-1); // fetch next Min
 
         //Checks the case where the X value is exactly what was requested
-        if ( (X == xMaxValue) || (x == 0) )
+        if (X == xMaxValue)
         {
           returnValue = table2D_getRawValue(fromTable, x); //Simply return the coresponding value
           valueFound = true;
@@ -286,6 +285,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
           break;
         }
         // Otherwise, continue to next bin
+        xMaxValue = xMinValue; // for the next bin, our Min is their Max
       }
     }
   } //X_in same as last time

--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -276,18 +276,16 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
           valueFound = true;
           break;
         }
-        else
+        else if (X > xMinValue)
         {
-          //Normal case
-          if ( (X <= xMaxValue) && (X > xMinValue) )
-          {
-            xMax = x;
-            fromTable->lastXMax = xMax;
-            xMin = x-1;
-            fromTable->lastXMin = xMin;
-            break;
-          }
+          // Value is in the current bin
+          xMax = x;
+          fromTable->lastXMax = xMax;
+          xMin = x-1;
+          fromTable->lastXMin = xMin;
+          break;
         }
+        // Otherwise, continue to next bin
       }
     }
   } //X_in same as last time


### PR DESCRIPTION
After the last changes to table2D_getValue() function (in 91206ac90e5cb25a27397bd7f3426bf6863a0599), the table is copied in full on each function call.
This is a proposal to improve the speed by roughly 7x (tested in separated code) by removing the full table copy and removing redundant array access.

I tested, with my unit-tests,

- the query of an axis value
  - below min
  - at min
  - in the middle and
  - at max
  - above max
- axis size of byte and int16
- values size of byte and int16

everything is still working as exepected.