### PR TITLE
Rover MEMS flywheel support

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -129,6 +129,7 @@
     #define trigger_ThirtySixMinus222   = 16
     #define trigger_ThirtySixMinus21    = 17
     #define trigger_420a                = 18
+    #define trigger_RoverMEMS           = 20
 
 [Constants]
 
@@ -420,7 +421,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "RoverMEMS", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -2442,9 +2443,9 @@ menuDialog = main
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "https://wiki.speeduino.com/en/decoders"
         field = "Trigger Pattern",                TrigPattern
-        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 }
-        field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 }
-        field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 }
+        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 20 }
+        field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 || TrigPattern == 20 }
+        field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 || TrigPattern == 20 }
         field = "Trigger angle multiplier",       TrigAngMul,     { TrigPattern == 11 }
         field = "Trigger Angle ",                 TrigAng
         field = "This number represents the angle ATDC when "

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2455,8 +2455,8 @@ menuDialog = main
         field = "Note: This is the number of revolutions that will be skipped during"
         field = "cranking before the injectors and coils are fired"
         field = "Trigger edge",                   TrigEdge      { TrigPattern != 4 } ;4G63 uses both edges
-        field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 } ;Missing tooth, dual wheel and Miata 9905
-        field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) }
+        field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 20 } ;Missing tooth, dual wheel and Miata 9905
+        field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) || TrigPattern == 20 }
         field = "Trigger Filter",                 TrigFilter,   { TrigPattern != 13 }
         field = "Re-sync every cycle",            useResync,    { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 || TrigPattern == 18 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05
 

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -157,6 +157,13 @@ void triggerSetEndTeeth_420a();
 void triggerPri_Webber();
 void triggerSec_Webber();
 
+void triggerSetup_RoverMEMS();
+void triggerPri_RoverMEMS();
+void triggerSec_RoverMEMS();
+uint16_t getRPM_RoverMEMS();
+int getCrankAngle_RoverMEMS();
+void triggerSetEndTeeth_RoverMEMS();
+
 extern void (*triggerHandler)(); //Pointer for the trigger function (Gets pointed to the relevant decoder)
 extern void (*triggerSecondaryHandler)(); //Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
 extern uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to the relevant decoder)
@@ -208,6 +215,9 @@ extern unsigned long elapsedTime;
 extern unsigned long lastCrankAngleCalc;
 extern int16_t lastToothCalcAdvance; //Invalid value here forces calculation of this on first main loop
 extern unsigned long lastVVTtime; //The time between the vvt reference pulse and the last crank pulse
+
+extern volatile word roverMemsTeethSeen; // used for flywheel gap pattern matching
+extern volatile int roverMemsFlywheelType;
 
 extern uint16_t ignition1EndTooth;
 extern uint16_t ignition2EndTooth;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3879,6 +3879,7 @@ void triggerSetup_RoverMEMS()
   toothOneMinusOneTime = 0;
   checkSyncToothCount = 64; // make sure we have definitely seen all teeth
   MAX_STALL_TIME = (3333UL * triggerToothAngle * 2 ); // Minimum 50rpm. (3333uS is the time per degree at 50rpm)
+  secondaryToothCount = 0;
 }
 
 void syncLoss_RoverMEMS()
@@ -3889,6 +3890,7 @@ void syncLoss_RoverMEMS()
   toothCurrentCount = 0;
   roverMemsTeethSeen = 0b0000000000000000;
   roverMemsFlywheelType = -1;
+  secondaryToothCount = 0;
   interrupts();
 }
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -79,6 +79,9 @@ unsigned long lastCrankAngleCalc;
 int16_t lastToothCalcAdvance = 99; //Invalid value here forces calculation of this on first main loop
 unsigned long lastVVTtime; //The time between the vvt reference pulse and the last crank pulse
 
+volatile word roverMemsTeethSeen = 0b0000000000000000; // used for flywheel gap pattern matching
+volatile int roverMemsFlywheelType = -1;
+
 uint16_t ignition1EndTooth = 0;
 uint16_t ignition2EndTooth = 0;
 uint16_t ignition3EndTooth = 0;
