### PR TITLE
Acceleration enrichment cold temperature adjustment

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -218,8 +218,13 @@
 ;--------------------------------------------------
 page = 1
       aseTsnDelay   = scalar, U08,       0,         "S",        0.1,       0.0,   0.0,    25.5,      1
-      unused1-1     = scalar, U08,       1,         "kPa",      1.0,       0.0,   0.0,    255,       0
-      unused1-2     = scalar, U08,       2,         "%",        1.0,       0.0,   0.0,    255,       0 ;This used to be asePct
+      aeColdPct     = scalar, U08,       1,         "%",      1.0,       0.0,   0.0,    255,       0 ;AE cold modifier %
+#if CELSIUS
+      aeColdTaperMin = scalar, U08,       2,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+#else
+      aeColdTaperMin = scalar, U08,       2,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+#endif
+	  
       aeMode        = bits,   U08,       3, [0:1],  "TPS", "MAP", "INVALID", "INVALID"
       battVCorMode  = bits,   U08,       3, [2:2],  "Whole PW", "Open Time only"
       unused1-3c    = bits,   U08,       3, [3:7],  "MAP", "TPS", "INVALID", "INVALID"
@@ -276,7 +281,12 @@ page = 1
       perToothIgn   = bits,   U08,      38, [6:6], "No", "Yes"
       dfcoEnabled   = bits,   U08,      38, [7:7], "Off",       "On"
 
-      unused2-39    = scalar, U08,      39,        "ms",        0.1,       0.0,   0.0,     25.5,     1 ;This used to be PrimePulse
+#if CELSIUS
+      aeColdTaperMax = scalar, U08,       39,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+#else
+      aeColdTaperMax = scalar, U08,       39,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold modifier, taper end clt (no modifier)
+#endif
+
       dutyLim       = scalar, U08,      40,        "%",         1.0,       0.0,   0.0,     95.0,     0
       flexFreqLow   = scalar, U08,      41,        "Hz",        1.0,       0.0,   0.0,     250.0,    0
       flexFreqHigh  = scalar, U08,      42,        "Hz",        1.0,       0.0,   0.0,     250.0,    0
@@ -1157,6 +1167,9 @@ page = 11
     defaultValue = bootloaderCaps, 0
     defaultValue = aeTaperMin, 1000
     defaultValue = aeTaperMax, 5000
+    defaultValue = aeColdPct, 100
+    defaultValue = aeColdTaperMin, 0
+    defaultValue = aeColdTaperMax, 60
     defaultValue = aeMode, 0 ;Set aeMode to TPS
 	  defaultValue = batVoltCorrect, 0
     defaultValue = legacyMAP, 0
@@ -1753,13 +1766,18 @@ menuDialog = main
         field = "Output speed",         tachoDiv
         field = "Pulse duration",       tachoDuration
 
-    dialog = accelEnrichments_center, "Acceleration Enrichment"
+    dialog = accelEnrichments_aeSettings, ""
         field = "Enrichment mode",      aeMode
         field = "TPSdot Threshold",     taeThresh,  { aeMode == 0 }
         field = "MAPdot Threshold",     maeThresh,  { aeMode == 1 }
         field = "Accel Time",           aeTime
         field = "Taper Start RPM",      aeTaperMin
         field = "Taper End RPM",        aeTaperMax
+
+	dialog = accelEnrichments_coldModifier, "Acceleration Enrichment cold modifier"
+        field = "Cold modifier",      aeColdPct
+        field = "Cold modifier taper start temperature",  aeColdTaperMin
+        field = "Cold modifier taper end temperature",  aeColdTaperMax
 
     dialog = accelEnrichments_south, "Decelleration Fuel Cutoff (DFCO)"
       field = "Enabled", dfcoEnabled
@@ -1778,6 +1796,10 @@ menuDialog = main
     dialog = accelEnrichments_north, "", xAxis
         panel = time_accel_tpsdot_curve,  { aeMode == 0 }
         panel = time_accel_mapdot_curve,  { aeMode == 1 }
+
+    dialog = accelEnrichments_center, "Acceleration Enrichment", xAxis
+        panel = accelEnrichments_aeSettings
+        panel = accelEnrichments_coldModifier
 
     dialog = accelEnrichments, "Acceleration Enrichment"
         topicHelp = "http://speeduino.com/wiki/index.php/Acceleration_Wizard"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -218,7 +218,7 @@
 ;--------------------------------------------------
 page = 1
       aseTsnDelay   = scalar, U08,       0,         "S",        0.1,       0.0,   0.0,    25.5,      1
