### PR TITLE
Universal trigger pattern 202012

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -84,30 +84,30 @@
     fuelLoadMax    = scalar, U08, "", 1, 0, 0, 511, 0
     ignLoadMax     = scalar, U08, "", 1, 0, 0, 511, 0
     AUXin00Alias  = string, ASCII, 20
-    AUXin01Alias  = string, ASCII, 20 
-    AUXin02Alias  = string, ASCII, 20 
-    AUXin03Alias  = string, ASCII, 20 
-    AUXin04Alias  = string, ASCII, 20 
-    AUXin05Alias  = string, ASCII, 20 
-    AUXin06Alias  = string, ASCII, 20 
-    AUXin07Alias  = string, ASCII, 20 
-    AUXin08Alias  = string, ASCII, 20 
-    AUXin09Alias  = string, ASCII, 20 
-    AUXin10Alias  = string, ASCII, 20 
-    AUXin11Alias  = string, ASCII, 20 
-    AUXin12Alias  = string, ASCII, 20 
-    AUXin13Alias  = string, ASCII, 20 
-    AUXin14Alias  = string, ASCII, 20 
+    AUXin01Alias  = string, ASCII, 20
+    AUXin02Alias  = string, ASCII, 20
+    AUXin03Alias  = string, ASCII, 20
+    AUXin04Alias  = string, ASCII, 20
+    AUXin05Alias  = string, ASCII, 20
+    AUXin06Alias  = string, ASCII, 20
+    AUXin07Alias  = string, ASCII, 20
+    AUXin08Alias  = string, ASCII, 20
+    AUXin09Alias  = string, ASCII, 20
+    AUXin10Alias  = string, ASCII, 20
+    AUXin11Alias  = string, ASCII, 20
+    AUXin12Alias  = string, ASCII, 20
+    AUXin13Alias  = string, ASCII, 20
+    AUXin14Alias  = string, ASCII, 20
     AUXin15Alias  = string, ASCII, 20
 
     prgm_out00Alias  = string, ASCII, 20
-    prgm_out01Alias  = string, ASCII, 20 
-    prgm_out02Alias  = string, ASCII, 20 
-    prgm_out03Alias  = string, ASCII, 20 
-    prgm_out04Alias  = string, ASCII, 20 
-    prgm_out05Alias  = string, ASCII, 20 
-    prgm_out06Alias  = string, ASCII, 20 
-    prgm_out07Alias  = string, ASCII, 20 
+    prgm_out01Alias  = string, ASCII, 20
+    prgm_out02Alias  = string, ASCII, 20
+    prgm_out03Alias  = string, ASCII, 20
+    prgm_out04Alias  = string, ASCII, 20
+    prgm_out05Alias  = string, ASCII, 20
+    prgm_out06Alias  = string, ASCII, 20
+    prgm_out07Alias  = string, ASCII, 20
 
     ;Define aliases for all the triggers. Naming pattern matches that used in decoders.ino
     #define trigger_missingTooth        = 0
@@ -129,6 +129,7 @@
     #define trigger_ThirtySixMinus222   = 16
     #define trigger_ThirtySixMinus21    = 17
     #define trigger_420a                = 18
+    #define trigger_universal           = 20
 
 [Constants]
 
@@ -208,7 +209,7 @@
     #define PIN_OUT10inv = "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
     #define PIN_OUT16inv = "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
     #define PIN_16inv = "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-  
+
     #define ANALOG_PIN = "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", $PIN_16inv, $PIN_16inv, $PIN_16inv
     #define DIGITAL_PIN = "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
     #define ANALOG_DIG_PIN_LIST = $DIGITAL_PIN, $ANALOG_PIN
@@ -239,7 +240,7 @@ page = 1
 #else
       aeColdTaperMin = scalar, U08,       2,       "F", 1.8,    -22.23,    -40,    215,      0     ;AE cold adjustment, taper start clt (full adjustment)
 #endif
-    
+
       aeMode        = bits,   U08,       3, [0:1],  "TPS", "MAP", "INVALID", "INVALID"
       battVCorMode  = bits,   U08,       3, [2:2],  "Whole PW", "Open Time only"
       SoftLimitMode = bits,   U08,       3, [3:3],  "Fixed", "Relative "
@@ -336,8 +337,8 @@ page = 1
       EMAPMin       = scalar, S08,      67,        "kpa",       1.0,       0.0,  -100,     127.0,    0
       EMAPMax       = scalar, U16,      68,        "kpa",       1.0,       0.0,   0.0,     25500,    0
 
-      fanWhenOff    = bits,   U08,     70, [0:0], "No",        "Yes" 
-      fanWhenCranking = bits, U08,     70, [1:1], "No",        "Yes" 
+      fanWhenOff    = bits,   U08,     70, [0:0], "No",        "Yes"
+      fanWhenCranking = bits, U08,     70, [1:1], "No",        "Yes"
       unused_fan_bits = bits,  U08,    70,[2:6]
       incorporateAFR  = bits,   U08,     70, [7:7], "No",        "Yes"
 
@@ -384,16 +385,16 @@ page = 1
       vssRatio4     = scalar, U16,      112, "km/h per 1000rpm", 0.1,         0,     0,     99.9,     1
       vssRatio5     = scalar, U16,      114, "km/h per 1000rpm", 0.1,         0,     0,     99.9,     1
       vssRatio6     = scalar, U16,      116, "km/h per 1000rpm", 0.1,         0,     0,     99.9,     1
-	  
+
       ;Idle up output (AC Fan) seettings
       idleUpOutputEnabled   = bits,   U08,      118, [0:0], "Off", "On"
       idleUpOutputInv       = bits,   U08,      118, [1:1], "No", "Yes"
       idleUpOutputPin       = bits,   U08,      118, [2:7], "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
-      
+
       tachoSweepMaxRPM  = scalar,   U08,        119,        "RPM", 100,       0.0,   100,    10000,    0
       primingDelay      = scalar,   U08,        120,        "S",   0.1,       0.0,   0.0,     25.5,      1
 
-      iacTPSlimit               = scalar, U08,  121,        "%",   1,         0,     0,        100,      0               
+      iacTPSlimit               = scalar, U08,  121,        "%",   1,         0,     0,        100,      0
       iacRPMlimitHysteresis     = scalar, U08,  122,        "RPM"  10,        0      10      2500,     0
 
       unused2-95    = array,  U08,      121, [5],   "%",        1.0,       0.0,   0.0,     255,      0
@@ -428,7 +429,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Universal", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -715,103 +716,103 @@ page = 9
       enable_secondarySerial    = bits,   U08,     0, [0:0], "Disable", "Enable"
       intcan_available          = bits,   U08,     0, [1:1], "Disable", "Enable"
       enable_intcan             = bits,   U08,     0, [2:2], "Disable", "Enable"
-    
+
       caninput_sel0a            = bits,   U08,     1, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel0b            = bits,   U08,     1, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel0extsourcea   = bits,   U08,     1, [5:5], "Via Secondary Serial", "INVALID"
-      caninput_sel0extsourceb   = bits,   U08,     1, [6:6], "Via Secondary Serial", "Via Internal CAN"        
+      caninput_sel0extsourceb   = bits,   U08,     1, [6:6], "Via Secondary Serial", "Via Internal CAN"
       caninput_sel0extsourcec   = bits,   U08,     1, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel1a            = bits,   U08,     2, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel1b            = bits,   U08,     2, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel1extsourcea   = bits,   U08,     2, [5:5], "Via Secondary Serial", "INVALID"
-      caninput_sel1extsourceb   = bits,   U08,     2, [6:6], "Via Secondary Serial", "Via Internal CAN"       
-      caninput_sel1extsourcec   = bits,   U08,     2, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel1extsourceb   = bits,   U08,     2, [6:6], "Via Secondary Serial", "Via Internal CAN"
+      caninput_sel1extsourcec   = bits,   U08,     2, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel2a            = bits,   U08,     3, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel2b            = bits,   U08,     3, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel2extsourcea   = bits,   U08,     3, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel2extsourceb   = bits,   U08,     3, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel2extsourcec   = bits,   U08,     3, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel2extsourcec   = bits,   U08,     3, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel3a            = bits,   U08,     4, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel3b            = bits,   U08,     4, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel3extsourcea   = bits,   U08,     4, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel3extsourceb   = bits,   U08,     4, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel3extsourcec   = bits,   U08,     4, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel3extsourcec   = bits,   U08,     4, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel4a            = bits,   U08,     5, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel4b            = bits,   U08,     5, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel4extsourcea   = bits,   U08,     5, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel4extsourceb   = bits,   U08,     5, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel4extsourcec   = bits,   U08,     5, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel4extsourcec   = bits,   U08,     5, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel5a            = bits,   U08,     6, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel5b            = bits,   U08,     6, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel5extsourcea   = bits,   U08,     6, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel5extsourceb   = bits,   U08,     6, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel5extsourcec   = bits,   U08,     6, [7:7], "INVALID", "Via Internal CAN"        
+      caninput_sel5extsourcec   = bits,   U08,     6, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel6a            = bits,   U08,     7, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel6b            = bits,   U08,     7, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel6extsourcea   = bits,   U08,     7, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel6extsourceb   = bits,   U08,     7, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel6extsourcec   = bits,   U08,     7, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel6extsourcec   = bits,   U08,     7, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel7a            = bits,   U08,     8, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel7b            = bits,   U08,     8, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel7extsourcea   = bits,   U08,     8, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel7extsourceb   = bits,   U08,     8, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel7extsourcec   = bits,   U08,     8, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel7extsourcec   = bits,   U08,     8, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel8a            = bits,   U08,     9, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel8b            = bits,   U08,     9, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel8extsourcea   = bits,   U08,     9, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel8extsourceb   = bits,   U08,     9, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel8extsourcec   = bits,   U08,     9, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel8extsourcec   = bits,   U08,     9, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel9a            = bits,   U08,     10, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel9b            = bits,   U08,     10, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel9extsourcea   = bits,   U08,     10, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel9extsourceb   = bits,   U08,     10, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel9extsourcec   = bits,   U08,     10, [7:7], "INVALID", "Via Internal CAN"    
-  
+      caninput_sel9extsourcec   = bits,   U08,     10, [7:7], "INVALID", "Via Internal CAN"
+
       caninput_sel10a           = bits,   U08,     11, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel10b           = bits,   U08,     11, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel10extsourcea  = bits,   U08,     11, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel10extsourceb  = bits,   U08,     11, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel10extsourcec  = bits,   U08,     11, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel10extsourcec  = bits,   U08,     11, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel11a           = bits,   U08,     12, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel11b           = bits,   U08,     12, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel11extsourcea  = bits,   U08,     12, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel11extsourceb  = bits,   U08,     12, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel11extsourcec  = bits,   U08,     12, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel11extsourcec  = bits,   U08,     12, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel12a           = bits,   U08,     13, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel12b           = bits,   U08,     13, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel12extsourcea  = bits,   U08,     13, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel12extsourceb  = bits,   U08,     13, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel12extsourcec  = bits,   U08,     13, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel12extsourcec  = bits,   U08,     13, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel13a           = bits,   U08,     14, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel13b           = bits,   U08,     14, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel13extsourcea  = bits,   U08,     14, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel13extsourceb  = bits,   U08,     14, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel13extsourcec  = bits,   U08,     14, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel13extsourcec  = bits,   U08,     14, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel14a           = bits,   U08,     15, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel14b           = bits,   U08,     15, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel14extsourcea  = bits,   U08,     15, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel14extsourceb  = bits,   U08,     15, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel14extsourcec  = bits,   U08,     15, [7:7], "INVALID", "Via Internal CAN"    