@@ -3838,4 +3841,191 @@ void triggerSec_Webber()
     triggerSecFilterTime = curGap + (curGap>>1); //Noise region, using 150% of crank tooth
     checkSyncToothCount = 1; //Reset tooth counter
   } //Trigger filter
+}
+
+
+/* -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Name: Rover MEMS
+Desc:
+Note:
+Mixture of trigger wheels for Rover cars
+One type is 36-1-1 (missing teeth at 0 and 180 degrees BTDC)
+Others are 36-1-1-1-1 (4 individually mising teeth at various locations)
+
+No cam support yet.
+
+The MPI Minis are the same flywheel as JDM Minis but also have a cam sensor to allow two separate injectors - one for cylinders 1+2, one for 3+4
+space between teeth = 5 degrees
+20 degrees from one tooth to the next across a gap
+I think the flywheel spins clockwise while looking at the trigger pattern - sensor points at back of flywheel
+
+tooth counts
+
+SPI Mini     - gaps at 0 180          - teeth count 17-17
+JDM/MPI MINI - gaps at 30 60 210 250  - teeth count 13-2-14-3
+MEMS 1.9?    - gaps at 0 120 180 310  - teeth count 11-5-12-4
+MEMS 3?      - gaps at 80 110 260 300 - teeth count 13-2-14-3 - crank sensor at 55 BTDC) (same as 2nd)
+*/
+
+void triggerSetup_RoverMEMS()
+{
+  triggerFilterTime = US_IN_MINUTE / (MAX_RPM * 36); //Trigger filter time is the shortest possible time (in uS) that there can be between crank teeth (ie at max RPM). Any pulses that occur faster than this time will be disgarded as noise
+  triggerToothAngle = 10; // The number of degrees that passes from tooth to tooth. Teeth approx 5 degrees wide each, normal gaps between 5 degrees, missing tooth ends up being 20 degrees of space
+  secondDerivEnabled = false;
+  decoderIsSequential = false;
+  toothLastMinusOneToothTime = 0;
+  toothCurrentCount = 0;
+  toothOneTime = 0;
+  toothOneMinusOneTime = 0;
+  checkSyncToothCount = 64; // make sure we have definitely seen all teeth
+  MAX_STALL_TIME = (3333UL * triggerToothAngle * 2 ); // Minimum 50rpm. (3333uS is the time per degree at 50rpm)
+}
+
+void syncLoss_RoverMEMS()
+{
+  noInterrupts();
+  currentStatus.hasSync = false;
+  currentStatus.syncLossCounter++;
+  toothCurrentCount = 0;
+  roverMemsTeethSeen = 0b0000000000000000;
+  roverMemsFlywheelType = -1;
+  interrupts();
+}
+
+void triggerPri_RoverMEMS()
+{
+  curTime = micros();
+  curGap = curTime - toothLastToothTime;
+
+  // Pulses should never be less than triggerFilterTime, so if they are it means a false trigger.
+  // this would break situations where the crank accelerates but the filter aggressiveness gives 25-75% leeway
+  if (currentStatus.hasSync == true && curGap < triggerFilterTime )
+  {
+    syncLoss_RoverMEMS();
+    return;
+  }
+
+  validTrigger = true;
+  toothCurrentCount++; //Increment the tooth counter
+  addToothLogEntry(curGap, 0);
+
+  // Begin the missing tooth detection
+  // If the time between the current tooth and the last is greater than 1.5x the time between the last tooth and the tooth before that,
+  // we make the assertion that we must be at the first tooth after a gap
+
+  targetGap = (3 * (toothLastToothTime - toothLastMinusOneToothTime)) >> 1; // Multiply by 1.5 (Checks for a gap 2x greater than the last one)
+
+  if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; } // ?? first tooth seen?
+
+  if (curGap > targetGap) // WAS a gap between the last tooth and this one
+  {
+      toothCurrentCount++; // add an extra "tooth" counter for the gap
+      triggerToothAngleIsCorrect = false; // angle is wrong because we just saw a gap
+
+      roverMemsTeethSeen = roverMemsTeethSeen << 1; // add the gap
+  }
+  else // normal tooth is found (immediately after another)
+  {
+      triggerToothAngleIsCorrect = true; // angle should be right becase we saw 2 teeth in a row
+      setFilter(curGap); // Filter can only be recalc'd for the regular teeth, not ones with gaps between
+  }
+  roverMemsTeethSeen = roverMemsTeethSeen << 1; // add the tooth we saw
+  roverMemsTeethSeen += 1;
+
+  // Rover Mini JDM/MPI/MEMS3 above
+  if (roverMemsTeethSeen == 0b1111111111101101) // 2 teeth in a gap
+  {
+    if (roverMemsFlywheelType == -1) // initially setting the flywheel type
+    {
+      roverMemsFlywheelType = 2;
+    }
+    else if (roverMemsFlywheelType != 2) // trying to swap flywheel types, something is wrong
+    {
+      syncLoss_RoverMEMS();
+      return;
+    }
+    currentStatus.hasSync = true;
+    toothCurrentCount = 1; // this is where we will say we are at the start of a rev
+    toothOneMinusOneTime = toothOneTime;
+    toothOneTime = curTime;
+    currentStatus.startRevolutions++; // and say we have done a rev
+  }
+
+  // 36-1-1 wheel on SPI Minis, some SPI rovers
+  // else
+  else if (roverMemsTeethSeen == 0b1111111011111111)
+  {
+    if (roverMemsFlywheelType == -1)  // initially setting the flywheel type
+    {
+      roverMemsFlywheelType = 1;
+    }
+    else if (roverMemsFlywheelType != 1)// trying to swap flywheel types, something is wrong
+    {
+      syncLoss_RoverMEMS();
+      return;
+    }
+
+    if (currentStatus.hasSync == true && toothCurrentCount < 30) // already synced, make sure we aren't doubling the RPM by using both marks as TDC
+    {
+      // do nothing, we are at the second gap/180 degrees from when we started
+    }
+    else
+    {
+      currentStatus.hasSync = true;
+      toothCurrentCount = 1; // this is where we will say we are at the start of a rev, it's the 3rd tooth after a gap
+      toothOneMinusOneTime = toothOneTime;
+      toothOneTime = curTime;
+      currentStatus.startRevolutions++; // and say we have done a rev
+    }
+  }
+
+  // MEMS 1.9? above
+  else if (roverMemsTeethSeen == 0b1111111110111101) // 4 teeth in a gap
+  {
+    if (roverMemsFlywheelType == -1)  // initially setting the flywheel type
+    {
+      roverMemsFlywheelType = 3;
+    }
+    else if (roverMemsFlywheelType != 3)// trying to swap flywheel types, something is wrong
+    {
+      syncLoss_RoverMEMS();
+      return;
+    }
+    currentStatus.hasSync = true;
+    toothCurrentCount = 1; // this is where we will say we are at the start of a rev
+    toothOneMinusOneTime = toothOneTime;
+    toothOneTime = curTime;
+    currentStatus.startRevolutions++; // and say we have done a rev
+  }
+
+
+  toothLastMinusOneToothTime = toothLastToothTime;
+  toothLastToothTime = curTime; // register us having seen a tooth at this time
+
+  //EXPERIMENTAL! new ignition mode
+  if(configPage2.perToothIgn == true)
+  {
+    uint16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
+    checkPerToothTiming(crankAngle, toothCurrentCount);
+  }
+}
+
+void triggerSec_RoverMEMS()
+{
+  // NOT USED - no cam support
+}
+
+uint16_t getRPM_RoverMEMS()
+{
+  // NOT USED - Uses getRPM_missingTooth
+}
+
+int getCrankAngle_RoverMEMS()
+{
+  // NOT USED - uses getCrankAngle_missingTooth
+}
+
+void triggerSetEndTeeth_RoverMEMS()
+{
+  // NOT USED - uses triggerSetEndTeeth_missingTooth
 }

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3945,7 +3945,8 @@ void triggerPri_RoverMEMS()
       return;
     }
     currentStatus.hasSync = true;
