### PR TITLE
Add idle ignition timing correction feature

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -315,11 +315,11 @@ page = 1
 #else
       primeBins     = array,  U08,       87, [4],  "F", 1.8,    -22.23,    -40,    215,      0
 #endif
-      idleSwitchPin       = bits,  U08,  91, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
-      idleSwitchPolarity  = bits,  U08,  91, [6:6], "Normal", "Inverted"
-      idleSwitchEnabled   = bits,  U08,  91, [7:7], "Off", "On"
+      CTPSPin       = bits,  U08,  91, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
+      CTPSPolarity  = bits,  U08,  91, [6:6], "Normal", "Inverted"
+      CTPSEnabled   = bits,  U08,  91, [7:7], "Off", "On"
       idleAdvEnabled      = bits,  U08,  92, [0:1], "Off", "Added", "Switched", "INVALID"
-      idleAdvAlgorithm    = bits,  U08,  92, [2:2], "TPS", "Idle Switch"
+      idleAdvAlgorithm    = bits,  U08,  92, [2:2], "TPS", "CTPS"
       unused_idle_bits    = bits,  U08,  92, [3:7]
       idleAdvRPM   = scalar,  U08,      93,       "rpm",        100,       0.0,   100,   25500,      0
       idleAdvTPS   = scalar,  U08,      94,         "%",          1,         0,     0,     120,      0
@@ -1038,9 +1038,9 @@ page = 11
     requiresPowerCycle = knock_trigger
     requiresPowerCycle = knock_pullup
     requiresPowerCycle = idleUpEnabled
-    requiresPowerCycle = idleSwitchEnabled
-    requiresPowerCycle = idleSwitchPin
-    requiresPowerCycle = idleSwitchPolarity
+    requiresPowerCycle = CTPSEnabled
+    requiresPowerCycle = CTPSPin
+    requiresPowerCycle = CTPSPolarity
     requiresPowerCycle = legacyMAP
     requiresPowerCycle = fuel2InputPin
     requiresPowerCycle = fuel2InputPolarity
@@ -1270,7 +1270,6 @@ menuDialog = main
         subMenu = iacStepCrank_curve,   "Idle - Stepper Motor Cranking", 7, { iacAlgorithm == 4 }
         subMenu = std_separator
         subMenu = idleUpSettings,       "Idle Up Settings", { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 4 || iacAlgorithm == 5 }
