### PR TITLE
Bug fix: Pointers to Idle pins/port must always be initialized. 

### DIFF
--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -23,6 +23,12 @@ void initialiseIdle()
   //By default, turn off the PWM interrupt (It gets turned on below if needed)
   IDLE_TIMER_DISABLE();
 
+  //pins must always be initialized. 
+  idle_pin_port = portOutputRegister(digitalPinToPort(pinIdle1));
+  idle_pin_mask = digitalPinToBitMask(pinIdle1);
+  idle2_pin_port = portOutputRegister(digitalPinToPort(pinIdle2));
+  idle2_pin_mask = digitalPinToBitMask(pinIdle2);
+
   //Initialising comprises of setting the 2D tables with the relevant values from the config pages
   switch(configPage6.iacAlgorithm)
   {

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -60,10 +60,6 @@ void initialiseIdle()
       iacCrankDutyTable.values = configPage6.iacCrankDuty;
       iacCrankDutyTable.axisX = configPage6.iacCrankBins;
 
-      idle_pin_port = portOutputRegister(digitalPinToPort(pinIdle1));
-      idle_pin_mask = digitalPinToBitMask(pinIdle1);
-      idle2_pin_port = portOutputRegister(digitalPinToPort(pinIdle2));
-      idle2_pin_mask = digitalPinToBitMask(pinIdle2);
       #if defined(CORE_AVR)
         idle_pwm_max_count = 1000000L / (16 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
       #elif defined(CORE_TEENSY)
@@ -86,10 +82,6 @@ void initialiseIdle()
       iacCrankDutyTable.values = configPage6.iacCrankDuty;
       iacCrankDutyTable.axisX = configPage6.iacCrankBins;
 
-      idle_pin_port = portOutputRegister(digitalPinToPort(pinIdle1));
-      idle_pin_mask = digitalPinToBitMask(pinIdle1);
-      idle2_pin_port = portOutputRegister(digitalPinToPort(pinIdle2));
-      idle2_pin_mask = digitalPinToBitMask(pinIdle2);
       #if defined(CORE_AVR)
         idle_pwm_max_count = 1000000L / (16 * configPage6.idleFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
       #elif defined(CORE_TEENSY)


### PR DESCRIPTION
The pointers to IDLE pins must always be initialized even if the PWM CL or PWM OL are not selected. This is general good practice to not leave pointers uninitialized.  

This is most important on STM32F4 because when the IDLE interrupts run (they do run after a EEPROM reset, all 0xFF) it access the pins/port pointers uninitialized.   

Uninitialized pointer point to Internal flash memory and trying to write to these uninitialized will break the access to the internal flash as EEPROM emulation. Because writing the internal flash when not initiated properly will put flash access in error state. 