-      aeColdPct     = scalar, U08,       1,         "%",      1.0,       0.0,   0.0,    255,       0 ;AE cold modifier %
+      aeColdPct     = scalar, U08,       1,         "%",      1.0,       0,   100,    255,       0 ;AE cold modifier %
 #if CELSIUS
       aeColdTaperMin = scalar, U08,       2,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
 #else
@@ -1465,6 +1465,9 @@ menuDialog = main
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
     oddfire4    = "The ATDC angle of channel 4 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 3)"
 
+	aeColdPct   = "Acceleration enrichment adjustment for cold engine. Cold adjustment % is tapered between start and end temperatures.\n100% = no adjustment."
+	aeColdTaperMin = "AE cold adjustment taper start temperature. When coolant is below this value, full cold adjustment is applied."
+	aeColdTaperMax = "AE cold adjustment taper end temperature. When coolant is above this value, no cold adjustment is applied."
 	dfcoRPM     = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
     dfcoHyster  = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
     dfcoTPSThresh= "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
@@ -1775,9 +1778,9 @@ menuDialog = main
         field = "Taper End RPM",        aeTaperMax
 
 	dialog = accelEnrichments_coldModifier, "Acceleration Enrichment cold modifier"
-        field = "Cold modifier",      aeColdPct
-        field = "Cold modifier taper start temperature",  aeColdTaperMin
-        field = "Cold modifier taper end temperature",  aeColdTaperMax
+        field = "Cold adjustment",      aeColdPct
+        field = "Cold adjustment taper start temperature",  aeColdTaperMin
+        field = "Cold adjustment taper end temperature",  aeColdTaperMax
 
     dialog = accelEnrichments_south, "Decelleration Fuel Cutoff (DFCO)"
       field = "Enabled", dfcoEnabled

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -218,11 +218,11 @@
 ;--------------------------------------------------
 page = 1
       aseTsnDelay   = scalar, U08,       0,         "S",        0.1,       0.0,   0.0,    25.5,      1
-      aeColdPct     = scalar, U08,       1,         "%",      1.0,       0,   100,    255,       0 ;AE cold modifier %
+      aeColdPct     = scalar, U08,       1,         "%",      1.0,       0,   100,    255,       0 ;AE cold adjustment %
 #if CELSIUS
-      aeColdTaperMin = scalar, U08,       2,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+      aeColdTaperMin = scalar, U08,       2,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold adjustment, taper start clt (full adjustment)
 #else
-      aeColdTaperMin = scalar, U08,       2,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+      aeColdTaperMin = scalar, U08,       2,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold adjustment, taper start clt (full adjustment)
 #endif
 	  
       aeMode        = bits,   U08,       3, [0:1],  "TPS", "MAP", "INVALID", "INVALID"
@@ -282,9 +282,9 @@ page = 1
       dfcoEnabled   = bits,   U08,      38, [7:7], "Off",       "On"
 
 #if CELSIUS
-      aeColdTaperMax = scalar, U08,       39,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold modifier, taper start clt (full modifier)
+      aeColdTaperMax = scalar, U08,       39,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold adjustment, taper start clt (full adjustment)
 #else
-      aeColdTaperMax = scalar, U08,       39,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold modifier, taper end clt (no modifier)
+      aeColdTaperMax = scalar, U08,       39,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold adjustment, taper end clt (no adjustment)
 #endif
 
       dutyLim       = scalar, U08,      40,        "%",         1.0,       0.0,   0.0,     95.0,     0
@@ -1777,7 +1777,7 @@ menuDialog = main
         field = "Taper Start RPM",      aeTaperMin
         field = "Taper End RPM",        aeTaperMax
 
-	dialog = accelEnrichments_coldModifier, "Acceleration Enrichment cold modifier"
+	dialog = accelEnrichments_coldAdj, "Acceleration Enrichment cold adjustment"
         field = "Cold adjustment",      aeColdPct
         field = "Cold adjustment taper start temperature",  aeColdTaperMin
         field = "Cold adjustment taper end temperature",  aeColdTaperMax
@@ -1802,7 +1802,7 @@ menuDialog = main
 
     dialog = accelEnrichments_center, "Acceleration Enrichment", xAxis
         panel = accelEnrichments_aeSettings
-        panel = accelEnrichments_coldModifier
+        panel = accelEnrichments_coldAdj
 
     dialog = accelEnrichments, "Acceleration Enrichment"
         topicHelp = "http://speeduino.com/wiki/index.php/Acceleration_Wizard"

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -321,7 +321,7 @@ uint16_t correctionAccel()
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
+              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
               accelValue = (uint16_t) accelValue_long;
             }
           }
