### PR TITLE
Small fix to prevent ASE being simultaneously on with crank enrichment

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -214,7 +214,7 @@ byte correctionASE()
     }
     else
     {
-      if ( (runSecsX10 - aseTsnStart) < configPage2.aseTsnDelay )
+      if (( (runSecsX10 - aseTsnStart) < configPage2.aseTsnDelay ) && (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) ) //Cranking check needs to be here also, so cranking and afterstart enrichments won't run simultaneously
       {
         BIT_SET(currentStatus.engine, BIT_ENGINE_ASE); //Mark ASE as active.
         ASEValue = 100 + map((runSecsX10 - aseTsnStart), 0, configPage2.aseTsnDelay,\


### PR DESCRIPTION
I noticed that addition of ASE taper needs another cranking check, otherwise both cranking enrichment and ASE are applied simultaneously.