### PR TITLE
Cranking enrichment to ASE (or run) taper

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1025,7 +1025,8 @@ page = 10
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
 
-        unused11_122_191    = array,  U08,    134,  [57], "RPM",  100.0,      0.0,  100,     25500,    0
+        crankingEnrichTaper = scalar,  U08,    134,  "s",  0.1,      0.0,  0.0,     25.5,    0
+        unused11_135_191    = array,  U08,    135,  [56], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1188,6 +1189,7 @@ page = 11
     defaultValue = idleTaperTime, 1.0
     defaultValue = dfcoDelay, 0.1
     defaultValue = dfcoMinCLT, 25
+	defaultValue = crankingEnrichTaper, 0.1
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -1589,6 +1591,149 @@ menuDialog = main
   caninput_sel14a = "This Enables local analog/digital on input channel 14 "
   caninput_sel15a = "This Enables local analog/digital on input channel 15 "
 
+    nCylinders  = "Cylinder count"
+    alternate   = "Whether or not the injectors should be fired at the same time. This setting is ignored when Sequential is selected below, however it will still affect the req_fuel value."
+    engineType  = "Engines with an equal number of degrees between all firings (This is most engines) should select Even fire. Some 2 and 6 cylinder engines are Odd fire however."
+    twoStroke   = "Four-Stroke (most engines), Two-stroke."
+    nInjectors  = "Number of primary injectors."
+    mapSample   = "The method used for calculating the MAP reading\nFor 1-2 Cylinder engines, Cycle Minimum is recommended.\nFor more than 2 cylinders Cycle Average is recommended"
+    stoich      = "The stoichiometric ration of the fuel being used. For flex fuel, choose the primary fuel"
+    injLayout   = "The injector layout and timing to be used. Options are: \n 1. Paired - 2 injectors per output. Outputs active is equal to half the number of cylinders. Outputs are timed over 1 crank revolution. \n 2. Semi-sequential: Same as paired except that injector channels are mirrored (1&4, 2&3) meaning the number of outputs used are equal to the number of cylinders. Only valid for 4 cylinders or less. \n 3. Banked: 2 outputs only used. \n 4. Sequential: 1 injector per output and outputs used equals the number of cylinders. Injection is timed over full cycle. "
+
+    TrigPattern = "The type of input trigger decoder to be used."
+	useResync   = "If enabled, sync will be rechecked once every full cycle from the cam input. This is good for accuracy, however if your cam input is noisy then this can cause issues."
+	trigPatternSec  = "Cam mode/type also known as Secondary Trigger Pattern."
+    numTeeth    = "Number of teeth on Primary Wheel."
+    TrigSpeed   = "Primary trigger speed."
+    missingTeeth= "Number of Missing teeth on Primary Wheel."
+    TrigAng     = "The Angle ATDC when tooth No:1 on the primary wheel passes the primary sensor. The range of this field is -360 to +360 degrees."
+    TrigAngMul  = "A multiplier used by non-360 degree tooth wheels (i.e. Wheels where the tooth count doesn't divide evenly into 360. Usage: (360 * <multiplier>) / tooth_count = Whole number"
+    SkipCycles   = "The number of revolutions that will be skipped during cranking before the injectors and coils are fired."
+	TrigEdge    = "The Trigger edge of the primary sensor.\nLeading.\nTrailing."
+	TrigEdgeSec = "The Trigger edge of the secondary (Cam) sensor.\nLeading.\nTrailing."
+	TrigFilter  = "Tuning of the trigger filter algorithm. The more aggressive the setting, the more noise will be removed, however this increases the chance of some true readings being filtered out (False positive). Medium is safe for most setups. Only select 'Aggressive' if no other options are working"
+
+	sparkMode   = "Wasted Spark: Ignition outputs are on the channels <= half the number of cylinders. Eg 4 cylinder outputs on IGN1 and IGN2.\nSingle Channel: All ignition pulses are output on IGN1.\nWasted COP: Ignition pulses are output on all ignition channels up to the number of cylinders. Eg 4 cylinder outputs on all ignition channels. Note that your board needs to have same number of igntion outputs as cylinders to be able to run this"
+	IgInv       = "Whether the spark fires when the ignition signal goes high or goes low. Nearly all ignition systems use 'Going Low' but please verify this as damage to coils can result from the incorrect selection. (NOTE: THIS IS NOT MEGASQUIRT. THIS SETTING IS USUALLY THE OPPOSITE OF WHAT THEY USE!)"
+    sparkDur    = "The duration of the spark at full dwell. Typically around 1ms"
+    fixAngEnable= "If enabled, timing will be locked/fixed and the ignition map will be ignored. Note that this value will be overriden by the fixed cranking value when cranking"
+    FixAng      = "Timing will be locked at this value if the above is enabled"
+
+    crankRPM    = "The cranking RPM threshold. When RPM is lower than this value (and above 0) the system will be considered to be cranking"
+    tpsflood    = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine"
+
+	fanInv      = ""
+	fanHyster   = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"
+
+	aeTime      = "The duration of the acceleration enrichment"
+    aseTsnDelay = "Transition time to disable ASE"
+	iacChannels = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
+	iacStepTime = "Duration of each stepping pulse. Values that are too low can cause the motor to behave erratically or not at all. See the manual for suggested step times"
+  iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
+  
+    iacStepHome = "Homing steps to perform on startup. Must be greater than the fully open steps value"
+    iacMaxSteps = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
+	iacStepHyster = "The minimum number of steps to move in any one go."
+	iacAlgorithm = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
+	iacPWMdir   = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
+	iacCLminDuty= "When using closed loop idle control, this is the minimum duty cycle that the PID loop will allow. Combined with the maximum value, this specifies the working range of your idle valve"
+	iacCLmaxDuty= "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
+	iacFastTemp = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
+    idleUpPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
+    CTPSPolarity = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
+    idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
+    idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
+    idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
+    idleAdvDelay= "The number of seconds after sync is achieved before the idle advance control begins"
+    idleTaperTime = "Soft time transition from crank to running PWM targets"
+
+	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
+    oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
+    oddfire4    = "The ATDC angle of channel 4 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 3)"
+
+	aeColdPct   = "Acceleration enrichment adjustment for cold engine. Cold adjustment % is tapered between start and end temperatures.\n100% = no adjustment."
+	aeColdTaperMin = "AE cold adjustment taper start temperature. When coolant is below this value, full cold adjustment is applied."
+	aeColdTaperMax = "AE cold adjustment taper end temperature. When coolant is above this value, no cold adjustment is applied."
+	dfcoRPM     = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
+    dfcoHyster  = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
+    dfcoTPSThresh= "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
+	dfcoDelay   = "Delay for activate DFCO."
+	dfcoMinCLT  = "Minimum temperature to enable DFCO."
+	crankingEnrichTaper = "Taper time from cranking enrichment to ASE or run."
+
+    launchPin   = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
+    launchHiLo  = "Whether the signal is High or Low when the clutch pedal is engaged. For a ground switching input (Most clutch switches), this should be LOW"
+    lnchPullRes = "Whether the internal pullup resistor is enabled or left floating. For a ground switching input (Most clutch switches), select Pullup. For a 0v-5v input, select Floating"
+    ignBypassPin = "The ARDUINO pin that the ignition bypass is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
+    ignBypassEnable = "If turned on, a ground signal will be output during cranking on the specified pin. This is used to bypass the Speeduino ignition control during cranking."
+    ignCranklock = "On certain low resolution ignition patterns, the cranking timing can be locked to occur when a pulse is recieved."
+
+    multiplyMAP = "If enabled, the MAP reading is included directly into the pulsewidth calculation by multiplying the VE lookup value by the MAP:Baro ratio. This results in a flatter VE table that can be easier to tune in some instances. VE table must be retuned when this value is changed."
+    legacyMAP   = "Use the legacy method of reading the MAP sensor that was used prior to the 201905 firmware. This should ONLY be enabled if you are upgrading from a firmware earlier than this"
+    includeAFR  = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed. "
+    useExtBaro  = "By Default, Speeduino will measure barometric pressure upon startup. Optionally however, a 2nd pressure sensor can be used to perform live barometric readings whilst the system is on."
+
+    flexEnabled  = "Turns on readings from the Flex sensor and enables the below adjustments"
+    flexFreqLow  = "The frequency of the sensor at 0% ethanol (50Hz for standard GM/Continental sensor)"
+    flexFreqHigh = "The frequency of the sensor at 100% ethanol (150Hz for standard GM/Continental sensor)"
+    flexFuelAdj  = "Fuel % to be used for the current ethanol % (Typically 100% @ 0%, 163% @ 100%)"
+    flexAdvAdj   = "Additional advance (in degrees) for the current ethanol % (Typically 0 @ 0%, 10-20 @ 100%)"
+    flexBoostAdj = "Adjustment, in kPa, to the boost target for the current ethanol %. Negative values are allowed to lower boost at lower ethanol % if necessary."
+
+    n2o_arming_pin = "Pin that the nitrous arming/enagement switch is on."
+    n2o_pin_polarity = "Whether Nitrous is active (Armed) when the pin is LOW or HIGH. If LOW is selected, the internal pullup will be used."
+
+    flatSArm    = "The RPM switch point that determines whether an eganged clutch is for launch control or flat shift. Below this figure, an engaged clutch is considered to be for launch, above this figure an active clutch input will be considered a flat shift. This should be set at least several hundred RPM above idle"
+    flatSSoftWin= "The number of RPM below the flat shift point where the softlimit will be applied (aka Soft limit window). Recommended values are 200-1000"
+    flatSRetard = "The absolute timing (BTDC) that will be used when within the soft limit window"
+    hardCutType = "How hard cuts should be performed for rev/launch limits. Full cut will stop all ignition events, Rolling cut will step through all ignition outputs, only cutting 1 per revolution"
+
+    fuel2InputPin = "The Arduino pin that is being used to trigger the second fuel table to be active"
+    fuel2InputPolarity = "Whether the 2nd fuel table should be active when input is high or low. This should be LOW for a typical ground switching input"
+    fuel2InputPullup = "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
+
+	enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
+	
+    cltAdvValues = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
+
+	;speeduino_tsCanId = "This is the TsCanId that the Speeduino ECU will respond to. This should match the main controller CAN ID in project properties if it is connected directy to TunerStudio, Otherwise the device ID if connected via CAN passthrough"
+	true_address = "This is the 11bit Can address of the Speeduino ECU "
+    realtime_base_address = "This is the 11bit CAN address of the realtime data broadcast from the Speeduino ECU. This MUST be at least 0x16 greater than the true address"
+	;obd_address = "The 11bit Can address that the Speeduino ECU responds to for OBD2 diagnostic requests"
+	AUXin00Alias = "The Ascii alias asigned to Aux input channel 0"
+	AUXin01Alias = "The Ascii alias asigned to Aux input channel 1"
+	AUXin02Alias = "The Ascii alias asigned to Aux input channel 2"
+	AUXin03Alias = "The Ascii alias asigned to Aux input channel 3"
+	AUXin04Alias = "The Ascii alias asigned to Aux input channel 4"
+	AUXin05Alias = "The Ascii alias asigned to Aux input channel 5"
+	AUXin06Alias = "The Ascii alias asigned to Aux input channel 6"
+	AUXin07Alias = "The Ascii alias asigned to Aux input channel 7"
+	AUXin08Alias = "The Ascii alias asigned to Aux input channel 8"
+	AUXin09Alias = "The Ascii alias asigned to Aux input channel 9"
+	AUXin10Alias = "The Ascii alias asigned to Aux input channel 10"
+	AUXin11Alias = "The Ascii alias asigned to Aux input channel 11"
+	AUXin12Alias = "The Ascii alias asigned to Aux input channel 12"
+	AUXin13Alias = "The Ascii alias asigned to Aux input channel 13"
+	AUXin14Alias = "The Ascii alias asigned to Aux input channel 14"
+	AUXin15Alias = "The Ascii alias asigned to Aux input channel 15"
+	
+	caninput_sel0a = "This Enables local analog/digital on input channel 0 "
+	caninput_sel1a = "This Enables local analog/digital on input channel 1 "
+	caninput_sel2a = "This Enables local analog/digital on input channel 2 "
+	caninput_sel3a = "This Enables local analog/digital on input channel 3 "
+	caninput_sel4a = "This Enables local analog/digital on input channel 4 "
+	caninput_sel5a = "This Enables local analog/digital on input channel 5 "
+	caninput_sel6a = "This Enables local analog/digital on input channel 6 "
+	caninput_sel7a = "This Enables local analog/digital on input channel 7 "
+    caninput_sel8a = "This Enables local analog/digital on input channel 8 "
+ 	caninput_sel9a = "This Enables local analog/digital on input channel 9 "
+ 	caninput_sel10a = "This Enables local analog/digital on input channel 10 "
+ 	caninput_sel11a = "This Enables local analog/digital on input channel 11 "
+ 	caninput_sel12a = "This Enables local analog/digital on input channel 12 "
+ 	caninput_sel13a = "This Enables local analog/digital on input channel 13 "
+ 	caninput_sel14a = "This Enables local analog/digital on input channel 14 "
+ 	caninput_sel15a = "This Enables local analog/digital on input channel 15 "
+	
   caninput_sel0b = "This Enables External CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 0 "
   caninput_sel1b = "This Enables External/CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 1 "
   caninput_sel2b = "This Enables External/CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 2 "
