### PR TITLE
drive distributor from single channel

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -10,8 +10,8 @@
   #define LED_BUILTIN 13
   #define CORE_AVR
   #define BOARD_H "board_avr2560.h"
-  #define INJ_CHANNELS 4
-  #define IGN_CHANNELS 5
+  #define INJ_CHANNELS 8
+  #define IGN_CHANNELS 1
 
   //#define TIMER5_MICROS
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -697,6 +697,14 @@ void initialiseAll()
         channel4IgnDegrees = 270;
         maxIgnOutputs = 4;
 
+    #if IGN_CHANNELS >= 1
+        if( (configPage4.sparkMode == IGN_MODE_SINGLE))
+        {
+        maxIgnOutputs = 1;
+        CRANK_ANGLE_MAX_IGN = 90;
+        }
+    #endif
+
     #if IGN_CHANNELS >= 8
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL))
         {

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -926,7 +926,7 @@ void loop()
         //Refresh the current crank angle info
         //ignition1StartAngle = 335;
         crankAngle = getCrankAngle(); //Refresh with the latest crank angle
-        if (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= 360; }
+        while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
         if ( (ignition1StartAngle <= crankAngle) && (ignitionSchedule1.Status == RUNNING) ) { ignition1StartAngle += CRANK_ANGLE_MAX_IGN; }


### PR DESCRIPTION
Enable a single ignition channel to fire multiple times per revolution instead of only once, in case there is only 1 timer channel for ignition on Mega when the others are occupied for 8 cyl sequential injection.

Note: Changes in globals.h only to remind you to adjust these before building!