-        subMenu = idleSwitchSettings,   "Idle Switch Settings", { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
 
     menu = "&Accessories"
         subMenu = fanSettings,          "Thermo Fan"
@@ -1377,10 +1376,10 @@ menuDialog = main
 	iacCLmaxDuty= "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
 	iacFastTemp = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
     idleUpPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
-    idleSwitchPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Switch. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Switch."
+    CTPSPolarity = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
     idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
     idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing.
-    idleAdvAlgorithm = "Use Throttle position sensor or physical idle switch to detect idle state."
+    idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
 
 	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
@@ -1811,11 +1810,6 @@ menuDialog = main
         field = "Idle Up Pin Polarity", idleUpPolarity,         { idleUpEnabled }
         field = "Idle Up Amount",       idleUpAdder,            { idleUpEnabled }
 
-    dialog = idleSwitchSettings, "Idle Switch Settings"
-        field = "Idle Switch Enabled",      idleSwitchEnabled
-        field = "Idle Switch Pin",          idleSwitchPin,              { idleSwitchEnabled }
-        field = "Idle Switch Pin Polarity", idleSwitchPolarity,         { idleSwitchEnabled }
-
     dialog = fuelpump, "Fuel pump"
         field = "Fuel pump pin",                    fuelPumpPin
         field = "Fuel pump prime duration",         fpPrime
@@ -1912,10 +1906,13 @@ menuDialog = main
         field = "your desired dwell time (Including cranking)"
 		
     dialog = idleAdvanceSettings,"Idle Advance Settings",4
-        field = "Idle advance correction",         idleAdvEnabled
-        field = "Idle advance mode",             idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
-        field = "Active Below TPS",                    idleAdvTPS,     { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
-        field = "Active Below RPM",                    idleAdvRPM,     { idleAdvEnabled >= 1 }
+        field = "Idle advance mode",                   idleAdvEnabled
+        field = "Idle detect mode",                    idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
+		field = "Active Below RPM",                    idleAdvRPM,           { idleAdvEnabled >= 1 }
+        field = "Active Below TPS",                    idleAdvTPS,           { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
+		field = "Closed Throttle Sensor Enabled",      CTPSEnabled,          { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
+        field = "Closed Throttle Sensor Pin",          CTPSPin,              { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
+        field = "Closed Throttle Sensor Pin Polarity", CTPSPolarity,         { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
 
     dialog = rotary_ignition,               "Rotary Ignition",  4
         field = "Ignition Configuration",   rotaryType

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -315,8 +315,16 @@ page = 1
 #else
       primeBins     = array,  U08,       87, [4],  "F", 1.8,    -22.23,    -40,    215,      0
 #endif
+      idleSwitchPin       = bits,  U08,  91, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
+      idleSwitchPolarity  = bits,  U08,  91, [6:6], "Normal", "Inverted"
+      idleSwitchEnabled   = bits,  U08,  91, [7:7], "Off", "On"
+      idleAdvEnabled      = bits,  U08,  92, [0:1], "Off", "Added", "Switched", "INVALID"
+      idleAdvAlgorithm    = bits,  U08,  92, [2:2], "TPS", "Idle Switch"
+      unused_idle_bits    = bits,  U08,  92, [3:7]
+      idleAdvRPM   = scalar,  U08,      93,       "rpm",        100,       0.0,   100,   25500,      0
+      idleAdvTPS   = scalar,  U08,      94,         "%",          1,         0,     0,     120,      0
 
-      unused2-91    = array,  U08,      91, [37],   "%",        1.0,       0.0,   0.0,     255,      0
+      unused2-95    = array,  U08,      95, [33],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -438,7 +446,12 @@ page = 4
         maeRates        = array,  U08,      87, [ 4],   "%",        1.0,    0.0,  0.00, 255.0,      0 ; 4 bytes
 
         batVoltCorrect  = scalar, S08,      91, "v",          0.1,  0.0,    -2,     2,        1 ;Battery reading calibration value. Note: Signed value
-        unused4-92      = array,  U08,      92, [36],   "%",  1.0,  0.0,   0.0,     255,      0
+
+;Idle timing advance
+        idleAdvBins     = array,  U08,      92, [6],    "RPM",    10.0,      -50,       -500,     500,         0
+	    idleAdvValues   = array,  U08,      98, [6],    "deg",     1.0,      -15,        -15,      50,         0
+
+        unused4-104     = array,  U08,     104, [24],   "%",  1.0,  0.0,   0.0,     255,      0
 ;--------------------------------------------------
 
 ;Start AFR page
@@ -1021,6 +1034,9 @@ page = 11
     requiresPowerCycle = knock_trigger
     requiresPowerCycle = knock_pullup
     requiresPowerCycle = idleUpEnabled
+    requiresPowerCycle = idleSwitchEnabled
+    requiresPowerCycle = idleSwitchPin
+    requiresPowerCycle = idleSwitchPolarity
     requiresPowerCycle = legacyMAP
     requiresPowerCycle = fuel2InputPin
     requiresPowerCycle = fuel2InputPolarity
@@ -1228,6 +1244,8 @@ menuDialog = main
       subMenu = sparkTbl,               "Spark Table", 2
       subMenu = dwellSettings,          "Dwell settings"
       subMenu = dwell_correction_curve, "Dwell Compensation"
+      subMenu = idleAdvanceSettings,    "Idle Advance Settings"
+      subMenu = idle_advance_curve,     "Idle Advance"        { idleAdvEnabled >= 1 }
       subMenu = iat_retard_curve,       "IAT Retard"
       subMenu = clt_advance_curve,      "Cold Advance"
       ;subMenu = knockSettings,          "Knock Settings"
@@ -1240,13 +1258,14 @@ menuDialog = main
         subMenu = ASE,                  "Afterstart Enrichment (ASE)"
         subMenu = std_separator
         subMenu = idleSettings,         "Idle Control"
-        subMenu = iacClosedLoop_curve,  "Idle - Closed loop targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 }
+        subMenu = iacClosedLoop_curve,  "Idle - RPM targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 || idleAdvEnabled >= 1 }
         subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 }
         subMenu = iacPwmCrank_curve,    "Idle - PWM Cranking Duty Cycle", 7, { iacAlgorithm == 2 }
         subMenu = iacStep_curve,        "Idle - Stepper Motor", 7, { iacAlgorithm == 4 }
         subMenu = iacStepCrank_curve,   "Idle - Stepper Motor Cranking", 7, { iacAlgorithm == 4 }
         subMenu = std_separator
         subMenu = idleUpSettings,       "Idle Up Settings", { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 4 || iacAlgorithm == 5 }
+        subMenu = idleSwitchSettings,   "Idle Switch Settings", { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
 
     menu = "&Accessories"
         subMenu = fanSettings,          "Thermo Fan"
@@ -1353,7 +1372,10 @@ menuDialog = main
 	iacCLmaxDuty= "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
 	iacFastTemp = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
     idleUpPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
+    idleSwitchPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Switch. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Switch."
     idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
+    idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing.
+    idleAdvAlgorithm = "Use Throttle position sensor or physical idle switch to detect idle state."
 
 	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
@@ -1784,6 +1806,11 @@ menuDialog = main
         field = "Idle Up Pin Polarity", idleUpPolarity,         { idleUpEnabled }
         field = "Idle Up Amount",       idleUpAdder,            { idleUpEnabled }
 
+    dialog = idleSwitchSettings, "Idle Switch Settings"
+        field = "Idle Switch Enabled",      idleSwitchEnabled
+        field = "Idle Switch Pin",          idleSwitchPin,              { idleSwitchEnabled }
+        field = "Idle Switch Pin Polarity", idleSwitchPolarity,         { idleSwitchEnabled }
+
     dialog = fuelpump, "Fuel pump"
         field = "Fuel pump pin",                    fuelPumpPin
         field = "Fuel pump prime duration",         fpPrime
@@ -1878,6 +1905,12 @@ menuDialog = main
         field = "Max dwell time",             dwellLim,	{ useDwellLim }
         field = "Note: Set the maximum dwell time at least 3ms above"
         field = "your desired dwell time (Including cranking)"
+		
+    dialog = idleAdvanceSettings,"Idle Advance Settings",4
+        field = "Idle advance correction",         idleAdvEnabled
+        field = "Idle advance mode",             idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
+        field = "Active Below TPS",                    idleAdvTPS,     { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
+        field = "Active Below RPM",                    idleAdvRPM,     { idleAdvEnabled >= 1 }
 
     dialog = rotary_ignition,               "Rotary Ignition",  4
         field = "Ignition Configuration",   rotaryType
@@ -2816,6 +2849,14 @@ cmdtestspk450dc = "E\x03\x0C"
             xBins = cltAdvBins, coolant
             yBins = cltAdvValues
 
+; Idle RPM target based ignition timing
+        curve = idle_advance_curve, "Idle Advance"
+            columnLabel =   "RPM Delta", "Advance"
+            xAxis       = -500, 500, 5
+            yAxis       =  -15,  50, 5
+            xBins       = idleAdvBins, CLIdleDelta
+            yBins       = idleAdvValues
+
 ; Curves for idle control
         ; Standard duty table for PWM valves
         curve = iacPwm_curve, "IAC PWM Duty"
@@ -2855,7 +2896,7 @@ cmdtestspk450dc = "E\x03\x0C"
             xBins = iacCrankBins, coolant
             yBins = iacCrankSteps
 
-        curve = iacClosedLoop_curve, "IAC Closed Loop Targets"
+        curve = iacClosedLoop_curve, "Idle RPM Targets"
             columnLabel = "Coolant Temperature", "Motor"
             xAxis = -40, 120, 6
             yAxis = 0, 2000, 4
@@ -3443,8 +3484,8 @@ cmdtestspk450dc = "E\x03\x0C"
    entry = hardLimitOn ,    "Hard Limiter", int,     "%d"
    entry = idleControlOn,   "Idle Control", int,     "%d"
    entry = idleLoad,        "IAC value",    int,     "%d"
-   entry = CLIdleTarget,    "Idle Target RPM", int,  "%%d",     { iacAlgorithm == 3 || iacAlgorithm == 5 } ;Only show for closed loop idle modes
-   entry = CLIdleDelta,     "Idle RPM Delta", int,   "%d",      { iacAlgorithm == 3 || iacAlgorithm == 5 } ;Only show for closed loop idle modes
+   entry = CLIdleTarget,    "Idle Target RPM", int,  "%%d",     { iacAlgorithm == 3 || iacAlgorithm == 5 || idleAdvEnabled >= 1 } ;Only show for closed loop idle modes and if idle advance is enabled
+   entry = CLIdleDelta,     "Idle RPM Delta", int,   "%d",      { iacAlgorithm == 3 || iacAlgorithm == 5 || idleAdvEnabled >= 1 } ;Only show for closed loop idle modes and if idle advance is enabled
    entry = baro,            "Baro Pressure",int,     "%d"
    entry = nitrousOn,       "Nitrous",      int,     "%d",      { n2o_enable > 0 }
    entry = syncLossCounter, "Sync Loss #",  int,     "%d"

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -26,6 +26,7 @@ static inline int8_t correctionCrankingFixedTiming(int8_t);
 static inline int8_t correctionFlexTiming(int8_t);
 static inline int8_t correctionIATretard(int8_t);
 static inline int8_t correctionCLTadvance(int8_t);
+static inline int8_t correctionIdleAdvance(int8_t);
 static inline int8_t correctionSoftRevLimit(int8_t);
 static inline int8_t correctionNitrous(int8_t);
 static inline int8_t correctionSoftLaunch(int8_t);

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -548,7 +548,7 @@ static inline int8_t correctionIdleAdvance(int8_t advance)
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }
       else if(configPage2.idleAdvEnabled == 2) { ignIdleValue = advanceIdleAdjust; }
     }
-    else if(configPage2.idleAdvAlgorithm == 1 && (currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100) && currentStatus.idleSwitchActive == 1)) // Idle switch based idle state
+    else if(configPage2.idleAdvAlgorithm == 1 && (currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100) && currentStatus.CTPSActive == 1)) // closed throttle position sensor (CTPS) based idle state
     {
       int8_t advanceIdleAdjust = (int16_t)(table2D_getValue(&idleAdvanceTable, idleRPMdelta)) - 15;
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -435,7 +435,7 @@ struct statuses {
   byte idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
   byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
-  bool idleSwitchActive; /**< Whether the externally controlled idle switch is currently active */
+  bool CTPSActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
   bool fanOn; /**< Whether or not the fan is turned on */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
@@ -602,9 +602,9 @@ struct config2 {
   byte primePulse[4]; //Priming pulsewidth
   byte primeBins[4]; //Priming temp axis
 
-  byte idleSwitchPin : 6;
-  byte idleSwitchPolarity : 1;
-  byte idleSwitchEnabled : 1;
+  byte CTPSPin : 6;
+  byte CTPSPolarity : 1;
+  byte CTPSEnabled : 1;
   byte idleAdvEnabled : 2;
   byte idleAdvAlgorithm : 1;
   byte idleUnused : 5;
@@ -1031,7 +1031,7 @@ byte pinFuelPump; //Fuel pump on/off
 byte pinIdle1; //Single wire idle control
 byte pinIdle2; //2 wire idle control (Not currently used)
 byte pinIdleUp; //Input for triggering Idle Up
-byte pinIdleSwitch; //Input for triggering idle state
+byte pinCTPS; //Input for triggering closed throttle state
 byte pinFuel2Input; //Input for switching to the 2nd fuel table
 byte pinSpareTemp1; // Future use only
 byte pinSpareTemp2; // Future use only

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -279,7 +279,8 @@ struct table2D dwellVCorrectionTable; //6 bin dwell voltage correction (2D)
 struct table2D injectorVCorrectionTable; //6 bin injector voltage correction (2D)
 struct table2D IATDensityCorrectionTable; //9 bin inlet air temperature density correction (2D)
 struct table2D IATRetardTable; //6 bin ignition adjustment based on inlet air temperature  (2D)
-struct table2D IDLEAdvanceTable; //6 bin idle advance adjustment table based on RPM difference  (2D)
+struct table2D idleTargetTable; //10 bin idle target table for idle timing (2D)
+struct table2D idleAdvanceTable; //6 bin idle advance adjustment table based on RPM difference  (2D)
 struct table2D CLTAdvanceTable; //6 bin ignition adjustment based on coolant temperature  (2D)
 struct table2D rotarySplitTable; //8 bin ignition split curve for rotary leading/trailing  (2D)
 struct table2D flexFuelTable;  //6 bin flex fuel correction table for fuel adjustments (2D)
@@ -432,6 +433,7 @@ struct statuses {
   byte idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
   byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
+  bool idleSwitchActive; /**< Whether the externally controlled idle switch is currently active */
   bool fanOn; /**< Whether or not the fan is turned on */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
@@ -597,7 +599,16 @@ struct config2 {
   byte aseBins[4]; //Afterstart enrichment temp axis
   byte primePulse[4]; //Priming pulsewidth
   byte primeBins[4]; //Priming temp axis
-  byte unused2_91[37];
+
+  byte idleSwitchPin : 6;
+  byte idleSwitchPolarity : 1;
+  byte idleSwitchEnabled : 1;
+  byte idleAdvEnabled : 2;
+  byte idleAdvAlgorithm : 1;
+  byte idleUnused : 5;
+  byte idleAdvRPM;
+  byte idleAdvTPS;
+  byte unused2_95[33];
 
 #if defined(CORE_AVR)
   };
@@ -678,7 +689,11 @@ struct config4 {
   byte maeRates[4]; /**< MAP based AE values */
 
   int8_t batVoltCorrect; /**< Battery voltage calibration offset */
-  byte unused2_91[36];
+
+  byte idleAdvBins[6];
+  byte idleAdvValues[6];
+
+  byte unused4_104[24];
 
 #if defined(CORE_AVR)
   };
@@ -1011,6 +1026,7 @@ byte pinFuelPump; //Fuel pump on/off
 byte pinIdle1; //Single wire idle control
 byte pinIdle2; //2 wire idle control (Not currently used)
 byte pinIdleUp; //Input for triggering Idle Up
+byte pinIdleSwitch; //Input for triggering idle state
 byte pinFuel2Input; //Input for switching to the 2nd fuel table
 byte pinSpareTemp1; // Future use only
 byte pinSpareTemp2; // Future use only

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1972,8 +1972,8 @@ void setPinMapping(byte boardID)
   //Currently there's no default pin for Idle Up
   pinIdleUp = pinTranslate(configPage2.idleUpPin);
 
-  //Currently there's no default pin for Idle Switch
-  pinIdleSwitch = pinTranslate(configPage2.idleSwitchPin);
+  //Currently there's no default pin for closed throttle position sensor
+  pinCTPS = pinTranslate(configPage2.CTPSPin);
 
   /* Reset control is a special case. If reset control is enabled, it needs its initial state set BEFORE its pinMode.
      If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
@@ -2092,10 +2092,10 @@ void setPinMapping(byte boardID)
     if (configPage2.idleUpPolarity == 0) { pinMode(pinIdleUp, INPUT_PULLUP); } //Normal setting
     else { pinMode(pinIdleUp, INPUT); } //inverted setting
   }
-  if(configPage2.idleSwitchEnabled > 0)
+  if(configPage2.CTPSEnabled > 0)
   {
-    if (configPage2.idleSwitchPolarity == 0) { pinMode(pinIdleSwitch, INPUT_PULLUP); } //Normal setting
-    else { pinMode(pinIdleSwitch, INPUT); } //inverted setting
+    if (configPage2.CTPSPolarity == 0) { pinMode(pinCTPS, INPUT_PULLUP); } //Normal setting
+    else { pinMode(pinCTPS, INPUT); } //inverted setting
   }
   if(configPage10.fuel2Mode == FUEL2_MODE_INPUT_SWITCH)
   {

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -117,6 +117,16 @@ void initialiseAll()
     CLTAdvanceTable.xSize = 6;
     CLTAdvanceTable.values = (byte*)configPage4.cltAdvValues;
     CLTAdvanceTable.axisX = configPage4.cltAdvBins;
+    idleTargetTable.valueSize = SIZE_BYTE;
+    idleTargetTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+    idleTargetTable.xSize = 10;
+    idleTargetTable.values = configPage6.iacCLValues;
+    idleTargetTable.axisX = configPage6.iacBins;
+    idleAdvanceTable.valueSize = SIZE_BYTE;
+    idleAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+    idleAdvanceTable.xSize = 6;
+    idleAdvanceTable.values = (byte*)configPage4.idleAdvValues;
+    idleAdvanceTable.axisX = configPage4.idleAdvBins;
     rotarySplitTable.valueSize = SIZE_BYTE;
     rotarySplitTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
     rotarySplitTable.xSize = 8;
@@ -1957,6 +1967,9 @@ void setPinMapping(byte boardID)
   //Currently there's no default pin for Idle Up
   pinIdleUp = pinTranslate(configPage2.idleUpPin);
 
+  //Currently there's no default pin for Idle Switch
+  pinIdleSwitch = pinTranslate(configPage2.idleSwitchPin);
+
   /* Reset control is a special case. If reset control is enabled, it needs its initial state set BEFORE its pinMode.
      If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
      because the control pin will go low as soon as the pinMode is set to OUTPUT. */
@@ -2073,6 +2086,11 @@ void setPinMapping(byte boardID)
   {
     if (configPage2.idleUpPolarity == 0) { pinMode(pinIdleUp, INPUT_PULLUP); } //Normal setting
     else { pinMode(pinIdleUp, INPUT); } //inverted setting
+  }
+  if(configPage2.idleSwitchEnabled > 0)
+  {
+    if (configPage2.idleSwitchPolarity == 0) { pinMode(pinIdleSwitch, INPUT_PULLUP); } //Normal setting
+    else { pinMode(pinIdleSwitch, INPUT); } //inverted setting
   }
   if(configPage10.fuel2Mode == FUEL2_MODE_INPUT_SWITCH)
   {

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -307,13 +307,13 @@ void readTPS()
     currentStatus.TPS = map(tempADC, configPage2.tpsMax, configPage2.tpsMin, 0, 100);
   }
 
-  //Check whether the idle switch is active
-  if(configPage2.idleSwitchEnabled == true)
+  //Check whether the closed throttle position sensor is active
+  if(configPage2.CTPSEnabled == true)
   {
-    if(configPage2.idleSwitchPolarity == 0) { currentStatus.idleSwitchActive = !digitalRead(pinIdleSwitch); } //Normal mode (ground switched)
-    else { currentStatus.idleSwitchActive = digitalRead(pinIdleSwitch); } //Inverted mode (5v activates idleSwitch)
+    if(configPage2.CTPSPolarity == 0) { currentStatus.CTPSActive = !digitalRead(pinCTPS); } //Normal mode (ground switched)
+    else { currentStatus.CTPSActive = digitalRead(pinCTPS); } //Inverted mode (5v activates closed throttle position sensor)
   }
-  else { currentStatus.idleSwitchActive = 0; }
+  else { currentStatus.CTPSActive = 0; }
   TPS_time = micros();
 }
 

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -307,6 +307,13 @@ void readTPS()
     currentStatus.TPS = map(tempADC, configPage2.tpsMax, configPage2.tpsMin, 0, 100);
   }
 
+  //Check whether the idle switch is active
+  if(configPage2.idleSwitchEnabled == true)
+  {
+    if(configPage2.idleSwitchPolarity == 0) { currentStatus.idleSwitchActive = !digitalRead(pinIdleSwitch); } //Normal mode (ground switched)
+    else { currentStatus.idleSwitchActive = digitalRead(pinIdleSwitch); } //Inverted mode (5v activates idleSwitch)
+  }
+  else { currentStatus.idleSwitchActive = 0; }
   TPS_time = micros();
 }
 


### PR DESCRIPTION
I added a new setting for idle ignition timing correction. Idle advance correction is useful if you don't have a idle air control valve or if idle control valve doesn't respond quick enough to sudden load changes.  This has been possible earlier by tweaking the main spark table but this makes it easier and allows better overall control.

This feature uses closed loop iac target rpm table and adjusts ignition advance at idle based on difference between current rpm and target idle rpm if conditions are met. Conditions are pretty basic at this time: active below TPS and active below RPM. Some oem throttle bodies or throttle position sensors have a separate idle switch and I added possibility to use it instead of TPS value.

Idle advance correction can be added to main spark table values or switched so when idle state is detected main spark table is ignored and ignition timing is what you set in the idle advance correction curve.

![idleadvancesettings](https://user-images.githubusercontent.com/3372213/68089041-c0243700-fe6d-11e9-9462-b055a6f9c954.png)