@@ -2013,6 +2158,7 @@ menuDialog = main
         panel = cranking_enrich_curve
         field = "#Note"
         field = "Values are specified as modifiers to the normal fueling. Eg 100% = No change."
+		field = "Cranking enrichment taper time", crankingEnrichTaper
 
     dialog = crankingIgnOptions, "Cranking Timing", yAxis
         field = "Cranking advance Angle",       CrankAng,       { ignCranklock == 0 }

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1025,7 +1025,7 @@ page = 10
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
 
-        crankingEnrichTaper = scalar,  U08,    134,  "s",  0.1,      0.0,  0.0,     25.5,    0
+        crankingEnrichTaper = scalar,  U08,    134,  "s",  0.1,      0.0,  0.0,     25.5,    1
         unused11_135_191    = array,  U08,    135,  [56], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
@@ -1659,7 +1659,7 @@ menuDialog = main
     dfcoTPSThresh= "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
 	dfcoDelay   = "Delay for activate DFCO."
 	dfcoMinCLT  = "Minimum temperature to enable DFCO."
-	crankingEnrichTaper = "Taper time from cranking enrichment to ASE or run."
+	crankingEnrichTaper = "Taper time from cranking enrichment to ASE or run (after engine has started)."
 
     launchPin   = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
     launchHiLo  = "Whether the signal is High or Low when the clutch pedal is engaged. For a ground switching input (Most clutch switches), this should be LOW"
