### PR TITLE
Updates based on testing CLT,IATand O2

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1274,11 +1274,12 @@ extern struct config10 configPage10;
 //extern byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
 //extern byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
-extern uint16_t cltCalibration_bins[32];
+extern uint16_t calibration_bins_10bit[32];  //just holds evenly spaced values from 0-2^10
+//extern uint16_t cltCalibration_bins[32];
 extern uint16_t cltCalibration_values[32];
-extern uint16_t iatCalibration_bins[32];
+//extern uint16_t iatCalibration_bins[32];
 extern uint16_t iatCalibration_values[32];
-extern uint16_t o2Calibration_bins[32];
+//extern uint16_t o2Calibration_bins[32];
 extern uint8_t  o2Calibration_values[32]; // Note 8-bit values
 extern struct table2D cltCalibrationTable; /**< A 32 bin array containing the coolant temperature sensor calibration values */
 extern struct table2D iatCalibrationTable; /**< A 32 bin array containing the inlet air temperature sensor calibration values */

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -233,12 +233,13 @@ struct config10 configPage10;
 //byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
 //byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
-uint16_t cltCalibration_bins[32];
+uint16_t calibration_bins_10bit[32];  //used for CLT, IAT, O2 calibration table bins
+//uint16_t cltCalibration_bins[32];
 uint16_t cltCalibration_values[32];
 struct table2D cltCalibrationTable;
-uint16_t iatCalibration_bins[32];
+//uint16_t iatCalibration_bins[32];
 uint16_t iatCalibration_values[32];
 struct table2D iatCalibrationTable;
-uint16_t o2Calibration_bins[32];
+//uint16_t o2Calibration_bins[32];
 uint8_t o2Calibration_values[32];
 struct table2D o2CalibrationTable;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -191,19 +191,19 @@ void initialiseAll()
     cltCalibrationTable.axisSize = SIZE_INT;
     cltCalibrationTable.xSize = 32;
     cltCalibrationTable.values = cltCalibration_values;
-    cltCalibrationTable.axisX = cltCalibration_bins;
+    cltCalibrationTable.axisX = calibration_bins_10bit;
 
     iatCalibrationTable.valueSize = SIZE_INT;
     iatCalibrationTable.axisSize = SIZE_INT;
     iatCalibrationTable.xSize = 32;
     iatCalibrationTable.values = iatCalibration_values;
-    iatCalibrationTable.axisX = iatCalibration_bins;
+    iatCalibrationTable.axisX = calibration_bins_10bit;
 
     o2CalibrationTable.valueSize = SIZE_BYTE;
     o2CalibrationTable.axisSize = SIZE_INT;
     o2CalibrationTable.xSize = 32;
     o2CalibrationTable.values = o2Calibration_values;
-    o2CalibrationTable.axisX = o2Calibration_bins;
+    o2CalibrationTable.axisX = calibration_bins_10bit;
 
     //Setup the calibration tables
     loadCalibration();

--- a/speeduino/storage.h
+++ b/speeduino/storage.h
@@ -166,9 +166,9 @@ Current layout of EEPROM data (Version 3) is as follows (All sizes are in bytes)
 #define EEPROM_PAGE_CRC32     3694 //Size of this is 4 * <number of pages> (CRC32 = 32 bits): 3742 - (12 * 4) = 3694
 #define EEPROM_LAST_BARO      3742 // 3743 - 1
 //New values using 2D tables
-#define EEPROM_CALIBRATION_O2   3743 //3839-96 +64
-#define EEPROM_CALIBRATION_IAT  3839 //3967-128
-#define EEPROM_CALIBRATION_CLT  3967 //4095-128
+#define EEPROM_CALIBRATION_O2   3935 //3967-32
+#define EEPROM_CALIBRATION_IAT  3967 //3967-64
+#define EEPROM_CALIBRATION_CLT  4031 //4095-64
 //These were the values used previously when all calibration tables were 512 long. They need to be retained for the update process (202005 -> 202008) can work. 
 #define EEPROM_CALIBRATION_O2_OLD   2559
 #define EEPROM_CALIBRATION_IAT_OLD  3071

--- a/speeduino/storage.ino
+++ b/speeduino/storage.ino
@@ -724,20 +724,15 @@ void loadCalibration()
   for(int x=0; x<32; x++) //Each calibration table is 32 bytes long
   {
     int y = EEPROM_CALIBRATION_CLT + (x * 2);
-    EEPROM.get(y, cltCalibration_bins[x]);
-    y += 64; 
     EEPROM.get(y, cltCalibration_values[x]);
 
     y = EEPROM_CALIBRATION_IAT + (x * 2);
-    EEPROM.get(y, iatCalibration_bins[x]);
-    y += 64; 
     EEPROM.get(y, iatCalibration_values[x]);
 
-    y = EEPROM_CALIBRATION_O2 + (x * 2);
-    EEPROM.get(y, o2Calibration_bins[x]);
-    y = EEPROM_CALIBRATION_O2 + 64 + x;
+    y = EEPROM_CALIBRATION_O2 + (x);
     o2Calibration_values[x] = EEPROM.read(y); //Byte values
 
+    calibration_bins_10bit[x]=x*32;  //bins for all previous tables
   }
 
 }
@@ -749,22 +744,16 @@ and saves them to the EEPROM.
 void writeCalibration()
 {
 
-  for(int x=0; x<32; x++) //Each calibration table is 32 bytes long
+  for(int x=0; x<32; x++) //Each calibration table is 32 values long
   {
     int y = EEPROM_CALIBRATION_CLT + (x * 2);
-    EEPROM.put(y, cltCalibration_bins[x]);
-    y += 64; 
-    EEPROM.put(y, cltCalibration_values[x]);
+    EEPROM.put(y, cltCalibration_values[x]);     //uint16
 
     y = EEPROM_CALIBRATION_IAT + (x * 2);
-    EEPROM.put(y, iatCalibration_bins[x]);
-    y += 64; 
-    EEPROM.put(y, iatCalibration_values[x]);
+    EEPROM.put(y, iatCalibration_values[x]);    //uint16
 
-    y = EEPROM_CALIBRATION_O2 + (x * 2);
-    EEPROM.put(y, o2Calibration_bins[x]);
-    y = EEPROM_CALIBRATION_O2 + 64 + x; 
-    EEPROM.update(y, o2Calibration_values[x]);
+    y = EEPROM_CALIBRATION_O2 + x; 
+    EEPROM.update(y, o2Calibration_values[x]);  //byte values
   }
 
 }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -378,15 +378,12 @@ void doUpdates()
     {
       y = EEPROM_CALIBRATION_CLT_OLD + (x * 16);
       cltCalibration_values[x] = EEPROM.read(y);
-      cltCalibration_bins[x] = (x * 32);
 
       y = EEPROM_CALIBRATION_IAT_OLD + (x * 16);
       iatCalibration_values[x] = EEPROM.read(y);
-      iatCalibration_bins[x] = (x * 32);
 
       y = EEPROM_CALIBRATION_O2_OLD + (x * 16);
       o2Calibration_values[x] = EEPROM.read(y);
-      o2Calibration_bins[x] = (x * 32);
     }
     writeCalibration();
 


### PR DESCRIPTION
Made common 10bit axis for CLT,IATand O2
Removed axis storing on EEPROM because those are just generated values. And made them to be generated at calibration loading.
Renewed EEPROM addresses to mach the smaller storage needed now.
Made calibration receive routine easier, because there was some issue with probably missing type casts when using pointer to pointer.
Reviewed and renewed the axis arrays declarations in the globals.