@@ -383,7 +383,7 @@ uint16_t correctionAccel()
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
+              uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
               accelValue = (uint16_t) accelValue_uint;
             }
           }

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -312,15 +312,17 @@ uint16_t correctionAccel()
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
             if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
-              accelValue += configPage2.aeColdPct;
+              unsigned long accelValue_long = (unsigned long) accelValue * configPage2.aeColdPct / 100;
+              accelValue = (uint16_t) accelValue_long;
             }
             //If CLT is between taper min and max, taper the modifier value and apply it on top of accelValue
             else
             {
-              int16_t taperRange = (int) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
+              int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
-              int16_t coldPct = (int) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              accelValue = (int) accelValue * coldPct / 100;
+              int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
+              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
+              accelValue = (uint16_t) accelValue_long;
             }
           }
           
@@ -372,15 +374,17 @@ uint16_t correctionAccel()
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
             if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
-              accelValue = accelValue * configPage2.aeColdPct / 100;
+              unsigned long accelValue_long = (unsigned long) accelValue * configPage2.aeColdPct / 100;
+              accelValue = (uint16_t) accelValue_long;
             }
             //If CLT is between taper min and max, taper the modifier value and apply it on top of accelValue
             else
             {
-              int16_t taperRange = (int) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
+              int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
-              int16_t coldPct = (int) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              accelValue = (int) accelValue * coldPct / 100;
+              int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
+              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
+              accelValue = (uint16_t) accelValue_long;
             }
           }
 

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -239,10 +239,12 @@ byte correctionASE()
  * @brief Acceleration enrichment correction calculation
  * 
  * Calculates the % change of the throttle over time (%/second) and performs a lookup based on this
+ * Coolant-based modifier is applied on the top of this.
  * When the enrichment is turned on, it runs at that amount for a fixed period of time (taeTime)
  * 
  * @return uint16_t The Acceleration enrichment modifier as a %. 100% = No modification. 
- * As the maximum enrichment amount is +255%, the overall return value from this function can be 100+255=355. Hence this function returns a uint16_t rather than byte
+ * As the maximum enrichment amount is +255% and maximum cold adjustment for this is 255%, the overall return value
+ * from this function can be 100+(255*255/100)=750. Hence this function returns a uint16_t rather than byte
  */
 uint16_t correctionAccel()
 {

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -315,7 +315,7 @@ uint16_t correctionAccel()
             if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
               uint16_t accelValue_uint = (uint16_t) accelValue * configPage2.aeColdPct / 100;
-              accelValue = (uint16_t) accelValue_uint;
+              accelValue = (int16_t) accelValue_uint;
             }
             //If CLT is between taper min and max, taper the modifier value and apply it on top of accelValue
             else
@@ -323,8 +323,8 @@ uint16_t correctionAccel()
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
-              accelValue = (uint16_t) accelValue_long;
+              uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
+              accelValue = (int16_t) accelValue_uint;
             }
           }
           
@@ -376,8 +376,8 @@ uint16_t correctionAccel()
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
             if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
-              unsigned long accelValue_long = (unsigned long) accelValue * configPage2.aeColdPct / 100;
-              accelValue = (uint16_t) accelValue_long;
+              uint16_t accelValue_uint = (uint16_t) accelValue * configPage2.aeColdPct / 100;
+              accelValue = (int16_t) accelValue_uint;
             }
             //If CLT is between taper min and max, taper the modifier value and apply it on top of accelValue
             else
@@ -386,7 +386,7 @@ uint16_t correctionAccel()
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
               uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
-              accelValue = (uint16_t) accelValue_uint;
+              accelValue = (int16_t) accelValue_uint;
             }
           }
 

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -312,8 +312,8 @@ uint16_t correctionAccel()
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
             if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
-              unsigned long accelValue_long = (unsigned long) accelValue * configPage2.aeColdPct / 100;
-              accelValue = (uint16_t) accelValue_long;
+              uint16_t accelValue_uint = (uint16_t) accelValue * configPage2.aeColdPct / 100;
+              accelValue = (uint16_t) accelValue_uint;
             }
             //If CLT is between taper min and max, taper the modifier value and apply it on top of accelValue
             else
@@ -383,8 +383,8 @@ uint16_t correctionAccel()
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
               int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
