### PR TITLE
Fix typo in condition

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -705,7 +705,7 @@ void initialiseAll()
         channel4IgnDegrees = 270;
         maxIgnOutputs = 4;
 
-    #if IGN_CHANNELS >= 1
+    #if IGN_CHANNELS == 1
         if( (configPage4.sparkMode == IGN_MODE_SINGLE))
         {
         maxIgnOutputs = 1;


### PR DESCRIPTION
CRANK_ANGLE_MAX_IGN = 90 should only be applied if there is only 1 IGN CHANNEL in 8 cylinder setup, not in any other case. This is the correct condition to check.