### PR TITLE
Conditions for entering PID control.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -971,8 +971,12 @@ page = 9
       unused10_153        = bits,   U08,   153, [5:7], ""
       
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
+      idlePidTimeDelay     = scalar, U08,  155, "s",       0.1, 0.0  , 0, 10.0, 1
+      idlePidRpmdotDisable = scalar, U08,  156, "MAX",      10, 0.0, 100, 1500, 0
+      idlePidTpsDisable    = scalar, U08,  157, "%",       1.0, 0.0,   0, 100, 0
+      iacMinSteps          = scalar, U08,  158, "Steps",     3, 0.0,    0,  {iacMaxSteps-20}, 0
 
-      unused10_154        = array, U08,    155, [37],       "",       1, 0, 0, 255, 0
+      unused10_154         = array,  U08,  159, [33],       "",       1, 0, 0, 255, 0
     
 page = 10
 #if CELSIUS
@@ -2351,6 +2355,7 @@ menuDialog = main
       field = "Home steps",           iacStepHome,              { iacAlgorithm == 4 || iacAlgorithm == 5 }
       field = "Minimum Steps",        iacStepHyster,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
       field = "Don't exceed",         iacMaxSteps,              { iacAlgorithm == 4 || iacAlgorithm == 5 } 
+      field = "Idle valve closed",    iacMinSteps,              { iacAlgorithm == 5 } 
       field = "Stepper Inverted",     iacStepperInv,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
 
     dialog = pwm_idle, "PWM Idle"
@@ -2363,6 +2368,10 @@ menuDialog = main
       field = "P",                    idleKP,                   { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6}
       field = "I",                    idleKI,                   { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6}
       field = "D",                    idleKD,                   { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6}
+      field = ""
+      field = "Delay PID",            idlePidTimeDelay,        { iacAlgorithm == 3 ||iacAlgorithm == 5 }
+      field = "PID Disable RPMdot",   idlePidRpmdotDisable,    { iacAlgorithm == 3 ||iacAlgorithm == 5 }
+      field = "PID TPS Disable",      idlePidTpsDisable,       { iacAlgorithm == 3 ||iacAlgorithm == 5 } 
       field = "Minimum valve duty",   iacCLminDuty,             { iacAlgorithm == 3 || iacAlgorithm == 6}
       field = "Maximum valve duty",   iacCLmaxDuty,             { iacAlgorithm == 3 || iacAlgorithm == 6}
       field = "Integeral reset above TPS",     iacTPSlimit,     { iacAlgorithm == 6 }
@@ -4567,6 +4576,7 @@ cmdVSSratio6 =      "E\x99\x06"
    indicator = { bootloaderCaps > 0 }, "Std. Boot",     "Custom Boot",  white, black, white,    black
    indicator = { nitrousOn          }, "Nitrous Off",   "Nitrous On",   white, black, red,      black
    indicator = { IOError            }, "I/O Ok",        "I/O Error!",   white, black, red,      black
+   indicator = { cl_idle            }, "CL idle", "CL idle",            white, black, green,    black
    ;Engine Protection status indicators
    indicator = { engineProtectStatus}, "Engine Protect OFF",   "Engine Protect ON",   white, black, red,      black
    indicator = { engineProtectRPM   }, "Rev Limiter Off",      "Rev Limiter ON",      white, black, red,      black
@@ -4592,7 +4602,7 @@ cmdVSSratio6 =      "E\x99\x06"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  117
+   ochBlockSize     =  118
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -4729,6 +4739,8 @@ cmdVSSratio6 =      "E\x99\x06"
    advance1         = scalar,   S08,    114, "deg",      1.000, 0.000
    advance2         = scalar,   S08,    115, "deg",      1.000, 0.000
    sd_status        = scalar,   U08,    116, "",         1.0,   0.0
+   status4          = scalar,   U08,    117, "bits",   1.000, 0.000 
+   cl_idle          = bits,     U08,    117, [0:0]
    ;sd_filenum       = scalar,   U16,    117, "", 1, 0
    ;sd_error         = scalar,   U08,    119, "", 1, 0
    ;sd_phase         = scalar,   U08,    120, "", 1, 0
