### PR TITLE
Antilag Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 ##### A low cost, DIY friendly Engine Management System (ECU) based on the Arduino framework
 </div>
 
+## ANTI-LAG FUNCTIONALITY
+I added the antilag to the speeduino code. On tunerstudio there is a modal where you can configure the anti lag. There are 3 options to configure:
+1) Max TPS before disabling
+2) Static Ignition Timing while active
+3) Amount of fuel to add while active
+Once configured, just activate it. If it is active, it will appear under a green rectangle with the word BANG ON.
+The antilag procedure is activated when the switch is set to 1. The switch connection pin is pin 26 (board 0.4)
 
 ## Speeduino
 The Speeduino project is a flexible, fully featured Engine Management Systems (EMS aka ECU) based on the low cost and open source Arduino platform. It provides the hardware, firmware and software components that make up an engine management system, all provided under open licenses. With over 1000 installations, Speeduino has matured into a product that meets the needs of the hobbyist and enthusiast community without driving prices to the levels of traditional aftermarket ECUs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ I added the antilag to the speeduino code. On tunerstudio there is a modal where
 1) Max TPS before disabling
 2) Static Ignition Timing while active
 3) Amount of fuel to add while active
+
 Once configured, just activate it. If it is active, it will appear under a green rectangle with the word BANG ON.
 The antilag procedure is activated when the switch is set to 1. The switch connection pin is pin 26 (board 0.4)
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1023,8 +1023,16 @@ page = 10
         vvtCLKD             = scalar, U08,     129,      "%",        1.0,   0.0,  0.0,  200.0,      0 ; * (  1 byte)
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
+        ;Antilag System
+        antilagEnable       = bits,   U08,     134, [0:0],      "Off","On"
+        antilagTPS          = scalar, U08,     135,  "%",       1, 0,  0,  100, 0
+        antilagRetard		= scalar, S08,     136,  "degrees", 1, 0,  -40,  50, 0
+        antilagFuelAdder    = scalar, U08,     137,  "%",       1, 0,  0,  255, 0
 
-        unused11_122_191    = array,  U08,    134,  [57], "RPM",  100.0,      0.0,  100,     25500,    0
+
+
+        ;Unused
+        unused11_138_191    = array,  U08,    138,  [54], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1091,6 +1099,7 @@ page = 11
     requiresPowerCycle = legacyMAP
     requiresPowerCycle = fuel2InputPin
     requiresPowerCycle = fuel2InputPolarity
+    requiresPowerCycle = antilagEnable
 
 	requiresPowerCycle = caninput_sel0a
 	requiresPowerCycle = caninput_sel0b
@@ -1187,6 +1196,9 @@ page = 11
     defaultValue = idleTaperTime, 1.0
     defaultValue = dfcoDelay, 0.1
     defaultValue = dfcoMinCLT, 25
+	defaultValue = antilagTPS, 5
+    defaultValue = antilagRetard, 10
+    defaultValue = antilagFuelAdder, 30
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -1375,6 +1387,7 @@ menuDialog = main
     menu = "&Accessories"
         subMenu = fanSettings,          "Thermo Fan"
         subMenu = LaunchControl,        "Launch Control / Flat Shift"
+        subMenu = AntilagSystem,        "Antilag System / Bang"
         subMenu = fuelpump,             "Fuel Pump"
         subMenu = NitrousControl,       "Nitrous"
         subMenu = vssSettings,          "VSS and Gear detection"
@@ -2168,6 +2181,15 @@ menuDialog = main
         field = "Enable flat shift",            flatSEnable
         field = "Soft rev window",              flatSSoftWin,   { flatSEnable }
         field = "Soft limit absolute timing",   flatSRetard,    { flatSEnable }
+
+        ;Anti- Lag System
+    dialog = AntilagSystem, "Antilag / Bang",
+		field = "Anti-Lag Enable", antilagEnable
+		field = "Anti-Lag is extremely harsh on all engine components"
+        field = "ENABLE BY SWITCH!"
+		field = "Max TPS before disabling", antilagTPS,		{ antilagEnable }
+		field = "Static Ignition Timing while active", antilagRetard, { antilagEnable }
+		field = "Amount of fuel to add while active", antilagFuelAdder, {antilagEnable}
 
     dialog = NitrousStage1,                 "Stage 1"
         field = "Nitrous Output Pin",           n2o_stage1_pin
@@ -3611,6 +3633,7 @@ cmdVSSratio6 =      "E\x99\x06"
    indicator = { resetLockOn        }, "Reset Lock OFF","Reset Lock ON",     red, black, green,    black
    indicator = { bootloaderCaps > 0 }, "Std. Boot",     "Custom Boot",  white, black, white,    black
    indicator = { nitrousOn          }, "Nitrous Off",   "Nitrous On",   white, black, red,      black