-              unsigned long accelValue_long = (unsigned long) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
-              accelValue = (uint16_t) accelValue_long;
+              uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using unsigned long
+              accelValue = (uint16_t) accelValue_uint;
             }
           }
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -528,8 +528,8 @@ struct statuses {
 struct config2 {
 
   byte aseTsnDelay;
-  byte unused2_1;
-  byte unused2_2;  //was ASE
+  byte aeColdPct;  //AE cold clt modifier %
+  byte aeColdTaperMin; //AE cold modifier, taper start temp (full modifier), was ASE in early versions
   byte aeMode : 2; /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */
   byte battVCorMode : 1;
   byte unused1_3c : 5;
@@ -587,7 +587,7 @@ struct config2 {
   byte perToothIgn : 1;
   byte dfcoEnabled : 1; //Whether or not DFCO is turned on
 
-  byte unused2_39;  //Was primePulse
+  byte aeColdTaperMax;  //AE cold modifier, taper end temp (no modifier applied), was primePulse in early versions
   byte dutyLim;
   byte flexFreqLow; //Lowest valid frequency reading from the flex sensor
   byte flexFreqHigh; //Highest valid frequency reading from the flex sensor

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -101,7 +101,7 @@ void doUpdates()
     //Convert whatever flex fuel settings are there into the new tables
 
     configPage10.flexBoostBins[0] = 0;
-    configPage10.flexBoostAdj[0]  = (int8_t)configPage2.unused2_1;
+    configPage10.flexBoostAdj[0]  = (int8_t)configPage2.aeColdPct;
 
     configPage10.flexFuelBins[0] = 0;
     configPage10.flexFuelAdj[0]  = configPage2.idleUpPin;
@@ -116,7 +116,7 @@ void doUpdates()
       configPage10.flexFuelBins[x] = pct;
       configPage10.flexAdvBins[x] = pct;
 
-      int16_t boostAdder = (((configPage2.unused2_2 - (int8_t)configPage2.unused2_1) * pct) / 100) + (int8_t)configPage2.unused2_1;
+      int16_t boostAdder = (((configPage2.aeColdTaperMin - (int8_t)configPage2.aeColdPct) * pct) / 100) + (int8_t)configPage2.aeColdPct;
       configPage10.flexBoostAdj[x] = boostAdder;
 
       uint8_t fuelAdder = (((configPage2.idleUpAdder - configPage2.idleUpPin) * pct) / 100) + configPage2.idleUpPin;
@@ -169,10 +169,10 @@ void doUpdates()
   {
     //May 2019 version adds the use of a 2D table for the priming pulse rather than a single value.
     //This sets all the values in the 2D table to be the same as the previous single value
-    configPage2.primePulse[0] = configPage2.unused2_39 / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
-    configPage2.primePulse[1] = configPage2.unused2_39 / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
-    configPage2.primePulse[2] = configPage2.unused2_39 / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
-    configPage2.primePulse[3] = configPage2.unused2_39 / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
+    configPage2.primePulse[0] = configPage2.aeColdTaperMax / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
+    configPage2.primePulse[1] = configPage2.aeColdTaperMax / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
+    configPage2.primePulse[2] = configPage2.aeColdTaperMax / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
+    configPage2.primePulse[3] = configPage2.aeColdTaperMax / 5; //New priming pulse values are in the range 0-127.5 rather than 0-25.5 so they must be divided by 5
     //Set some sane default temperatures for this table
     configPage2.primeBins[0] = 0;
     configPage2.primeBins[1] = 40;
@@ -181,10 +181,10 @@ void doUpdates()
 
     //Also added is coolant based ASE for both duration and amount
     //All the adder amounts are set to what the single value was previously
-    configPage2.asePct[0] = configPage2.unused2_2;
-    configPage2.asePct[1] = configPage2.unused2_2;
-    configPage2.asePct[2] = configPage2.unused2_2;
-    configPage2.asePct[3] = configPage2.unused2_2;
+    configPage2.asePct[0] = configPage2.aeColdTaperMin;
+    configPage2.asePct[1] = configPage2.aeColdTaperMin;
+    configPage2.asePct[2] = configPage2.aeColdTaperMin;
+    configPage2.asePct[3] = configPage2.aeColdTaperMin;
     //ASE duration is set to 10s for all coolant values
     configPage2.aseCount[0] = 10;
     configPage2.aseCount[1] = 10;
@@ -329,6 +329,11 @@ void doUpdates()
     {
       configPage10.flexAdvAdj[i] += 40;
     }
+    
+    //AE cold modifier added. Default to sane values
+    configPage2.aeColdPct = 100;
+    configPage2.aeColdTaperMin = 40;
+    configPage2.aeColdTaperMax = 100;
     
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 14);


### PR DESCRIPTION
This adds possibility to increase AE amount when engine is cold. Needed ie for E85 and stone cold engine. Cold modifier is tapered between two temperature points. Default values are set so this adjustment won't apply (so no change for those who won't notice this feature).

![image](https://user-images.githubusercontent.com/55035659/79192972-64a1a080-7e32-11ea-965f-e35c78130ef7.png)


