### PR TITLE
Configurable fallback ethanol pct if flex sensor reads outside range.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1023,8 +1023,9 @@ page = 10
         vvtCLKD             = scalar, U08,     129,      "%",        1.0,   0.0,  0.0,  200.0,      0 ; * (  1 byte)
         vvtCLMinAng         = scalar, U16,     130,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
         vvtCLMaxAng         = scalar, U16,     132,      "deg",      1.0,   0.0,  0.0,  360.0,      0 ; * (  1 bytes)
-
-        unused11_122_191    = array,  U08,    134,  [57], "RPM",  100.0,      0.0,  100,     25500,    0
+        
+        flexFallbackPct     = scalar, U08,     134,      "%",        1.0,   0.0,  0.0,  100.0,      0 ; 
+        unused11_135_191    = array,  U08,    135,  [56], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1187,6 +1188,7 @@ page = 11
     defaultValue = idleTaperTime, 1.0
     defaultValue = dfcoDelay, 0.1
     defaultValue = dfcoMinCLT, 25
+    defaultValue = flexFallbackPct, 0
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -1527,6 +1529,7 @@ menuDialog = main
     flexFuelAdj  = "Fuel % to be used for the current ethanol % (Typically 100% @ 0%, 163% @ 100%)"
     flexAdvAdj   = "Additional advance (in degrees) for the current ethanol % (Typically 0 @ 0%, 10-20 @ 100%)"
     flexBoostAdj = "Adjustment, in kPa, to the boost target for the current ethanol %. Negative values are allowed to lower boost at lower ethanol % if necessary."
+    flexFallbackPct = "If flex sensor reading falls outside limits, fuel calculations will assume this eth. %. Ignition and boost corrections will assume 0%."
 
     n2o_arming_pin = "Pin that the nitrous arming/enagement switch is on."
     n2o_pin_polarity = "Whether Nitrous is active (Armed) when the pin is LOW or HIGH. If LOW is selected, the internal pullup will be used."
@@ -1741,6 +1744,7 @@ menuDialog = main
         field = "Flex Fuel Sensor ", flexEnabled
         field = "Low (E0) ",         flexFreqLow,  { flexEnabled }
         field = "High (E100) ",      flexFreqHigh, { flexEnabled }
+        field = "Fallback % ",       flexFallbackPct, { flexEnabled }
 
     dialog = flexFuelWest, ""
         panel = flex_fuel_curve,     { flexEnabled }
@@ -3293,7 +3297,7 @@ cmdVSSratio6 =      "E\x99\x06"
             columnLabel    = "Ethanol", "Fuel"
             xAxis          = 0, 100, 10
             yAxis          = 50, 250, 5
-            xBins          = flexFuelBins, flex
+            xBins          = flexFuelBins, flexPctFuel
             yBins          = flexFuelAdj
             size           = 400, 200
 
@@ -3621,7 +3625,7 @@ cmdVSSratio6 =      "E\x99\x06"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  104
+   ochBlockSize     =  105
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -3730,6 +3734,7 @@ cmdVSSratio6 =      "E\x99\x06"
    ASECurr          = scalar,   U08,   100, "%",      1.000, 0.000
    vss              = scalar,   U16,   101, "km/h",   1.000, 0.000
    gear             = scalar,   U08,    103, "",       1.000, 0.000
+   flexPctFuel      = scalar,   U08,   104, "%",      1.000, 0.000 ; This is the eth % used to calculate fuel
    #sd_status        = scalar,   U08,    99, "",         1.0,   0.0
 
 #if CELSIUS
@@ -3839,6 +3844,7 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = batteryVoltage,  "Battery V",    float,   "%.1f"
    entry = rpmDOT,          "rpm/s",        int,     "%d"
    entry = flex,            "Eth %",        int,     "%d",       { flexEnabled }
+   entry = flexPctFuel,     "Eth %(fuel)",  int,     "%d",       { flexEnabled }
    entry = errorNum,        "Error #",      int,     "%d",       { errorNum }
    entry = currentError,    "Error ID",     int,     "%d",       { errorNum }
    entry = map_psi,         "Boost PSI",    float,   "%.1f"

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -268,6 +268,7 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portTy
 
   fullStatus[73] = currentStatus.tpsADC;
   fullStatus[74] = getNextError();
