### PR TITLE
add hardware schedule test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ reference/hardware/v0.4/gerbers/Archive.zip
 speeduino/board_samd21*
 reference/doxygen
 speeduino.ino.cpp
+test/output_export.cpp

--- a/platformio.ini
+++ b/platformio.ini
@@ -111,6 +111,5 @@ default_envs = megaatmega2560
 ;env_default = LaunchPad_tm4c1294ncpdt
 ;env_default = genericSTM32F103RB
 ;env_default = bluepill_f103c8
-monitor_speed = 115200
 
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -128,23 +128,23 @@ struct FuelSchedule {
 //Schedule *timer3Bqueue[4];
 //Schedule *timer3Cqueue[4];
 
-FuelSchedule fuelSchedule1;
-FuelSchedule fuelSchedule2;
-FuelSchedule fuelSchedule3;
-FuelSchedule fuelSchedule4;
-FuelSchedule fuelSchedule5;
-FuelSchedule fuelSchedule6;
-FuelSchedule fuelSchedule7;
-FuelSchedule fuelSchedule8;
+extern FuelSchedule fuelSchedule1;
+extern FuelSchedule fuelSchedule2;
+extern FuelSchedule fuelSchedule3;
+extern FuelSchedule fuelSchedule4;
+extern FuelSchedule fuelSchedule5;
+extern FuelSchedule fuelSchedule6;
+extern FuelSchedule fuelSchedule7;
+extern FuelSchedule fuelSchedule8;
 
-Schedule ignitionSchedule1;
-Schedule ignitionSchedule2;
-Schedule ignitionSchedule3;
-Schedule ignitionSchedule4;
-Schedule ignitionSchedule5;
-Schedule ignitionSchedule6;
-Schedule ignitionSchedule7;
-Schedule ignitionSchedule8;
+extern Schedule ignitionSchedule1;
+extern Schedule ignitionSchedule2;
+extern Schedule ignitionSchedule3;
+extern Schedule ignitionSchedule4;
+extern Schedule ignitionSchedule5;
+extern Schedule ignitionSchedule6;
+extern Schedule ignitionSchedule7;
+extern Schedule ignitionSchedule8;
 
 //IgnitionSchedule nullSchedule; //This is placed at the end of the queue. It's status will always be set to OFF and hence will never perform any action within an ISR
 

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -8,6 +8,23 @@ A full copy of the license may be found in the projects root directory
 #include "scheduler.h"
 #include "scheduledIO.h"
 
+FuelSchedule fuelSchedule1;
+FuelSchedule fuelSchedule2;
+FuelSchedule fuelSchedule3;
+FuelSchedule fuelSchedule4;
+FuelSchedule fuelSchedule5;
+FuelSchedule fuelSchedule6;
+FuelSchedule fuelSchedule7;
+FuelSchedule fuelSchedule8;
+
+Schedule ignitionSchedule1;
+Schedule ignitionSchedule2;
+Schedule ignitionSchedule3;
+Schedule ignitionSchedule4;
+Schedule ignitionSchedule5;
+Schedule ignitionSchedule6;
+Schedule ignitionSchedule7;
+Schedule ignitionSchedule8;
 
 void initialiseSchedulers()
 {

--- a/test/tests_main.cpp
+++ b/test/tests_main.cpp
@@ -1,8 +1,9 @@
 #include <Arduino.h>
+#include <unity.h>
 
 #include "tests_corrections.h"
 #include "tests_init.h"
-#include <unity.h>
+#include "tests_schedules.h"
 
 void setup() {
     // NOTE!!! Wait for >2 secs
@@ -22,6 +23,7 @@ void loop()
 {
   testInitialisation();
   testCorrections();
+  testSchedules();
 
   UNITY_END(); // stop unit testing
 }

--- a/test/tests_schedules.cpp
+++ b/test/tests_schedules.cpp
@@ -1,0 +1,202 @@
+#include <globals.h>
+#include <init.h>
+#include <unity.h>
+#include "tests_schedules.h"
+#include "scheduler.h"
+
+
+/* ****************************************************************************
+ * Static functions
+ * ***************************************************************************/
+
+static void test_schedule_fuel_time(void);
+static void test_schedule_fuel_pending(void);
+static void test_schedule_ignition_time(void);
+static void test_schedule_ignition_pending(void);
+
+static uint32_t beginTime, endTime;
+static void beginCallback(void) { beginTime = micros(); }
+static void endCallback(void) { endTime = micros(); }
+
+
+/* ****************************************************************************
+ * Global variables
+ * ***************************************************************************/
+
+static FuelSchedule* fuelSchedule[] = {
+  &fuelSchedule1,
+  &fuelSchedule2,
+  &fuelSchedule3,
+  &fuelSchedule4,
+  &fuelSchedule5,
+  &fuelSchedule6,
+  &fuelSchedule7,
+  &fuelSchedule8,
+};
+
+static Schedule* ignitionSchedule[] = {
+  &ignitionSchedule1,
+  &ignitionSchedule2,
+  &ignitionSchedule3,
+  &ignitionSchedule4,
+  &ignitionSchedule5,
+  &ignitionSchedule6,
+  &ignitionSchedule7,
+  &ignitionSchedule8,
+};
+
+void (*setFuelSchedule[])(unsigned long, unsigned long) = {
+  setFuelSchedule1,
+  setFuelSchedule2,
+  setFuelSchedule3,
+  setFuelSchedule4,
+#if INJ_CHANNELS >= 5
+  setFuelSchedule5,
+#endif
+#if INJ_CHANNELS >= 6
+  setFuelSchedule6,
+#endif
+#if INJ_CHANNELS >= 7
+  setFuelSchedule7,
+#endif
+#if INJ_CHANNELS >= 8
+  setFuelSchedule8,
+#endif
+};
+
+void (*setIgnitionSchedule[])(void (*)(), unsigned long, unsigned long, void (*)()) = {
+  setIgnitionSchedule1,
+  setIgnitionSchedule2,
+  setIgnitionSchedule3,
+  setIgnitionSchedule4,
+#if IGN_CHANNELS >= 5
+  setIgnitionSchedule5,
+#endif
+#if IGN_CHANNELS >= 6
+  setIgnitionSchedule6,
+#endif
+#if IGN_CHANNELS >= 7
+  setIgnitionSchedule7,
+#endif
+#if IGN_CHANNELS >= 8
+  setIgnitionSchedule8,
+#endif
+};
+
+
+/* ****************************************************************************
+ * Test Main
+ * ***************************************************************************/
+
+void testSchedules()
+{
+  RUN_TEST(test_schedule_fuel_time);
+  RUN_TEST(test_schedule_fuel_pending);
+  RUN_TEST(test_schedule_ignition_time);
+  RUN_TEST(test_schedule_ignition_pending);
+}
+
+
+/* ****************************************************************************
+ * Test Functions
+ * ***************************************************************************/
+
+static void test_schedule_fuel_time(void)
+{
+  TEST_ASSERT_EQUAL(true, initialisationComplete);
+
+  for(int i = 0; i < INJ_CHANNELS; i++)
+  {
+    TEST_ASSERT_EQUAL(OFF, fuelSchedule[i]->Status);
+
+    uint32_t time1 = micros();
+    setFuelSchedule[i](1000, 1000);
+    TEST_ASSERT_EQUAL(PENDING, fuelSchedule[i]->Status);
+
+    while(fuelSchedule[i]->Status == PENDING); // wait
+    uint32_t time2 = micros();
+    TEST_ASSERT_EQUAL(RUNNING, fuelSchedule[i]->Status);
+
+    while(fuelSchedule[i]->Status == RUNNING); // wait
+    uint32_t time3 = micros();
+    TEST_ASSERT_EQUAL(OFF, fuelSchedule[i]->Status);
+
+    TEST_ASSERT_EQUAL(1016, time2 - time1);
+    TEST_ASSERT_EQUAL(1008, time3 - time2);
+  }
+}
+
+static void test_schedule_fuel_pending(void)
+{
+  TEST_ASSERT_EQUAL(true, initialisationComplete);
+
+  for(int i = 0; i < INJ_CHANNELS; i++)
+  {
+    TEST_ASSERT_EQUAL(OFF, fuelSchedule[i]->Status);
+
+    setFuelSchedule[i](1000, 1000);
+    TEST_ASSERT_EQUAL(PENDING, fuelSchedule[i]->Status);
+
+    while(fuelSchedule[i]->Status == PENDING); // wait
+    TEST_ASSERT_EQUAL(RUNNING, fuelSchedule[i]->Status);
+    setFuelSchedule[i](1500, 500); // Once running, set another schedule
+
+    while(fuelSchedule[i]->Status == RUNNING); // wait
+    TEST_ASSERT_EQUAL(PENDING, fuelSchedule[i]->Status);
+
+    while(fuelSchedule[i]->Status == PENDING); // wait
+    TEST_ASSERT_EQUAL(RUNNING, fuelSchedule[i]->Status);
+
+    while(fuelSchedule[i]->Status == RUNNING); // wait
+    TEST_ASSERT_EQUAL(OFF, fuelSchedule[i]->Status);
+  }
+}
+
+static void test_schedule_ignition_time(void)
+{
+  TEST_ASSERT_EQUAL(true, initialisationComplete);
+
+  for(int i = 0; i < IGN_CHANNELS; i++)
+  {
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[i]->Status);
+
+    uint32_t time1 = micros();
+    setIgnitionSchedule[i](beginCallback, 1000, 1000, endCallback);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[i]->Status);
+
+    while(ignitionSchedule[i]->Status == PENDING); // wait
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[i]->Status);
+
+    while(ignitionSchedule[i]->Status == RUNNING); // wait
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[i]->Status);
+
+    TEST_ASSERT_EQUAL(1012, beginTime - time1);
+    TEST_ASSERT_EQUAL(1012, endTime - beginTime);
+  }
+}
+
+static void test_schedule_ignition_pending(void)
+{
+  TEST_ASSERT_EQUAL(true, initialisationComplete);
+
+  for(int i = 0; i < IGN_CHANNELS; i++)
+  {
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[i]->Status);
+
+    setIgnitionSchedule[i](beginCallback, 1000, 1000, endCallback);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[i]->Status);
+
+    while(ignitionSchedule[i]->Status == PENDING); // wait
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[i]->Status);
+    setIgnitionSchedule[i](beginCallback, 1500, 500, endCallback); // Once running, set another schedule
+
+    while(ignitionSchedule[i]->Status == RUNNING); // wait
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[i]->Status);
+
+    while(ignitionSchedule[i]->Status == PENDING); // wait
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[i]->Status);
+
+    while(ignitionSchedule[i]->Status == RUNNING); // wait
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[i]->Status);
+  }
+}

--- a/test/tests_schedules.h
+++ b/test/tests_schedules.h
@@ -1,0 +1,1 @@
+void testSchedules();


### PR DESCRIPTION
Add tests to verify the schedule mechanics and timing.

Because micros() has a resolution of 4uS, the reported timing is slightly more than what requested, but it still fulfill the requirements.