### PR TITLE
STM32F407 fixes

### DIFF
--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -20,8 +20,8 @@
 */
 #define PORT_TYPE uint32_t
 #define PINMASK_TYPE uint32_t
-#define COMPARE_TYPE uint16_t
-#define COUNTER_TYPE uint16_t
+#define COMPARE_TYPE uint32_t
+#define COUNTER_TYPE uint32_t
 #define micros_safe() micros() //timer5 method is not used on anything but AVR, the micros_safe() macro is simply an alias for the normal micros()
 #if defined(SRAM_AS_EEPROM)
     #define EEPROM_LIB_H "src/BackupSram/BackupSramAsEEPROM.h"

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -71,8 +71,8 @@ extern "C" char* sbrk(int incr);
 ***********************************************************************************************************
 * Schedules
 */
-#define MAX_TIMER_PERIOD 65535*2 //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 2, as each timer tick is 2uS)
-#define uS_TO_TIMER_COMPARE(uS) (uS>>1) //Converts a given number of uS into the required number of timer ticks until that time has passed.
+#define MAX_TIMER_PERIOD 65535*4 //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 4, as each timer tick is 4uS)
+#define uS_TO_TIMER_COMPARE(uS) (uS>>2) //Converts a given number of uS into the required number of timer ticks until that time has passed.
 
 #define FUEL1_COUNTER (TIM3)->CNT
 #define FUEL2_COUNTER (TIM3)->CNT

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -71,8 +71,8 @@ extern "C" char* sbrk(int incr);
 ***********************************************************************************************************
 * Schedules
 */
-#define MAX_TIMER_PERIOD 65535*4 //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 2, as each timer tick is 2uS)
-#define uS_TO_TIMER_COMPARE(uS) (uS>>2) //Converts a given number of uS into the required number of timer ticks until that time has passed.
+#define MAX_TIMER_PERIOD 65535*2 //The longest period of time (in uS) that the timer can permit (IN this case it is 65535 * 2, as each timer tick is 2uS)
+#define uS_TO_TIMER_COMPARE(uS) (uS>>1) //Converts a given number of uS into the required number of timer ticks until that time has passed.
 
 #define FUEL1_COUNTER (TIM3)->CNT
 #define FUEL2_COUNTER (TIM3)->CNT

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -51,18 +51,20 @@ void initBoard();
 uint16_t freeRam();
 extern "C" char* sbrk(int incr);
 
