### PR TITLE
Prevent priming pulse if flood clear is active

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1360,6 +1360,7 @@ menuDialog = main
     FixAng      = "Timing will be locked at this value if the above is enabled"
 
     crankRPM    = "The cranking RPM threshold. When RPM is lower than this value (and above 0) the system will be considered to be cranking"
+    tpsflood    = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine"
 
 	fanInv      = ""
 	fanHyster   = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -869,8 +869,9 @@ void initialiseAll()
     interrupts();
     //Perform the priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
     readCLT(false); // Need to read coolant temp to make priming pulsewidth work correctly. The false here disables use of the filter
+    readTPS(false); // Need to read tps to detect flood clear state
     unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
-    if(primingValue > 0)
+    if((primingValue > 0) && (currentStatus.TPS < configPage4.floodClear))
     {
       setFuelSchedule1(100, (primingValue * 100 * 5)); //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
       setFuelSchedule2(100, (primingValue * 100 * 5));

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -58,7 +58,7 @@ byte cltErrorCount = 0;
 static inline void instanteneousMAPReading() __attribute__((always_inline));
 static inline void readMAP() __attribute__((always_inline));
 void initialiseADC();
-void readTPS();
+void readTPS(bool=true); //Allows the option to override the use of the filter
 void readO2_2();
 void flexPulse();
 uint16_t readAuxanalog(uint8_t analogPin);

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -319,7 +319,7 @@ static inline void readMAP()
   }
 }
 
-void readTPS()
+void readTPS(bool useFilter)
 {
   TPSlast = currentStatus.TPS;
   TPSlast_time = TPS_time;
@@ -329,7 +329,9 @@ void readTPS()
     analogRead(pinTPS);
     byte tempTPS = fastMap1023toX(analogRead(pinTPS), 255); //Get the current raw TPS ADC value and map it into a byte
   #endif
-  currentStatus.tpsADC = ADC_FILTER(tempTPS, configPage4.ADCFILTER_TPS, currentStatus.tpsADC);
+  //The use of the filter can be overridden if required. This is used on startup to disable priming pulse if flood clear is wanted
+  if(useFilter == true) { currentStatus.tpsADC = ADC_FILTER(tempTPS, configPage4.ADCFILTER_TPS, currentStatus.tpsADC); }
+  else { currentStatus.tpsADC = tempTPS; }
   //currentStatus.tpsADC = ADC_FILTER(tempTPS, 128, currentStatus.tpsADC);
   byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 


### PR DESCRIPTION
As a big priming pulsewidth is usually required with ethanol in cold climates, you might want to have an option to disable the priming pulse. For example in situations when you need to power cycle multiple times without starting. This pr disables the priming pulse if tps is over the flood clear value when you switch power on.