### PR TITLE
Fix sram as eeprom

### DIFF
--- a/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.cpp
+++ b/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.cpp
@@ -436,7 +436,7 @@ int8_t InternalSTM32F4_EEPROM_Class::eraseFlashSector(uint32_t address, uint32_t
 
 #if defined(USE_SPI_EEPROM)
   SPI_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-#elif defined(STM32F407xx) 
+#elif defined(STM32F407xx) & !defined(SRAM_AS_EEPROM)
   InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 #endif
 

--- a/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.h
+++ b/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.h
@@ -422,7 +422,7 @@ class InternalSTM32F4_EEPROM_Class : public FLASH_EEPROM_BaseClass
 
 #if defined(USE_SPI_EEPROM)
   extern SPI_EEPROM_Class EEPROM;
-#elif defined(STM32F407xx)
+#elif defined(STM32F407xx) & !defined(SRAM_AS_EEPROM)
   extern InternalSTM32F4_EEPROM_Class EEPROM;
 #endif
 


### PR DESCRIPTION
After my last changes to eeprom emulation for the STM32 family @iLeeeZi noticed the sram as eeprom was not functioning anymore. This is the fix.  