### PR TITLE
Secondary serial requests are sometimes ignored

### DIFF
--- a/speeduino/cancomms.h
+++ b/speeduino/cancomms.h
@@ -20,6 +20,7 @@ uint8_t canlisten = 0;
 uint8_t Lbuffer[8];         //8 byte buffer to store incomng can data
 uint8_t Gdata[9];
 uint8_t Glow, Ghigh;
+bool canCmdPending = false;
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   HardwareSerial &CANSerial = Serial3;

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -18,7 +18,8 @@ sendcancommand is called when a command is to be sent via serial3 to the Can int
 
 void canCommand()
 {
-  currentcanCommand = CANSerial.read();
+  if (! canCmdPending)  
+  {  currentcanCommand = CANSerial.read();  }
 
   switch (currentcanCommand)
   {
@@ -30,6 +31,7 @@ void canCommand()
        byte destcaninchannel;
       if (CANSerial.available() >= 9)
       {
+        canCmdPending = false;
         cancmdfail = CANSerial.read();        //0 == fail,  1 == good.
         destcaninchannel = CANSerial.read();  // the input channel that requested the data value
         if (cancmdfail != 0)
@@ -58,6 +60,11 @@ void canCommand()
         else{}  //continue as command request failed and/or data/device was not available
 
       }
+      else
+      {
+        canCmdPending = true;
+      }
+      
         break;
 
     case 'k':   //placeholder for new can interface (toucan etc) commands
@@ -106,6 +113,7 @@ void canCommand()
           tmp = CANSerial.read();
           length = word(CANSerial.read(), tmp);
           sendcanValues(offset, length,Cmd, 1);
+          canCmdPending = false;
 //Serial.print(Cmd);
         }
         else
@@ -113,6 +121,11 @@ void canCommand()
           //No other r/ commands should be called
         }
       }
+      else
+      {
+        canCmdPending = true;
+      }
+      
       break;
 
     case 's': // send the "a" stream code version

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -18,8 +18,7 @@ sendcancommand is called when a command is to be sent via serial3 to the Can int
 
 void canCommand()
 {
-  if (! canCmdPending)  
-  {  currentcanCommand = CANSerial.read();  }
+  if (! canCmdPending) {  currentcanCommand = CANSerial.read();  }
 
   switch (currentcanCommand)
   {


### PR DESCRIPTION
This change fixes a problem where secondary serial requests are sometimes ignored when the command string is more than one byte in length.

The problem is caused by the fact that the secondary serial code makes an assumption that all of the bytes of a multi-byte command (e.g. the 'r' command) are sitting in the serial buffer as soon as CANSerial.available() returns a non-zero value.  This is of course not true because the completeness of the message is very timing dependent. Requesting at a rate of 2 requests per second it can only take around 30 requests or so before the serial buffer is only partially filled. The higher the request rate, the more frequently it happens. This fix delays processing of the command until the whole command string is available.

I suspect this bug is the cause of some problems people have had in the past getting reliable data out of the serial feed. Only people who use 'r' would notice this because the 'A' command is a single byte command, so it is either there in its entirety or not at all and thus does not suffer this issue.

I have tested the fix on the 'r' command and fixed others in the same way, but have not been able to test them all.