### PR TITLE
Add H-Bridge DC Motor idle control method

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1822,7 +1822,7 @@ menuDialog = main
         field = "Fan temperature SP",  		 fanSP, { fanEnable }
         field = "Fan hysteresis", 		 fanHyster, { fanEnable }
 
-    dialog = idle_settings,""
+    dialog = main_idle, ""
         field = "Idle control type",     iacAlgorithm
         field = "Enable before start",   idleEngOff,            { iacAlgorithm == 2 || iacAlgorithm == 6 }
 
@@ -1834,8 +1834,8 @@ menuDialog = main
         field = "Cool time (ms)",       iacCoolTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Home steps",           iacStepHome,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Minimum Steps",		iacStepHyster,			{ iacAlgorithm == 4 || iacAlgorithm == 5 }
-        field = "Don't exceed",           iacMaxSteps,          { iacAlgorithm == 4 || iacAlgorithm == 5 } 
-        field = "Stepper Inverted", iacStepperInv,              { iacAlgorithm == 4 || iacAlgorithm == 5 }
+        field = "Don't exceed",         iacMaxSteps,            { iacAlgorithm == 4 || iacAlgorithm == 5 } 
+        field = "Stepper Inverted",     iacStepperInv,          { iacAlgorithm == 4 || iacAlgorithm == 5 }
 
     dialog = pwm_idle, "PWM Idle"
         field = "Number of outputs",    iacChannels,            { iacAlgorithm == 2 || iacAlgorithm == 3 }
@@ -1854,18 +1854,18 @@ menuDialog = main
         field = "Maximum valve duty",   iacCLmaxDuty,           { iacAlgorithm == 3 || iacAlgorithm == 6 }
 
     dialog = hbridge_idle, "H-Bridge DC Motor Idle"
-        field = "H-Bridge driver",      hbDriver,               { iacAlgorithm == 6 }
-        field = "Direction pin 1",     hbDirPin1,               { iacAlgorithm == 6 && hbDriver == 1 }
-        field = "Direction pin 2",     hbDirPin2,               { iacAlgorithm == 6 && hbDriver == 1 }
-        field = "ITPS input pin",        itpsPin,               { iacAlgorithm == 6 }
-        field = "ITPS Min opening value", itpsMin,              { iacAlgorithm == 6 }
-        field = "ITPS Max opening value", itpsMax,              { iacAlgorithm == 6 }
-        field = "CTPS enabled",      ctpsEnabled
-        field = "CTPS input pin",        ctpsPin,               { ctpsEnabled == 1 }
-        field = "CTPS polarity",    ctpsPolarity,               { ctpsEnabled == 1 }
+        field = "H-Bridge driver",        hbDriver,             { iacAlgorithm == 6 }
+        field = "Direction pin 1",        hbDirPin1,            { iacAlgorithm == 6 && hbDriver == 1 }
+        field = "Direction pin 2",        hbDirPin2,            { iacAlgorithm == 6 && hbDriver == 1 }
+        field = "ITPS input pin",         itpsPin,              { iacAlgorithm == 6 }
+        field = "ITPS Min value",         itpsMin,              { iacAlgorithm == 6 }
+        field = "ITPS Max value",         itpsMax,              { iacAlgorithm == 6 }
+        field = "CTPS enabled",           ctpsEnabled
+        field = "CTPS input pin",         ctpsPin,              { ctpsEnabled == 1 }
+        field = "CTPS polarity",          ctpsPolarity,         { ctpsEnabled == 1 }
 
     dialog = idle_west, ""
-        panel = idle_settings
+        panel = main_idle
         panel = fast_idle
         panel = pwm_idle
         panel = closedloop_idle

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -998,7 +998,10 @@ page = 10
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
 
-        unused11_122_191    = array,  U08,    134,  [57], "RPM",  100.0,      0.0,  100,     25500,    0
+        idleSens            = scalar, U16,     134,      "",           1,     0,    0,   5000,      0
+        idleIntv            = scalar, U08,     136,      "ms",         1,     0,    0,    250,      0
+
+        unused11_137_191    = array,  U08,     137,  [55], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1135,6 +1138,8 @@ page = 11
     defaultValue = fanPin,      0
     defaultValue = iacCLminDuty,0
     defaultValue = iacCLmaxDuty,100
+    defaultValue = idleSens,    2000
+    defaultValue = idleIntv,    30
     defaultValue = boostMinDuty,0
     defaultValue = boostMaxDuty,100
     defaultValue = boostSens,   2000
@@ -1840,6 +1845,8 @@ menuDialog = main
     	field = "Idle valve direction", iacPWMdir,				{ iacAlgorithm == 2 || iacAlgorithm == 3 }
 
     dialog = closedloop_idle, "Closed loop Idle"
+        slider = "Sensitivity",         idleSens,   horizontal, { iacAlgorithm == 6 }
+        field = "Control interval",     idleIntv,     			{ iacAlgorithm == 6 }
         field = "P",                    idleKP,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
         field = "I",                    idleKI,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
         field = "D",                    idleKD,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
@@ -3268,6 +3275,7 @@ cmdtestspk450dc = "E\x03\x0C"
 
     tpsADCGauge       = tpsADC,        "TPS ADC",            "",        0,   255,     -1,    -1,  256,  256, 0, 0
     throttleGauge     = throttle,      "Throttle Position",  "%TPS",    0,   100,     -1,     1,   90,  100, 0, 0
+    itpsADCGauge      = itpsADC,       "ITPS ADC",           "",        0,   255,     -1,    -1,  256,  256, 0, 0
     idlethrottleGauge = idlethrottle,  "Idle Throttle Position",   "%ITPS",   0,   100,     -1,     1,   90,  100, 0, 0
 
     afrGauge          = afr,           "Air:Fuel Ratio",     "",        7,    25,     12,    13,   15,   16, 2, 2
@@ -3362,7 +3370,7 @@ cmdtestspk450dc = "E\x03\x0C"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  100
+   ochBlockSize     =  101
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -3471,6 +3479,7 @@ cmdtestspk450dc = "E\x03\x0C"
    flexBoostCor     = scalar,   S16,    96, "kPa",    1.000, 0.000
    baroCorrection   = scalar,   U08,    98, "%",      1.000, 0.000
    idletps          = scalar,   U08,    99, "%",      1.000, 0.000
+   itpsADC          = scalar,   U08,    100, "%",     1.000, 0.000
 
 #if CELSIUS
    coolant          = { coolantRaw - 40                               } ; Temperature readings are offset by 40 to allow for negatives

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1853,9 +1853,9 @@ menuDialog = main
         field = "ITPS input pin",        itpsPin,               { iacAlgorithm == 6 }
         field = "ITPS Min opening value", itpsMin,              { iacAlgorithm == 6 }
         field = "ITPS Max opening value", itpsMax,              { iacAlgorithm == 6 }
