### PR TITLE
fix building for ST arduino core 1.9

### DIFF
--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -200,6 +200,7 @@ HardwareTimer Timer11(TIM7);
 #endif
 #endif
 
+#if ((STM32_CORE_VERSION_MINOR<=8) & (STM32_CORE_VERSION_MAJOR==1)) 
 void oneMSInterval(HardwareTimer*);
 void boostInterrupt(HardwareTimer*);
 void fuelSchedule1Interrupt(HardwareTimer*);
@@ -236,6 +237,7 @@ void ignitionSchedule7Interrupt(HardwareTimer*);
 #if (IGN_CHANNELS >= 8)
 void ignitionSchedule8Interrupt(HardwareTimer*);
 #endif
+#endif //End core<=1.8
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -162,6 +162,7 @@
   ***********************************************************************************************************
   * Interrupt callback functions
   */
+  #if ((STM32_CORE_VERSION_MINOR<=8) & (STM32_CORE_VERSION_MAJOR==1)) 
   void oneMSInterval(HardwareTimer*){oneMSInterval();}
   void boostInterrupt(HardwareTimer*){boostInterrupt();}
   void fuelSchedule1Interrupt(HardwareTimer*){fuelSchedule1Interrupt();}
@@ -198,5 +199,5 @@
   #if (IGN_CHANNELS >= 8)
   void ignitionSchedule8Interrupt(HardwareTimer*){ignitionSchedule8Interrupt();}
   #endif
-
+  #endif //End core<=1.8
 #endif


### PR DESCRIPTION
This will fix building for the new ST arduino core 1.9. Changes are made to attach interrupt Hardware timers. 