### PR TITLE
Small change to write Aux in channel names to Data Logs.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -3618,14 +3618,14 @@ cmdtestspk450dc = "E\x03\x0C"
    entry = vvtTarget,       "VVT Target Angle", int, "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvtDuty,         "VVT Duty",     int,     "%d",          { vvtEnabled > 0 }
 
-   entry = auxin_gauge0,    "AuxIn CH0",    int,     "%d"
-   entry = auxin_gauge1,    "AuxIn CH1",    int,     "%d"
-   entry = auxin_gauge2,    "AuxIn CH2",    int,     "%d"
-   entry = auxin_gauge3,    "AuxIn CH3",    int,     "%d"
-   entry = auxin_gauge4,    "AuxIn CH4",    int,     "%d"
-   entry = auxin_gauge5,    "AuxIn CH5",    int,     "%d"
-   entry = auxin_gauge6,    "AuxIn CH6",    int,     "%d"
-   entry = auxin_gauge7,    "AuxIn CH7",    int,     "%d"
+   entry = auxin_gauge0, { stringValue(AUXin00Alias)},    int,     "%d"
+   entry = auxin_gauge1, { stringValue(AUXin01Alias)},    int,     "%d"
+   entry = auxin_gauge2, { stringValue(AUXin02Alias)},    int,     "%d"
+   entry = auxin_gauge3, { stringValue(AUXin03Alias)},    int,     "%d"
+   entry = auxin_gauge4, { stringValue(AUXin04Alias)},    int,     "%d"
+   entry = auxin_gauge5, { stringValue(AUXin05Alias)},    int,     "%d"
+   entry = auxin_gauge6, { stringValue(AUXin06Alias)},    int,     "%d"
+   entry = auxin_gauge7, { stringValue(AUXin07Alias)},    int,     "%d"
 
 
 [LoggerDefinition]

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -3618,15 +3618,22 @@ cmdtestspk450dc = "E\x03\x0C"
    entry = vvtTarget,       "VVT Target Angle", int, "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvtDuty,         "VVT Duty",     int,     "%d",          { vvtEnabled > 0 }
 
-   entry = auxin_gauge0, { stringValue(AUXin00Alias)},    int,     "%d"
-   entry = auxin_gauge1, { stringValue(AUXin01Alias)},    int,     "%d"
-   entry = auxin_gauge2, { stringValue(AUXin02Alias)},    int,     "%d"
-   entry = auxin_gauge3, { stringValue(AUXin03Alias)},    int,     "%d"
-   entry = auxin_gauge4, { stringValue(AUXin04Alias)},    int,     "%d"
-   entry = auxin_gauge5, { stringValue(AUXin05Alias)},    int,     "%d"
-   entry = auxin_gauge6, { stringValue(AUXin06Alias)},    int,     "%d"
-   entry = auxin_gauge7, { stringValue(AUXin07Alias)},    int,     "%d"
-
+   entry = auxin_gauge0, { stringValue(AUXin00Alias)},    int,     "%d", {(caninput_sel0b != 0)}
+   entry = auxin_gauge1, { stringValue(AUXin01Alias)},    int,     "%d", { (caninput_sel1b != 0)}
+   entry = auxin_gauge2, { stringValue(AUXin02Alias)},    int,     "%d", { (caninput_sel2b != 0)}
+   entry = auxin_gauge3, { stringValue(AUXin03Alias)},    int,     "%d", { (caninput_sel3b != 0)}
+   entry = auxin_gauge4, { stringValue(AUXin04Alias)},    int,     "%d", { (caninput_sel4b != 0)}
+   entry = auxin_gauge5, { stringValue(AUXin05Alias)},    int,     "%d", { (caninput_sel5b != 0)}
+   entry = auxin_gauge6, { stringValue(AUXin06Alias)},    int,     "%d", { (caninput_sel6b != 0)}
+   entry = auxin_gauge7, { stringValue(AUXin07Alias)},    int,     "%d", { (caninput_sel7b != 0)}
+   entry = auxin_gauge8, { stringValue(AUXin08Alias)},    int,     "%d", { (caninput_sel8b != 0)}
+   entry = auxin_gauge9, { stringValue(AUXin09Alias)},    int,     "%d", { (caninput_sel9b != 0)}
+   entry = auxin_gauge10, { stringValue(AUXin10Alias)},    int,     "%d", { (caninput_sel10b != 0)}
+   entry = auxin_gauge11, { stringValue(AUXin11Alias)},    int,     "%d", { (caninput_sel11b != 0)}
+   entry = auxin_gauge12, { stringValue(AUXin12Alias)},    int,     "%d", { (caninput_sel12b != 0)}
+   entry = auxin_gauge13, { stringValue(AUXin13Alias)},    int,     "%d", { (caninput_sel13b != 0)}
+   entry = auxin_gauge14, { stringValue(AUXin14Alias)},    int,     "%d", { (caninput_sel14b != 0)}
+   entry = auxin_gauge15, { stringValue(AUXin15Alias)},    int,     "%d", { (caninput_sel15b != 0)}
 
 [LoggerDefinition]
     ; valid logger types: composite, tooth, trigger, csv


### PR DESCRIPTION
Small change to write Aux in channel names to Data Logs. Previously these were just named as AuxIn CHx in datalog file. But now the channel name defined in TS as AUXinxxAlias is written instead. Also added the last missing 8 aux in channels to the datalog and changed so that only the channels that are configured in TS are written to DataLog file.