### PR TITLE
injection channel 2 angle don't depend on nSquirt for 4-cylinder setup

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -456,11 +456,6 @@ void initialiseAll()
         if (configPage2.engineType == EVEN_FIRE )
         {
           channel2IgnDegrees = 180;
-          //Adjust the injection angles based on the number of squirts
-          if (currentStatus.nSquirts > 2)
-          {
-            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
-          }
 
           if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) )
           {
@@ -495,6 +490,11 @@ void initialiseAll()
             //For simultaneous, all squirts happen at the same time
             channel1InjDegrees = 0;
             channel2InjDegrees = 0; 
+          }
+          else if (currentStatus.nSquirts > 2)
+          {
+            //Adjust the injection angles based on the number of squirts
+            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
           }
         }
         else if (configPage2.injLayout == INJ_SEQUENTIAL)


### PR DESCRIPTION
The line `channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;` is before `channel2InjDegrees = 180;`, so `channel2InjDegrees` is wrong for values of nSquirt higher than 2.