@@ -2158,7 +2158,6 @@ menuDialog = main
         panel = cranking_enrich_curve
         field = "#Note"
         field = "Values are specified as modifiers to the normal fueling. Eg 100% = No change."
-		field = "Cranking enrichment taper time", crankingEnrichTaper
 
     dialog = crankingIgnOptions, "Cranking Timing", yAxis
         field = "Cranking advance Angle",       CrankAng,       { ignCranklock == 0 }
@@ -2170,6 +2169,7 @@ menuDialog = main
         field = "Cranking RPM (Max)", crankRPM
         field = "Flood Clear level", tpsflood
         field = "Fuel pump prime duration", fpPrime
+		field = "Cranking enrichment taper time", crankingEnrichTaper
 
     dialog = primePW, "Priming Pulsewidth"
         panel = priming_pw_curve

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -189,7 +189,7 @@ uint16_t correctionCranking()
   }
   
   //If we're not cranking, check if if cranking enrichment tapering to ASE should be done
-  else if ( (uint16_t) (currentStatus.runSecs*10) <= configPage10.crankingEnrichTaper)
+  else if ( (uint32_t) runSecsX10 <= configPage10.crankingEnrichTaper)
   {
     crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -181,11 +181,18 @@ Additional fuel % to be added when the engine is cranking
 uint16_t correctionCranking()
 {
   uint16_t crankingValue = 100;
-  //if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) ) { crankingValue = 100 + configPage2.crankingPct; }
+  //Check if we are actually cranking
   if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) )
   {
     crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%
+
+  //If we're not cranking, check if if cranking enrichment tapering to ASE still applies
+  } else if ( (uint16_t) (currentStatus.runSecs*10) < configPage10.crankingEnrichTaper)
+  {
+    crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
+    crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%
+    crankingValue = (uint16_t) map(runSecsX10, 0, configPage10.crankingEnrichTaper, (crankingValue - currentStatus.ASEValue + 100), 100);
   }
   return crankingValue;
 }

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -188,7 +188,7 @@ uint16_t correctionCranking()
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%
 
   //If we're not cranking, check if if cranking enrichment tapering to ASE should be done
