### PR TITLE
small fix for the idle advance settings dialog

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -982,7 +982,7 @@ page = 10
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
 
-        unused11_122_191    = array,  U08,    134,  [57], "RPM",  100.0,      0.0,  100,     25500,    0
+        unused11_122_191    = array,  U08,     134,  [58], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1918,9 +1918,9 @@ menuDialog = main
         field = "Delay before idle control starts (s)",idleAdvDelay,         { idleAdvEnabled >= 1 }
 		field = "Active Below RPM",                    idleAdvRPM,           { idleAdvEnabled >= 1 }
         field = "Active Below TPS",                    idleAdvTPS,           { idleAdvEnabled >= 1 && idleAdvAlgorithm == 0 }
-		field = "Closed Throttle Sensor Enabled",      CTPSEnabled,          { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 }
-        field = "Closed Throttle Sensor Pin",          CTPSPin,              { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
-        field = "Closed Throttle Sensor Pin Polarity", CTPSPolarity,         { idleAdvEnabled >= 1 && idleAdvAlgorithm == 1 && CTPSEnabled == 1 }
+		field = "Closed Throttle Sensor Enabled",      CTPSEnabled
+        field = "Closed Throttle Sensor Pin",          CTPSPin,              { CTPSEnabled == 1 }
+        field = "Closed Throttle Sensor Pin Polarity", CTPSPolarity,         { CTPSEnabled == 1 }
 
     dialog = idleAdvanceSettings,"Idle Advance Settings", xAxis
         panel = idleAdvanceSettings_east


### PR DESCRIPTION
allow to change ctps pin settings even if the idle advance is not in use to avoid leaving it accidentally on. ctps pin might be used for other functions in the future so its best to be able to change it all the time.