+      caninput_sel14extsourcec  = bits,   U08,     15, [7:7], "INVALID", "Via Internal CAN"
 
       caninput_sel15a           = bits,   U08,     16, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel15b           = bits,   U08,     16, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
       caninput_sel15extsourcea  = bits,   U08,     16, [5:5], "Via Secondary Serial", "INVALID"
       caninput_sel15extsourceb  = bits,   U08,     16, [6:6], "Via Secondary Serial", "Via Internal CAN"
-      caninput_sel15extsourcec  = bits,   U08,     16, [7:7], "INVALID", "Via Internal CAN"    
-          
+      caninput_sel15extsourcec  = bits,   U08,     16, [7:7], "INVALID", "Via Internal CAN"
+
       caninput_source_can_address0 = bits,   U16,     17,         [0:10], $CAN_ADDRESS_HEX
       caninput_source_can_address1 = bits,   U16,     19,         [0:10], $CAN_ADDRESS_HEX
       caninput_source_can_address2 = bits,   U16,     21,         [0:10], $CAN_ADDRESS_HEX
@@ -865,7 +866,7 @@ page = 9
 
       unused10_67         = scalar, U08,     67,        "",       1, 0, 0, 255, 0
       unused10_68         = scalar, U08,     68,        "",       1, 0, 0, 255, 0
-  
+
       enable_intcandata_out  = bits,   U08,     69, [0:0], "Off", "On"
       canoutput_sel0       = bits,   U08,    70, [0:0], "Off", "On"
       canoutput_sel1       = bits,   U08,    71, [0:0], "Off", "On"
@@ -919,7 +920,7 @@ page = 9
       Auxin13pina       = bits,   U08,    134,     [0:5],  $ANALOG_PIN
       Auxin14pina       = bits,   U08,    135,     [0:5],  $ANALOG_PIN
       Auxin15pina       = bits,   U08,    136,     [0:5],  $ANALOG_PIN
-  
+
       Auxin0pinb        = bits,   U08,    137,     [0:5],  $DIGITAL_PIN
       Auxin1pinb        = bits,   U08,    138,     [0:5],  $DIGITAL_PIN
       Auxin2pinb        = bits,   U08,    139,     [0:5],  $DIGITAL_PIN
@@ -942,11 +943,11 @@ page = 9
       blankfield          = bits,   U08,   153, [4:4], "",""
 
       unused10_153        = bits,   U08,   153, [5:7], ""
-      
+
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
 
       unused10_154        = array, U08,    155, [37],       "",       1, 0, 0, 255, 0
-    
+
 page = 10
 #if CELSIUS
       crankingEnrichBins  = array,  U08,       0, [4],  "C",        1.0,    -40,    -40,    215,      0
@@ -987,7 +988,7 @@ page = 10
       n2o_maxMAP          = scalar, U08,      77,      "kPa",      2.0,   0.0,  0.0,  511.0,      0
       n2o_minTPS          = scalar, U08,      78,      "%TPS",     1.0,   0.0,  0.0,  100,        0
       n2o_maxAFR          = scalar, U08,      79,      "AFR",      0.1,   0.0,  0.0,  25.5,       1
-      
+
       n2o_stage1_pin      = bits ,  U08,      80, [0:5],           $IO_Pins_no_def
       n2o_pin_polarity    = bits ,  U08,      80, [6:6],           "HIGH", "LOW"
       n2o_unused          = bits ,  U08,      80, [7:7],           "No", "Yes"
@@ -1004,7 +1005,7 @@ page = 10
       n2o_stage2_adderMin = scalar, U08,      89,      "ms",        0.1,       0,        0,       32,    1
       n2o_stage2_adderMax = scalar, U08,      90,      "ms",        0.1,       0,        0,       32,    1
       n2o_stage2_retard   = scalar, U08,      91,      "Deg",       1.0,       0.0,   0.0,     250.0,    0
-      
+
       ; Knock settings
       knock_mode          = bits ,  U08,      92, [0:1],           "Off","Digital","Analog", "INVALID"
       knock_pin           = bits ,  U08,      92, [2:7],           "INVALID", "INVALID", "2", "3", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "18", "19", "20", "21", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
@@ -1028,7 +1029,7 @@ page = 10
       knock_firstStep     = scalar, U08,     116,      "Deg",      1.0,       0.0,   0.0,     50,    0
       knock_stepSize      = scalar, U08,     117,      "Deg",      1.0,       0.0,   0.0,     50,    0
       knock_stepTime      = scalar, U08,     118,      "Sec",      0.1,       0.0,   0.0,     2.5,   1
-      
+
       knock_duration      = scalar, U08,     119,      "Sec",      0.1,       0.0,   0.0,     2.5,   1 ;//Time after knock retard starts that it should start recovering
       knock_recoveryStepTime  = scalar, U08, 120,      "Sec",      0.1,       0.0,   0.0,     2.5,   1
       knock_recoveryStep  = scalar, U08,     121,      "Deg",      1.0,       0.0,   0.0,     50,    0
@@ -1067,11 +1068,11 @@ page = 10
 
       oilPressureProtRPM  = array,  U08,     141, [  4], "RPM",     100.0,       0.0,   100.0, 25500,    0
       oilPressureProtMins = array,  U08,     145, [  4], "psi",       1.0,       0.0,   0.0,     255,    0
-      
+
       wmiEnabled          = bits,   U08,     149, [0:0], "Off", "On"
       wmiMode             = bits,   U08,     149, [1:2], "Simple", "Proportional", "Openloop", "Closedloop"
 
-      wmiAdvEnabled   = bits,   U08,     149, [7:7], "Off", "On" 
+      wmiAdvEnabled   = bits,   U08,     149, [7:7], "Off", "On"
 
       wmiTPS              = scalar, U08,     150,        "%TPS",     1.0,    0.0,    0.0,   100,    0
       wmiRPM              = scalar, U08,     151,        "RPM",      100.0,  0.0,    0,     10000,  0
@@ -1084,11 +1085,11 @@ page = 10
 #endif
       wmiOffset           = scalar, S08,     155,        "ms",      1.0,    0.0,    -12.7,  12.7,    0 ;Note signed int
 
-      wmiIndicatorEnabled  = bits,   U08,     156, [0:0], "Off", "On" 
+      wmiIndicatorEnabled  = bits,   U08,     156, [0:0], "Off", "On"
       wmiIndicatorPin      = bits,   U08,     156, [1:6], "Board Default", $DIGITAL_PIN
       wmiIndicatorPolarity = bits ,  U08,     156, [7:7], "Normal", "Inverted"
 
-      wmiEmptyEnabled  = bits,   U08,     157, [0:0], "Off", "On" 
+      wmiEmptyEnabled  = bits,   U08,     157, [0:0], "Off", "On"
       wmiEmptyPin      = bits,   U08,     157, [1:6], "Board Default", $DIGITAL_PIN
       wmiEmptyPolarity = bits ,  U08,     157, [7:7], "Normal", "Inverted"
 
@@ -1429,7 +1430,7 @@ page = 14
     controllerPriority = vssRatio3
     controllerPriority = vssRatio4
     controllerPriority = vssRatio5
-    controllerPriority = vssRatio6 
+    controllerPriority = vssRatio6
 
     ;These are the limits for each of the load algorithms (Refer to the PC Variables section)
     ;Order is:                        MAP   TPS   IMAP/EMAP ITB UNUSED  UNUSED  UNUSED  UNUSED
@@ -1456,8 +1457,8 @@ page = 14
     defaultValue = vssSmoothing, 50
 
     ;pinLayout     = bits,   U08,      15, [0:7],  "Speeduino v0.1", "Speeduino v0.2", "Speeduino v0.3", "Speeduino v0.4", "INVALID", "INVALID", "01-05 MX5 PNP", "INVALID", "96-97 MX5 PNP", "NA6 MX5 PNP", "Turtana PCB", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Plazomat I/O 0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "Daz V6 Shield 0.1", "BMW PnP", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "NO2C", "UA4C", "INVALID", "INVALID", "INVALID", "DIY-EFI CORE4 v1.0", "INVALID", "INVALID", "INVALID", "INVALID", "dvjcodec Teensy RevA", "dvjcodec Teensy RevB", "INVALID", "INVALID", "INVALID", "DropBear", "INVALID", "INVALID", "INVALID", "INVALID", "Black STM32F407VET6 V0.1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-    defaultValue = boardFuelOutputs,                4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
-    defaultValue = boardIgnOutputs,                 4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4     
+    defaultValue = boardFuelOutputs,                4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4
+    defaultValue = boardIgnOutputs,                 4                 4                 4                 4                 4           4         4                 4         4                 4               4             4          4          4         4           4         4           4         4           4         4                   4           4         4           4          4          4         4           4         4           4                    6          4          4          4         4           4         4           4          4          4       4       4           4         4         4                     4           4         4           4         4                       4                       4          4          4          8          4           4           4         4         8                           4          4          4           4          4          4          4          4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4         4           4
 
     controllerPriority = bootloaderCaps
 
@@ -1604,7 +1605,7 @@ menuDialog = main
         subMenu = vvtTbl,               "VVT duty cycle", 8,  { vvtEnabled }
         subMenu = std_separator
         subMenu = wmiSettings,          "WMI Control", { !vvtEnabled }
-        subMenu = wmiTbl,               "WMI duty cycle", 8,  { !vvtEnabled && wmiEnabled && wmiMode > 1 }  
+        subMenu = wmiTbl,               "WMI duty cycle", 8,  { !vvtEnabled && wmiEnabled && wmiMode > 1 }
         subMenu = std_separator
         subMenu = tacho,                "Tacho Output"
 
@@ -1620,7 +1621,7 @@ menuDialog = main
     #else
         subMenu = serial3IO,            "Canbus/Secondary Serial IO Interface"
         subMenu = std_separator
-        subMenu = Canin_config,         "External Auxillary Input Channel Configuration", {enable_secondarySerial || (enable_intcan && intcan_available)}    
+        subMenu = Canin_config,         "External Auxillary Input Channel Configuration", {enable_secondarySerial || (enable_intcan && intcan_available)}
         subMenu = Auxin_config,         "Local Auxillary Input Channel Configuration"
     #endif
         subMenu = pressureSensors,      "Fuel/Oil pressure"
@@ -1923,7 +1924,7 @@ menuDialog = main
   fuel2InputPullup= "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
 
   enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
-  
+
   cltAdvValues    = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
 
   ;speeduino_tsCanId = "This is the TsCanId that the Speeduino ECU will respond to. This should match the main controller CAN ID in project properties if it is connected directy to TunerStudio, Otherwise the device ID if connected via CAN passthrough"
@@ -1946,7 +1947,7 @@ menuDialog = main
   AUXin13Alias    = "The Ascii alias asigned to Aux input channel 13"
   AUXin14Alias    = "The Ascii alias asigned to Aux input channel 14"
   AUXin15Alias    = "The Ascii alias asigned to Aux input channel 15"
-  
+
   caninput_sel0a  = "This Enables local analog/digital on input channel 0 "
   caninput_sel1a  = "This Enables local analog/digital on input channel 1 "
   caninput_sel2a  = "This Enables local analog/digital on input channel 2 "
@@ -1963,7 +1964,7 @@ menuDialog = main
   caninput_sel13a = "This Enables local analog/digital on input channel 13 "
   caninput_sel14a = "This Enables local analog/digital on input channel 14 "
   caninput_sel15a = "This Enables local analog/digital on input channel 15 "
-  
+
   caninput_sel0b  = "This Enables External CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 0 "
   caninput_sel1b  = "This Enables External/CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 1 "
   caninput_sel2b  = "This Enables External/CAN data via the Secondary Serial CANBUS expansion module or local analog/digital on input channel 2 "
@@ -2157,14 +2158,14 @@ menuDialog = main
         field = "Knock threshold required", knock_threshold,    { knock_mode == 2}
         field = "Maximum MAP",              knock_maxMAP,       { knock_mode }
         field = "Maximum RPM",              knock_maxRPM,       { knock_mode }