-        field = "CTPS enabled",      ctpsEnabled,               { iacAlgorithm == 6 }
-        field = "CTPS input pin",        ctpsPin,               { iacAlgorithm == 6 && ctpsEnabled == 1 }
-        field = "CTPS polarity",    ctpsPolarity,               { iacAlgorithm == 6 && ctpsEnabled == 1 }
+        field = "CTPS enabled",      ctpsEnabled
+        field = "CTPS input pin",        ctpsPin,               { ctpsEnabled == 1 }
+        field = "CTPS polarity",    ctpsPolarity,               { ctpsEnabled == 1 }
 
     dialog = idle_west, ""
         panel = idle_settings
@@ -1979,9 +1979,9 @@ menuDialog = main
         field = "Delay before idle control starts (s)",idleAdvDelay,         { idleAdvEnabled >= 1 }
         field = "Active Below RPM",                    idleAdvRPM,           { idleAdvEnabled >= 1 }
         field = "Active Below TPS",                    idleAdvTPS,           { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
-	    field = "CTPS Enabled",                        ctpsEnabled,          { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
-        field = "CTPS Pin",                            ctpsPin,              { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && ctpsEnabled == 1 }
-        field = "CTPS Polarity",                       ctpsPolarity,         { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && ctpsEnabled == 1 }
+	    field = "CTPS Enabled",                        ctpsEnabled
+        field = "CTPS Pin",                            ctpsPin,              { ctpsEnabled == 1 }
+        field = "CTPS Polarity",                       ctpsPolarity,         { ctpsEnabled == 1 }
 
     dialog = idleAdvanceSettings,"Idle Advance Settings", xAxis
         panel = idleAdvanceSettings_east

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -46,7 +46,7 @@
     rpmwarn = scalar,   U16,    "rpm", 1, 0, 0, 30000, 0
     rpmdang = scalar,   U16,    "rpm", 1, 0, 0, 30000, 0
 
-    idleUnits = bits,   U08,    [0:2], "None", "On/Off", "Duty Cycle", "Duty Cycle", "Steps", "Steps"
+    idleUnits = bits,   U08,    [0:2], "None", "On/Off", "Duty Cycle", "Duty Cycle", "Steps", "Steps", "Duty Cycle"
 
 
     #define loadSourceNames = "MAP", "TPS", "IMAP/EMAP", "INVALID",   "INVALID", "INVALID", "INVALID", "INVALID"
@@ -300,7 +300,7 @@ page = 1
       EMAPMin       = scalar, S08,      67,        "kpa",       1.0,       0.0,  -100,     127.0,    0
       EMAPMax       = scalar, U16,      68,        "kpa",       1.0,       0.0,   0.0,     25500,    0
 
-      fanWhenOff   = bits,   U08,     70, [0:0], "No",        "Yes" 
+      fanWhenOff    = bits,   U08,     70, [0:0], "No",        "Yes" 
       unused_fan_bits = bits,  U08,    70,[1:7]
 
       asePct        = array,  U08,       71, [4],    "%",        1.0,       0.0,     0,    155,       0
@@ -316,17 +316,33 @@ page = 1
 #else
       primeBins     = array,  U08,       87, [4],  "F", 1.8,    -22.23,    -40,    215,      0
 #endif
-      CTPSPin       = bits,  U08,  91, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
-      CTPSPolarity  = bits,  U08,  91, [6:6], "Normal", "Inverted"
-      CTPSEnabled   = bits,  U08,  91, [7:7], "Off", "On"
-      idleAdvEnabled      = bits,  U08,  92, [0:1], "Off", "Added", "Switched", "INVALID"
-      idleAdvAlgorithm    = bits,  U08,  92, [2:2], "TPS", "CTPS"
-      idleAdvDelay        = bits,  U08,  92, [3:7], "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "INVALID", "INVALID"
-      idleAdvRPM   = scalar,  U08,      93,       "rpm",        100,       0.0,   100,   25500,      0
-      idleAdvTPS   = scalar,  U08,      94,         "%",          1,         0,     0,     120,      0
+;Closed throttle positon switch
+      ctpsPin       = bits,   U08,       91, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
+      ctpsPolarity  = bits,   U08,       91, [6:6], "Normal", "Inverted"
+      ctpsEnabled   = bits,   U08,       91, [7:7], "Off", "On"
 
-      unused2-95    = array,  U08,      95, [33],   "%",        1.0,       0.0,   0.0,     255,      0
+;Idle advance settings
+      idleAdvEnabled  = bits, U08,       92, [0:1], "Off", "Added", "Switched", "INVALID"
+      idleAdvAlgorithm= bits, U08,       92, [2:2], "TPS", "CTPS"
+      idleAdvDelay  = bits,   U08,       92, [3:7], "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "INVALID", "INVALID"
+      idleAdvRPM    = scalar, U08,       93,       "rpm",        100,       0.0,   100,   25500,      0
+      idleAdvTPS    = scalar, U08,       94,         "%",          1,         0,     0,     120,      0
 
+  	  itpsMin       = scalar, U08,       95,        "ADC",       1.0,       0.0,   0.0,   255.0,      0
+      itpsMax       = scalar, U08,      96,        "ADC",       1.0,       0.0,   0.0,   255.0,      0
+      itpsPin       = bits,   U08,      97, [0:3], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A8", "A10", "A11", "A12", "A13", "A14", "A15"
+      idleEngOff    = bits,   U08,      97, [4:5], "Disabled", "Enabled", "INVALID", "INVALID"
+      hbDriver      = bits,   U08,      97, [6:7], "None", "VNH2SP30", "INVALID", "INVALID"
+      idlePin1	    = bits,   U08,      98, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      unused_idle_bits1 = bits, U08,    98, [6:7]
+      idlePin2	    = bits,   U08,      99, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      unused_idle_bits2 = bits, U08,    99, [6:7]
+      hbDirPin1     = bits,   U08,      100, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      unused_idle_bits3 = bits, U08,    100, [6:7]
+      hbDirPin2     = bits,   U08,      101, [0:5], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      unused_idle_bits4 = bits, U08,    101, [6:7]
+
+      unused2-102   = array,  U08,      102,  [26],   "%",       1.0,       0.0,   0.0,     255,      0
 ;Page 2 is the fuel map and axis bins only
 page = 2
    ;  name       = bits,   type,    offset, bits
@@ -568,7 +584,7 @@ page = 6
         iacCrankBins = array, U08,      112, [4],        "F",        1.8,    -22.23,    -40,    215,      0
     #endif
 
-        iacAlgorithm = bits , U08,      116, [0:2],      "None", "On/Off", "PWM Open loop", "PWM Closed loop", "Stepper Open Loop", "Stepper Closed Loop", "INVALID", "INVALID"
+        iacAlgorithm = bits , U08,      116, [0:2],      "None", "On/Off", "PWM Open loop", "PWM Closed loop", "Stepper Open Loop", "Stepper Closed Loop", "H-Bridge DC Motor", "INVALID"
         iacStepTime  = bits , U08,      116, [3:5],      "INVALID","1", "2", "3", "4", "5", "6","INVALID"
         iacChannels  = bits,  U08,      116, [6:6],      "1", "2"
         iacPWMdir    = bits , U08,      116, [7:7],      "Normal", "Reverse"
@@ -1039,12 +1055,17 @@ page = 11
     requiresPowerCycle = knock_trigger
     requiresPowerCycle = knock_pullup
     requiresPowerCycle = idleUpEnabled
-    requiresPowerCycle = CTPSEnabled
-    requiresPowerCycle = CTPSPin
-    requiresPowerCycle = CTPSPolarity
+    requiresPowerCycle = ctpsEnabled
+    requiresPowerCycle = ctpsPin
+    requiresPowerCycle = ctpsPolarity
     requiresPowerCycle = legacyMAP
     requiresPowerCycle = fuel2InputPin
     requiresPowerCycle = fuel2InputPolarity
+    requiresPowerCycle = idlePin1
+    requiresPowerCycle = idlePin2
+    requiresPowerCycle = itpsPin
+    requiresPowerCycle = hbDirPin1
+    requiresPowerCycle = hbDirPin2
 
 	requiresPowerCycle = caninput_sel0a
 	requiresPowerCycle = caninput_sel0b
@@ -1136,8 +1157,17 @@ page = 11
     defaultValue = legacyMAP, 0
     defaultValue = battVCorMode, 1
     defaultValue = idleAdvEnabled, 0 ;Idle advance control turned off
+    defaultValue = itpsMin, 1
+    defaultValue = itpsMax, 250
+    defaultValue = idleEngOff, 0
+    defaultValue = hbDriver, 0
 
     ;Default pins
+    defaultValue = idlePin1,  	0
+    defaultValue = idlePin2,  	0
+    defaultValue = itpsPin,     0
+    defaultValue = hbDirPin1,   0
+    defaultValue = hbDirPin2,   0
     defaultValue = fanPin,      0
     defaultValue = vvtPin,      0
     defaultValue = launchPin,   0
@@ -1263,14 +1293,14 @@ menuDialog = main
         subMenu = warmup,               "Warmup Enrichment"
         subMenu = ASE,                  "Afterstart Enrichment (ASE)"
         subMenu = std_separator
-        subMenu = idleSettings,         "Idle Control"
+        subMenu = idle_settings,        "Idle Control"
         subMenu = iacClosedLoop_curve,  "Idle - RPM targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 || idleAdvEnabled >= 1 }
-        subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 }
-        subMenu = iacPwmCrank_curve,    "Idle - PWM Cranking Duty Cycle", 7, { iacAlgorithm == 2 }
+        subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6 }
+        subMenu = iacPwmCrank_curve,    "Idle - PWM Cranking Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6 }
         subMenu = iacStep_curve,        "Idle - Stepper Motor", 7, { iacAlgorithm == 4 }
         subMenu = iacStepCrank_curve,   "Idle - Stepper Motor Cranking", 7, { iacAlgorithm == 4 }
         subMenu = std_separator
