### PR TITLE
Reducing the minimum limit of barometric pressure.

### DIFF
--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -15,7 +15,7 @@
 #define ADCFILTER_BARO  64
 */
 
-#define BARO_MIN      87
+#define BARO_MIN      65
 #define BARO_MAX      108
 
 #define KNOCK_MODE_DIGITAL  1


### PR DESCRIPTION
Reducing the minimum limit of barometric pressure (when using map as baro sensor)
The highest motorable road is "Khardung La" with 49 kPa barometric pressure but I think 65 kPa is a safer limit than that.
maybe it needs to be customizable in TS ?