-    toothCurrentCount = 1; // this is where we will say we are at the start of a rev
+    toothCurrentCount = 1; // this is where we will say we are at the start of a rev // TODO: fix this to the actual tooth number
+    revolutionOne = !revolutionOne; // toggle rpm/cycle counter
     toothOneMinusOneTime = toothOneTime;
     toothOneTime = curTime;
     currentStatus.startRevolutions++; // and say we have done a rev
@@ -3972,7 +3973,8 @@ void triggerPri_RoverMEMS()
     else
     {
       currentStatus.hasSync = true;
-      toothCurrentCount = 1; // this is where we will say we are at the start of a rev, it's the 3rd tooth after a gap
+      toothCurrentCount = 1; // this is where we will say we are at the start of a rev // TODO: fix this to the actual tooth number
+      revolutionOne = !revolutionOne; // toggle rpm/cycle counter
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
       currentStatus.startRevolutions++; // and say we have done a rev
@@ -3992,7 +3994,8 @@ void triggerPri_RoverMEMS()
       return;
     }
     currentStatus.hasSync = true;
-    toothCurrentCount = 1; // this is where we will say we are at the start of a rev
+    toothCurrentCount = 1; // this is where we will say we are at the start of a rev // TODO: fix this to the actual tooth number
+    revolutionOne = !revolutionOne; // toggle rpm/cycle counter
     toothOneMinusOneTime = toothOneTime;
     toothOneTime = curTime;
     currentStatus.startRevolutions++; // and say we have done a rev

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2939,6 +2939,19 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
+    case 20:
+      triggerSetup_RoverMEMS();
+      triggerHandler = triggerPri_RoverMEMS;
+      decoderHasSecondary = true;
+      getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth;
+      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
+
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
+
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      break;
 
     default:
       triggerHandler = triggerPri_missingTooth;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2942,6 +2942,7 @@ void initialiseTriggers()
     case 20:
       triggerSetup_RoverMEMS();
       triggerHandler = triggerPri_RoverMEMS;