-        subMenu = idleUpSettings,       "Idle Up Settings", { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 4 || iacAlgorithm == 5 }
+        subMenu = idleUpSettings,       "Idle Up Settings", { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 6 }
         subMenu = std_separator
         subMenu = idleAdvanceSettings,  "Idle Advance Settings"
 
@@ -1368,7 +1398,7 @@ menuDialog = main
 
 	iacChannels = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
 	iacStepTime = "Pause time between each step. Values that are too low can cause the motor to behave erratically or not at all"
-  iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
+    iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
   
     iacStepHome = "Homing steps to perform on startup. Must be greater than the fully open steps value"
     iacMaxSteps = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
@@ -1379,11 +1409,16 @@ menuDialog = main
 	iacCLmaxDuty= "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
 	iacFastTemp = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
     idleUpPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
-    CTPSPolarity = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
     idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
     idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
-    idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
-    idleAdvDelay= "The number of seconds after sync is achieved before the idle advance control begins"
+    idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position switch (CTPS) to detect idle state."
+    idleAdvDelay = "The number of seconds after sync is achieved before the idle advance control begins"
+    ctpsEnabled = "This should only be enabled if you have a physical closed throttle position switch"
+    ctpsPolarity = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
+    idleEngOff  = "If enabled the idle valve will run even if the engine is off."
+    itpsPin     = "This is the input pin for a idle range throttle position sensor"
+    itpsMin     = "This is the value of minimum throttle flap opening"
+    itpsMax     = "This is the value of maximum throttle flap opening"
 
 	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
@@ -1782,34 +1817,60 @@ menuDialog = main
         field = "Fan temperature SP",  		 fanSP, { fanEnable }
         field = "Fan hysteresis", 		 fanHyster, { fanEnable }
 
+    dialog = idle_settings,""
+        field = "Idle control type",     iacAlgorithm
+        field = "Enable before start",   idleEngOff,            { iacAlgorithm == 2 || iacAlgorithm == 6 }
+
+    dialog = fast_idle, "Fast Idle"
+        field = "Fast idle temperature", iacFastTemp,           { iacAlgorithm == 1 }
+
     dialog = stepper_idle, "Stepper Idle"
         field = "Step time (ms)",       iacStepTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Cool time (ms)",       iacCoolTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Home steps",           iacStepHome,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Minimum Steps",		iacStepHyster,			{ iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Don't exceed",           iacMaxSteps,          { iacAlgorithm == 4 || iacAlgorithm == 5 } 
-        field = "Stepper Inverted", iacStepperInv,       { iacAlgorithm == 4 || iacAlgorithm == 5 }
+        field = "Stepper Inverted", iacStepperInv,              { iacAlgorithm == 4 || iacAlgorithm == 5 }
 
     dialog = pwm_idle, "PWM Idle"
         field = "Number of outputs",    iacChannels,            { iacAlgorithm == 2 || iacAlgorithm == 3 }