+   indicator = { antilagEnable      }, "BANG Off",      "BANG On",   white, black, green,      black
 
 ;-------------------------------------------------------------------------------
 

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -20,6 +20,7 @@ byte correctionIATDensity(); //Inlet temp density correction
 byte correctionBaro(); //Barometric pressure correction
 byte correctionLaunch(); //Launch control correction
 bool correctionDFCO(); //Decelleration fuel cutoff
+byte correctionAntiLagfuel(); //Antilag Fuel Adder
 
 int8_t correctionsIgn(int8_t advance);
 int8_t correctionFixedTiming(int8_t);
@@ -33,6 +34,7 @@ int8_t correctionNitrous(int8_t);
 int8_t correctionSoftLaunch(int8_t);
 int8_t correctionSoftFlatShift(int8_t);
 int8_t correctionKnock(int8_t);
+int8_t correctionAntiLagIgn(int8_t); //Antilag Ignition Retard
 
 uint16_t correctionsDwell(uint16_t dwell);
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -133,7 +133,7 @@
 
 #define BIT_SPARK2_FLATSH         0  //Flat shift hard cut
 #define BIT_SPARK2_FLATSS         1  //Flat shift soft cut
-#define BIT_SPARK2_UNUSED3        2
+#define BIT_SPARK2_ANTILAG        2 //Antilag Indicator
 #define BIT_SPARK2_UNUSED4        3
 #define BIT_SPARK2_UNUSED5        4
 #define BIT_SPARK2_UNUSED6        5
@@ -504,6 +504,8 @@ struct statuses {
   uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it everytime it's used (Config page value is stored divided by 10) */
   volatile byte status3;
   int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
+  boolean antilagActive; //true when all conditions are met
+  byte antilagCorrection;  //Fuel correction when antilag is enabled
   byte nitrous_status;
   byte nSquirts;
   byte nChannels; /**< Number of fuel and ignition channels.  */
@@ -1045,8 +1047,14 @@ struct config10 {
   byte vvtCLKD;
   uint16_t vvtCLMinAng;
   uint16_t vvtCLMaxAng;
+  //Byte 134
+  byte antilagEnable : 1;
+  byte antilagTPS;
+  byte antilagRetard;
+  byte antilagFuelAdder;
 
-  byte unused11_123_191[58];
+  //Byte 138
+  byte unused11_138_191[54];
 
 #if defined(CORE_AVR)
   };
@@ -1118,6 +1126,7 @@ extern byte pinFlex; //Pin with the flex sensor attached
 extern byte pinVSS; 
 extern byte pinBaro; //Pin that an external barometric pressure sensor is attached to (If used)
 extern byte pinResetControl; // Output pin used control resetting the Arduino
+extern byte pinALS; //Antilag Switch
 #ifdef USE_MC33810
   //If the MC33810 IC\s are in use, these are the chip select pins
   extern byte pinMC33810_1_CS;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -204,6 +204,7 @@ byte pinFlex; //Pin with the flex sensor attached
 byte pinVSS;
 byte pinBaro; //Pin that an al barometric pressure sensor is attached to (If used)
 byte pinResetControl; // Output pin used control resetting the Arduino
+byte pinALS;       // Antilag Switch
 #ifdef USE_MC33810
   //If the MC33810 IC\s are in use, these are the chip select pins
   byte pinMC33810_1_CS;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1289,6 +1289,7 @@ void setPinMapping(byte boardID)
       pinResetControl = 43; //Reset control output
       pinBaro = A5;
       pinVSS = 20;
+      pinALS = 26; //Anti-Lag System Switch
 
       #if defined(CORE_TEENSY35)
         pinInjector6 = 51;
@@ -2448,7 +2449,8 @@ void setPinMapping(byte boardID)
       pinMode(pinIAT, INPUT);
       pinMode(pinCLT, INPUT);
       pinMode(pinBat, INPUT);
-      pinMode(pinBaro, INPUT);
+      pinMode(pinBaro,INPUT);
+      pinMode(pinALS, INPUT); //Anti-lag Switch Input
     #endif
   #endif
   pinMode(pinTrigger, INPUT);


### PR DESCRIPTION
Hi everyone, I have finally completed the Antilag functionality. 
Now this new version of code has the possibility to enable the antilag functionality by means of a switch. If we want the antilag just enable the function on tunerstudio and then we can activate it when we want with the switch. On tunerstudio we have to configure 3 options: The maximum opening of the tps (When the antilag reaches this value it is automatically disabled), The advance / postponement of the ignition and the quantity of fuel to add when ALS is active. The system works only when the engine is running and not when it is in the cranking phase. Soon I will also add a led when the antilag is on. In addition to this I will add other features :D

P.S: The code was only tested in the laboratory using the simulator. As soon as the text on the car I write here: D. Before then use it with caution