### PR TITLE
Add support for stm32F401internal flash as EEPROM emulation

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -83,6 +83,17 @@ upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
 
+;STM32 Official core
+[env:black_F401CC]
+platform = ststm32
+framework = arduino
+board = blackpill_f401cc
+board_build.core = stm32
+build_flags = -fpermissive -std=gnu++11 -UBOARD_NR_GPIO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_UART_MODULE_ENABLED -DHAL_DAC_MODULE_DISABLED -DHAL_RTC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED
+upload_protocol = dfu
+debug_tool = stlink
+monitor_speed = 115200
+
 [env:bluepill_f103c8]
 platform = ststm32
 framework = arduino
@@ -123,5 +134,6 @@ default_envs = megaatmega2560
 ;env_default = LaunchPad_tm4c1294ncpdt
 ;env_default = genericSTM32F103RB
 ;env_default = bluepill_f103c8
+;env_default = black_F401CC
 
 

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -88,6 +88,13 @@ extern "C" char* sbrk(int incr);
     EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 262144UL, 4095UL, 0x08180000UL};
   #endif
     InternalSTM32F7_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+
+#elif defined(STM32F401xC)
+  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
+  #include EEPROM_LIB_H
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 8191UL, 0x08020000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+
 #else //default case, internal flash as EEPROM for STM32F4
   #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #include EEPROM_LIB_H

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -92,7 +92,7 @@ extern "C" char* sbrk(int incr);
 #elif defined(STM32F401xC)
   #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #include EEPROM_LIB_H
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 8191UL, 0x08020000UL};
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 131072UL, 4095UL, 0x08040000UL};
     InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 
 #else //default case, internal flash as EEPROM for STM32F4


### PR DESCRIPTION
Add support for STM32F401 internal flash as EEPROM emulation.