### PR TITLE
Incorporate AFR (stoich/target)

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -322,7 +322,8 @@ page = 1
 
       fanWhenOff    = bits,   U08,     70, [0:0], "No",        "Yes" 
       fanWhenCranking = bits, U08,     70, [1:1], "No",        "Yes" 
-      unused_fan_bits = bits,  U08,    70,[2:7]
+      unused_fan_bits = bits,  U08,    70,[2:6]
+	  incorporateAFR  = bits,   U08,     70, [7:7], "No",        "Yes"
 
       asePct        = array,  U08,       71, [4],    "%",        1.0,       0.0,     0,    155,       0
       aseCount      = array,  U08,       75, [4],    "s", 		1.0,       0.0,     0.0,     255,    0 ; Values for the afterstart enrichment curve
@@ -1168,6 +1169,7 @@ page = 11
     defaultValue = ignCranklock,0
     defaultValue = multiplyMAP, 0
     defaultValue = includeAFR,  0
+	defaultValue = incorporateAFR,  0
     defaultValue = stoich,      14.7
     defaultValue = flexEnabled, 0
     defaultValue = oddfire2,    0
@@ -1548,6 +1550,7 @@ menuDialog = main
   multiplyMAP       = "If enabled, the MAP reading is included directly into the pulsewidth calculation by multiplying the VE lookup value by the MAP:Baro ratio. This results in a flatter VE table that can be easier to tune in some instances. VE table must be retuned when this value is changed."
   legacyMAP         = "Use the legacy method of reading the MAP sensor that was used prior to the 201905 firmware. This should ONLY be enabled if you are upgrading from a firmware earlier than this"
   includeAFR        = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed. "
+  incorporateAFR    = "When enabled, the AFR stoich/AFR target -ratio is incorporated directly in the pulsewidth calculation. When enabled, AFR target table affects pulsewidth even with EGO disabled. VE table must be retuned when this value is changed."
   useExtBaro        = "By Default, Speeduino will measure barometric pressure upon startup. Optionally however, a 2nd pressure sensor can be used to perform live barometric readings whilst the system is on."
 
   flexEnabled       = "Turns on readings from the Flex sensor and enables the below adjustments"
@@ -2068,7 +2071,8 @@ menuDialog = main
 
     dialog = veTableDialog_south, ""
         field = "Multiply VE value by MAP:Baro ratio", multiplyMAP
-        field = "Multiply by ratio of AFR to Target AFR", includeAFR,         { egoType == 2 }
+        field = "Multiply by ratio of AFR to Target AFR", includeAFR,         { egoType == 2 && !incorporateAFR  || (incorporateAFR==includeAFR) }
+        field = "Multiply by ratio of stoich AFR/target AFR (incorporate AFR)", incorporateAFR,  { !includeAFR || (incorporateAFR==includeAFR) }
 
     dialog = veTableDialog, "VE Table"
         panel = veTableDialog_north, North

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -538,8 +538,8 @@ byte correctionAFRClosedLoop()
     currentStatus.afrTarget = currentStatus.O2; //Catch all incase the below doesn't run. This prevents the Include AFR option from doing crazy things if the AFR target conditions aren't met. This value is changed again below if all conditions are met.
 
     //Determine whether the Y axis of the AFR target table tshould be MAP (Speed-Density) or TPS (Alpha-N)
-    //Note that this should only run after the sensor warmup delay necause it is used within the Include AFR option
-    if(currentStatus.runSecs > configPage6.ego_sdelay) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
+    //Note that this should only run after the sensor warmup delay when using Include AFR option, but on Incorporate AFR option it needs to be done at all times
+    if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
 
     AFRValue = currentStatus.egoCorrection; //Need to record this here, just to make sure the correction stays 'on' even if the nextCycle count isn't ready
     

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -679,7 +679,8 @@ struct config2 {
 
   byte fanWhenOff : 1;      // Only run fan when engine is running
   byte fanWhenCranking : 1;      //**< Setting whether the fan output will stay on when the engine is cranking */ 
-  byte fanUnused : 6;
+  byte fanUnused : 5;
+  byte incorporateAFR : 1;  //Incorporate AFR
   byte asePct[4];  //Afterstart enrichment (%)
   byte aseCount[4]; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
   byte aseBins[4]; //Afterstart enrichment temp axis

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1221,6 +1221,9 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
   if ( (configPage2.includeAFR == true) && (configPage6.egoType == 2) && (currentStatus.runSecs > configPage6.ego_sdelay) ) {
     iAFR = ((unsigned int)currentStatus.O2 << 7) / currentStatus.afrTarget;  //Include AFR (vs target) if enabled
   }
+  if ( (configPage2.incorporateAFR == true) && (configPage2.includeAFR == false) ) {
+    iAFR = ((unsigned int)configPage2.stoich << 7) / currentStatus.afrTarget;  //Incorporate stoich vs target AFR, if enabled.
+  }
   iCorrections = (corrections << bitShift) / 100;
 
 
@@ -1232,6 +1235,10 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
     //EGO type must be set to wideband and the AFR warmup time must've elapsed for this to be used
     intermediate = (intermediate * (unsigned long)iAFR) >> 7;  
   }
+  if ( (configPage2.incorporateAFR == true) && (configPage2.includeAFR == false) ) {
+    intermediate = (intermediate * (unsigned long)iAFR) >> 7;
+  }
+  
   intermediate = (intermediate * (unsigned long)iCorrections) >> bitShift;
   if (intermediate != 0)
   {


### PR DESCRIPTION
This adds the option to incorporate AFR target to pulsewidth calculation. It makes VE table a better representation of actual VE, without AFR targets greatly affecting numbers. After VE table has been tuned, one can adjust an area richer or leaner just from AFR target table -- basically (within limits) without need to touch VE table.

The feature can not be used with "include AFR", hence if one is enabled, the other is disabled. This works in a similar way, but instead of measured AFR it uses stoich AFR, so it is not affected by EGO sensor. It uses the stoich ratio defined in the engine constants tab.

I had this feature in use in my daily driver last year, now made it compatible to current master.

![image](https://user-images.githubusercontent.com/55035659/85331292-8bd5b780-b4de-11ea-8671-3542ddc92b91.png)
![image](https://user-images.githubusercontent.com/55035659/89494962-f194af00-d7bf-11ea-9f0a-464399cf64fb.png)