-  } else if ( (uint16_t) (currentStatus.runSecs*10) < configPage10.crankingEnrichTaper)
+  } else if ( (uint16_t) (currentStatus.runSecs*10) <= configPage10.crankingEnrichTaper)
   {
     crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -186,9 +186,10 @@ uint16_t correctionCranking()
   {
     crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%
-
+  }
+  
   //If we're not cranking, check if if cranking enrichment tapering to ASE should be done
-  } else if ( (uint16_t) (currentStatus.runSecs*10) <= configPage10.crankingEnrichTaper)
+  else if ( (uint16_t) (currentStatus.runSecs*10) <= configPage10.crankingEnrichTaper)
   {
     crankingValue = table2D_getValue(&crankingEnrichTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
     crankingValue = (uint16_t) crankingValue * 5; //multiplied by 5 to get range from 0% to 1275%

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1035,21 +1035,24 @@ struct config10 {
   byte fuel2Algorithm : 3;
   byte fuel2Mode : 3;
   byte fuel2SwitchVariable : 2;
+
+  //Bytes 123-124
   uint16_t fuel2SwitchValue;
 
-  //Byte 123
+  //Byte 125
   byte fuel2InputPin : 6;
   byte fuel2InputPolarity : 1;
   byte fuel2InputPullup : 1;
 
-  byte vvtCLholdDuty;
-  byte vvtCLKP;
-  byte vvtCLKI;
-  byte vvtCLKD;
-  uint16_t vvtCLMinAng;
-  uint16_t vvtCLMaxAng;
+  byte vvtCLholdDuty; //Byte 126
+  byte vvtCLKP; //Byte 127
+  byte vvtCLKI; //Byte 128
+  byte vvtCLKD; //Byte 129
+  uint16_t vvtCLMinAng; //Bytes 130-131
+  uint16_t vvtCLMaxAng; //Bytes 132-133
 
-  byte unused11_123_191[58];
+  byte crankingEnrichTaper; //Byte 134
+  byte unused11_135_191[57]; //Bytes 135-191
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -335,6 +335,9 @@ void doUpdates()
     configPage2.aeColdTaperMin = 40;
     configPage2.aeColdTaperMax = 100;
     
+    //Cranking enrichment to run taper added. Default it to 0,1 secs
+    configPage10.crankingEnrichTaper = 1;
+    
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 14);
 


### PR DESCRIPTION
This adds possibility to taper cranking enrichment smoothly to ASE value instead of rapid drop.

With large cranking enrichment the taper allows to have less ASE without stalling the engine right after it starts. The functionality and use case of this goes hand in hand with IAC taper from crank to run.

Valid range is from 0 to 25,5 seconds. If ASE has less duration than this, then this will just taper to 100 %.

![image](https://user-images.githubusercontent.com/55035659/79882162-d8c3e180-83fa-11ea-839f-da9ab57fe46c.png)


An example log of this from my car, the vertical line is on the moment cranking ends in both logs. First without taper, second with it.
![image](https://user-images.githubusercontent.com/55035659/79940509-a81b9080-846a-11ea-993c-6dc4433d72d0.png)