+      triggerSecondaryHandler = triggerSec_missingTooth;
       decoderHasSecondary = true;
       getRPM = getRPM_missingTooth;
       getCrankAngle = getCrankAngle_missingTooth;
@@ -2949,8 +2950,11 @@ void initialiseTriggers()
 
       if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
       else { primaryTriggerEdge = FALLING; }
+      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
+      else { secondaryTriggerEdge = FALLING; }
 
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     default:


### PR DESCRIPTION
The code picks up all of the Rover MEMS flywheel variations

Tested with crank, with and without a cam sensor in tunerstudio - gets full sync and RPM displays correctly.
Tested with a logic analyser running as different combinations correctly:
- crank only - wasted spark, single throttle body injector (sets 2 outputs minimum) - screenshot attached
- crank and cam - wasted spark, 2 sequential port injectors - screenshot attached

Issues to be addressed:
- change the code where it syncs to set the correct tooth count (not just 1), then add code for rolling over from 37 teeth back to 1
- Unknown exact crank sensor location, plus it differs between cars even with the same flywheel - the flywheels and stock ECUs are mix-and-matched it seems, so no way to get this code correct for every car (unless the cam vs flywheel position is unique per setup?). Offset setting should allow this to work anyway

Screenshots:
![Screenshot from 2020-11-13 18-37-32](https://user-images.githubusercontent.com/9017352/99108552-6eb19a80-25df-11eb-837c-d2d623edec8d.png)
![Screenshot from 2020-11-13 18-34-16](https://user-images.githubusercontent.com/9017352/99108558-6f4a3100-25df-11eb-9edd-3c876157c657.png)
