### PR TITLE
DFCO minimum temperature

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -336,7 +336,12 @@ page = 1
       injAngRPM     = array,  U08,      95, [4],   "RPM"        100,       0.0,   100,    10000,    0
       idleTaperTime = scalar, U08,      99,    "S",         0.1,       0.0,   0.0,    25.5,      1
       dfcoDelay     = scalar, U08,      100,   "S",         0.1,       0.0,   0.0,    25.5,      1
-      unused2-95    = array,  U08,      101, [27],   "%",        1.0,       0.0,   0.0,     255,      0
+#if CELSIUS
+      dfcoTemp    = scalar, U08,      101,   "C", 1.0,       -40,    -40,    215,      0
+#else
+      dfcoTemp    = scalar, U08,      101,   "F", 1.8,    -22.23,    -40,    215,      0
+#endif
+      unused2-102    = array,  U08,      102, [26],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -1146,6 +1151,7 @@ page = 11
     defaultValue = idleAdvEnabled, 0 ;Idle advance control turned off
     defaultValue = aseTsnDelay, 0.0
     defaultValue = dfcoDelay, 0.1
+	defaultValue = dfcoTemp, 0
     defaultValue = idleTaperTime, 1.0
 
     ;Default pins
@@ -1436,6 +1442,7 @@ menuDialog = main
     dfcoHyster  = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
     dfcoTPSThresh= "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
 	dfcoDelay   = "Delay for activate DFCO."
+	dfcoTemp   = "Minimum coolant temperature for DFCO activation. Below this DFCO is always disabled."
 
     launchPin   = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
     launchHiLo  = "Whether the signal is High or Low when the clutch pedal is engaged. For a ground switching input (Most clutch switches), this should be LOW"
@@ -1745,6 +1752,7 @@ menuDialog = main
       field = "Cutoff delay", dfcoDelay,            { dfcoEnabled }
       field = "Cutoff RPM", dfcoRPM,                { dfcoEnabled }
       field = "RPM Hysteresis", dfcoHyster,         { dfcoEnabled }
+      field = "Minimum temperature", dfcoTemp,      { dfcoEnabled }
 
     dialog = accelEnrichments_north_south, ""
       liveGraph = pump_ae_Graph, "AE Graph"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1151,8 +1151,12 @@ page = 11
     defaultValue = idleAdvEnabled, 0 ;Idle advance control turned off
     defaultValue = aseTsnDelay, 0.0
     defaultValue = dfcoDelay, 0.1
-	defaultValue = dfcoTemp, 0
-    defaultValue = idleTaperTime, 1.0
+#if CELSIUS
+	defaultValue = dfcoTemp, -40
+#else
+	defaultValue = dfcoTemp, -22.23
+#endif
+   defaultValue = idleTaperTime, 1.0
 
     ;Default pins
     defaultValue = fanPin,      0

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -435,7 +435,8 @@ bool correctionDFCO()
     }
     else {
       if ( dfcoStart == 0 ) { dfcoStart = runSecsX10; }
-      if ( ( currentStatus.RPM > (unsigned int)( (configPage4.dfcoRPM * 10) + configPage4.dfcoHyster) ) && ( currentStatus.TPS < configPage4.dfcoTPSThresh ) && ( (runSecsX10 - dfcoStart) > configPage2.dfcoDelay ) ){
+      if ( ( currentStatus.RPM > (unsigned int)( (configPage4.dfcoRPM * 10) + configPage4.dfcoHyster) ) && ( currentStatus.TPS < configPage4.dfcoTPSThresh )
+      && ( (runSecsX10 - dfcoStart) > configPage2.dfcoDelay ) && ((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET) > configPage2.dfcoTemp) ){
         DFCOValue = true;
       }
     }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -643,8 +643,9 @@ struct config2 {
 
   byte idleTaperTime;
   byte dfcoDelay;
+  byte dfcoTemp; //Minimum CLT for DFCO
 
-  byte unused2_95[27];
+  byte unused2_102[26];
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
This is to add a minimum coolant temperature setting for DFCO. Cold starts often require increased idle, and in order to avoid rpm hunting the DFCO needs to be disabled.

Default value has been intentionally set to minimum, so this basically won't affect anyone not willing to use it and not touching the settings.