### PR TITLE
Fix recently added functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/noisymime/speeduino/blob/master/LICENSE)
 [![Build Status](https://img.shields.io/travis/noisymime/speeduino.svg)](https://travis-ci.org/noisymime/speeduino/)
 [![Open Bounties](https://img.shields.io/bountysource/team/speeduino/activity.svg)](https://www.bountysource.com/teams/speeduino)
-[![GitHub commits](https://img.shields.io/github/commits-since/noisymime/speeduino/202002.svg)](https://github.com/noisymime/speeduino/compare/202002...master)
+[![GitHub commits](https://img.shields.io/github/commits-since/noisymime/speeduino/202005.svg)](https://github.com/noisymime/speeduino/compare/202005...master)
 ![MISRA](https://img.shields.io/azure-devops/tests/speeduino/Speeduino/1?label=MISRA&passed_label=warnings&failed_label=violations)
 [![Chat on Slack](https://img.shields.io/badge/slack-speeduino-CC2B5E.svg?style=flat&logo=slack)](https://speeduino.com/home/community/slack)
 

--- a/reference/Base Tunes/NA6 PNP base tune.msq
+++ b/reference/Base Tunes/NA6 PNP base tune.msq
@@ -314,7 +314,7 @@
         <pcVariable digits="0" name="tsEtRollOut" units="in">0.0</pcVariable>
     </page>
     <page number="0" size="128">
-        <constant digits="1" name="aseTsnDelay" units="S">4.0</constant>
+        <constant digits="1" name="aseTaperTime" units="S">4.0</constant>
         <constant digits="0" name="aeColdPct" units="%">100.0</constant>
         <constant digits="0" name="aeColdTaperMin" units="C">0.0</constant>
         <constant name="aeMode">"TPS"</constant>

--- a/reference/Base Tunes/Speeduino base tune.msq
+++ b/reference/Base Tunes/Speeduino base tune.msq
@@ -326,7 +326,7 @@
         <pcVariable digits="0" name="tsEtRollOut" units="in">0.0</pcVariable>
     </page>
     <page number="0" size="128">
-        <constant digits="1" name="aseTsnDelay" units="S">4.0</constant>
+        <constant digits="1" name="aseTaperTime" units="S">4.0</constant>
         <constant digits="0" name="aeColdPct" units="%">100.0</constant>
         <constant digits="0" name="aeColdTaperMin" units="C">0.0</constant>
         <constant name="aeMode">"TPS"</constant>

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -218,7 +218,7 @@
 ;Page 1 is all general settings. Note that some of these (algorithm and ignAlgorithm) MUST come before their use in the bitStringValue() calls in the fuel and ignition tables
 ;--------------------------------------------------
 page = 1
-      aseTsnDelay   = scalar, U08,       0,         "S",        0.1,       0.0,   0.0,    25.5,      1
+      aseTaperTime   = scalar, U08,       0,         "S",        0.1,       0.0,   0.0,    25.5,      1
       aeColdPct     = scalar, U08,       1,         "%",      1.0,       0,   100,    255,       0 ;AE cold adjustment %
 #if CELSIUS
       aeColdTaperMin = scalar, U08,       2,       "C", 1.0,       -40,    -40,    215,      0     ;AE cold adjustment, taper start clt (full adjustment)
@@ -1185,7 +1185,7 @@ page = 11
     defaultValue = legacyMAP, 0
     defaultValue = battVCorMode, 1
     defaultValue = idleAdvEnabled, 0 ;Idle advance control turned off
-    defaultValue = aseTsnDelay, 0.0
+    defaultValue = aseTaperTime, 0.0
     defaultValue = dfcoDelay, 0.1
     defaultValue = idleTaperTime, 1.0
     defaultValue = dfcoDelay, 0.1
@@ -1483,7 +1483,7 @@ menuDialog = main
   vssSmoothing      = "A smoothing factor to help reduce noise in the VSS signal. Typical values are between 0 and 50"
 
   aeTime            = "The duration of the acceleration enrichment"
-  aseTsnDelay       = "Transition time to disable ASE"
+  aseTaperTime      = "Transition time to disable ASE"
   iacChannels       = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
   iacStepTime       = "Duration of each stepping pulse. Values that are too low can cause the motor to behave erratically or not at all. See the manual for suggested step times"
   iacCoolTime       = "Cool time between each step. Set to zero if you don't want any cooling at all"
@@ -1627,26 +1627,26 @@ menuDialog = main
 	fanHyster   = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"
 
 	aeTime      = "The duration of the acceleration enrichment"
-    aseTsnDelay = "Transition time to disable ASE"
+    aseTaperTime= "Transition time to disable ASE"
 	iacChannels = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
 	iacStepTime = "Duration of each stepping pulse. Values that are too low can cause the motor to behave erratically or not at all. See the manual for suggested step times"
-  iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
+    iacCoolTime = "Cool time between each step. Set to zero if you don't want any cooling at all"
   
-    iacStepHome = "Homing steps to perform on startup. Must be greater than the fully open steps value"
-    iacMaxSteps = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
-	iacStepHyster = "The minimum number of steps to move in any one go."
-	iacAlgorithm = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
-	iacPWMdir   = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
-	iacCLminDuty= "When using closed loop idle control, this is the minimum duty cycle that the PID loop will allow. Combined with the maximum value, this specifies the working range of your idle valve"
-	iacCLmaxDuty= "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
-	iacFastTemp = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
-    idleUpPolarity = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
-    CTPSPolarity = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
-    idleUpAdder = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
-    idleAdvEnabled = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
-    idleAdvAlgorithm = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
-    idleAdvDelay= "The number of seconds after sync is achieved before the idle advance control begins"
-    idleTaperTime = "Soft time transition from crank to running PWM targets"
+    iacStepHome     = "Homing steps to perform on startup. Must be greater than the fully open steps value"
+    iacMaxSteps     = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
+	iacStepHyster   = "The minimum number of steps to move in any one go."
+	iacAlgorithm    = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
+	iacPWMdir       = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
+	iacCLminDuty    = "When using closed loop idle control, this is the minimum duty cycle that the PID loop will allow. Combined with the maximum value, this specifies the working range of your idle valve"
+	iacCLmaxDuty    = "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
+	iacFastTemp     = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
+    idleUpPolarity  = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
+    CTPSPolarity    = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
+    idleUpAdder     = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
+    idleAdvEnabled  = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
+    idleAdvAlgorithm= "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
+    idleAdvDelay    = "The number of seconds after sync is achieved before the idle advance control begins"
+    idleTaperTime   = "Soft time transition from crank to running PWM targets"
 
 	oddfire2    = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
     oddfire3    = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
@@ -2127,7 +2127,6 @@ menuDialog = main
         field = "Number of outputs",    iacChannels,            { iacAlgorithm == 2 || iacAlgorithm == 3 }
     	field = "Idle valve frequency",	idleFreq,				{ iacAlgorithm == 2 || iacAlgorithm == 3 }
     	field = "Idle valve direction", iacPWMdir,				{ iacAlgorithm == 2 || iacAlgorithm == 3 }
-        field = "Crank to run taper", idleTaperTime,            { iacAlgorithm == 2 }
 
     dialog = closedloop_idle, "Closed loop Idle"
         field = "P",                    idleKP,                 { iacAlgorithm == 3 || iacAlgorithm == 5 }
@@ -2139,6 +2138,7 @@ menuDialog = main
     dialog = idleSettings, "Idle Settings"
 	    topicHelp = "https://wiki.speeduino.com/en/configuration/Idle"
 	    field = "Idle control type",    iacAlgorithm
+        field = "Crank to run taper", idleTaperTime,            { iacAlgorithm == 2 || iacAlgorithm == 4 }
         field = "#Fast Idle"
         field = "Fast idle temp",       iacFastTemp,            { iacAlgorithm == 1 }
         panel = pwm_idle
@@ -2190,7 +2190,7 @@ menuDialog = main
     dialog = ASE_time, "Duration (s)", yAxis
         field = "How long time the After Start Enrichment is applied in seconds."
         field = "Usually this is varies from 1-2s when engine is hot up to 20s on a cold engine."
-        field = "Transition time to disable", aseTsnDelay
+        field = "Transition time to disable", aseTaperTime
         panel = afterstart_enrichment_time
 
     dialog = ASE, "Afterstart Enrichment(ASE)", yAxis

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -41,7 +41,6 @@ extern unsigned long knockStartTime;
 extern byte lastKnockCount;
 extern int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 extern int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid
-extern byte aseTsnStart;
 extern uint16_t dfcoStart;
 
 #endif // CORRECTIONS_H

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -29,7 +29,6 @@ unsigned long knockStartTime;
 byte lastKnockCount;
 int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid
-byte aseTsnStart;
 uint16_t dfcoStart;
 
 void initialiseCorrections()
@@ -102,7 +101,7 @@ uint16_t correctionsFuel()
   if (currentStatus.launchCorrection != 100) { sumCorrections = (sumCorrections * currentStatus.launchCorrection); activeCorrections++; }
 
   bitWrite(currentStatus.status1, BIT_STATUS1_DFCO, correctionDFCO());
-  if ( bitRead(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) { sumCorrections = 0; }
+  if ( BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) { sumCorrections = 0; }
 
   sumCorrections = sumCorrections / powint(100,activeCorrections);
 
@@ -134,7 +133,7 @@ static inline byte correctionsFuel_new()
   currentStatus.launchCorrection = correctionLaunch(); numCorrections++;
 
   bitWrite(currentStatus.status1, BIT_STATUS1_DFCO, correctionDFCO());
-  if ( bitRead(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) { sumCorrections = 0; }
+  if ( BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) { sumCorrections = 0; }
 
   sumCorrections = currentStatus.wueCorrection \
                   + correctionASEvalue \
@@ -221,14 +220,13 @@ byte correctionASE()
     {
       BIT_SET(currentStatus.engine, BIT_ENGINE_ASE); //Mark ASE as active.
       ASEValue = 100 + table2D_getValue(&ASETable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
-      aseTsnStart = runSecsX10;
     }
     else
     {
-      if (( (runSecsX10 - aseTsnStart) < configPage2.aseTsnDelay ) && (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) ) //Cranking check needs to be here also, so cranking and afterstart enrichments won't run simultaneously
+      if ( (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) && (runSecsX10 < configPage2.aseTaperTime) ) //Cranking check needs to be here also, so cranking and afterstart enrichments won't run simultaneously
       {
         BIT_SET(currentStatus.engine, BIT_ENGINE_ASE); //Mark ASE as active.
-        ASEValue = 100 + map((runSecsX10 - aseTsnStart), 0, configPage2.aseTsnDelay,\
+        ASEValue = 100 + map(runSecsX10, 0, configPage2.aseTaperTime,\
           table2D_getValue(&ASETable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET), 0);
       }
       else
@@ -484,7 +482,7 @@ bool correctionDFCO()
   bool DFCOValue = false;
   if ( configPage2.dfcoEnabled == 1 )
   {
-    if ( bitRead(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) 
+    if ( BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1 ) 
     {
       DFCOValue = ( currentStatus.RPM > ( configPage4.dfcoRPM * 10) ) && ( currentStatus.TPS < configPage4.dfcoTPSThresh ); 
       if ( DFCOValue == false) { dfcoStart = 0; }
@@ -496,6 +494,7 @@ bool correctionDFCO()
         if ( dfcoStart == 0 ) { dfcoStart = runSecsX10; }
         if( (runSecsX10 - dfcoStart) > configPage2.dfcoDelay ) { DFCOValue = true; }
       }
+      else { dfcoStart = 0; } //Prevent future activation right away if previous time wasn't activated
     } // DFCO active check
   } // DFCO enabled check
   return DFCOValue;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -549,7 +549,7 @@ struct statuses {
  */
 struct config2 {
 
-  byte aseTsnDelay;
+  byte aseTaperTime;
   byte aeColdPct;  //AE cold clt modifier %
   byte aeColdTaperMin; //AE cold modifier, taper start temp (full modifier), was ASE in early versions
   byte aeMode : 2; /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -307,7 +307,18 @@ void idleControl()
           //We must also have more than zero RPM for the running state
           if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_4HZ) && (currentStatus.RPM > 0))
           {
-            idleStepper.targetIdleStep = table2D_getValue(&iacStepTable, (currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) * 3; //All temps are offset by 40 degrees. Step counts are divided by 3 in TS. Multiply back out here
+            if ( runSecsX10 < configPage2.idleTaperTime )
+            {
+              //Tapering between cranking IAC value and running
+              idleStepper.targetIdleStep = map(runSecsX10, 0, configPage2.idleTaperTime,\
+              table2D_getValue(&iacCrankStepsTable, (currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) * 3,\
+              table2D_getValue(&iacStepTable, (currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) * 3);
+            }
+            else
+            {
+              //Standard running
+              idleStepper.targetIdleStep = table2D_getValue(&iacStepTable, (currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET)) * 3; //All temps are offset by 40 degrees. Step counts are divided by 3 in TS. Multiply back out here
+            }
             if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } //Add Idle Up amount if active
             iacStepTime_uS = configPage6.iacStepTime * 1000;
             iacCoolTime_uS = configPage9.iacCoolTime * 1000;

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -322,7 +322,7 @@ void doUpdates()
     //Introdced a DFCO delay option. Default it to 0
     configPage2.dfcoDelay = 0;
     //Introdced a minimum temperature for DFCO. Default it to 40C
-    configPage2.dfcoMinCLT = 40;
+    configPage2.dfcoMinCLT = 80; //CALIBRATION_TEMPERATURE_OFFSET is 40
 
     //Update flexfuel ignition config values for 40 degrees offset
     for (int i=0; i<6; i++)
@@ -352,6 +352,9 @@ void doUpdates()
     //Cranking enrichment to run taper added. Default it to 0,1 secs
     configPage10.crankingEnrichTaper = 1;
     
+    //ASE to run taper added. Default it to 0,1 secs
+    configPage2.aseTaperTime = 1;
+
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 14);
 


### PR DESCRIPTION
Changed aseTsnDelay name to aseTaperTime
Added a default aseTaperTime to 0.1S
aseTsnStart isn't needed, removed
Added IAC_STEP_OL taper, big thanks to Ryan
Default dfcoMinCLT is 0C, added calibration offset and increased it to 40C as described on updates.ino
Changed bitRead to BIT_CHECK
Fix dfcoStart wasn't been reseted if conditions was droped before elapsed time causing next DFCO activation right away
Few cosmetical changes on ini