### PR TITLE
Fix flex ignition correction value displayed in TS

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -3532,7 +3532,7 @@ cmdtestspk450dc = "E\x03\x0C"
    rpmDOT           = scalar,   S16,    32, "rpm/s",  1.000, 0.000
    flex             = scalar,   U08,    34, "%",      1.000, 0.000
    flexFuelCor      = scalar,   U08,    35, "%",      1.000, 0.000
-   flexIgnCor       = scalar,   U08,    36, "deg",    1.000, 0.000
+   flexIgnCor       = scalar,   S08,    36, "deg",    1.000, 0.000
 
    idleLoad         = scalar,   U08,    37, { bitStringValue( idleUnits , iacAlgorithm  ) },    { (iacAlgorithm == 2 || iacAlgorithm == 3) ? 1.000 : 2.000 }, 0.000 ; This is a combined variable covering both PWM and stepper IACs. The units and precision used depend on which idle algorithm is chosen
    testoutputs      = scalar,   U08,    38, "bits",   1.000, 0.000


### PR DESCRIPTION
This should have been included in the PR #360 , so also negative correction values are displayed correctly in TS.