-        
+
         ;Retard and recovery
         field = "#Retard"
         field = "Total retard",             knock_maxRetard,    { knock_mode }
         field = "First step size",          knock_firstStep,    { knock_mode }
         field = "Other step size",          knock_stepSize,     { knock_mode }
         field = "Step time",                knock_stepTime,     { knock_mode }
-        
+
         field = "#Recovery"
         field = "Retard duration",          knock_duration,     { knock_mode } ;Time before retard starts ending
         field = "Recovery step time",       knock_recoveryStepTime,     { knock_mode } ;Time between each recovery step
@@ -2212,13 +2213,13 @@ menuDialog = main
         field = "Pulses Per KM",            vssPulsesPerKm, { vssMode > 1 }
         commandButton = "60km/h auto-calibrate",       cmdVSS60kmh, { vssMode > 1 }
         field = "Smoothing Factor",         vssSmoothing,   { vssMode > 1 }
-        
+
     dialog = vssSettings, "", yAxis
         topicHelp = "https://wiki.speeduino.com/en/configuration/VSS"
         field = "VSS Input Mode",           vssMode
         field = "VSS Pin",                  vssPin,         { vssMode > 1 }
         ;field = "Use Pullup",               vssPullup,      { vssMode > 1 }
-        
+
         panel = vss_calibration
         panel = vss_gear_detection
 
@@ -2284,11 +2285,11 @@ menuDialog = main
         panel = veTableDialog_north, North
         panel = veTableDialog_south, South
 
-    dialog = fuelTable2Dialog_switch, "Switch Conditions", xAxis 
+    dialog = fuelTable2Dialog_switch, "Switch Conditions", xAxis
         field = "Use secondary table when:",     fuel2SwitchVariable
         field = "is greater than:",              fuel2SwitchValue
 
-    dialog = fuelTable2Dialog_input, "Input Options", yAxis 
+    dialog = fuelTable2Dialog_input, "Input Options", yAxis
         field = "Use secondary table when pin",     fuel2InputPin
         field = "Is",                               fuel2InputPolarity
         field = "Use internal pullup on pin",       fuel2InputPullup, { fuel2InputPolarity == 0 }
@@ -2306,11 +2307,11 @@ menuDialog = main
         panel = fuelTable2Dialog_north, North
         panel = fuelTable2Dialog_south, South,  { fuel2Mode }
 
-    dialog = sparkTable2Dialog_switch, "Switch Conditions", xAxis 
+    dialog = sparkTable2Dialog_switch, "Switch Conditions", xAxis
         field = "Use secondary table when:",     spark2SwitchVariable
         field = "is greater than:",              spark2SwitchValue
 
-    dialog = sparkTable2Dialog_input, "Input Options", yAxis 
+    dialog = sparkTable2Dialog_input, "Input Options", yAxis
         field = "Use secondary table when pin",     spark2InputPin
         field = "Is",                               spark2InputPolarity
         field = "Use internal pullup on pin",       spark2InputPullup, { spark2InputPolarity == 0 }
@@ -2375,7 +2376,7 @@ menuDialog = main
         field = "Cool time (ms)",       iacCoolTime,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Home steps",           iacStepHome,            { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Minimum Steps",    iacStepHyster,      { iacAlgorithm == 4 || iacAlgorithm == 5 }
-        field = "Don't exceed",           iacMaxSteps,          { iacAlgorithm == 4 || iacAlgorithm == 5 } 
+        field = "Don't exceed",           iacMaxSteps,          { iacAlgorithm == 4 || iacAlgorithm == 5 }
         field = "Stepper Inverted", iacStepperInv,       { iacAlgorithm == 4 || iacAlgorithm == 5 }
 
     dialog = pwm_idle, "PWM Idle"
@@ -2410,7 +2411,7 @@ menuDialog = main
 
     dialog = idleUpOutputSettingsPanel, "Idle Up Output Settings", yAxis
         field = "Idle Up Output Enabled", 	idleUpOutputEnabled, 	{ idleUpEnabled }
-        field = "Idle Up Output Inverted",  idleUpOutputInv,        { idleUpEnabled && idleUpOutputEnabled 
+        field = "Idle Up Output Inverted",  idleUpOutputInv,        { idleUpEnabled && idleUpOutputEnabled
         field = "Idle Up Output Pin",       idleUpOutputPin,        { idleUpEnabled && idleUpOutputEnabled }
 
     dialog = idleUpSettings, "Idle Up Settings"
@@ -2468,7 +2469,7 @@ menuDialog = main
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "https://wiki.speeduino.com/en/decoders"
         field = "Trigger Pattern",                TrigPattern
-        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 }
+        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 }
         field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 }
         field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 }
         field = "Trigger angle multiplier",       TrigAngMul,     { TrigPattern == 11 }
@@ -2503,8 +2504,8 @@ menuDialog = main
         field = "Cranking advance Angle",       CrankAng
         field = "Spark Outputs triggers",        IgInv
         panel = lockSparkSettings
-        panel = newIgnitionMode, {}, {TrigPattern == 0 || TrigPattern == 1 || TrigPattern == 2 || TrigPattern == 3 || TrigPattern == 4 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19} ;Only works for missing tooth, distributor, dual wheel, GM 7X, 4g63, Miata 99-05, nissan 360, Subaru 6/7, 420a, weber-marelli
-        
+        panel = newIgnitionMode, {}, {TrigPattern == 0 || TrigPattern == 1 || TrigPattern == 2 || TrigPattern == 3 || TrigPattern == 4 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20} ;Only works for missing tooth, distributor, dual wheel, GM 7X, 4g63, Miata 99-05, nissan 360, Subaru 6/7, 420a, weber-marelli
+
     dialog = dwellSettings,                 "Dwell Settings",   4
         topicHelp = "https://wiki.speeduino.com/en/configuration/Dwell"
         field = "  Cranking dwell",           dwellcrank
@@ -2521,7 +2522,7 @@ menuDialog = main
         field = "Max dwell time",             dwellLim,  { useDwellLim }
         field = "Note: Set the maximum dwell time at least 3ms above"
         field = "your desired dwell time (Including cranking)"
-    
+
     dialog = idleAdvanceSettings_east
         field = "Idle advance mode",                   idleAdvEnabled
         field = "Idle detect mode",                    idleAdvAlgorithm,     { idleAdvEnabled >= 1 }
@@ -2537,7 +2538,7 @@ menuDialog = main
         panel = idleAdvanceSettings_east
         panel = idle_advance_curve,         { idleAdvEnabled >= 1 }
         panel = iacClosedLoop_curve,        { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 || idleAdvEnabled >= 1 }
-        
+
 
     dialog = rotary_ignition,               "Rotary Ignition",  4
         field = "Ignition Configuration",   rotaryType
@@ -2556,17 +2557,17 @@ menuDialog = main
     dialog = revLimiterDialog, "Rev Limiter"
         field = "Rev Limiter"
         field = "!Soft limiter only available with ignition cut", {}, {}, { engineProtectType == 2 }