+  fullStatus[75] = currentStatus.ethanolPctFuel; //Ethanol % for fuelling purposes (or 0 if not used)
 
   for(byte x=0; x<packetLength; x++)
   {

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -650,6 +650,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
   fullStatus[101] = lowByte(currentStatus.vss);
   fullStatus[102] = highByte(currentStatus.vss);
   fullStatus[103] = currentStatus.gear;
+  fullStatus[104] = currentStatus.ethanolPctFuel; //Ethanol % for fuelling purposes (or 0 if not used)
 
   for(byte x=0; x<packetLength; x++)
   {
@@ -1836,4 +1837,3 @@ void testComm()
   Serial.write(1);
   return;
 }
-

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -500,7 +500,7 @@ byte correctionFlex()
 
   if (configPage2.flexEnabled == 1)
   {
-    flexValue = table2D_getValue(&flexFuelTable, currentStatus.ethanolPct);
+    flexValue = table2D_getValue(&flexFuelTable, currentStatus.ethanolPctFuel);
   }
   return flexValue;
 }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -472,6 +472,7 @@ struct statuses {
   bool CTPSActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
   bool fanOn; /**< Whether or not the fan is turned on */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
+  volatile byte ethanolPctFuel; /** Ethanol pct used to calculate fueling, normally == ethanolPct. May use a fallback value if sensor reads outside limits */
   unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
   volatile byte status1;
   volatile byte spark;
@@ -1046,7 +1047,9 @@ struct config10 {
   uint16_t vvtCLMinAng;
   uint16_t vvtCLMaxAng;
 
-  byte unused11_123_191[58];
+  byte flexFallbackPct; // Fallback eth pct, used in sensor failure. Byte 134
+
+  byte unused11_123_191[57];
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -273,6 +273,7 @@ void initialiseAll()
     {
       attachInterrupt(digitalPinToInterrupt(pinFlex), flexPulse, RISING);
       currentStatus.ethanolPct = 0;
+      currentStatus.ethanolPctFuel = configPage10.flexFallbackPct; // set to default fallback value
     }
     //Same as above, but for the VSS input
     if(configPage2.vssMode > 1) // VSS modes 2 and 3 are interrupt drive (Mode 1 is CAN)

--- a/speeduino/logger.h
+++ b/speeduino/logger.h
@@ -9,8 +9,8 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#define LOG_ENTRY_SIZE      104 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
-#define SD_LOG_ENTRY_SIZE   104 /**< The size of the live data packet used by the SD car.*/
+#define LOG_ENTRY_SIZE      105 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+#define SD_LOG_ENTRY_SIZE   105 /**< The size of the live data packet used by the SD car.*/
 
 void createLog(uint8_t *array);
 void createSDLog(uint8_t *array);

--- a/speeduino/logger.ino
+++ b/speeduino/logger.ino
@@ -120,4 +120,5 @@ void createLog(uint8_t *logBuffer)
     logBuffer[96] = lowByte(currentStatus.flexBoostCorrection);
     logBuffer[97] = highByte(currentStatus.flexBoostCorrection);
     logBuffer[98] = currentStatus.baroCorrection;
+    logBuffer[99] = currentStatus.ethanolPctFuel; //Ethanol % for fuelling purposes (or 0 if not used)
 }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -406,7 +406,7 @@ void loop()
         }
         else if(configPage10.fuel2SwitchVariable == FUEL2_CONDITION_ETH)
         {
-          if(currentStatus.ethanolPct > configPage10.fuel2SwitchValue)
+          if(currentStatus.ethanolPctFuel > configPage10.fuel2SwitchValue)
           {
             BIT_SET(currentStatus.status3, BIT_STATUS3_FUEL2_ACTIVE); //Set the bit indicating that the 2nd fuel table is in use. 
             currentStatus.VE2 = getVE2();

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -198,6 +198,7 @@ void oneMSInterval() //Most ARM chips can simply call a function
       if(flexCounter < 50)
       {
         currentStatus.ethanolPct = 0; //Standard GM Continental sensor reads from 50Hz (0 ethanol) to 150Hz (Pure ethanol). Subtracting 50 from the frequency therefore gives the ethanol percentage.
+        currentStatus.ethanolPctFuel = configPage10.flexFallbackPct; //TODO: Should there be a margin eg below 40 pulses to set fallback value?
         flexCounter = 0;
       }
       else if (flexCounter > 151) //1 pulse buffer
@@ -206,23 +207,27 @@ void oneMSInterval() //Most ARM chips can simply call a function
         if(flexCounter < 169)
         {
           currentStatus.ethanolPct = 100;
+          currentStatus.ethanolPctFuel = currentStatus.ethanolPct;
           flexCounter = 0;
         }
         else
         {
           //This indicates an error condition. Spec of the sensor is that errors are above 170Hz)
           currentStatus.ethanolPct = 0;
+          currentStatus.ethanolPctFuel = configPage10.flexFallbackPct; // Set to default value
           flexCounter = 0;
         }
       }
       else
       {
         currentStatus.ethanolPct = flexCounter - 50; //Standard GM Continental sensor reads from 50Hz (0 ethanol) to 150Hz (Pure ethanol). Subtracting 50 from the frequency therefore gives the ethanol percentage.
+        currentStatus.ethanolPctFuel = currentStatus.ethanolPct;
         flexCounter = 0;
       }
 
       //Off by 1 error check
       if (currentStatus.ethanolPct == 1) { currentStatus.ethanolPct = 0; }
+      if (currentStatus.ethanolPctFuel == 1) { currentStatus.ethanolPctFuel = 0; }
 
     }
 
@@ -259,4 +264,3 @@ void oneMSInterval() //Most ARM chips can simply call a function
     TCNT2 = 131;            //Preload timer2 with 100 cycles, leaving 156 till overflow.
 #endif
 }
-


### PR DESCRIPTION
A feature to set a configurable default ethanol content for the ecu to fall back to in case the flex sensor readings fall outside range. This value is used for fueling calculations while advance and boost corrections use 0% as fallback for safety. Also the default value is used at init so that you don't need to wait up to 1,5s to get a sensor reading before start.

Now fixed some rebasing errors...