### PR TITLE
Fix idle advance delay and add baro correction comms

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -321,7 +321,7 @@ page = 1
       CTPSEnabled   = bits,  U08,  91, [7:7], "Off", "On"
       idleAdvEnabled      = bits,  U08,  92, [0:1], "Off", "Added", "Switched", "INVALID"
       idleAdvAlgorithm    = bits,  U08,  92, [2:2], "TPS", "CTPS"
-      IdleAdvDelay        = bits,  U08,  92, [3:7], "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "INVALID", "INVALID"
+      idleAdvDelay        = bits,  U08,  92, [3:7], "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "INVALID", "INVALID"
       idleAdvRPM   = scalar,  U08,      93,       "rpm",        100,       0.0,   100,   25500,      0
       idleAdvTPS   = scalar,  U08,      94,         "%",          1,         0,     0,     120,      0
 
@@ -1382,7 +1382,7 @@ menuDialog = main
     idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
     idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
     idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
-    idleAdvDelay= "The number of seconds after sync is achieved before the idle advvance control begins"
+    idleAdvDelay= "The number of seconds after sync is achieved before the idle advance control begins"
 
 	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
@@ -3183,6 +3183,7 @@ cmdtestspk450dc = "E\x03\x0C"
     aseEnrichGauge    = ase_enrich,    "Afterstart Enrichment","%",     0,   200,    130,   140,  140,  150, 0, 0
     batCorrectGauge   = batCorrection, "Voltage Correction", "%",       0,   200,    130,   140,  140,  150, 0, 0
     iatCorrectGauge   = airCorrection, "IAT Correction",     "%",       0,   200,    130,   140,  140,  150, 0, 0
+    baroCorrectGauge  = baroCorrection,"Baro Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
     flexEnrich        = flexFuelCor,   "Flex Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
     advanceGauge      = advance,       "Spark Advance",      "deg BTDC", 50, -10,      0,     0,    35,    45, 0, 0
     dwellGauge        = dwell,         "Ign Dwell",          "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
@@ -3296,7 +3297,7 @@ cmdtestspk450dc = "E\x03\x0C"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  98
+   ochBlockSize     =  99
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -3403,6 +3404,7 @@ cmdtestspk450dc = "E\x03\x0C"
    vvtTarget        = scalar,   U08,    94, "deg",    1.00, 0.000
    vvtDuty          = scalar,   U08,    95, "%",      1.00, 0.000
    flexBoostCor     = scalar,   S16,    96, "kPa",  1.000, 0.000
+   baroCorrection   = scalar,   U08,    98, "%",      1.000, 0.000
 
 #if CELSIUS
    coolant          = { coolantRaw - 40                               } ; Temperature readings are offset by 40 to allow for negatives
@@ -3487,7 +3489,7 @@ cmdtestspk450dc = "E\x03\x0C"
    entry = airCorrection,   "Gair",         int,    "%d"
    entry = batCorrection,   "Gbattery",     int,    "%d"
    entry = warmupEnrich,    "Gwarm",        int,    "%d"
-   ;entry = baroCorrection,  "Gbaro",       int,    "%d"
+   entry = baroCorrection,  "Gbaro",        int,    "%d"
    entry = gammaEnrich,     "Gammae",       int,     "%d"
    entry = accelEnrich,     "Accel Enrich", int,     "%d"
    entry = veCurr,          "Current VE",   int,     "%d"

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -22,7 +22,7 @@
 #define warmupPage   10 //Config Page 10
 #define fuelMap2Page 11
 
-#define SERIAL_PACKET_SIZE   98 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+#define SERIAL_PACKET_SIZE   99 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
 
 byte currentPage = 1;//Not the same as the speeduino config page numbers
 bool isMap = true; /**< Whether or not the currentPage contains only a 3D map that would require translation */

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -613,6 +613,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
   fullStatus[95] = currentStatus.vvtDuty;
   fullStatus[96] = lowByte(currentStatus.flexBoostCorrection);
   fullStatus[97] = highByte(currentStatus.flexBoostCorrection);
+  fullStatus[98] = currentStatus.baroCorrection;
 
   for(byte x=0; x<packetLength; x++)
   {

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -17,7 +17,7 @@ static inline byte correctionAFRClosedLoop() __attribute__((always_inline)); //C
 static inline byte correctionFlex() __attribute__((always_inline)); //Flex fuel adjustment
 static inline byte correctionBatVoltage() __attribute__((always_inline)); //Battery voltage correction
 static inline byte correctionIATDensity() __attribute__((always_inline)); //Inlet temp density correction
-static inline byte correctionBaro() __attribute__((always_inline)); //Inlet temp density correction
+static inline byte correctionBaro() __attribute__((always_inline)); //Barometric pressure correction
 static inline byte correctionLaunch() __attribute__((always_inline)); //Launch control correction
 static inline bool correctionDFCO() __attribute__((always_inline)); //Decelleration fuel cutoff
 


### PR DESCRIPTION
There was a small typo preventing idle advance delay field to show in tunerstudio.
Added baro correction output channel too.