-
-#ifndef PB11 //Hack for F4 BlackPills
-  #define PB11 PB10
-#endif
-//Hack to alow compile on small STM boards
-#ifndef A10
-  #define A10  PA0
-  #define A11  PA1
-  #define A12  PA2
-  #define A13  PA3
-  #define A14  PA4
-  #define A15  PA5
+#if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_BLUEPILL_F103CB) \
+ || defined(ARDUINO_BLACKPILL_F401CC) || defined(ARDUINO_BLACKPILL_F411CE)
+  #ifndef PB11 //Hack for F4 BlackPills
+    #define PB11 PB10
+  #endif
+  //Hack to alow compile on small STM boards
+  #ifndef A10
+    #define A10  PA0
+    #define A11  PA1
+    #define A12  PA2
+    #define A13  PA3
+    #define A14  PA4
+    #define A15  PA5
+  #endif
 #endif
 
 /*

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -208,13 +208,36 @@ void fuelSchedule1Interrupt(HardwareTimer*);
 void fuelSchedule2Interrupt(HardwareTimer*);
 void fuelSchedule3Interrupt(HardwareTimer*);
 void fuelSchedule4Interrupt(HardwareTimer*);
+#if (INJ_CHANNELS >= 5)
+void fuelSchedule5Interrupt(HardwareTimer*);
+#endif
+#if (INJ_CHANNELS >= 6)
+void fuelSchedule6Interrupt(HardwareTimer*);
+#endif
+#if (INJ_CHANNELS >= 7)
+void fuelSchedule7Interrupt(HardwareTimer*);
+#endif
+#if (INJ_CHANNELS >= 8)
+void fuelSchedule8Interrupt(HardwareTimer*);
+#endif
 void idleInterrupt(HardwareTimer*);
 void vvtInterrupt(HardwareTimer*);
 void ignitionSchedule1Interrupt(HardwareTimer*);
 void ignitionSchedule2Interrupt(HardwareTimer*);
 void ignitionSchedule3Interrupt(HardwareTimer*);
 void ignitionSchedule4Interrupt(HardwareTimer*);
+#if (IGN_CHANNELS >= 5)
 void ignitionSchedule5Interrupt(HardwareTimer*);
+#endif
+#if (IGN_CHANNELS >= 6)
+void ignitionSchedule6Interrupt(HardwareTimer*);
+#endif
+#if (IGN_CHANNELS >= 7)
+void ignitionSchedule7Interrupt(HardwareTimer*);
+#endif
+#if (IGN_CHANNELS >= 8)
+void ignitionSchedule8Interrupt(HardwareTimer*);
+#endif
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -163,12 +163,35 @@
   void fuelSchedule2Interrupt(HardwareTimer*){fuelSchedule2Interrupt();}
   void fuelSchedule3Interrupt(HardwareTimer*){fuelSchedule3Interrupt();}
   void fuelSchedule4Interrupt(HardwareTimer*){fuelSchedule4Interrupt();}
+  #if (INJ_CHANNELS >= 5)
+  void fuelSchedule5Interrupt(HardwareTimer*){fuelSchedule5Interrupt();}
+  #endif
+  #if (INJ_CHANNELS >= 6)
+  void fuelSchedule6Interrupt(HardwareTimer*){fuelSchedule6Interrupt();}
+  #endif
+  #if (INJ_CHANNELS >= 7)
+  void fuelSchedule7Interrupt(HardwareTimer*){fuelSchedule7Interrupt();}
+  #endif
+  #if (INJ_CHANNELS >= 8)
+  void fuelSchedule8Interrupt(HardwareTimer*){fuelSchedule8Interrupt();}
+  #endif
   void idleInterrupt(HardwareTimer*){idleInterrupt();}
   void vvtInterrupt(HardwareTimer*){vvtInterrupt();}
   void ignitionSchedule1Interrupt(HardwareTimer*){ignitionSchedule1Interrupt();}
   void ignitionSchedule2Interrupt(HardwareTimer*){ignitionSchedule2Interrupt();}
   void ignitionSchedule3Interrupt(HardwareTimer*){ignitionSchedule3Interrupt();}
   void ignitionSchedule4Interrupt(HardwareTimer*){ignitionSchedule4Interrupt();}
+  #if (IGN_CHANNELS >= 5)
   void ignitionSchedule5Interrupt(HardwareTimer*){ignitionSchedule5Interrupt();}
+  #endif
+  #if (IGN_CHANNELS >= 6)
+  void ignitionSchedule6Interrupt(HardwareTimer*){ignitionSchedule6Interrupt();}
+  #endif
+  #if (IGN_CHANNELS >= 7)
+  void ignitionSchedule7Interrupt(HardwareTimer*){ignitionSchedule7Interrupt();}
+  #endif
+  #if (IGN_CHANNELS >= 8)
+  void ignitionSchedule8Interrupt(HardwareTimer*){ignitionSchedule8Interrupt();}
+  #endif
 
 #endif

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -25,7 +25,7 @@
     */
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) )
     {
-        idle_pwm_max_count = 1000000L / (2 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 5KHz
+        idle_pwm_max_count = 1000000L / (4 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 5KHz
     } 
 
     //This must happen at the end of the idle init
@@ -55,8 +55,8 @@
     * Auxilliaries
     */
     //2uS resolution Min 8Hz, Max 5KHz
-    boost_pwm_max_count = 1000000L / (2 * configPage6.boostFreq * 2); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow freqneucies up to 511Hz
-    vvt_pwm_max_count = 1000000L / (2 * configPage6.vvtFreq * 2); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle
+    boost_pwm_max_count = 1000000L / (4 * configPage6.boostFreq * 2); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow freqneucies up to 511Hz
+    vvt_pwm_max_count = 1000000L / (4 * configPage6.vvtFreq * 2); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle
 
     //Need to be initialised last due to instant interrupt
     Timer1.setMode(2, TIMER_OUTPUT_COMPARE);
@@ -69,12 +69,16 @@
     * Schedules
     */
     Timer1.setOverflow(0xFFFF, TICK_FORMAT);
+    #if defined(STM32F4)
     Timer2.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
+    #else
+    Timer2.setOverflow(0xFFFF, TICK_FORMAT);
+    #endif
     Timer3.setOverflow(0xFFFF, TICK_FORMAT);
 
-    Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
-    Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
-    Timer3.setPrescaleFactor(((Timer3.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
+    Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
+    Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
+    Timer3.setPrescaleFactor(((Timer3.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
 
     Timer2.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer2.setMode(2, TIMER_OUTPUT_COMPARE);
@@ -94,8 +98,12 @@
     Timer3.attachInterrupt(3, fuelSchedule3Interrupt);
     Timer3.attachInterrupt(4, fuelSchedule4Interrupt);
     #if (INJ_CHANNELS >= 5)
+    #if defined(STM32F4)
     Timer5.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
-    Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
+    #else
+    Timer5.setOverflow(0xFFFF, TICK_FORMAT);
+    #endif
+    Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
     Timer5.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer5.attachInterrupt(1, fuelSchedule5Interrupt);
     #endif
@@ -119,7 +127,7 @@
     Timer2.attachInterrupt(4, ignitionSchedule4Interrupt);
     #if (IGN_CHANNELS >= 5)
     Timer4.setOverflow(0xFFFF, TICK_FORMAT);
-    Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
+    Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
     Timer4.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer4.attachInterrupt(1, ignitionSchedule5Interrupt);
     #endif

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -72,9 +72,9 @@
     Timer2.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
     Timer3.setOverflow(0xFFFF, TICK_FORMAT);
 
-    Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
-    Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
-    Timer3.setPrescaleFactor(((Timer3.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
+    Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
+    Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
+    Timer3.setPrescaleFactor(((Timer3.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
 
     Timer2.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer2.setMode(2, TIMER_OUTPUT_COMPARE);
@@ -95,7 +95,7 @@
     Timer3.attachInterrupt(4, fuelSchedule4Interrupt);
     #if (INJ_CHANNELS >= 5)
     Timer5.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
-    Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
+    Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
     Timer5.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer5.attachInterrupt(1, fuelSchedule5Interrupt);
     #endif
@@ -119,7 +119,7 @@
     Timer2.attachInterrupt(4, ignitionSchedule4Interrupt);
     #if (IGN_CHANNELS >= 5)
     Timer4.setOverflow(0xFFFF, TICK_FORMAT);
-    Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
+    Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * 2)-1);   //2us resolution
     Timer4.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer4.attachInterrupt(1, ignitionSchedule5Interrupt);
     #endif

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -68,9 +68,9 @@
     ***********************************************************************************************************
     * Schedules
     */
-    Timer1.setOverflow(0xFFFF, MICROSEC_FORMAT);
-    Timer2.setOverflow(0xFFFF, MICROSEC_FORMAT);
-    Timer3.setOverflow(0xFFFF, MICROSEC_FORMAT);
+    Timer1.setOverflow(0xFFFF, TICK_FORMAT);
+    Timer2.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
+    Timer3.setOverflow(0xFFFF, TICK_FORMAT);
 
     Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
     Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
@@ -87,14 +87,14 @@
     Timer3.setMode(4, TIMER_OUTPUT_COMPARE);
     Timer1.setMode(1, TIMER_OUTPUT_COMPARE);
 
-    //Attach interupt functions
+    //Attach interrupt functions
     //Injection
     Timer3.attachInterrupt(1, fuelSchedule1Interrupt);
     Timer3.attachInterrupt(2, fuelSchedule2Interrupt);
     Timer3.attachInterrupt(3, fuelSchedule3Interrupt);
     Timer3.attachInterrupt(4, fuelSchedule4Interrupt);
     #if (INJ_CHANNELS >= 5)
-    Timer5.setOverflow(0xFFFF, MICROSEC_FORMAT);
+    Timer5.setOverflow(0xFFFFFFFF, TICK_FORMAT); //32bit timer
     Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
     Timer5.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer5.attachInterrupt(1, fuelSchedule5Interrupt);
@@ -118,8 +118,8 @@
     Timer2.attachInterrupt(3, ignitionSchedule3Interrupt);
     Timer2.attachInterrupt(4, ignitionSchedule4Interrupt);
     #if (IGN_CHANNELS >= 5)
+    Timer4.setOverflow(0xFFFF, TICK_FORMAT);
     Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * 4)-1);   //4us resolution
-    Timer4.setOverflow(0xFFFF, MICROSEC_FORMAT);
     Timer4.setMode(1, TIMER_OUTPUT_COMPARE);
     Timer4.attachInterrupt(1, ignitionSchedule5Interrupt);
     #endif

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -375,7 +375,8 @@ void sendCancommand(uint8_t cmdtype, uint16_t canaddress, uint8_t candata1, uint
 void obd_response(uint8_t thePIDmode, uint8_t therequestedPIDlow, uint8_t therequestedPIDhigh)
 {
 
-#if defined(CORE_STM32) || defined(CORE_TEENSY)  
+// #if defined(CORE_STM32) || defined(CORE_TEENSY)
+#if defined(CORE_TEENSY)
 //only build the PID if the mcu has onboard/attached can 
 
   uint16_t obdcalcA;    //used in obd calcs

--- a/speeduino/src/BackupSram/BackupSramAsEEPROM.cpp
+++ b/speeduino/src/BackupSram/BackupSramAsEEPROM.cpp
@@ -7,16 +7,24 @@
           RCC->APB1ENR |= RCC_APB1ENR_PWREN;
         
           //Enable the backup SRAM clock by setting BKPSRAMEN bit i
-          RCC->AHB1ENR |= RCC_AHB1ENR_BKPSRAMEN; 
+          RCC->AHB1ENR |= RCC_AHB1ENR_BKPSRAMEN;
+
+          /** If the HSE divided by 2, 3, ..31 is used as the RTC clock, the
+            * Backup Domain Access should be kept enabled. */
+
+          // Enable access to Backup domain
+          PWR->CR |= PWR_CR_DBP;
 
           /** enable the backup regulator (used to maintain the backup SRAM content in
             * standby and Vbat modes).  NOTE : this bit is not reset when the device
             * wakes up from standby, system reset or power reset. You can check that
             * the backup regulator is ready on PWR->CSR.brr, see rm p144 */
 
-          //enable backup power regulator this makes sram backup posible. bit is not reset by software!
+          //Enable the backup power regulator. This makes the sram backup possible. bit is not reset by software!
           PWR->CSR |= PWR_CSR_BRE;
 
+          //Wait until the backup power regulator is ready
+          while ((PWR->CSR & PWR_CSR_BRR) == 0);
     }
     int8_t BackupSramAsEEPROM::write_byte( uint8_t *data, uint16_t bytes, uint16_t offset ) {
         uint8_t* base_addr = (uint8_t *) BKPSRAM_BASE;
@@ -28,18 +36,17 @@
         
           /* disable backup domain write protection */
           //Set the Disable Backup Domain write protection (DBP) bit in PWR power control register
-          PWR->CR |= PWR_CR_DBP;
+          //PWR->CR |= PWR_CR_DBP;
 
           for( i = 0; i < bytes; i++ ) {
             *(base_addr + offset + i) = *(data + i);
           }
           //Enable write protection backup sram when finished  
-          PWR->CR &= ~PWR_CR_DBP;
+          //PWR->CR &= ~PWR_CR_DBP;
           return 0;
         }
         
     int8_t BackupSramAsEEPROM::read_byte( uint8_t *data, uint16_t bytes, uint16_t offset ) {
-        
           uint8_t* base_addr = (uint8_t *) BKPSRAM_BASE;
           uint16_t i;
           if( bytes + offset >= backup_size ) {
@@ -54,7 +61,6 @@
         }
   
     uint8_t BackupSramAsEEPROM::read(uint16_t address) {
-
         uint8_t val = 0;
         read_byte(&val, 1, address);
       
@@ -74,4 +80,3 @@
 BackupSramAsEEPROM EEPROM;
 
 #endif
-


### PR DESCRIPTION
These should fix 32bit timers missing/double pulses and SRAM backup write/read problems. Some board configurations did break because of the bluepill/blackpill "hacks" so those are now checked only with bluepill/blackpill boards.