-        field = "Soft rev limit",             SoftRevLim,     { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition. 
-        field = "Soft limiter mode",          SoftLimitMode,  { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition. 
-        field = "Soft limit timing",          SoftLimRetard,  { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition. 
-        field = "Soft limit max time",        SoftLimMax,     { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition. 
+        field = "Soft rev limit",             SoftRevLim,     { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition.
+        field = "Soft limiter mode",          SoftLimitMode,  { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition.
+        field = "Soft limit timing",          SoftLimRetard,  { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition.
+        field = "Soft limit max time",        SoftLimMax,     { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition.
         field = "Hard Rev limit",             HardRevLim
-        
+
     dialog = oilPressureProtection, "Oil Pressure"
         field = "Oil Pressure Protection",  oilPressureProtEnbl, { oilPressureEnable }
         panel = oil_pressure_prot_curve, { oilPressureEnable && oilPressureProtEnbl }
 
-    indicatorPanel = protectIndicatorPanel, 1, { 1 } 
+    indicatorPanel = protectIndicatorPanel, 1, { 1 }
         indicator = { engineProtectStatus}, "Engine Protect OFF",   "Engine Protect ON",   green, black, red,      black
         indicator = { engineProtectRPM   }, "Rev Limiter Off",      "Rev Limiter ON",      green, black, red,      black
         indicator = { engineProtectMAP   }, "Boost Limit OFF",      "Boost Limit ON",      green, black, red,      black
@@ -2576,7 +2577,7 @@ menuDialog = main
     dialog = engineProtectionWest, ""
         field = "Protection Cut",              engineProtectType
         field = "Engine Protection RPM min",   engineProtectMaxRPM, { engineProtectType }
-        field = "Cut method",                  hardCutType,         { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition. 
+        field = "Cut method",                  hardCutType,         { engineProtectType == 1 || engineProtectType == 3 } ;Only available for the protection modes that include ignition.
         panel = protectIndicatorPanel,                              { engineProtectType }
 
     dialog = RevLimiterS,                   "Engine Protection and Limiters",      xAxis
@@ -2585,7 +2586,7 @@ menuDialog = main
         panel = revLimiterDialog,           { engineProtectType }
         panel = boostCut,                   { engineProtectType }
         panel = oilPressureProtection,      { engineProtectType }
-        
+
 
     dialog = clutchInput,                   "Clutch input"
         field = "Clutch Input Pin",             launchPin,      { launchEnable || flatSEnable }
@@ -2735,7 +2736,7 @@ menuDialog = main
         field = "Pin",                      fuelPressurePin,    { fuelPressureEnable }
         settingSelector = "Common Sensors",                     { fuelPressureEnable }
             settingOption = "0-100 PSI",  fuelPressureMin=-3,   fuelPressureMax=103 ; Vout = VCC x (P x .97 / 200 + 0.5)
-            settingOption = "0-150 PSI",  fuelPressureMin=-18,   fuelPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png 
+            settingOption = "0-150 PSI",  fuelPressureMin=-18,   fuelPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png
         field = "Pressure at 0v",           fuelPressureMin,    { fuelPressureEnable }
         field = "Pressure at 5v",           fuelPressureMax,    { fuelPressureEnable }
 
@@ -2748,7 +2749,7 @@ menuDialog = main
         field = "Pin",                      oilPressurePin,    { oilPressureEnable }
         settingSelector = "Common Sensors",                     { oilPressureEnable }
             settingOption = "0-100 PSI",  oilPressureMin=-3,   oilPressureMax=103 ; Vout = VCC x (P x .97 / 200 + 0.5)
-            settingOption = "0-150 PSI",  oilPressureMin=-18,   oilPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png 
+            settingOption = "0-150 PSI",  oilPressureMin=-18,   oilPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png
         field = "Pressure at 0v",           oilPressureMin,    { oilPressureEnable }
         field = "Pressure at 5v",           oilPressureMax,    { oilPressureEnable }
 
@@ -2989,20 +2990,20 @@ menuDialog = main
         panel = outputtest_spark
         ;panel = outputtest_io2
         panel = outputtest_warningmessage
-    
+
     dialog = stm32cmd, "STM32 Commands", yAxis
       commandButton = "Reboot to system", cmdstm32reboot
       commandButton = "Reboot to bootloader", cmdstm32bootloader
 
-  dialog = Auxin_north  
-        displayOnlyField = #"Secondary Serial ENABLED", blankfield, {enable_secondarySerial},{enable_secondarySerial}    
-      displayOnlyField = !"Secondary Serial DISABLED", blankfield, {enable_secondarySerial == 0},{enable_secondarySerial == 0}    
-      displayOnlyField = #"Internal CANBUS ENABLED", blankfield, {enable_intcan && intcan_available},{enable_intcan && intcan_available}    
-      displayOnlyField = !"Internal CANBUS DISABLED", blankfield, {enable_intcan == 0 && intcan_available},{enable_intcan == 0 && intcan_available}    
-      displayOnlyField = !"Internal CANBUS NOT AVAILABLE to MCU", blankfield, {enable_intcan == 1 && intcan_available == 0},{enable_intcan == 1 && intcan_available == 0}    
-      displayOnlyField = !"Internal CANBUS NOT AVAILABLE to MCU", blankfield, {enable_intcan == 0 && intcan_available == 0},{enable_intcan == 0 && intcan_available == 0}    
-        field = "   If Secondary Serial or Internal CANBUS is DISABLED then any input channel assigned to that external source will NOT function"  
-    
+  dialog = Auxin_north
+        displayOnlyField = #"Secondary Serial ENABLED", blankfield, {enable_secondarySerial},{enable_secondarySerial}
+      displayOnlyField = !"Secondary Serial DISABLED", blankfield, {enable_secondarySerial == 0},{enable_secondarySerial == 0}
+      displayOnlyField = #"Internal CANBUS ENABLED", blankfield, {enable_intcan && intcan_available},{enable_intcan && intcan_available}
+      displayOnlyField = !"Internal CANBUS DISABLED", blankfield, {enable_intcan == 0 && intcan_available},{enable_intcan == 0 && intcan_available}
+      displayOnlyField = !"Internal CANBUS NOT AVAILABLE to MCU", blankfield, {enable_intcan == 1 && intcan_available == 0},{enable_intcan == 1 && intcan_available == 0}
+      displayOnlyField = !"Internal CANBUS NOT AVAILABLE to MCU", blankfield, {enable_intcan == 0 && intcan_available == 0},{enable_intcan == 0 && intcan_available == 0}
+        field = "   If Secondary Serial or Internal CANBUS is DISABLED then any input channel assigned to that external source will NOT function"
+
   dialog = canAuxinput_alias, "", yAxis
         field = "Input Alias"
         field = "", AUXin00Alias , {(caninput_sel0a && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel0b && (enable_secondarySerial || (enable_intcan && intcan_available)))}
@@ -3057,7 +3058,7 @@ menuDialog = main
         field = "CAN Input 14", caninput_sel14b, {}, { (enable_secondarySerial && enable_intcan) || (!enable_secondarySerial && (enable_intcan && intcan_available)) || (enable_secondarySerial && !enable_intcan) }
         field = "CAN Input 15", caninput_sel15a, {}, { (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0))) }
         field = "CAN Input 15", caninput_sel15b, {}, { (enable_secondarySerial && enable_intcan) || (!enable_secondarySerial && (enable_intcan && intcan_available)) || (enable_secondarySerial && !enable_intcan) }
-    
+
     dialog = caninput_parameter_group, "", yAxis
         field = "             Source CAN Address"
         field = "", caninput_source_can_address0, { (caninput_sel0a == 1 || caninput_sel0b == 1) && (enable_secondarySerial || (enable_intcan && intcan_available)) }
@@ -3119,53 +3120,53 @@ menuDialog = main
         field = "Serial/CAN"
         field = "", caninput_sel0extsourcea, {(caninput_sel0a == 1 || caninput_sel0b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel0extsourceb, {(caninput_sel0a == 1 || caninput_sel0b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel0extsourcec, {(caninput_sel0a == 1 || caninput_sel0b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel0extsourcec, {(caninput_sel0a == 1 || caninput_sel0b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel1extsourcea, {(caninput_sel1a == 1 || caninput_sel1b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel1extsourceb, {(caninput_sel1a == 1 || caninput_sel1b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel1extsourcec, {(caninput_sel1a == 1 || caninput_sel1b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel1extsourcec, {(caninput_sel1a == 1 || caninput_sel1b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel2extsourcea, {(caninput_sel2a == 1 || caninput_sel2b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel2extsourceb, {(caninput_sel2a == 1 || caninput_sel2b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel2extsourcec, {(caninput_sel2a == 1 || caninput_sel2b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel2extsourcec, {(caninput_sel2a == 1 || caninput_sel2b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel3extsourcea, {(caninput_sel3a == 1 || caninput_sel3b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel3extsourceb, {(caninput_sel3a == 1 || caninput_sel3b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel3extsourcec, {(caninput_sel3a == 1 || caninput_sel3b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel3extsourcec, {(caninput_sel3a == 1 || caninput_sel3b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel4extsourcea, {(caninput_sel4a == 1 || caninput_sel4b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel4extsourceb, {(caninput_sel4a == 1 || caninput_sel4b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel4extsourcec, {(caninput_sel4a == 1 || caninput_sel4b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel4extsourcec, {(caninput_sel4a == 1 || caninput_sel4b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel5extsourcea, {(caninput_sel5a == 1 || caninput_sel5b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel5extsourceb, {(caninput_sel5a == 1 || caninput_sel5b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel5extsourcec, {(caninput_sel5a == 1 || caninput_sel5b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel5extsourcec, {(caninput_sel5a == 1 || caninput_sel5b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel6extsourcea, {(caninput_sel6a == 1 || caninput_sel6b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel6extsourceb, {(caninput_sel6a == 1 || caninput_sel6b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel6extsourcec, {(caninput_sel6a == 1 || caninput_sel6b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel6extsourcec, {(caninput_sel6a == 1 || caninput_sel6b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel7extsourcea, {(caninput_sel7a == 1 || caninput_sel7b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel7extsourceb, {(caninput_sel7a == 1 || caninput_sel7b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel7extsourcec, {(caninput_sel7a == 1 || caninput_sel7b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel7extsourcec, {(caninput_sel7a == 1 || caninput_sel7b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel8extsourcea, {(caninput_sel8a == 1 || caninput_sel8b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel8extsourceb, {(caninput_sel8a == 1 || caninput_sel8b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel8extsourcec, {(caninput_sel8a == 1 || caninput_sel8b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel8extsourcec, {(caninput_sel8a == 1 || caninput_sel8b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel9extsourcea, {(caninput_sel9a == 1 || caninput_sel9b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel9extsourceb, {(caninput_sel9a == 1 || caninput_sel9b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel9extsourcec, {(caninput_sel9a == 1 || caninput_sel9b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel9extsourcec, {(caninput_sel9a == 1 || caninput_sel9b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel10extsourcea, {(caninput_sel10a == 1 || caninput_sel10b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel10extsourceb, {(caninput_sel10a == 1 || caninput_sel10b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel10extsourcec, {(caninput_sel10a == 1 || caninput_sel10b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel10extsourcec, {(caninput_sel10a == 1 || caninput_sel10b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel11extsourcea, {(caninput_sel11a == 1 || caninput_sel11b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}
         field = "", caninput_sel11extsourceb, {(caninput_sel11a == 1 || caninput_sel11b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel11extsourcec, {(caninput_sel11a == 1 || caninput_sel11b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel11extsourcec, {(caninput_sel11a == 1 || caninput_sel11b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel12extsourcea, {(caninput_sel12a == 1 || caninput_sel12b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}}
         field = "", caninput_sel12extsourceb, {(caninput_sel12a == 1 || caninput_sel12b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel12extsourcec, {(caninput_sel12a == 1 || caninput_sel12b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel12extsourcec, {(caninput_sel12a == 1 || caninput_sel12b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel13extsourcea, {(caninput_sel13a == 1 || caninput_sel13b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}}
         field = "", caninput_sel13extsourceb, {(caninput_sel13a == 1 || caninput_sel13b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel13extsourcec, {(caninput_sel13a == 1 || caninput_sel13b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel13extsourcec, {(caninput_sel13a == 1 || caninput_sel13b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel14extsourcea, {(caninput_sel14a == 1 || caninput_sel14b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}}
         field = "", caninput_sel14extsourceb, {(caninput_sel14a == 1 || caninput_sel14b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
-        field = "", caninput_sel14extsourcec, {(caninput_sel14a == 1 || caninput_sel14b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}    
+        field = "", caninput_sel14extsourcec, {(caninput_sel14a == 1 || caninput_sel14b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel15extsourcea, {(caninput_sel15a == 1 || caninput_sel15b == 1) }, {enable_secondarySerial && (!enable_intcan || (enable_intcan && !intcan_available))}}
         field = "", caninput_sel15extsourceb, {(caninput_sel15a == 1 || caninput_sel15b == 1) }, {enable_secondarySerial && (enable_intcan && intcan_available)}
         field = "", caninput_sel15extsourcec, {(caninput_sel15a == 1 || caninput_sel15b == 1) }, {!enable_secondarySerial && (enable_intcan && intcan_available)}
-    
+
     dialog = caninconfig_blank1,""
         field = ""
 
@@ -3180,7 +3181,7 @@ menuDialog = main
         panel = caninconfig_blank1
         panel = caninput_parameter_start_byte
         panel = caninconfig_blank1
-        panel = caninput_parameter_num_byte        
+        panel = caninput_parameter_num_byte
 
   ;dialog = Canin_config2, "External Data Input"
     ;    field = "Enable External data input",    enable_intcandata_in
@@ -3189,7 +3190,7 @@ menuDialog = main
   topicHelp = "http://speeduino.com/wiki/index.php/Secondary_Serial_IO_interface#Read_external_analog_data"
         panel = Auxin_north
         panel = Canin_config1
-    
+
   dialog = canAuxoutput_alias, "", yAxis
         field = "Input Alias"
         field = "", AUXin00Alias , {canoutput_sel0}
@@ -3208,7 +3209,7 @@ menuDialog = main
         ;field = "", AUXin13Alias , {canoutput_sel13}
         ;field = "", AUXin14Alias , {canoutput_sel14}
         ;field = "", AUXin15Alias , {canoutput_sel15}
-        
+
   dialog = canoutput_sel, "", yAxis
     ;CAN outputs
         field = "CAN Output Channel on/off"
@@ -3327,14 +3328,14 @@ menuDialog = main
       field = "NOTE! Realtime Data Base Address MUST be at least 0x16 GREATER than the True Address as they are reserved for future expansion"
       field = "Realtime Data Base Can Address", realtime_base_address {enable_secondarySerial||enable_intcan}
       field = "Speeduino OBD address", obd_address
-  
+
     dialog = reset_control, "Reset Control"
         ; Control type options for custom firmware
         field = "Control Type", resetControl
         field = "Control Pin", resetControlPin
 
     dialog = Auxinput_pin_selection, "", yAxis
-        field = "             Source"       
+        field = "             Source"
         displayOnlyField = "Off 0", blankfield, {},{(caninput_sel0a == 0 && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel0b == 0 && (enable_secondarySerial && enable_intcan)) || (caninput_sel0b == 0 && (enable_secondarySerial && !enable_intcan)) || (caninput_sel0b == 0 && (!enable_secondarySerial && (enable_intcan && intcan_available == 1)))}
         displayOnlyField = "External Source 0 Via Secondary Serial", blankfield, {},{(caninput_sel0b == 1 && enable_secondarySerial && ((enable_intcan && intcan_available == 0) || !enable_intcan)) || (caninput_sel0b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel0extsourceb == 0)}
         displayOnlyField = "External Source 0 Via Internal CAN", blankfield, {},{(caninput_sel0b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel0extsourceb == 1) ||(caninput_sel0b == 1 && !enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel0extsourcec == 1)}
@@ -3346,7 +3347,7 @@ menuDialog = main
         displayOnlyField = "External Source 1 Via Internal CAN", blankfield, {},{(caninput_sel1b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel1extsourceb == 1) ||(caninput_sel1b == 1 && !enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel1extsourcec == 1)}
         field = "Local Analog Source 1                 Pin No:", Auxin1pina , {}, {(caninput_sel1a == 2 && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel1b == 2 && (enable_secondarySerial || (enable_intcan && intcan_available == 1 )))}
         field = "Local Digital Source 1                  Pin No:", Auxin1pinb , {}, {(caninput_sel1a == 3 && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel1b == 3 && (enable_secondarySerial || (enable_intcan && intcan_available == 1 )))}
-        
+
         displayOnlyField = "Off 2", blankfield, {},{(caninput_sel2a == 0 && (!enable_secondarySerial && !enable_intcan)) || (caninput_sel2b == 0 && (enable_secondarySerial && enable_intcan)) || (caninput_sel2b == 0 && (enable_secondarySerial && !enable_intcan)) || (caninput_sel2b == 0 && (!enable_secondarySerial && enable_intcan))}
         displayOnlyField = "External Source 2 Via Secondary Serial", blankfield, {},{(caninput_sel2b == 1 && enable_secondarySerial && ((enable_intcan && intcan_available == 0) || !enable_intcan)) || (caninput_sel2b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel2extsourceb == 0)}
         displayOnlyField = "External Source 2 Via Internal CAN", blankfield, {},{(caninput_sel2b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel2extsourceb == 1) ||(caninput_sel2b == 1 && !enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel2extsourcec == 1)}
@@ -3430,7 +3431,7 @@ menuDialog = main
         displayOnlyField = "External Source 15 Via Internal CAN", blankfield, {},{(caninput_sel15b == 1 && enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel15extsourceb == 1) ||(caninput_sel15b == 1 && !enable_secondarySerial && (enable_intcan && intcan_available) && caninput_sel15extsourcec == 1)}
         field = "Local Analog Source 15                 Pin No:", Auxin15pina , {}, {(caninput_sel15a == 2 && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel15b == 2 && (enable_secondarySerial || (enable_intcan && intcan_available == 1 )))}
         field = "Local Digital Source 15                  Pin No:", Auxin15pinb , {}, {(caninput_sel15a == 3 && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel15b == 3 && (enable_secondarySerial || (enable_intcan && intcan_available == 1 )))}
-          
+
     dialog = Auxinput_alias, "", yAxis
         field = "Input Alias"
         field = "", AUXin00Alias , {(caninput_sel0a && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel0b && (enable_secondarySerial || (enable_intcan && intcan_available)))}
@@ -3449,7 +3450,7 @@ menuDialog = main
         field = "", AUXin13Alias , {(caninput_sel13a && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel13b && (enable_secondarySerial || (enable_intcan && intcan_available)))}
         field = "", AUXin14Alias , {(caninput_sel14a && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel14b && (enable_secondarySerial || (enable_intcan && intcan_available)))}
         field = "", AUXin15Alias , {(caninput_sel15a && (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0)))) || (caninput_sel15b && (enable_secondarySerial || (enable_intcan && intcan_available)))}
-                
+
     dialog = Auxinput_channelenable, "", yAxis
         field = "               Aux Input Channel Enable"
         field = "AUX Input 0", caninput_sel0a {}, { (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0))) }
@@ -3484,13 +3485,13 @@ menuDialog = main
         field = "AUX Input 14", caninput_sel14b {}, { (enable_secondarySerial && enable_intcan) || (!enable_secondarySerial && (enable_intcan && intcan_available)) || (enable_secondarySerial && !enable_intcan) }
         field = "AUX Input 15", caninput_sel15a {}, { (!enable_secondarySerial && (!enable_intcan || (enable_intcan && intcan_available == 0))) }
         field = "AUX Input 15", caninput_sel15b {}, { (enable_secondarySerial && enable_intcan) || (!enable_secondarySerial && (enable_intcan && intcan_available)) || (enable_secondarySerial && !enable_intcan) }
-  
+
     dialog = Auxin_south, "Auxillary Input Configuration",xAxis
         panel = Auxinput_alias
         panel = Auxinput_channelenable
-        panel = Auxinput_pin_selection 
-  
-    dialog = Auxin_config, "",yAxis      
+        panel = Auxinput_pin_selection
+
+    dialog = Auxin_config, "",yAxis
       panel = Auxin_north
       panel = Auxin_south
 
@@ -3532,7 +3533,7 @@ menuDialog = main
         displayOnlyField = "Programmable out 6", outputPin5, {outputPin[5]}
         displayOnlyField = "Programmable out 7", outputPin6, {outputPin[6]}
         displayOnlyField = "Programmable out 8", outputPin7, {outputPin[7]}
-    
+
     dialog = prgm_out_pin_selection_1, "", yAxis
         field = ""
         field = "",     outputInverted0,    {outputPin[0]}
@@ -3675,7 +3676,7 @@ menuDialog = main
         field = "", prgm_out05Alias,    {outputPin[5]}
         field = "", prgm_out06Alias,    {outputPin[6]}
         field = "", prgm_out07Alias,    {outputPin[7]}
-                
+
     dialog = prgm_out_channelenable, "", yAxis
         field = "Pin No:"
         field = "", outputPin0
@@ -3736,7 +3737,7 @@ menuDialog = main
     field = "",   secondDataIn3,      {outputPin[3] && bitwise3}
     field = "",   secondCompType3,    {outputPin[3] && bitwise3}
     field = "",   secondTarget[3],    {outputPin[3] && bitwise3}
-  ;Rule 5 
+  ;Rule 5
   dialog = prgm_out_rules_5_condition_1, "Condition 1", xAxis
     field = "",   firstDataIn4,       {outputPin[4]}
     field = "",   firstCompType4,     {outputPin[4]}
@@ -3844,7 +3845,7 @@ menuDialog = main
     field = "Activation Delay",     outputDelay[7],     {outputPin[7]}
     field = "2nd Condition",        bitwise7,           {outputPin[7]}
     panel = prgm_out_rules_8_condition_1
-    panel = prgm_out_rules_8_condition_2 
+    panel = prgm_out_rules_8_condition_2
 
   dialog = prgm_out_rules_master, "", card
     panel = prgm_out_rules_1, Center,   { prgm_out_selection == 0 }
@@ -3855,7 +3856,7 @@ menuDialog = main
     panel = prgm_out_rules_6, Center,   { prgm_out_selection == 5 }
     panel = prgm_out_rules_7, Center,   { prgm_out_selection == 6 }
     panel = prgm_out_rules_8, Center,   { prgm_out_selection == 7 }
-  
+
   dialog = prgm_out_config, "",yAxis
     ;panel = prgm_out_unique
     field = "Select Rule Number",  prgm_out_selection
@@ -4417,7 +4418,7 @@ cmdVSSratio6 =      "E\x99\x06"
     vvt2AngleGauge    = vvt2Angle,     "VVT Angle",          "deg",   -20,  100,      0,    -5,    70,  90, 0, 0
 
     WMIdutyCycleGauge = wmiPW,         "WMI Duty Cycle",     "%",       0,   100,     -1,    -1,  101,  110, 1, 1
-  
+
     gaugeCategory = "Sensor inputs"
     mapGauge          = map,           "Engine MAP",              "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
     mapGauge_psi      = map_psi,       "Engine MAP (PSI)",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
@@ -4701,12 +4702,12 @@ cmdVSSratio6 =      "E\x99\x06"
    strokeMultipler  = { twoStroke == 1 ? 1 : 2                        }
    cycleTime        = { revolutionTime * strokeMultipler              }
    pulseLimit       = { cycleTime / nSquirts                          }
-   
+
    nFuelChannels    = { arrayValue( array.boardFuelOutputs, pinLayout ) }
    nIgnChannels     = { arrayValue( array.boardIgnOutputs, pinLayout ) }
    sequentialFuelAvailable = { nCylinders <= nFuelChannels }
    sequentialIgnitionAvailable = { nCylinders <= nIgnChannels }
-   
+
    dutyCycle        = { rpm ? ( 100.0*pulseWidth/pulseLimit ) : 0     }
    stgDutyCycle     = { rpm && stagingEnabled ? ( 100.0*pulseWidth3/pulseLimit ) : 0      }
 
@@ -4815,11 +4816,11 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = vvt1Angle,       "VVT Angle",        int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt1Target,      "VVT Target Angle", int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt1Duty,        "VVT Duty",         int,    "%d",          { vvtEnabled > 0 }
-   entry = vss,             "Wheel Speed (kph)",int,    "%d",          { vssMode > 1 }   
-   entry = vssMPH,          "Wheel Speed (mph)",int,    "%d",          { vssMode > 1 }   
-   entry = gear,            "Gear",             int,    "%d",          { vssMode > 1 }  
-   entry = fuelPressure,    "Fuel Pressure",    int,    "%d",          { fuelPressureEnable > 0 }   
-   entry = oilPressure,     "Oil Pressure",     int,    "%d",          { oilPressureEnable > 0 }  
+   entry = vss,             "Wheel Speed (kph)",int,    "%d",          { vssMode > 1 }
+   entry = vssMPH,          "Wheel Speed (mph)",int,    "%d",          { vssMode > 1 }
+   entry = gear,            "Gear",             int,    "%d",          { vssMode > 1 }
+   entry = fuelPressure,    "Fuel Pressure",    int,    "%d",          { fuelPressureEnable > 0 }
+   entry = oilPressure,     "Oil Pressure",     int,    "%d",          { oilPressureEnable > 0 }
    entry = vvt2Angle,        "VVT Angle",       int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Target,       "VVT Target Angle",int,    "%d",          { vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Duty,         "VVT Duty",        int,    "%d",          { vvtEnabled > 0 }
@@ -4905,17 +4906,17 @@ cmdVSSratio6 =      "E\x99\x06"
     referenceTable = std_ms2gentherm, "Calibrate Thermistor Tables."
       topicHelp = "https://wiki.speeduino.com/en/configuration/Sensor_Calibration"
       tableIdentifier = 000, "Coolant Temperature Sensor", 001, "Air Temperature Sensor", 003, "Custom#1 Temperature Sensor"
-      ; tableLimits (optional) = intentifier, min, max, defaultVal 
+      ; tableLimits (optional) = intentifier, min, max, defaultVal
       ; will set the default value if value is outside the min and max limits.
       tableLimits = 000, -40, 350, 180 ;Coolant
       tableLimits = 001, -40, 350, 70  ;IAT
       ;Table 002 is AFR
       tableLimits = 003, -40, 400, 70 ; Not currently used
-      
+
       adcCount            = 32  ; length of the table
       bytesPerAdc         = 2     ; using shorts
       scale               = 10    ; scale by 10 before sending to controller
-      ;tableGenerator = Generator type, Label 
+      ;tableGenerator = Generator type, Label
       tableGenerator  = thermGenerator, "Thermistor Measurements"
       tableGenerator  = fileBrowseGenerator, "Browse for Inc File"
       ; thermOption       = name,             resistor bias,  tempPoint1(C),  resPoint1,  tempPoint2, resPoint2, tempPoint3, resPoint3
@@ -4946,7 +4947,7 @@ cmdVSSratio6 =      "E\x99\x06"
 
       solutionsLabel = "EGO Sensor"
       solution  = " ",                                { } ; blank row in case no match found. Must reman at top.
-      solution  = "Narrowband",                       { table(adcValue*5/1023 , "nb.inc") } ;     
+      solution  = "Narrowband",                       { table(adcValue*5/1023 , "nb.inc") } ;
       solution  = "14Point7",                         { 10.0001 + ( adcValue * 0.0097752 )} ; 10.0001 causes 1 adc to round different for unique match.
       solution  = "AEM Linear AEM-30-42xx",           { 9.72 + (adcValue * 0.0096665) } ; 9.72:1 - 19.60:1
       solution  = "AEM Linear (30-2310 & 30-4900)",   { 7.3125 + (adcValue * 0.0116080) } ; 7.31:1 - 19.18:1

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -429,7 +429,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Universal", "Rover-36-1-1", "Renault-44-1-1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Universal", "Rover-36-1-1", "Renault-44-1-1", "Rover Mini JDM", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -2469,7 +2469,7 @@ menuDialog = main
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "https://wiki.speeduino.com/en/decoders"
         field = "Trigger Pattern",                TrigPattern
-        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 || TrigPattern == 21 || TrigPattern == 22 }
+        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 || TrigPattern == 21 || TrigPattern == 22 || TrigPattern == 23 }
         field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 }
         field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 }
         field = "Trigger angle multiplier",       TrigAngMul,     { TrigPattern == 11 }

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -429,7 +429,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Universal", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Universal", "Rover-36-1-1", "Renault-44-1-1", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -2469,7 +2469,7 @@ menuDialog = main
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "https://wiki.speeduino.com/en/decoders"
         field = "Trigger Pattern",                TrigPattern
-        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 }
+        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 || TrigPattern == 21 || TrigPattern == 22 }
         field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 }
         field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 }
         field = "Trigger angle multiplier",       TrigAngMul,     { TrigPattern == 11 }

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2504,7 +2504,7 @@ menuDialog = main
         field = "Cranking advance Angle",       CrankAng
         field = "Spark Outputs triggers",        IgInv
         panel = lockSparkSettings
-        panel = newIgnitionMode, {}, {TrigPattern == 0 || TrigPattern == 1 || TrigPattern == 2 || TrigPattern == 3 || TrigPattern == 4 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20} ;Only works for missing tooth, distributor, dual wheel, GM 7X, 4g63, Miata 99-05, nissan 360, Subaru 6/7, 420a, weber-marelli
+        panel = newIgnitionMode, {}, {TrigPattern == 0 || TrigPattern == 1 || TrigPattern == 2 || TrigPattern == 3 || TrigPattern == 4 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 || TrigPattern == 21 || TrigPattern == 22} ;Only works for missing tooth, distributor, dual wheel, GM 7X, 4g63, Miata 99-05, nissan 360, Subaru 6/7, 420a, weber-marelli
 
     dialog = dwellSettings,                 "Dwell Settings",   4
         topicHelp = "https://wiki.speeduino.com/en/configuration/Dwell"

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -157,6 +157,16 @@ void triggerSetEndTeeth_420a();
 void triggerPri_Webber();
 void triggerSec_Webber();
 
+void triggerSetup_universal();
+void triggerSetup_universal(int);
+void syncLoss_universal();
+void appendTooth_universal(byte);
+void checkPattern_universal();
+void triggerPri_universal();
+
+void triggerSetup_rover3611();
+void triggerSetup_renault4411();
+
 extern void (*triggerHandler)(); //Pointer for the trigger function (Gets pointed to the relevant decoder)
 extern void (*triggerSecondaryHandler)(); //Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
 extern uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to the relevant decoder)

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3929,11 +3929,11 @@ void triggerPri_universal()
 
   // Pulses should never be less than triggerFilterTime, so if they are it means a false trigger.
   // this would break situations where the crank accelerates but the filter aggressiveness gives 25-75% leeway
-  // if (currentStatus.hasSync == true && curGap < triggerFilterTime )
-  // {
-  //   syncLoss_universal();
-  //   return;
-  // }
+  if (currentStatus.hasSync == true && curGap < triggerFilterTime )
+  {
+    syncLoss_universal();
+    return;
+  }
 
   validTrigger = true;
   addToothLogEntry(curGap, 0);
@@ -3946,13 +3946,10 @@ void triggerPri_universal()
 
   if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; } // ?? first tooth seen?
 
-
-
-
   if (curGap > targetGap) // WAS a gap between the last tooth and this one
   {
       toothCurrentCount++; // add a "tooth" counter for the gap
-      // triggerToothAngleIsCorrect = false; // angle is wrong because we just saw a gap - this is now fixed below
+      // triggerToothAngleIsCorrect = false; // angle is wrong because we just saw a gap - is this fixed by the below time measurement repair?
 
       appendTooth_universal(0); // add the gap we saw to our "seen" teeth
       checkPattern_universal(); // check if the teeth we've seen match the pattern we are expecting

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3884,6 +3884,16 @@ void triggerSetup_renault4411()
   triggerSetup_universal();
 }
 
+void triggerSetup_roverMiniJdm()
+{
+  configPage4.triggerTeeth = 36;
+  // gaps at 30 60 210 250  - teeth count 13-2-14-3, from TDC: 2,2,14,3,11
+  char roverMiniJdm[36] = {1,1,0,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1};
+  for (int i=0; i<36; i++) { universalExpectedPattern[i] = roverMiniJdm[i]; }
+  triggerSetup_universal();
+}
+
+
 void syncLoss_universal()
 {
   noInterrupts();

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -90,16 +90,8 @@ uint16_t ignition8EndTooth = 0;
 
 int16_t toothAngles[24]; //An array for storing fixed tooth angles. Currently sized at 24 for the GM 24X decoder, but may grow later if there are other decoders that use this style
 
-// TODO:
-// can tunerstudio convert to some format for us?
-// TODO: byte array using all 8 bits per byte - more complicated but would be smaller
-// just using lots of memory for now as a test
-// Rover 36-1-1 as an example:
-// byte expectedPattern[64] = {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-
-// Renault 44 with 2 gaps and 2 double teeth, using falling edge!
-byte expectedPattern[64] = {1,1,1,1,1,1,1,1,1,1,1,1,0,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,0,1,1,1,1,1,1,1, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-byte universalTeethSeen[64] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+volatile char universalTeethSeen[64] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+volatile char universalExpectedPattern[64] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
 /*
 *
@@ -3876,6 +3868,22 @@ void triggerSetup_universal()
   secondaryToothCount = 0;
 }
 
+void triggerSetup_rover3611()
+{
+  configPage4.triggerTeeth = 36;
+  char rover6311[36] = {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0};
+  for (int i=0; i<36; i++) { universalExpectedPattern[i] = rover6311[i]; }
+  triggerSetup_universal();
+}
+
+void triggerSetup_renault4411()
+{
+  configPage4.triggerTeeth = 44;
+  char renault4411[44] = {1,1,1,1,1,1,1,1,1,1,1,1,0,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,0,1,1,1,1,1,1,1};
+  for (int i=0; i<44; i++) { universalExpectedPattern[i] = renault4411[i]; }
+  triggerSetup_universal();
+}
+
 void syncLoss_universal()
 {
   noInterrupts();
@@ -3910,7 +3918,7 @@ void checkPattern_universal()
   // compare what we saw with the expected pattern
   for (int i=0; i<configPage4.triggerTeeth; i++)
   {
-    if (universalTeethSeen[i] != expectedPattern[i]) { return; }
+    if (universalTeethSeen[i] != universalExpectedPattern[i]) { return; }
   }
 
   // must be exactly matching the pattern if we get this far
@@ -3989,22 +3997,22 @@ void triggerPri_universal()
   }
 }
 
-void triggerSec_universal()
-{
-  // NOT USED - no cam support
-}
-
-uint16_t getRPM_universal()
-{
-  // NOT USED - Uses getRPM_missingTooth
-}
-
-int getCrankAngle_universal()
-{
-  // NOT USED - uses getCrankAngle_missingTooth
-}
-
-void triggerSetEndTeeth_universal()
-{
-  // NOT USED - uses triggerSetEndTeeth_missingTooth
-}
+// void triggerSec_universal()
+// {
+//   // NOT USED - no cam support
+// }
+//
+// uint16_t getRPM_universal()
+// {
+//   // NOT USED - Uses getRPM_missingTooth
+// }
+//
+// int getCrankAngle_universal()
+// {
+//   // NOT USED - uses getCrankAngle_missingTooth
+// }
+//
+// void triggerSetEndTeeth_universal()
+// {
+//   // NOT USED - uses triggerSetEndTeeth_missingTooth
+// }

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -95,7 +95,7 @@ int16_t toothAngles[24]; //An array for storing fixed tooth angles. Currently si
 // TODO: byte array using all 8 bits per byte - more complicated but would be smaller
 // just using lots of memory for now as a test
 // Rover 36-1-1 as an example:
-byte expectedPattern[64] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0};
+byte expectedPattern[64] = {1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 byte universalTeethSeen[64] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
 /*
@@ -3868,7 +3868,7 @@ void triggerSetup_universal()
   toothCurrentCount = 0;
   toothOneTime = 0;
   toothOneMinusOneTime = 0;
-  checkSyncToothCount = 64; // make sure we have definitely seen all teeth
+  checkSyncToothCount = configPage4.triggerTeeth; // make sure we have definitely seen all teeth
   MAX_STALL_TIME = (3333UL * triggerToothAngle * 2 ); // Minimum 50rpm. (3333uS is the time per degree at 50rpm)
   secondaryToothCount = 0;
 }
@@ -3895,7 +3895,7 @@ void appendTooth_universal(byte value)
   {
     universalTeethSeen[i] = universalTeethSeen[i+1];
   }
-  // "append" the value
+  // "append" the value to the end
   universalTeethSeen[configPage4.triggerTeeth-1] = value;
 }
 
@@ -3926,11 +3926,11 @@ void triggerPri_universal()
 
   // Pulses should never be less than triggerFilterTime, so if they are it means a false trigger.
   // this would break situations where the crank accelerates but the filter aggressiveness gives 25-75% leeway
-  if (currentStatus.hasSync == true && curGap < triggerFilterTime )
-  {
-    syncLoss_universal();
-    return;
-  }
+  // if (currentStatus.hasSync == true && curGap < triggerFilterTime )
+  // {
+  //   syncLoss_universal();
+  //   return;
+  // }
 
   validTrigger = true;
   addToothLogEntry(curGap, 0);
@@ -3939,7 +3939,7 @@ void triggerPri_universal()
   // If the time between the current tooth and the last is greater than 1.5x the time between the last tooth and the tooth before that,
   // we make the assertion that we must be at the first tooth after a gap
 
-  targetGap = (3 * (toothLastToothTime - toothLastMinusOneToothTime)) >> 1; // Multiply by 1.5 (Checks for a gap 2x greater than the last one)
+  targetGap = (3 * (toothLastToothTime - toothLastMinusOneToothTime)) >> 1; // Multiply by 1.5 (Checks for a gap 2x greater (more than 1.5x greater) than the last one)
 
   if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; } // ?? first tooth seen?
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -3887,7 +3887,8 @@ void triggerSetup_renault4411()
 void triggerSetup_roverMiniJdm()
 {
   configPage4.triggerTeeth = 36;
-  // gaps at 30 60 210 250  - teeth count 13-2-14-3, from TDC: 2,2,14,3,11
+  // gaps at deg after TDC 30 60 210 250  - teeth count 13-2-14-3, from TDC: 2,2,14,3,11
+  // might have to use crank sensor offset, it is not at TDC
   char roverMiniJdm[36] = {1,1,0,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1};
   for (int i=0; i<36; i++) { universalExpectedPattern[i] = roverMiniJdm[i]; }
   triggerSetup_universal();

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -3019,6 +3019,17 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
+    case 23: //Universal - JDM/MPI MINI
+      triggerSetup_roverMiniJdm();
+      triggerHandler = triggerPri_universal;
+      decoderHasSecondary = false;
+      getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth;
+      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
+      primaryTriggerEdge = FALLING; // force this
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      break;
+
     default:
       triggerHandler = triggerPri_missingTooth;
       getRPM = getRPM_missingTooth;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2983,7 +2983,6 @@ void initialiseTriggers()
       //Universal
       triggerSetup_universal();
       triggerHandler = triggerPri_universal;
-      // triggerSecondaryHandler = triggerSec_missingTooth;
       decoderHasSecondary = false;
       getRPM = getRPM_missingTooth;
       getCrankAngle = getCrankAngle_missingTooth;
@@ -2991,11 +2990,8 @@ void initialiseTriggers()
 
       if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
       else { primaryTriggerEdge = FALLING; }
-      // if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      // else { secondaryTriggerEdge = FALLING; }
 
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      // attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     default:

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -3015,7 +3015,9 @@ void initialiseTriggers()
       getRPM = getRPM_missingTooth;
       getCrankAngle = getCrankAngle_missingTooth;
       triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
-      primaryTriggerEdge = FALLING; // force this
+      // primaryTriggerEdge = FALLING; // ideally force this, but not doing for now so possible to debug a backwards wired VR sensor
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -15,12 +15,12 @@
 #include "idle.h"
 #include "table.h"
 #include "acc_mc33810.h"
-#include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
-#include EEPROM_LIB_H 
+#include BOARD_H //Note that this is not a real file, it is defined in globals.h.
+#include EEPROM_LIB_H
 
 
 void initialiseAll()
-{   
+{
     fpPrimed = false;
 
     pinMode(LED_BUILTIN, OUTPUT);
@@ -43,14 +43,14 @@ void initialiseAll()
     configPage9.intcan_available = 1;   // device has internal canbus
     //STM32 can not currently enabled
     #endif
-    
+
     loadConfig();
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)
 
     //Always start with a clean slate on the bootloader capabilities level
     //This should be 0 until we hear otherwise from the 16u2
     configPage4.bootloaderCaps = 0;
-    
+
     initBoard(); //This calls the current individual boards init function. See the board_xxx.ino files for these.
     initialiseTimers();
 
@@ -216,7 +216,7 @@ void initialiseAll()
       configPage9.intcan_available = 1;   // device has internal canbus
       //Teensy uses the Flexcan_T4 library to use the internal canbus
       //enable local can interface
-      //setup can interface to 500k   
+      //setup can interface to 500k
       Can0.begin();
       Can0.setBaudRate(500000);
       Can0.enableFIFO();
@@ -226,7 +226,7 @@ void initialiseAll()
     if((configPage2.pinMapping == 255) || (configPage2.pinMapping == 0)) //255 = EEPROM value in a blank AVR; 0 = EEPROM value in new FRAM
     {
       //First time running on this board
-      resetConfigPages(); 
+      resetConfigPages();
       setPinMapping(3); //Force board to v0.4
     }
     else { setPinMapping(configPage2.pinMapping); }
@@ -370,7 +370,7 @@ void initialiseAll()
     timer5_overflow_count = 0;
     toothHistoryIndex = 0;
     toothHistorySerialIndex = 0;
-    
+
     noInterrupts();
     initialiseTriggers();
 
@@ -387,10 +387,10 @@ void initialiseAll()
     mainLoopCount = 0;
 
     currentStatus.nSquirts = configPage2.nCylinders / configPage2.divider; //The number of squirts being requested. This is manaully overriden below for sequential setups (Due to TS req_fuel calc limitations)
-    if(currentStatus.nSquirts == 0) { currentStatus.nSquirts = 1; } //Safety check. Should never happen as TS will give an error, but leave incase tune is manually altered etc. 
+    if(currentStatus.nSquirts == 0) { currentStatus.nSquirts = 1; } //Safety check. Should never happen as TS will give an error, but leave incase tune is manually altered etc.
 
     //Calculate the number of degrees between cylinders
-    //Swet some default values. These will be updated below if required. 
+    //Swet some default values. These will be updated below if required.
     CRANK_ANGLE_MAX = 720;
     CRANK_ANGLE_MAX_IGN = 360;
     CRANK_ANGLE_MAX_INJ = 360;
@@ -421,7 +421,7 @@ void initialiseAll()
         channel1InjDegrees = 0;
         maxIgnOutputs = 1;
 
-        //Sequential ignition works identically on a 1 cylinder whether it's odd or even fire. 
+        //Sequential ignition works identically on a 1 cylinder whether it's odd or even fire.
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) ) { CRANK_ANGLE_MAX_IGN = 720; }
 
         if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) )
@@ -448,7 +448,7 @@ void initialiseAll()
         if (configPage2.engineType == EVEN_FIRE ) { channel2IgnDegrees = 180; }
         else { channel2IgnDegrees = configPage2.oddfire2; }
 
-        //Sequential ignition works identically on a 2 cylinder whether it's odd or even fire (With the default being a 180 degree second cylinder). 
+        //Sequential ignition works identically on a 2 cylinder whether it's odd or even fire (With the default being a 180 degree second cylinder).
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) ) { CRANK_ANGLE_MAX_IGN = 720; }
 
         if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage2.strokes == FOUR_STROKE) )
@@ -460,11 +460,11 @@ void initialiseAll()
         //The below are true regardless of whether this is running sequential or not
         if (configPage2.engineType == EVEN_FIRE ) { channel2InjDegrees = 180; }
         else { channel2InjDegrees = configPage2.oddfire2; }
-        if (!configPage2.injTiming) 
-        { 
+        if (!configPage2.injTiming)
+        {
           //For simultaneous, all squirts happen at the same time
           channel1InjDegrees = 0;
-          channel2InjDegrees = 0; 
+          channel2InjDegrees = 0;
         }
 
         channel1InjEnabled = true;
@@ -487,7 +487,7 @@ void initialiseAll()
         maxIgnOutputs = 3;
         if (configPage2.engineType == EVEN_FIRE )
         {
-        //Sequential and Single channel modes both run over 720 crank degrees, but only on 4 stroke engines. 
+        //Sequential and Single channel modes both run over 720 crank degrees, but only on 4 stroke engines.
         if( ( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) || (configPage4.sparkMode == IGN_MODE_SINGLE) ) && (configPage2.strokes == FOUR_STROKE) )
         {
           channel2IgnDegrees = 240;
@@ -521,13 +521,13 @@ void initialiseAll()
             channel3InjDegrees = (channel3InjDegrees * 2) / currentStatus.nSquirts;
           }
 
-          if (!configPage2.injTiming) 
-          { 
+          if (!configPage2.injTiming)
+          {
             //For simultaneous, all squirts happen at the same time
             channel1InjDegrees = 0;
             channel2InjDegrees = 0;
-            channel3InjDegrees = 0; 
-          } 
+            channel3InjDegrees = 0;
+          }
         }
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
@@ -582,11 +582,11 @@ void initialiseAll()
         {
           channel2InjDegrees = 180;
 
-          if (!configPage2.injTiming) 
-          { 
+          if (!configPage2.injTiming)
+          {
             //For simultaneous, all squirts happen at the same time
             channel1InjDegrees = 0;
-            channel2InjDegrees = 0; 
+            channel2InjDegrees = 0;
           }
           else if (currentStatus.nSquirts > 2)
           {
@@ -642,14 +642,14 @@ void initialiseAll()
         //For alternating injection, the squirt occurs at different times for each channel
         if( (configPage2.injLayout == INJ_SEMISEQUENTIAL) || (configPage2.injLayout == INJ_PAIRED) || (configPage2.strokes == TWO_STROKE) )
         {
-          if (!configPage2.injTiming) 
-          { 
+          if (!configPage2.injTiming)
+          {
             //For simultaneous, all squirts happen at the same time
             channel1InjDegrees = 0;
             channel2InjDegrees = 0;
             channel3InjDegrees = 0;
             channel4InjDegrees = 0;
-            channel5InjDegrees = 0; 
+            channel5InjDegrees = 0;
           }
           else
           {
@@ -836,7 +836,7 @@ void initialiseAll()
     else if (CRANK_ANGLE_MAX_IGN > CRANK_ANGLE_MAX_INJ) { CRANK_ANGLE_MAX = CRANK_ANGLE_MAX_IGN; }
     else { CRANK_ANGLE_MAX = CRANK_ANGLE_MAX_INJ; }
     currentStatus.status3 = currentStatus.nSquirts << BIT_STATUS3_NSQUIRTS1; //Top 3 bits of the status3 variable are the number of squirts. This must be done after the above section due to nSquirts being forced to 1 for sequential
-    
+
     //Special case:
     //3 or 5 squirts per cycle MUST be tracked over 720 degrees. This is because the angles for them (Eg 720/3=240) are not evenly divisible into 360
     //This is ONLY the case on 4 stroke systems
@@ -844,7 +844,7 @@ void initialiseAll()
     {
       if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX = 720; }
     }
-    
+
     switch(configPage2.injLayout)
     {
     case INJ_PAIRED:
@@ -1260,7 +1260,7 @@ void setPinMapping(byte boardID)
       pinInjector3 = 10; //Output pin injector 3 is on
       pinInjector4 = 11; //Output pin injector 4 is on
       pinInjector5 = 12; //Output pin injector 5 is on
-      pinInjector6 = 50; //CAUTION: Uses the same as Coil 4 below. 
+      pinInjector6 = 50; //CAUTION: Uses the same as Coil 4 below.
       pinCoil1 = 40; //Pin for coil 1
       pinCoil2 = 38; //Pin for coil 2
       pinCoil3 = 52; //Pin for coil 3
@@ -1310,11 +1310,11 @@ void setPinMapping(byte boardID)
         pinCoil3 = 30;
         pinO2 = A22;
       #elif defined(STM32F407xx)
-     //Pin definitions for experimental board Tjeerd 
+     //Pin definitions for experimental board Tjeerd
         //Black F407VE wiki.stm32duino.com/index.php?title=STM32F407
 
         //******************************************
-        //******** PORTA CONNECTIONS *************** 
+        //******** PORTA CONNECTIONS ***************
         //******************************************
         /* = PA0 */ //Wakeup ADC123
         // = PA1;
@@ -1328,17 +1328,17 @@ void setPinMapping(byte boardID)
         /* = PA9 */ //TXD1
         /* = PA10 */ //RXD1
         /* = PA11 */ //(DO NOT USE FOR SPEEDUINO) USB
-        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB 
+        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB
         /* = PA13 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         /* = PA14 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         /* = PA15 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
-        //******** PORTB CONNECTIONS *************** 
+        //******** PORTB CONNECTIONS ***************
         //******************************************
         /* = PB0; */ //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1
         /* = PB3; */ //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
         /* = PB4; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
         /* = PB5; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
@@ -1356,9 +1356,9 @@ void setPinMapping(byte boardID)
         /* = PB15; */ //SPI2_MOSI
 
         //******************************************
-        //******** PORTC CONNECTIONS *************** 
+        //******** PORTC CONNECTIONS ***************
         //******************************************
-        pinMAP = PC0; //ADC123 
+        pinMAP = PC0; //ADC123
         pinTPS = PC1; //ADC123
         pinIAT = PC2; //ADC123
         pinCLT = PC3; //ADC123
@@ -1376,7 +1376,7 @@ void setPinMapping(byte boardID)
         /* = PC15; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
-        //******** PORTD CONNECTIONS *************** 
+        //******** PORTD CONNECTIONS ***************
         //******************************************
         /* = PD0; */ //CANRX
         /* = PD1; */ //CANTX
@@ -1396,7 +1396,7 @@ void setPinMapping(byte boardID)
         pinInjector4 = PD15; //
 
         //******************************************
-        //******** PORTE CONNECTIONS *************** 
+        //******** PORTE CONNECTIONS ***************
         //******************************************
         pinTrigger = PE0; //
         pinTrigger2 = PE1; //
@@ -1906,7 +1906,7 @@ void setPinMapping(byte boardID)
       pinCoil3 = 31; //Pin for coil 3 - ONLY WITH DB2
       pinCoil4 = 32; //Pin for coil 4 - ONLY WITH DB2
       //Placeholder only - NOT USED:
-      //pinCoil5 = 46; 
+      //pinCoil5 = 46;
       pinTrigger = 23; //The CAS pin
       pinTrigger2 = 36; //The Cam Sensor pin
       pinTPS = 16; //TPS input pin
@@ -2033,23 +2033,23 @@ void setPinMapping(byte boardID)
       MC33810_BIT_IGN7 = 6;
       MC33810_BIT_IGN8 = 7;
 
-      //CS pin number is now set in a compile flag. 
+      //CS pin number is now set in a compile flag.
       // #ifdef USE_SPI_EEPROM
       //   pinSPIFlash_CS = 6;
       // #endif
 
       #endif
       break;
-    
- 
+
+
     case 60:
         #if defined(STM32F407xx)
-        //Pin definitions for experimental board Tjeerd 
+        //Pin definitions for experimental board Tjeerd
         //Black F407VE wiki.stm32duino.com/index.php?title=STM32F407
         //https://github.com/Tjeerdie/SPECTRE/tree/master/SPECTRE_V0.5
-        
+
         //******************************************
-        //******** PORTA CONNECTIONS *************** 
+        //******** PORTA CONNECTIONS ***************
         //******************************************
         // = PA0; //Wakeup ADC123
         // = PA1; //ADC123
@@ -2063,17 +2063,17 @@ void setPinMapping(byte boardID)
         // = PA9;  //TXD1=Bluetooth module
         // = PA10; //RXD1=Bluetooth module
         // = PA11; //(DO NOT USE FOR SPEEDUINO) USB
-        // = PA12; //(DO NOT USE FOR SPEEDUINO) USB 
+        // = PA12; //(DO NOT USE FOR SPEEDUINO) USB
         // = PA13;  //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         // = PA14;  //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         // = PA15;  //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
-        //******** PORTB CONNECTIONS *************** 
+        //******** PORTB CONNECTIONS ***************
         //******************************************
         // = PB0;  //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        // = PB2;  //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        // = PB2;  //(DO NOT USE FOR SPEEDUINO) BOOT1
         // = PB3;  //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
         // = PB4;  //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
         // = PB5;  //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
@@ -2090,11 +2090,11 @@ void setPinMapping(byte boardID)
         // = PB15;  //SPI2_MOSI
 
         //******************************************
-        //******** PORTC CONNECTIONS *************** 
+        //******** PORTC CONNECTIONS ***************
         //******************************************
-        pinIAT = PC0; //ADC123 
+        pinIAT = PC0; //ADC123
         pinTPS = PC1; //ADC123
-        pinMAP = PC2; //ADC123 
+        pinMAP = PC2; //ADC123
         pinCLT = PC3; //ADC123
         pinO2 = PC4; //ADC12
         pinBat = PC5;  //ADC12
@@ -2110,7 +2110,7 @@ void setPinMapping(byte boardID)
         // = PC15;  //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
-        //******** PORTD CONNECTIONS *************** 
+        //******** PORTD CONNECTIONS ***************
         //******************************************
         // = PD0;  //CANRX
         // = PD1;  //CANTX
@@ -2132,7 +2132,7 @@ void setPinMapping(byte boardID)
         pinInjector4 = PD15; //
 
         //******************************************
-        //******** PORTE CONNECTIONS *************** 
+        //******** PORTE CONNECTIONS ***************
         //******************************************
         pinTrigger = PE0; //
         pinTrigger2 = PE1; //
@@ -2150,7 +2150,7 @@ void setPinMapping(byte boardID)
         pinInjector8 = PE13; //
         pinInjector7 = PE14; //
         // = PE15;  //
-       
+
      #elif defined(CORE_STM32)
         //blue pill wiki.stm32duino.com/index.php?title=Blue_Pill
         //Maple mini wiki.stm32duino.com/index.php?title=Maple_Mini
@@ -2187,16 +2187,16 @@ void setPinMapping(byte boardID)
         pinFlex = PB8; // Flex sensor (Must be external interrupt enabled)
         pinTrigger = PA10; //The CAS pin
         pinTrigger2 = PA13; //The Cam Sensor pin
-      
+
     #endif
       break;
     default:
       #if defined(STM32F407xx)
-      //Pin definitions for experimental board Tjeerd 
+      //Pin definitions for experimental board Tjeerd
         //Black F407VE wiki.stm32duino.com/index.php?title=STM32F407
 
         //******************************************
-        //******** PORTA CONNECTIONS *************** 
+        //******** PORTA CONNECTIONS ***************
         //******************************************
         /* = PA0 */ //Wakeup ADC123
         // = PA1;
@@ -2210,17 +2210,17 @@ void setPinMapping(byte boardID)
         /* = PA9 */ //TXD1
         /* = PA10 */ //RXD1
         /* = PA11 */ //(DO NOT USE FOR SPEEDUINO) USB
-        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB 
+        /* = PA12 */ //(DO NOT USE FOR SPEEDUINO) USB
         /* = PA13 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         /* = PA14 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
         /* = PA15 */ //(DO NOT USE FOR SPEEDUINO) NOT ON GPIO - DEBUG ST-LINK
 
         //******************************************
-        //******** PORTB CONNECTIONS *************** 
+        //******** PORTB CONNECTIONS ***************
         //******************************************
         /* = PB0; */ //(DO NOT USE FOR SPEEDUINO) ADC123 - SPI FLASH CHIP CS pin
         pinBaro = PB1; //ADC12
-        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1 
+        /* = PB2; */ //(DO NOT USE FOR SPEEDUINO) BOOT1
         /* = PB3; */ //(DO NOT USE FOR SPEEDUINO) SPI1_SCK FLASH CHIP
         /* = PB4; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MISO FLASH CHIP
         /* = PB5; */ //(DO NOT USE FOR SPEEDUINO) SPI1_MOSI FLASH CHIP
@@ -2238,9 +2238,9 @@ void setPinMapping(byte boardID)
         /* = PB15; */ //SPI2_MOSI
 
         //******************************************
-        //******** PORTC CONNECTIONS *************** 
+        //******** PORTC CONNECTIONS ***************
         //******************************************
-        pinMAP = PC0; //ADC123 
+        pinMAP = PC0; //ADC123
         pinTPS = PC1; //ADC123
         pinIAT = PC2; //ADC123
         pinCLT = PC3; //ADC123
@@ -2258,7 +2258,7 @@ void setPinMapping(byte boardID)
         /* = PC15; */ //(DO NOT USE FOR SPEEDUINO) - OSC32_OUT
 
         //******************************************
-        //******** PORTD CONNECTIONS *************** 
+        //******** PORTD CONNECTIONS ***************
         //******************************************
         /* = PD0; */ //CANRX
         /* = PD1; */ //CANTX
@@ -2280,7 +2280,7 @@ void setPinMapping(byte boardID)
         pinInjector4 = PD15; //
 
         //******************************************
-        //******** PORTE CONNECTIONS *************** 
+        //******** PORTE CONNECTIONS ***************
         //******************************************
         pinTrigger = PE0; //
         pinTrigger2 = PE1; //
@@ -2332,10 +2332,10 @@ void setPinMapping(byte boardID)
         pinIdle1 = 6;
         pinResetControl = 43; //Reset control output
         #endif
-      #endif  
+      #endif
       break;
   }
-  
+
 
   //Setup any devices that are using selectable pins
 
@@ -2353,7 +2353,7 @@ void setPinMapping(byte boardID)
   if ( (configPage2.vssPin != 0) && (configPage2.vssPin < BOARD_NR_GPIO_PINS) ) { pinVSS = pinTranslate(configPage2.vssPin); }
   if ( (configPage10.fuelPressurePin != 0) && (configPage10.fuelPressurePin < BOARD_NR_GPIO_PINS) ) { pinFuelPressure = configPage10.fuelPressurePin + A0; }
   if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = configPage10.oilPressurePin + A0; }
-  
+
   if ( (configPage10.wmiEmptyPin != 0) && (configPage10.wmiEmptyPin < BOARD_NR_GPIO_PINS) ) { pinWMIEmpty = pinTranslate(configPage10.wmiEmptyPin); }
   if ( (configPage10.wmiIndicatorPin != 0) && (configPage10.wmiIndicatorPin < BOARD_NR_GPIO_PINS) ) { pinWMIIndicator = pinTranslate(configPage10.wmiIndicatorPin); }
   if ( (configPage10.wmiEnabledPin != 0) && (configPage10.wmiEnabledPin < BOARD_NR_GPIO_PINS) ) { pinWMIEnabled = pinTranslate(configPage10.wmiEnabledPin); }
@@ -2432,7 +2432,7 @@ void setPinMapping(byte boardID)
     ign7_pin_mask = digitalPinToBitMask(pinCoil7);
     ign8_pin_port = portOutputRegister(digitalPinToPort(pinCoil8));
     ign8_pin_mask = digitalPinToBitMask(pinCoil8);
-  } 
+  }
 
   if(injectorOutputControl == OUTPUT_CONTROL_DIRECT)
   {
@@ -2481,7 +2481,7 @@ void setPinMapping(byte boardID)
     initMC33810();
   }
 
-//CS pin number is now set in a compile flag. 
+//CS pin number is now set in a compile flag.
 // #ifdef USE_SPI_EEPROM
 //   //We need to send the flash CS (SS) pin if we're using SPI flash. It cannot read from globals.
 //   EEPROM.begin(USE_SPI_EEPROM);
@@ -2573,7 +2573,7 @@ void setPinMapping(byte boardID)
       if (configPage10.wmiEmptyPolarity == 0) { pinMode(pinWMIEmpty, INPUT_PULLUP); } //Normal setting
       else { pinMode(pinWMIEmpty, INPUT); } //inverted setting
     }
-  }  
+  }
 
   //These must come after the above pinMode statements
   triggerPri_pin_port = portInputRegister(digitalPinToPort(pinTrigger));
@@ -2979,6 +2979,24 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
+    case 20:
+      //Universal
+      triggerSetup_universal();
+      triggerHandler = triggerPri_universal;
+      triggerSecondaryHandler = triggerSec_missingTooth;
+      decoderHasSecondary = false;
+      getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth;
+      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
+
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
+      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
+      else { secondaryTriggerEdge = FALLING; }
+
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      // attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
+      break;
 
     default:
       triggerHandler = triggerPri_missingTooth;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2979,8 +2979,7 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
-    case 20:
-      //Universal
+    case 20: //Universal - this one probably needs removing, it won't do anything
       triggerSetup_universal();
       triggerHandler = triggerPri_universal;
       decoderHasSecondary = false;
@@ -2991,6 +2990,32 @@ void initialiseTriggers()
       if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
       else { primaryTriggerEdge = FALLING; }
 
+      // override and force renault 44-1-1 to falling edge
+      if (configPage4.TrigPattern == 22) { primaryTriggerEdge = FALLING; }
+
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      break;
+
+    case 21: //Universal - Rover 36-1-1
+      triggerSetup_rover3611();
+      triggerHandler = triggerPri_universal;
+      decoderHasSecondary = false;
+      getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth;
+      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      break;
+
+    case 22: //Universal - Renault 44-1-1
+      triggerSetup_renault4411();
+      triggerHandler = triggerPri_universal;
+      decoderHasSecondary = false;
+      getRPM = getRPM_missingTooth;
+      getCrankAngle = getCrankAngle_missingTooth;
+      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
+      primaryTriggerEdge = FALLING; // force this
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2983,7 +2983,7 @@ void initialiseTriggers()
       //Universal
       triggerSetup_universal();
       triggerHandler = triggerPri_universal;
-      triggerSecondaryHandler = triggerSec_missingTooth;
+      // triggerSecondaryHandler = triggerSec_missingTooth;
       decoderHasSecondary = false;
       getRPM = getRPM_missingTooth;
       getCrankAngle = getCrankAngle_missingTooth;
@@ -2991,8 +2991,8 @@ void initialiseTriggers()
 
       if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
       else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
+      // if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
+      // else { secondaryTriggerEdge = FALLING; }
 
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       // attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);


### PR DESCRIPTION
Tested on the bench with a Rover 36-1-1 pattern and a strange Renault 44-1-1, both working sensibly.

Configuration done through tunerstudio to select the trigger pattern but then shares the same code in decoders.ino

Ideas to squash the used memory down:
class to wrap saving/loading/shifting bits inside an array of bytes
toothAngles array is 48 bits apparently - could use
bitfields (in structs) - seem messy to access
64 bit types - don't seem to work properly

Hide the whitespace in the diff, there are loads of stray spaces etc that my editor keeps fixing:
https://github.com/noisymime/speeduino/pull/492/files?w=1