### PR TITLE
Temporary fix for Teensy CanBus ALT pins being set

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -43,18 +43,6 @@ void initialiseAll()
     configPage9.intcan_available = 1;   // device has internal canbus
     //STM32 can not currently enabled
     #endif
-    #if defined(CORE_TEENSY35)
-      configPage9.intcan_available = 1;   // device has internal canbus
-      //Teensy uses the Flexcan_T4 library to use the internal canbus
-      //enable local can interface
-      //setup can interface to 500k
-
-      //Can0.setTX(3);
-      //Can0.setRX(4);    
-      Can0.begin();
-      Can0.setBaudRate(500000);
-      Can0.enableFIFO();
-    #endif
     
     loadConfig();
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)
@@ -224,6 +212,16 @@ void initialiseAll()
     //Setup the calibration tables
     loadCalibration();
 
+    #if defined(CORE_TEENSY35)
+      configPage9.intcan_available = 1;   // device has internal canbus
+      //Teensy uses the Flexcan_T4 library to use the internal canbus
+      //enable local can interface
+      //setup can interface to 500k   
+      Can0.begin();
+      Can0.setBaudRate(500000);
+      Can0.enableFIFO();
+    #endif
+
     //Set the pin mappings
     if((configPage2.pinMapping == 255) || (configPage2.pinMapping == 0)) //255 = EEPROM value in a blank AVR; 0 = EEPROM value in new FRAM
     {
@@ -232,6 +230,11 @@ void initialiseAll()
     configPage2.flexEnabled = false; //Have to disable flex. If this isn't done and the wrong flex pin is interrupt attached below, system can hang.
     }
     else { setPinMapping(configPage2.pinMapping); }
+
+    #if defined(CORE_TEENSY35)
+      Can0.setRX(DEF);
+      Can0.setTX(DEF);
+    #endif
 
     //Need to check early on whether the coil charging is inverted. If this is not set straight away it can cause an unwanted spark at bootup
     if(configPage4.IgInv == 1) { coilHIGH = LOW; coilLOW = HIGH; }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -231,6 +231,7 @@ void initialiseAll()
     }
     else { setPinMapping(configPage2.pinMapping); }
 
+    //Note: This must come after the call to setPinMapping() or else pins 29 and 30 will become unusable as outputs. Workaround for: https://github.com/tonton81/FlexCAN_T4/issues/14
     #if defined(CORE_TEENSY35)
       Can0.setRX(DEF);
       Can0.setTX(DEF);


### PR DESCRIPTION
Change is to fix issues with Teensy 3.5/3.6 FlexCan_t4 library setting ALT pins to unspecified state.
That prevents Speeduino from using pins like 29, 30 for anything else.

The fix involves resetting RX and TX pins after setPinMapping to DEF mappings.