@@ -4875,6 +4887,7 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = vvt2Angle,        "VVT Angle",       int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Target,       "VVT Target Angle",int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Duty,         "VVT Duty",        int,    "%d",          { vvtEnabled > 0 }
+   entry = cl_idle,         "Idle Closed loop", int,    "%d",          { iacAlgorithm == 3 || iacAlgorithm == 5}
 
    entry = auxin_gauge0,  { stringValue(AUXin00Alias) },  int,     "%d", {(caninput_sel0b != 0)}
    entry = auxin_gauge1,  { stringValue(AUXin01Alias) },  int,     "%d", { (caninput_sel1b != 0)}

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -882,6 +882,7 @@ byte getStatusEntry(uint16_t byteNum)
     case 114: statusValue = currentStatus.advance1; break; //advance 1 (%)
     case 115: statusValue = currentStatus.advance2; break; //advance 2 (%)
     case 116: statusValue = currentStatus.TS_SD_Status; break; //SD card status
+    case 117: statusValue = currentStatus.status4; break;
   }
 
   return statusValue;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -195,6 +195,15 @@
 #define BIT_STATUS3_NSQUIRTS2     6
 #define BIT_STATUS3_NSQUIRTS3     7
 
+#define BIT_STATUS4_CLIDLE        0
+#define BIT_STATUS4_UNUSED1       1
+#define BIT_STATUS4_UNUSED2       2
+#define BIT_STATUS4_UNUSED3       3
+#define BIT_STATUS4_UNUSED4       4
+#define BIT_STATUS4_UNUSED5       5
+#define BIT_STATUS4_UNUSED6       6
+#define BIT_STATUS4_UNUSED7       7
+
 #define VALID_MAP_MAX 1022 //The largest ADC value that is valid for the MAP sensor
 #define VALID_MAP_MIN 2 //The smallest ADC value that is valid for the MAP sensor
 
@@ -638,6 +647,7 @@ struct statuses {
   uint8_t current_caninchannel = 0; /**< Current CAN channel, defaults to 0 */
   uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it everytime it's used (Config page value is stored divided by 10) */
   volatile byte status3;
+  volatile byte status4;
   int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
   byte nitrous_status;
   byte nSquirts;
@@ -1067,10 +1077,10 @@ struct config9 {
 
   byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
 
-  byte unused10_155;
-  byte unused10_156;
-  byte unused10_157;
-  byte unused10_158;
+  byte idlePidTimeDelay;
+  byte idlePidRpmdotDisable;
+  byte idlePidTpsDisable;
+  byte iacMinSteps;
   byte unused10_159;
   byte unused10_160;
   byte unused10_161;

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -16,6 +16,7 @@
 #define STEPPER_FORWARD 0
 #define STEPPER_BACKWARD 1
 #define IDLE_TABLE_SIZE 10
+unsigned long IdleOldTime=0;
 
 enum StepperStatus {SOFF, STEPPING, COOLING}; //The 2 statuses that a stepper can have. STEPPING means that a high pulse is currently being sent and will need to be turned off at some point.
 

--- a/speeduino/logger.h
+++ b/speeduino/logger.h
@@ -10,8 +10,8 @@
 #define LOGGER_H
 
 #ifndef UNIT_TEST // Scope guard for unit testing
-  #define LOG_ENTRY_SIZE      117 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
-  #define SD_LOG_ENTRY_SIZE   117 /**< The size of the live data packet used by the SD car.*/
+  #define LOG_ENTRY_SIZE      118 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+  #define SD_LOG_ENTRY_SIZE   118 /**< The size of the live data packet used by the SD car.*/
 #else
   #define LOG_ENTRY_SIZE      1 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
   #define SD_LOG_ENTRY_SIZE   1 /**< The size of the live data packet used by the SD car.*/


### PR DESCRIPTION
-Active PID indicator (CL idle).
- Added idle valve closed configuration

Disables PID in situations:
-Over the configured TPS position. When stepping on the accelerator, preventing the PID from closing the valve, returning after the time configured in the Delay PID.
-RPM oscillation greater than that configured in rpmDOT Max, for the actuator during transients or large oscillations in the RPM.
-Disabled when active DFCO

When PID returns, the position remains at the last one before disabling.

Works on stepper motor,and PWM

[](url)
![Anotação 2020-08-16 022815](https://user-images.githubusercontent.com/41055332/90327275-48d91300-df68-11ea-89b4-6e8025cdbe50.png)


![image](https://user-images.githubusercontent.com/41055332/82968621-1d1b4200-9fa4-11ea-91d7-edeef902f54d.png)
