### PR TITLE
Fix for negative pressure sensor readings

### DIFF
--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -592,7 +592,7 @@ byte getGear()
 
 byte getFuelPressure()
 {
-  uint16_t tempFuelPressure = 0;
+  int16_t tempFuelPressure = 0;
   uint16_t tempReading;
 
   if(configPage10.fuelPressureEnable > 0)
@@ -605,6 +605,7 @@ byte getFuelPressure()
     tempFuelPressure = ADC_FILTER(tempFuelPressure, 150, currentStatus.fuelPressure); //Apply speed smoothing factor
     //Sanity checks
     if(tempFuelPressure > configPage10.fuelPressureMax) { tempFuelPressure = configPage10.fuelPressureMax; }
+    if(tempFuelPressure < 0 ) { tempFuelPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
   }
 
   return (byte)tempFuelPressure;
@@ -612,7 +613,7 @@ byte getFuelPressure()
 
 byte getOilPressure()
 {
-  uint16_t tempOilPressure = 0;
+  int16_t tempOilPressure = 0;
   uint16_t tempReading;
 
   if(configPage10.oilPressureEnable > 0)
@@ -626,6 +627,7 @@ byte getOilPressure()
     tempOilPressure = ADC_FILTER(tempOilPressure, 150, currentStatus.oilPressure); //Apply speed smoothing factor
     //Sanity check
     if(tempOilPressure > configPage10.oilPressureMax) { tempOilPressure = configPage10.oilPressureMax; }
+    if(tempOilPressure < 0 ) { tempOilPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
   }
 
 


### PR DESCRIPTION
If the pressure sensor readings are negative, this fix will set the value to zero in that case. Previously the negative values caused the readings to roll over to highest possible value. Like what happens here:
![image](https://user-images.githubusercontent.com/48950874/90435567-dc7d2180-e0d7-11ea-8205-659e54999af9.png)
