### PR TITLE
Fix negative values in flexfuel ignition advance

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -936,7 +936,7 @@ page = 10
         flexFuelBins        = array,  U08,      51, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
         flexFuelAdj         = array,  U08,      57, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
         flexAdvBins         = array,  U08,      63, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
-        flexAdvAdj          = array,  S08,      69, [6], "Deg",  1.0,       0.0,   -125,    125.0,    0
+        flexAdvAdj          = array,  U08,      69, [6], "Deg",  1.0,       -40,   -40,     215.0,    0
 
         n2o_enable          = bits ,  U08,      75, [0:1],           "Off","1 Stage","2 stage", "INVALID"
         n2o_arming_pin      = bits ,  U08,      75, [2:7],           $IO_Pins_no_def

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -580,11 +580,11 @@ int8_t correctionCrankingFixedTiming(int8_t advance)
 
 int8_t correctionFlexTiming(int8_t advance)
 {
-  int8_t ignFlexValue = advance;
+  int16_t ignFlexValue = advance;
   if( configPage2.flexEnabled == 1 ) //Check for flex being enabled
   {
-    int16_t flexIgnCorrection = table2D_getValue(&flexAdvTable, currentStatus.ethanolPct) - OFFSET_IGNITION; //Negative values are achieved with offset
-    currentStatus.flexIgnCorrection = (int8_t) flexIgnCorrection; //This gets cast to a signed 8 bit value to allows for negative advance (ie retard) values here. 
+    ignFlexValue = (int16_t) table2D_getValue(&flexAdvTable, currentStatus.ethanolPct) - OFFSET_IGNITION; //Negative values are achieved with offset
+    currentStatus.flexIgnCorrection = (int8_t) ignFlexValue; //This gets cast to a signed 8 bit value to allows for negative advance (ie retard) values here. 
     ignFlexValue = (int8_t) advance + currentStatus.flexIgnCorrection;
   }
   return (int8_t) ignFlexValue;

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -580,13 +580,14 @@ int8_t correctionCrankingFixedTiming(int8_t advance)
 
 int8_t correctionFlexTiming(int8_t advance)
 {
-  byte ignFlexValue = advance;
+  int8_t ignFlexValue = advance;
   if( configPage2.flexEnabled == 1 ) //Check for flex being enabled
   {
-    currentStatus.flexIgnCorrection = (int8_t)table2D_getValue(&flexAdvTable, currentStatus.ethanolPct); //This gets cast to a signed 8 bit value to allows for negative advance (ie retard) values here. 
-    ignFlexValue = advance + currentStatus.flexIgnCorrection;
+    int16_t flexIgnCorrection = table2D_getValue(&flexAdvTable, currentStatus.ethanolPct) - OFFSET_IGNITION; //Negative values are achieved with offset
+    currentStatus.flexIgnCorrection = (int8_t) flexIgnCorrection; //This gets cast to a signed 8 bit value to allows for negative advance (ie retard) values here. 
+    ignFlexValue = (int8_t) advance + currentStatus.flexIgnCorrection;
   }
-  return ignFlexValue;
+  return (int8_t) ignFlexValue;
 }
 
 int8_t correctionIATretard(int8_t advance)

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -324,7 +324,7 @@ void doUpdates()
     //Introdced a minimum temperature for DFCO. Default it to 40C
     configPage2.dfcoMinCLT = 40;
 
-    //Update config values for 40 degrees offset
+    //Update flexfuel ignition config values for 40 degrees offset
     for (int i=0; i<6; i++)
     {
       configPage10.flexAdvAdj[i] += 40;

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -323,6 +323,12 @@ void doUpdates()
     configPage2.dfcoDelay = 0;
     //Introdced a minimum temperature for DFCO. Default it to 40C
     configPage2.dfcoMinCLT = 40;
+
+    //Update config values for 40 degrees offset
+    for (int i=0; i<6; i++)
+    {
+      configPage10.flexAdvAdj[i] += 40;
+    }
     
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 14);


### PR DESCRIPTION
This fixes inconsistent values when using negative flexfuel ignition advance modifiers (mentioned in issue #254). Changed signed 8-bit modifiers to unsigned 8-bit + 40 degree offset, which allows for adjustment from -40 to 215 degrees (should be more than enough, upper end is limited by int8_t base_advance way before this).