### PR TITLE
Fix building for STM32 in Arduino IDE

### DIFF
--- a/speeduino/TS_CommandButtonHandler.ino
+++ b/speeduino/TS_CommandButtonHandler.ino
@@ -6,7 +6,7 @@
 
 #include "TS_CommandButtonHandler.h"
 #include "globals.h"
-#include "utils.h"
+#include "speeduinoUtils.h"
 #include "scheduledIO.h"
 #include "sensors.h"
 #include "storage.h"

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -19,7 +19,7 @@ sendcancommand is called when a command is to be sent either to serial3
 #include "cancomms.h"
 #include "maths.h"
 #include "errors.h"
-#include "utils.h"
+#include "speeduinoUtils.h"
 
 void secondserial_Command()
 {

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -8,7 +8,7 @@ A full copy of the license may be found in the projects root directory
 #include "cancomms.h"
 #include "storage.h"
 #include "maths.h"
-#include "utils.h"
+#include "speeduinoUtils.h"
 #include "decoders.h"
 #include "TS_CommandButtonHandler.h"
 #include "errors.h"

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -5,7 +5,7 @@
 #include "speeduino.h"
 #include "timers.h"
 #include "cancomms.h"
-#include "utils.h"
+#include "speeduinoUtils.h"
 #include "scheduledIO.h"
 #include "scheduler.h"
 #include "auxiliaries.h"

--- a/speeduino/speeduinoUtils.h
+++ b/speeduino/speeduinoUtils.h
@@ -6,7 +6,7 @@ These are some utility functions and variables used through the main code
 
 #include <Arduino.h>
 
-#define CONCATS(s1, s2) (s1" " s2) //needed for some reason. not defined correctly because of utils.h file of speeduino (same name as one in arduino core)
+//#define CONCATS(s1, s2) (s1" " s2) //needed for some reason. not defined correctly because of utils.h file of speeduino (same name as one in arduino core)
 
 #define COMPARATOR_EQUAL 0
 #define COMPARATOR_NOT_EQUAL 1

--- a/speeduino/speeduinoUtils.ino
+++ b/speeduino/speeduinoUtils.ino
@@ -6,7 +6,7 @@
 
 #include <avr/pgmspace.h>
 #include "globals.h"
-#include "utils.h"
+#include "speeduinoUtils.h"
 #include "decoders.h"
 #include "comms.h"
 #include "src/FastCRC/FastCRC.h"


### PR DESCRIPTION
Fix building for STM32 in Arduino IDE by renaming the utils.h and utils.ino, because utils.h was used in arduino core and that was causing build issues. At least with STM32. If there is other better way to fix this, ignore the PR.