-    	field = "Idle valve frequency",	idleFreq,				{ iacAlgorithm == 2 || iacAlgorithm == 3 }
+		field = "PWM output pin 1",     idlePin1,               { iacAlgorithm == 2 || iacAlgorithm == 3 || (iacAlgorithm == 6 && hbDriver == 1) }
+		field = "PWM output pin 2",     idlePin2,               { iacChannels && (iacAlgorithm == 2 || iacAlgorithm == 3)}
+    	field = "Idle valve frequency",	idleFreq,				{ iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }
     	field = "Idle valve direction", iacPWMdir,				{ iacAlgorithm == 2 || iacAlgorithm == 3 }
 
     dialog = closedloop_idle, "Closed loop Idle"
-        field = "P",                    idleKP,                 { iacAlgorithm == 3 || iacAlgorithm == 5 }
-        field = "I",                    idleKI,                 { iacAlgorithm == 3 || iacAlgorithm == 5 }
-        field = "D",                    idleKD,                 { iacAlgorithm == 3 || iacAlgorithm == 5 }
-        field = "Minimum valve duty",   iacCLminDuty,           { iacAlgorithm == 3 }
-        field = "Maximum valve duty",   iacCLmaxDuty,           { iacAlgorithm == 3 }
+        field = "P",                    idleKP,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
+        field = "I",                    idleKI,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
+        field = "D",                    idleKD,                 { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 }
+        field = "Minimum valve duty",   iacCLminDuty,           { iacAlgorithm == 3 || iacAlgorithm == 6 }
+        field = "Maximum valve duty",   iacCLmaxDuty,           { iacAlgorithm == 3 || iacAlgorithm == 6 }
 
-    dialog = idleSettings, "Idle Settings"
-	    topicHelp = "http://speeduino.com/wiki/index.php/Idle"
-	    field = "Idle control type",    iacAlgorithm
-        field = "#Fast Idle"
-        field = "Fast idle temp",       iacFastTemp,            { iacAlgorithm == 1 }
+    dialog = hbridge_idle, "H-Bridge DC Motor Idle"
+        field = "H-Bridge driver",      hbDriver,               { iacAlgorithm == 6 }
+        field = "Direction pin 1",     hbDirPin1,               { iacAlgorithm == 6 && hbDriver == 1 }
+        field = "Direction pin 2",     hbDirPin2,               { iacAlgorithm == 6 && hbDriver == 1 }
+        field = "ITPS input pin",        itpsPin,               { iacAlgorithm == 6 }
+        field = "ITPS Min opening value", itpsMin,              { iacAlgorithm == 6 }
+        field = "ITPS Max opening value", itpsMax,              { iacAlgorithm == 6 }
+        field = "CTPS enabled",      ctpsEnabled,               { iacAlgorithm == 6 }
+        field = "CTPS input pin",        ctpsPin,               { iacAlgorithm == 6 && ctpsEnabled == 1 }
+        field = "CTPS polarity",    ctpsPolarity,               { iacAlgorithm == 6 && ctpsEnabled == 1 }
+
+    dialog = idle_west, ""
+        panel = idle_settings
+        panel = fast_idle
         panel = pwm_idle
-        panel = stepper_idle
         panel = closedloop_idle
+
+    dialog = idle_east, ""
+        panel = stepper_idle
+        panel = hbridge_idle
+
+    dialog = idle_settings, "Idle Control", border
+        topicHelp = "http://speeduino.com/wiki/index.php/Idle"
+        panel = idle_west,  West
+        panel = idle_east,  East
 
     dialog = idleUpSettings, "Idle Up Settings"
         field = "Idle Up Enabled",      idleUpEnabled
@@ -1914,13 +1975,13 @@ menuDialog = main
 		
     dialog = idleAdvanceSettings_east
         field = "Idle advance mode",                   idleAdvEnabled
-        field = "Idle detect mode",                    idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
+        field = "Idle state detect method",                    idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
         field = "Delay before idle control starts (s)",idleAdvDelay,         { idleAdvEnabled >= 1 }
-		field = "Active Below RPM",                    idleAdvRPM,           { idleAdvEnabled >= 1 }
+        field = "Active Below RPM",                    idleAdvRPM,           { idleAdvEnabled >= 1 }
         field = "Active Below TPS",                    idleAdvTPS,           { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
-		field = "Closed Throttle Sensor Enabled",      CTPSEnabled,          { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
-        field = "Closed Throttle Sensor Pin",          CTPSPin,              { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
-        field = "Closed Throttle Sensor Pin Polarity", CTPSPolarity,         { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
+	    field = "CTPS Enabled",                        ctpsEnabled,          { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
+        field = "CTPS Pin",                            ctpsPin,              { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && ctpsEnabled == 1 }
+        field = "CTPS Polarity",                       ctpsPolarity,         { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && ctpsEnabled == 1 }
 
     dialog = idleAdvanceSettings,"Idle Advance Settings", xAxis
         panel = idleAdvanceSettings_east
@@ -3207,6 +3268,7 @@ cmdtestspk450dc = "E\x03\x0C"
 
     tpsADCGauge       = tpsADC,        "TPS ADC",            "",        0,   255,     -1,    -1,  256,  256, 0, 0
     throttleGauge     = throttle,      "Throttle Position",  "%TPS",    0,   100,     -1,     1,   90,  100, 0, 0
+    idlethrottleGauge = idlethrottle,  "Idle Throttle Position",   "%ITPS",   0,   100,     -1,     1,   90,  100, 0, 0
 
     afrGauge          = afr,           "Air:Fuel Ratio",     "",        7,    25,     12,    13,   15,   16, 2, 2
     afrGauge2         = afr2,          "Air:Fuel Ratio 2",   "",        7,    25,     12,    13,   15,   16, 2, 2
@@ -3300,7 +3362,7 @@ cmdtestspk450dc = "E\x03\x0C"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  99
+   ochBlockSize     =  100
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -3406,8 +3468,9 @@ cmdtestspk450dc = "E\x03\x0C"
    vvtAngle         = scalar,   S08,    93, "deg",    1.00, 0.000
    vvtTarget        = scalar,   U08,    94, "deg",    1.00, 0.000
    vvtDuty          = scalar,   U08,    95, "%",      1.00, 0.000
-   flexBoostCor     = scalar,   S16,    96, "kPa",  1.000, 0.000
+   flexBoostCor     = scalar,   S16,    96, "kPa",    1.000, 0.000
    baroCorrection   = scalar,   U08,    98, "%",      1.000, 0.000
+   idletps          = scalar,   U08,    99, "%",      1.000, 0.000
 
 #if CELSIUS
    coolant          = { coolantRaw - 40                               } ; Temperature readings are offset by 40 to allow for negatives
@@ -3420,6 +3483,7 @@ cmdtestspk450dc = "E\x03\x0C"
    seconds          = { secl                                          }
 
    throttle         = { tps }, "%"
+   idlethrottle     = { idletps }, "%"
 
    revolutionTime   = { rpm ? ( 60000.0 / rpm) : 0                    }
    strokeMultipler  = { twoStroke == 1 ? 1 : 2                        }

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -22,7 +22,7 @@
 #define warmupPage   10 //Config Page 10
 #define fuelMap2Page 11
 
-#define SERIAL_PACKET_SIZE   99 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+#define SERIAL_PACKET_SIZE   100 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
 
 byte currentPage = 1;//Not the same as the speeduino config page numbers
 bool isMap = true; /**< Whether or not the currentPage contains only a 3D map that would require translation */

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -22,7 +22,7 @@
 #define warmupPage   10 //Config Page 10
 #define fuelMap2Page 11
 
-#define SERIAL_PACKET_SIZE   100 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+#define SERIAL_PACKET_SIZE   101 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
 
 byte currentPage = 1;//Not the same as the speeduino config page numbers
 bool isMap = true; /**< Whether or not the currentPage contains only a 3D map that would require translation */

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -615,6 +615,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
   fullStatus[97] = highByte(currentStatus.flexBoostCorrection);
   fullStatus[98] = currentStatus.baroCorrection;
   fullStatus[99] = currentStatus.ITPS; // ITPS (0% to 100%)
+  fullStatus[100] = currentStatus.itpsADC;
 
   for(byte x=0; x<packetLength; x++)
   {

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -614,6 +614,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
   fullStatus[96] = lowByte(currentStatus.flexBoostCorrection);
   fullStatus[97] = highByte(currentStatus.flexBoostCorrection);
   fullStatus[98] = currentStatus.baroCorrection;
+  fullStatus[99] = currentStatus.ITPS; // ITPS (0% to 100%)
 
   for(byte x=0; x<packetLength; x++)
   {

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -551,7 +551,7 @@ static inline int8_t correctionIdleAdvance(int8_t advance)
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }
       else if(configPage2.idleAdvEnabled == 2) { ignIdleValue = advanceIdleAdjust; }
     }
-    else if(configPage2.idleAdvAlgorithm == 1 && (currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100) && currentStatus.CTPSActive == 1)) // closed throttle position sensor (CTPS) based idle state
+    else if(configPage2.idleAdvAlgorithm == 1 && (currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100) && currentStatus.ctpsActive == 1)) // closed throttle position sensor (CTPS) based idle state
     {
       int8_t advanceIdleAdjust = (int16_t)(table2D_getValue(&idleAdvanceTable, idleRPMdelta)) - 15;
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -437,7 +437,7 @@ struct statuses {
   byte flexCorrection; /**< Amount of correction being applied to compensate for ethanol content */
   int8_t flexIgnCorrection; /**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
   byte afrTarget;
-  long idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
+  uint16_t idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
   byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
   bool ctpsActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
@@ -1010,7 +1010,10 @@ struct config10 {
   uint16_t vvtCLMinAng;
   uint16_t vvtCLMaxAng;
 
-  byte unused11_123_191[58];
+  uint16_t idleSens;
+  byte idleIntv;
+  
+  byte unused11_137_191[55];
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -387,7 +387,7 @@ volatile byte LOOP_TIMER;
 //These functions all do checks on a pin to determine if it is already in use by another (higher importance) function
 #define pinIsInjector(pin)  ( ((pin) == pinInjector1) || ((pin) == pinInjector2) || ((pin) == pinInjector3) || ((pin) == pinInjector4) )
 #define pinIsIgnition(pin)  ( ((pin) == pinCoil1) || ((pin) == pinCoil2) || ((pin) == pinCoil3) || ((pin) == pinCoil4) )
-#define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinO2) || ((pin) == pinBat) )
+#define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinITPS) || ((pin) == pinO2) || ((pin) == pinBat) )
 #define pinIsUsed(pin)      ( pinIsInjector((pin)) || pinIsIgnition((pin)) || pinIsSensor((pin)) )
 #define pinIsOutput(pin)    ( ((pin) == pinFuelPump) || ((pin) == pinFan) || ((pin) == pinVVT_1) || ((pin) == pinVVT_2) || ((pin) == pinBoost) || ((pin) == pinIdle1) || ((pin) == pinIdle2) || ((pin) == pinTachOut) )
 
@@ -405,6 +405,8 @@ struct statuses {
   byte baro; //Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
   byte TPS; /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
   byte tpsADC; /**< 0-255 byte representation of the TPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
+  long ITPS; /**< The current ITPS reading (0% - 100%). Is the itpsADC value after the calibration is applied */
+  byte itpsADC; /**< 0-255 byte representation of the ITPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
   byte tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
   byte mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
   volatile int rpmDOT;
@@ -435,10 +437,10 @@ struct statuses {
   byte flexCorrection; /**< Amount of correction being applied to compensate for ethanol content */
   int8_t flexIgnCorrection; /**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
   byte afrTarget;
-  byte idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
+  long idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
   byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
-  bool CTPSActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
+  bool ctpsActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
   bool fanOn; /**< Whether or not the fan is turned on */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
@@ -606,15 +608,30 @@ struct config2 {
   byte primePulse[4]; //Priming pulsewidth
   byte primeBins[4]; //Priming temp axis
 
-  byte CTPSPin : 6;
-  byte CTPSPolarity : 1;
-  byte CTPSEnabled : 1;
+  byte ctpsPin : 6;
+  byte ctpsPolarity : 1;
+  byte ctpsEnabled : 1;
   byte idleAdvEnabled : 2;
   byte idleAdvAlgorithm : 1;
   byte IdleAdvDelay : 5;
   byte idleAdvRPM;
   byte idleAdvTPS;
-  byte unused2_95[33];
+
+  byte itpsMin;
+  byte itpsMax;
+  byte itpsPin : 4;
+  byte idleEngOff : 2;
+  byte hbDriver : 2;
+  byte pinIdle1 : 6;
+  byte unused_idle_bits1 : 2;
+  byte pinIdle2 : 6;
+  byte unused_idle_bits2 : 2;
+  byte hbDirPin1 : 6;
+  byte unused_idle_bits3 : 2;
+  byte hbDirPin2 : 6;
+  byte unused_idle_bits4 : 2;
+
+  byte unused2_102[26];
 
 #if defined(CORE_AVR)
   };
@@ -1034,8 +1051,11 @@ byte pinTachOut; //Tacho output
 byte pinFuelPump; //Fuel pump on/off
 byte pinIdle1; //Single wire idle control
 byte pinIdle2; //2 wire idle control (Not currently used)
+byte pinHBdir1; //H-bridge Idle direction pin 1
+byte pinHBdir2; //H-bridge Idle direction pin 2
 byte pinIdleUp; //Input for triggering Idle Up
 byte pinCTPS; //Input for triggering closed throttle state
+byte pinITPS; //Input for idle range TPS
 byte pinFuel2Input; //Input for switching to the 2nd fuel table
 byte pinSpareTemp1; // Future use only
 byte pinSpareTemp2; // Future use only

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -11,6 +11,7 @@
 #define IAC_ALGORITHM_PWM_CL  3
 #define IAC_ALGORITHM_STEP_OL 4
 #define IAC_ALGORITHM_STEP_CL 5
+#define IAC_ALGORITHM_HB      6
 
 #define STEPPER_FORWARD 0
 #define STEPPER_BACKWARD 1
@@ -51,6 +52,7 @@ volatile bool idle_pwm_state;
 unsigned int idle_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int idle_pwm_cur_value;
 long idle_pid_target_value;
+long idle_pid_hb_target_value;
 long idle_pwm_target_value;
 long idle_cl_target_rpm;
 byte idleCounter; //Used for tracking the number of calls to the idle control function

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -52,7 +52,7 @@ volatile bool idle_pwm_state;
 unsigned int idle_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int idle_pwm_cur_value;
 long idle_pid_target_value;
-long idle_pid_hb_target_value;
+uint16_t idle_pid_hb_target_value;
 long idle_pwm_target_value;
 long idle_cl_target_rpm;
 byte idleCounter; //Used for tracking the number of calls to the idle control function

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -48,6 +48,11 @@ volatile PINMASK_TYPE idle_pin_mask;
 volatile PORT_TYPE *idle2_pin_port;
 volatile PINMASK_TYPE idle2_pin_mask;
 
+volatile PORT_TYPE *hbDir1_pin_port;
+volatile PINMASK_TYPE hbDir1_pin_mask;
+volatile PORT_TYPE *hbDir2_pin_port;
+volatile PINMASK_TYPE hbDir2_pin_mask;
+
 volatile bool idle_pwm_state;
 unsigned int idle_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int idle_pwm_cur_value;

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -381,8 +381,8 @@ void idleControl()
           //Standard running
           currentStatus.idleDuty = table2D_getValue(&iacPWMTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
         }
+        if(currentStatus.idleUpActive == true) { currentStatus.idleDuty += configPage2.idleUpAdder; } //Add Idle Up amount if active
       }
-      if(currentStatus.idleUpActive == true) { currentStatus.idleDuty += configPage2.idleUpAdder; } //Add Idle Up amount if active
       
       //If idle state is not active, if tps is over 30% or idle duty is set to zero then disable the idle control
       if(currentStatus.ctpsActive == false || currentStatus.TPS >= 30 || currentStatus.idleDuty == 0) 
@@ -407,18 +407,20 @@ void idleControl()
         {
           *hbDir1_pin_port |= (hbDir1_pin_mask); // Switch direction pin 1 to high
           *hbDir2_pin_port &= ~(hbDir2_pin_mask); // Switch direction pin 2 to low
+          idle_pwm_target_value = abs(idle_pid_hb_target);
         }
         else if (idle_pid_hb_target < 0)
         {
           *hbDir1_pin_port &= ~(hbDir1_pin_mask); // Switch direction pin 1 to low
           *hbDir2_pin_port |= (hbDir2_pin_mask); // Switch direction pin 2 to high
+          idle_pwm_target_value = abs(idle_pid_hb_target);
         }
         else // Motor brake to ground
         {
           *hbDir1_pin_port &= ~(hbDir1_pin_mask); // Switch direction pin 1 to low
           *hbDir2_pin_port &= ~(hbDir2_pin_mask); // Switch direction pin 2 to low
+          *idle_pin_port &= ~(idle_pin_mask);  // Switch pwm pin to low
         }
-        idle_pwm_target_value = abs(idle_pid_hb_target);
         BIT_SET(currentStatus.spark, BIT_SPARK_IDLE); //Turn the idle control flag on
       }
       break;

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -185,6 +185,10 @@ void initialiseIdle()
       {
         idle_pin_port = portOutputRegister(digitalPinToPort(pinIdle1));
         idle_pin_mask = digitalPinToBitMask(pinIdle1);
+        hbDir1_pin_port = portOutputRegister(digitalPinToPort(pinHBdir1));
+        hbDir1_pin_mask = digitalPinToBitMask(pinHBdir1);
+        hbDir2_pin_port = portOutputRegister(digitalPinToPort(pinHBdir2));
+        hbDir2_pin_mask = digitalPinToBitMask(pinHBdir2);
         #if defined(CORE_AVR)
           idle_pwm_max_count = 1000000L / (16 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
         #elif defined(CORE_TEENSY)
@@ -401,18 +405,18 @@ void idleControl()
         idle_pid_hb_target = (idle_pid_hb_target - (idle_pwm_max_count >> 1)) * 2;
         if (idle_pid_hb_target > 0)
         {
-          digitalWrite(pinHBdir1, HIGH);
-          digitalWrite(pinHBdir2, LOW);
+          *hbDir1_pin_port |= (hbDir1_pin_mask); // Switch direction pin 1 to high
+          *hbDir2_pin_port &= ~(hbDir2_pin_mask); // Switch direction pin 2 to low
         }
         else if (idle_pid_hb_target < 0)
         {
-          digitalWrite(pinHBdir1, LOW);
-          digitalWrite(pinHBdir2, HIGH);
+          *hbDir1_pin_port &= ~(hbDir1_pin_mask); // Switch direction pin 1 to low
+          *hbDir2_pin_port |= (hbDir2_pin_mask); // Switch direction pin 2 to high
         }
         else // Motor brake to ground
         {
-          digitalWrite(pinHBdir1, LOW);
-          digitalWrite(pinHBdir2, LOW);
+          *hbDir1_pin_port &= ~(hbDir1_pin_mask); // Switch direction pin 1 to low
+          *hbDir2_pin_port &= ~(hbDir2_pin_mask); // Switch direction pin 2 to low
         }
         idle_pwm_target_value = abs(idle_pid_hb_target);
         BIT_SET(currentStatus.spark, BIT_SPARK_IDLE); //Turn the idle control flag on

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -190,7 +190,7 @@ void initialiseIdle()
         #elif defined(CORE_TEENSY)
           idle_pwm_max_count = 1000000L / (32 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
         #endif
-        idlePID.SetSampleTime(100);
+        idleHB_PID.SetSampleTime(67);
         idleHB_PID.SetOutputLimits(percentage(configPage2.iacCLminDuty, idle_pwm_max_count), percentage(configPage2.iacCLmaxDuty, idle_pwm_max_count));
         idleHB_PID.SetTunings(configPage6.idleKP, configPage6.idleKI, configPage6.idleKD);
         idleHB_PID.SetMode(AUTOMATIC); //Turn PID on

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -401,8 +401,9 @@ void idleControl()
         idleHB_PID.SetOutputLimits(configPage2.iacCLminDuty, configPage2.iacCLmaxDuty);
         idleHB_PID.SetTunings(configPage6.idleKP, configPage6.idleKI, configPage6.idleKD); 
       }
-      bool hbPIDcomputed = idleHB_PID.Compute(); //Compute() returns false if the required interval has not yet passed.
-      if(hbPIDcomputed == true)
+
+      PID_computed = idleHB_PID.Compute(); //Compute() returns false if the required interval has not yet passed.
+      if(PID_computed == true)
       {
         int16_t idle_pid_hb_target = ((unsigned long)(idle_pid_hb_target_value) * idle_pwm_max_count) / 10000; //Convert idle duty (Which is a % multipled by 100) to a pwm count
         currentStatus.idleLoad = ((unsigned long)(idle_pid_hb_target * 100UL) / idle_pwm_max_count) >> 1;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1968,12 +1968,23 @@ void setPinMapping(byte boardID)
   if ( (configPage6.useExtBaro != 0) && (configPage6.baroPin < BOARD_NR_GPIO_PINS) ) { pinBaro = configPage6.baroPin + A0; }
   if ( (configPage6.useEMAP != 0) && (configPage10.EMAPPin < BOARD_NR_GPIO_PINS) ) { pinEMAP = configPage10.EMAPPin + A0; }
   if ( (configPage10.fuel2InputPin != 0) && (configPage10.fuel2InputPin < BOARD_NR_GPIO_PINS) ) { pinFuel2Input = pinTranslate(configPage10.fuel2InputPin); }
+  if ( (configPage2.pinIdle1 != 0) && (configPage2.pinIdle1 < BOARD_NR_GPIO_PINS) ) { pinIdle1 = pinTranslate(configPage2.pinIdle1); }
+  if ( (configPage2.pinIdle2 != 0) && (configPage2.pinIdle2 < BOARD_NR_GPIO_PINS) ) { pinIdle2 = pinTranslate(configPage2.pinIdle2); }
 
   //Currently there's no default pin for Idle Up
   pinIdleUp = pinTranslate(configPage2.idleUpPin);
 
   //Currently there's no default pin for closed throttle position sensor
-  pinCTPS = pinTranslate(configPage2.CTPSPin);
+  pinCTPS = pinTranslate(configPage2.ctpsPin);
+  
+  //Currently there's no default pin for idle throttle position sensor
+  pinITPS = pinTranslate(configPage2.itpsPin);
+
+  //Currently there's no default pin for H-Bridge driver direction 1
+  pinHBdir1 = pinTranslate(configPage2.hbDirPin1);
+
+  //Currently there's no default pin for H-Bridge driver direction 2
+  pinHBdir2 = pinTranslate(configPage2.hbDirPin2);
 
   /* Reset control is a special case. If reset control is enabled, it needs its initial state set BEFORE its pinMode.
      If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
@@ -2008,6 +2019,8 @@ void setPinMapping(byte boardID)
   pinMode(pinStepperEnable, OUTPUT);
   pinMode(pinBoost, OUTPUT);
   pinMode(pinVVT_1, OUTPUT);
+  pinMode(pinHBdir1, OUTPUT);
+  pinMode(pinHBdir2, OUTPUT);
 
   //This is a legacy mode option to revert the MAP reading behaviour to match what was in place prior to the 201905 firmware
   if(configPage2.legacyMAP > 0) { digitalWrite(pinMAP, HIGH); }
@@ -2058,6 +2071,7 @@ void setPinMapping(byte boardID)
       pinMode(pinO2, INPUT_ANALOG);
       pinMode(pinO2_2, INPUT_ANALOG);
       pinMode(pinTPS, INPUT_ANALOG);
+      pinMode(pinITPS, INPUT_ANALOG);
       pinMode(pinIAT, INPUT_ANALOG);
       pinMode(pinCLT, INPUT_ANALOG);
       pinMode(pinBat, INPUT_ANALOG);
@@ -2067,6 +2081,7 @@ void setPinMapping(byte boardID)
       pinMode(pinO2, INPUT);
       pinMode(pinO2_2, INPUT);
       pinMode(pinTPS, INPUT);
+      pinMode(pinITPS, INPUT);
       pinMode(pinIAT, INPUT);
       pinMode(pinCLT, INPUT);
       pinMode(pinBat, INPUT);
@@ -2092,9 +2107,9 @@ void setPinMapping(byte boardID)
     if (configPage2.idleUpPolarity == 0) { pinMode(pinIdleUp, INPUT_PULLUP); } //Normal setting
     else { pinMode(pinIdleUp, INPUT); } //inverted setting
   }
-  if(configPage2.CTPSEnabled > 0)
+  if(configPage2.ctpsEnabled > 0)
   {
-    if (configPage2.CTPSPolarity == 0) { pinMode(pinCTPS, INPUT_PULLUP); } //Normal setting
+    if (configPage2.ctpsPolarity == 0) { pinMode(pinCTPS, INPUT_PULLUP); } //Normal setting
     else { pinMode(pinCTPS, INPUT); } //inverted setting
   }
   if(configPage10.fuel2Mode == FUEL2_MODE_INPUT_SWITCH)

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -371,26 +371,26 @@ void readTPS()
     #endif
 
     currentStatus.itpsADC = ADC_FILTER(tempITPS, configPage4.ADCFILTER_TPS, currentStatus.itpsADC); // Idle range tps shares the adc filter with main tps
-    byte tempADC2 = currentStatus.itpsADC;
+    tempADC = currentStatus.itpsADC;
 
     if(configPage2.itpsMax > configPage2.itpsMin)
     {
       //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).
-      if (currentStatus.itpsADC < configPage2.itpsMin) { tempADC2 = configPage2.itpsMin; }
-      else if(currentStatus.itpsADC > configPage2.itpsMax) { tempADC2 = configPage2.itpsMax; }
-      currentStatus.ITPS = map(tempADC2, configPage2.itpsMin, configPage2.itpsMax, 0, 100); //Take the raw ITPS ADC value and convert it into a ITPS% based on the calibrated values
+      if (currentStatus.itpsADC < configPage2.itpsMin) { tempADC = configPage2.itpsMin; }
+      else if(currentStatus.itpsADC > configPage2.itpsMax) { tempADC = configPage2.itpsMax; }
+      currentStatus.ITPS = map(tempADC, configPage2.itpsMin, configPage2.itpsMax, 0, 100); //Take the raw ITPS ADC value and convert it into a ITPS% based on the calibrated values
     }
     else
     {
       //This case occurs when the ITPS +5v and gnd are wired backwards, but the user wishes to retain this configuration.
       //In such a case, itpsMin will be greater then itpsMax and hence checks and mapping needs to be reversed
 
-      tempADC2 = 255 - currentStatus.itpsADC; //Reverse the ADC values
+      tempADC = 255 - currentStatus.itpsADC; //Reverse the ADC values
 
       //All checks below are reversed from the standard case above
-      if (tempADC2 > configPage2.itpsMin) { tempADC2 = configPage2.itpsMin; }
-      else if(tempADC2 < configPage2.itpsMax) { tempADC2 = configPage2.itpsMax; }
-      currentStatus.ITPS = map(tempADC2, configPage2.itpsMax, configPage2.itpsMin, 0, 100);
+      if (tempADC > configPage2.itpsMin) { tempADC = configPage2.itpsMin; }
+      else if(tempADC < configPage2.itpsMax) { tempADC = configPage2.itpsMax; }
+      currentStatus.ITPS = map(tempADC, configPage2.itpsMax, configPage2.itpsMin, 0, 100);
     }
   }
   TPS_time = micros();

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -371,25 +371,26 @@ void readTPS()
     #endif
 
     currentStatus.itpsADC = ADC_FILTER(tempITPS, configPage4.ADCFILTER_TPS, currentStatus.itpsADC); // Idle range tps shares the adc filter with main tps
+    byte tempADC2 = currentStatus.itpsADC;
 
     if(configPage2.itpsMax > configPage2.itpsMin)
     {
       //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).
-      if (currentStatus.itpsADC < configPage2.itpsMin) { currentStatus.itpsADC = configPage2.itpsMin; }
-      else if(currentStatus.itpsADC > configPage2.itpsMax) { currentStatus.itpsADC = configPage2.itpsMax; }
-      currentStatus.ITPS = map(currentStatus.itpsADC, configPage2.itpsMin, configPage2.itpsMax, 0, 100); //Take the raw ITPS ADC value and convert it into a ITPS% based on the calibrated values
+      if (currentStatus.itpsADC < configPage2.itpsMin) { tempADC2 = configPage2.itpsMin; }
+      else if(currentStatus.itpsADC > configPage2.itpsMax) { tempADC2 = configPage2.itpsMax; }
+      currentStatus.ITPS = map(tempADC2, configPage2.itpsMin, configPage2.itpsMax, 0, 100); //Take the raw ITPS ADC value and convert it into a ITPS% based on the calibrated values
     }
     else
     {
       //This case occurs when the ITPS +5v and gnd are wired backwards, but the user wishes to retain this configuration.
       //In such a case, itpsMin will be greater then itpsMax and hence checks and mapping needs to be reversed
 
-      currentStatus.itpsADC = 255 - currentStatus.itpsADC; //Reverse the ADC values
+      tempADC2 = 255 - currentStatus.itpsADC; //Reverse the ADC values
 
       //All checks below are reversed from the standard case above
-      if (currentStatus.itpsADC > configPage2.itpsMin) { currentStatus.itpsADC = configPage2.itpsMin; }
-      else if(currentStatus.itpsADC < configPage2.itpsMax) { currentStatus.itpsADC = configPage2.itpsMax; }
-      currentStatus.ITPS = map(currentStatus.itpsADC, configPage2.itpsMax, configPage2.itpsMin, 0, 100);
+      if (tempADC2 > configPage2.itpsMin) { tempADC2 = configPage2.itpsMin; }
+      else if(tempADC2 < configPage2.itpsMax) { tempADC2 = configPage2.itpsMax; }
+      currentStatus.ITPS = map(tempADC2, configPage2.itpsMax, configPage2.itpsMin, 0, 100);
     }
   }
   TPS_time = micros();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -117,7 +117,7 @@ void loop()
       ignitionOn = false;
       fuelOn = false;
       if (fpPrimed == true) { FUEL_PUMP_OFF(); currentStatus.fuelPumpOn = false; } //Turn off the fuel pump, but only if the priming is complete
-      disableIdle(); //Turn off the idle PWM
+      if(!configPage2.idleEngOff) { disableIdle(); } //Turn off the idle PWM
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK); //Clear cranking bit (Can otherwise get stuck 'on' even with 0 rpm)
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_WARMUP); //Same as above except for WUE
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_RUN); //Same as above except for RUNNING status
@@ -286,7 +286,7 @@ void loop()
       readBaro(); //Infrequent baro readings are not an issue.
     } //1Hz timer
 
-    if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) )  { idleControl(); } //Run idlecontrol every loop for stepper idle.
+    if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_HB) )  { idleControl(); } //Run idlecontrol every loop for stepper and h-bridge dc motor idle.
 
     
     //VE calculation was moved outside the sync/RPM check so that the fuel load value will be accurately shown when RPM=0

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -278,7 +278,7 @@ void loop()
         } //For loop going through each channel
       } //aux channels are enabled
 
-       idleControl(); //Perform any idle related actions. Even at higher frequencies, running 4x per second is sufficient.
+      if( (configPage6.iacAlgorithm == IAC_ALGORITHM_NONE) || (configPage6.iacAlgorithm == IAC_ALGORITHM_ONOFF) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) )  { idleControl(); } //Perform any idle related actions. Even at higher frequencies, running 4x per second is sufficient.
     } //4Hz timer
     if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_1HZ)) //Once per second)
     {


### PR DESCRIPTION
This pull request adds initial support for H-bridge controlled DC idle motor using VNH2SP30 H-Bridge driver board. This control method is used mostly in some VW/Audi cable throttle bodies which uses a DC motor to control throttle flap at idle range. For position control I used a pid control which uses throttle body idle range position sensor as input and open loop pwm tables for setpoint so it is kinda closed loop position control and open loop idle control for now.

The code also adds selectable pins for idle pwm outputs and option to have idle control running even if engine is off for open loop pwm and the new h-bridge control methods.

![hbidle](https://user-images.githubusercontent.com/3372213/68994665-34a79e80-088e-11ea-81e4-2c866235acd0.png)

I opened this pull request to show the current state of the code so if anyone has suggestions to do things other way I'm happy to modify it. I don't know how many is going to use this feature but for me it is necessary.
