### PR TITLE
Hella OPS+T Sensor interface

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -898,10 +898,15 @@ page = 9
       oilTemperaturePin      = bits,   U08,     110, [1:4], "51", "52"
       oilTemperatureFault    = bits,   U08,     110, [5:5], "Off", "On"
       unused10_110           = bits,   U08,     110, [6:7], ""
-      oilTemperatureMin      = scalar, S08,     190,        "psi",       1.0,       0.0,  -100,     127,    0 ;Note signed int
-      oilTemperatureMax      = scalar, U08,     191,        "psi",       1.0,       0.0,   0.0,     255,    0
-      unused10_111         = scalar, U08,     111,        "",       1, 0, 0, 255, 0
-      unused10_112         = scalar, U08,     112,        "",       1, 0, 0, 255, 0
+
+    #if CELSIUS
+      oilTemperatureMin      = scalar, S08,     111,        "TEMP",       -40,       215,   -15,     0,      0
+      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       0,         0.0,   0.0,     255,    0
+    #else
+      oilTemperatureMin      = scalar, S08,     111,        "TEMP",       -40,       0.0,  -100,     127,    0 ;Note signed int
+      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       0,         0.0,   0.0,     255,    0
+    #endif
+
       unused10_113         = scalar, U08,     113,        "",       1, 0, 0, 255, 0
 
       speeduino_tsCanId     = bits,   U08,    114,     [0:3],  $tsCanId_list
@@ -1064,7 +1069,7 @@ page = 10
       oilPressureProtEnbl = bits,   U08,     135, [2:2], "Off", "On"
 
       fuelPressurePin     = bits,   U08,     136, [0:3], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
-      oilPressurePin      = bits,   U08,     136, [4:7], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
+      unused10_136        = bits,   U08,     136, [4:7], "" 
 
       fuelPressureMin     = scalar, S08,     137,        "psi",       1.0,       0.0,  -100,     127,    0 ;Note signed int
       fuelPressureMax     = scalar, U08,     138,        "psi",       1.0,       0.0,   0.0,     255,    0
@@ -1124,7 +1129,10 @@ page = 10
       spark2InputPolarity  = bits ,  U08,     189, [6:6],           "LOW", "HIGH"
       spark2InputPullup    = bits ,  U08,     189, [7:7],           "No", "Yes"
 
-      unused11_190_191    = array,  U08,     90,  [2], "RPM",  100.0,      0.0,  100,     25500,    0
+      oilPressurePin      = bits,   U08,     190, [0:5], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "51", "52"
+
+      unused10_190        = bits,   U08,     190, [5:7], ""
+      unused10_191        = scalar, S08,     191,  "",       1, 0, 0, 255, 0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1630,6 +1638,7 @@ menuDialog = main
         subMenu = Auxin_config,         "Local Auxillary Input Channel Configuration"
     #endif
         subMenu = pressureSensors,      "Fuel/Oil pressure"
+        subMenu = oilTempSensors,       "Oil Temperature"
 
   menuDialog = main
    menu = "Tools"
@@ -2766,6 +2775,18 @@ menuDialog = main
         topicHelp = "https://wiki.speeduino.com/en/configuration/Sensor_Calibration"
         panel = fuelPressureDialog
         panel = oilPressureDialog
+
+    dialog = oilTemperatureSettings
+        field = "Enabled",                  oilTemperatureEnable
+        field = "Pin",                      oilTemperaturePin,    { oilTemperatureEnable }
+        settingSelector = "Hella OPS+T",                     { oilTemperatureEnable }
+
+    dialog = oilTemperatureDialog, "Oil Temperature", xAxis
+        gauge = oilTemperatureGauge
+        panel = oilTemperatureSettings
+
+    dialog = oilTempSensors, "Oil temperature sensors"
+        panel = oilTemperatureDialog
 
     dialog = boostSettings, "Boost Control"
         topicHelp = "https://wiki.speeduino.com/en/configuration/Boost_Control"
@@ -4454,6 +4475,8 @@ cmdVSSratio6 =      "E\x99\x06"
 
     fuelPressureGauge = fuelPressure,  "Fuel Pressure",       "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
     oilPressureGauge  = oilPressure,   "Oil Pressure",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
+
+    oilTemperatureGauge  = oilTemperature, "Oil Temperature", "TEMP", -40,   215,      0,    30,  200,  220, 0, 0
 
     gaugeCategory     = "Auxillary Input Channels"
     AuxInGauge0       = auxin_gauge0,    { stringValue(AUXin00Alias) },        "",             0,    1024,  -1,    -1,  1025,    1025,  0,  0

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -893,7 +893,13 @@ page = 9
       canoutput_param_num_bytes6 = bits,   U08,     108, [0:1], "INVALID", "1", "2", "INVALID"
       canoutput_param_num_bytes7 = bits,   U08,     109, [0:1], "INVALID", "1", "2", "INVALID"
 
-      unused10_110         = scalar, U08,     110,        "",       1, 0, 0, 255, 0
+
+      oilTemperatureEnable   = bits,   U08,     110, [0:0], "Off", "On"
+      oilTemperaturePin      = bits,   U08,     110, [1:4], "51", "52"
+      oilTemperatureFault    = bits,   U08,     110, [5:5], "Off", "On"
+      unused10_110           = bits,   U08,     110, [6:7], ""
+      oilTemperatureMin      = scalar, S08,     190,        "psi",       1.0,       0.0,  -100,     127,    0 ;Note signed int
+      oilTemperatureMax      = scalar, U08,     191,        "psi",       1.0,       0.0,   0.0,     255,    0
       unused10_111         = scalar, U08,     111,        "",       1, 0, 0, 255, 0
       unused10_112         = scalar, U08,     112,        "",       1, 0, 0, 255, 0
       unused10_113         = scalar, U08,     113,        "",       1, 0, 0, 255, 0
@@ -4680,14 +4686,16 @@ cmdVSSratio6 =      "E\x99\x06"
    fuelTempCor      = scalar,   U08,    113, "%",     1.000, 0.000
    advance1         = scalar,   U08,    114, "%",      1.000, 0.000
    advance2         = scalar,   U08,    115, "%",      1.000, 0.000
-   unused116        = scalar,   U08,    116, "",      1.000, 0.000
+   oilTemperatureRaw = scalar,   U08,    116, "",      1.000, 0.000
    #sd_status        = scalar,   U08,    99, "",         1.0,   0.0
 
 #if CELSIUS
+   oilTemperature   = { oilTemperatureRaw - 40                        } ; Temperature readings are offset by 40 to allow for negatives
    coolant          = { coolantRaw - 40                               } ; Temperature readings are offset by 40 to allow for negatives
    iat              = { iatRaw - 40                                   } ; Temperature readings are offset by 40 to allow for negatives
    fuelTemp         = { fuelTempRaw - 40                              } ; Temperature readings are offset by 40 to allow for negatives
 #else
+   oilTemperature	= { (oilTemperatureRaw - 40) * 1.8 + 32           } ;Convert C to F (Offset by 40)
    coolant          = { (coolantRaw - 40) * 1.8 + 32                  } ;Convert C to F (Offset by 40)
    iat              = { (iatRaw - 40) * 1.8 + 32                      } ;Convert C to F (Offset by 40)
    fuelTemp         = { (fuelTempRaw - 40) * 1.8 + 32                 } ;Convert C to F (Offset by 40)

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -894,17 +894,14 @@ page = 9
       canoutput_param_num_bytes7 = bits,   U08,     109, [0:1], "INVALID", "1", "2", "INVALID"
 
 
-      oilTemperatureEnable   = bits,   U08,     110, [0:0], "Off", "On"
-      oilTemperaturePin      = bits,   U08,     110, [1:4], "51", "52"
-      oilTemperatureFault    = bits,   U08,     110, [5:5], "Off", "On"
-      unused10_110           = bits,   U08,     110, [6:7], ""
+      unused10_110           = scalar,   U08,     110,    "",       1, 0, 0, 255, 0
 
     #if CELSIUS
       oilTemperatureMin      = scalar, S08,     111,        "TEMP",       -40,       215,   -15,     0,      0
-      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       0,         0.0,   0.0,     255,    0
+      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       255,         0.0,   0.0,     255,    0
     #else
       oilTemperatureMin      = scalar, S08,     111,        "TEMP",       -40,       0.0,  -100,     127,    0 ;Note signed int
-      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       0,         0.0,   0.0,     255,    0
+      oilTemperatureMax      = scalar, U08,     112,        "TEMP",       215,         0.0,   0.0,     255,    0
     #endif
 
       unused10_113         = scalar, U08,     113,        "",       1, 0, 0, 255, 0
@@ -956,7 +953,10 @@ page = 9
       
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
 
-      unused10_154        = array, U08,    155, [37],       "",       1, 0, 0, 255, 0
+      oilSensorOPStPin     = bits,   U08,     155, [0:5], "INVALID", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+
+      unused10_155        = bits, U08,    155, [6:7],       "",       1, 0, 0, 255, 0
+      unused10_156        = array, U08,    155, [36],       "",       1, 0, 0, 255, 0
     
 page = 10
 #if CELSIUS
@@ -1065,8 +1065,9 @@ page = 10
 
       ;Pressure transducers
       fuelPressureEnable  = bits,   U08,     135, [0:0], "Off", "On"
-      oilPressureEnable   = bits,   U08,     135, [1:1], "Off", "On"
-      oilPressureProtEnbl = bits,   U08,     135, [2:2], "Off", "On"
+      oilPressureEnable   = bits,   U08,     135, [1:2], "Off", "Analog", "Hella OPS+T", "INVALID"
+      oilPressureProtEnbl = bits,   U08,     135, [3:3], "Off", "On"
+      oilPressurePin      = bits,   U08,     135, [4:7], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
 
       fuelPressurePin     = bits,   U08,     136, [0:3], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
       unused10_136        = bits,   U08,     136, [4:7], "" 
@@ -1129,10 +1130,7 @@ page = 10
       spark2InputPolarity  = bits ,  U08,     189, [6:6],           "LOW", "HIGH"
       spark2InputPullup    = bits ,  U08,     189, [7:7],           "No", "Yes"
 
-      oilPressurePin      = bits,   U08,     190, [0:5], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "51", "52"
-
-      unused10_190        = bits,   U08,     190, [5:7], ""
-      unused10_191        = scalar, S08,     191,  "",       1, 0, 0, 255, 0
+      unused10_190_191         = array, U08,     190,  [2],       1, 0, 0, 255, 0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1638,7 +1636,6 @@ menuDialog = main
         subMenu = Auxin_config,         "Local Auxillary Input Channel Configuration"
     #endif
         subMenu = pressureSensors,      "Fuel/Oil pressure"
-        subMenu = oilTempSensors,       "Oil Temperature"
 
   menuDialog = main
    menu = "Tools"
@@ -2758,14 +2755,25 @@ menuDialog = main
         gauge = fuelPressureGauge
         panel = fuelPressureSettings
 
-    dialog = oilPressureSettings
-        field = "Enabled",                  oilPressureEnable
-        field = "Pin",                      oilPressurePin,    { oilPressureEnable }
-        settingSelector = "Common Sensors",                     { oilPressureEnable }
+    dialog = oilPressureAnalog,                 "Analog Pressure Sensors"
+        field = "Pin",                      oilPressurePin,    { oilPressureEnable == 1 }
+        settingSelector = "Common Sensors",                     { oilPressureEnable == 1 }
             settingOption = "0-100 PSI",  oilPressureMin=-3,   oilPressureMax=103 ; Vout = VCC x (P x .97 / 200 + 0.5)
             settingOption = "0-150 PSI",  oilPressureMin=-18,   oilPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png 
-        field = "Pressure at 0v",           oilPressureMin,    { oilPressureEnable }
-        field = "Pressure at 5v",           oilPressureMax,    { oilPressureEnable }
+        field = "Pressure at 0v",           oilPressureMin,    { oilPressureEnable == 1 }
+        field = "Pressure at 5v",           oilPressureMax,    { oilPressureEnable == 1 }
+
+    dialog = oilPressureOPSt,                 "Hella OPS+T Sensor"
+        field = "Enabling will also provide oil temperature readings."
+        field = "Pin",                      oilSensorOPStPin,    { oilPressureEnable == 2 }
+        
+    dialog = oilPressureMain,                   "Settings"
+        field = "Enabled",                  oilPressureEnable 
+
+    dialog = oilPressureSettings
+        panel = oilPressureMain             North
+        panel = oilPressureAnalog           West,   { oilPressureEnable == 1 }
+        panel = oilPressureOPSt             East,   { oilPressureEnable == 2 }
 
     dialog = oilPressureDialog, "Oil Pressure", xAxis
         gauge = oilPressureGauge
@@ -2775,18 +2783,6 @@ menuDialog = main
         topicHelp = "https://wiki.speeduino.com/en/configuration/Sensor_Calibration"
         panel = fuelPressureDialog
         panel = oilPressureDialog
-
-    dialog = oilTemperatureSettings
-        field = "Enabled",                  oilTemperatureEnable
-        field = "Pin",                      oilTemperaturePin,    { oilTemperatureEnable }
-        settingSelector = "Hella OPS+T",                     { oilTemperatureEnable }
-
-    dialog = oilTemperatureDialog, "Oil Temperature", xAxis
-        gauge = oilTemperatureGauge
-        panel = oilTemperatureSettings
-
-    dialog = oilTempSensors, "Oil temperature sensors"
-        panel = oilTemperatureDialog
 
     dialog = boostSettings, "Boost Control"
         topicHelp = "https://wiki.speeduino.com/en/configuration/Boost_Control"
@@ -4476,7 +4472,7 @@ cmdVSSratio6 =      "E\x99\x06"
     fuelPressureGauge = fuelPressure,  "Fuel Pressure",       "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
     oilPressureGauge  = oilPressure,   "Oil Pressure",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
 
-    oilTemperatureGauge  = oilTemperature, "Oil Temperature", "TEMP", -40,   215,      0,    30,  200,  220, 0, 0
+    oilTemperatureGauge  = oilTemperature, "Oil Temperature", "TEMP", -20,   150,      0,    30,  105,  120, 0, 0
 
     gaugeCategory     = "Auxillary Input Channels"
     AuxInGauge0       = auxin_gauge0,    { stringValue(AUXin00Alias) },        "",             0,    1024,  -1,    -1,  1025,    1025,  0,  0

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -15,7 +15,7 @@
   #define COMPARE_TYPE uint16_t
   #define COUNTER_TYPE uint16_t
   #define BOARD_DIGITAL_GPIO_PINS 34
-  #define BOARD_NR_GPIO_PINS 34
+  #define BOARD_NR_GPIO_PINS 58
   #ifdef USE_SPI_EEPROM
     #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #else

--- a/speeduino/board_teensy35.ino
+++ b/speeduino/board_teensy35.ino
@@ -79,29 +79,8 @@ void initBoard()
     /*
     ***********************************************************************************************************
     * Auxilliaries
-    * HELLA OPS+T Sensor
     */
-    if (configPage10.oilPressureEnable == 1 && configPage9.oilTemperatureEnable == 1)
-    {
-      if (configPage9.oilTemperaturePin == pinOilPressure)
-      {
-          pinMode(pinOilPressure, INPUT);
-          attachInterrupt(digitalPinToInterrupt(pinOilPressure), oilSensorInterrupt, CHANGE);
-      } 
-      else
-      {
-        if (configPage10.oilPressureEnable == 1 && (pinOilPressure == 51 || pinOilPressure == 52)) 
-        {
-          pinMode(pinOilPressure, INPUT);
-          attachInterrupt(digitalPinToInterrupt(pinOilPressure), oilSensorInterrupt, CHANGE);
-        }
-        if (configPage9.oilTemperatureEnable == 1) {
-          pinMode(pinOilTemperature, INPUT);
-          attachInterrupt(digitalPinToInterrupt(pinOilTemperature), oilSensorInterrupt, CHANGE);
-        }
-      }
-      
-    }
+
     /*
     ***********************************************************************************************************
     * BOOST and VVT

--- a/speeduino/board_teensy35.ino
+++ b/speeduino/board_teensy35.ino
@@ -79,8 +79,29 @@ void initBoard()
     /*
     ***********************************************************************************************************
     * Auxilliaries
+    * HELLA OPS+T Sensor
     */
-
+    if (configPage10.oilPressureEnable == 1 && configPage9.oilTemperatureEnable == 1)
+    {
+      if (configPage9.oilTemperaturePin == configPage10.oilPressurePin)
+      {
+          pinMode(configPage10.oilPressurePin, INPUT);
+          attachInterrupt(digitalPinToInterrupt(configPage10.oilPressurePin), oilSensorInterrupt, CHANGE);
+      } 
+      else
+      {
+        if (configPage10.oilPressureEnable == 1 && (configPage10.oilPressurePin == 51 || configPage10.oilPressurePin == 52)) 
+        {
+          pinMode(configPage10.oilPressurePin, INPUT);
+          attachInterrupt(digitalPinToInterrupt(configPage10.oilPressurePin), oilSensorInterrupt, CHANGE);
+        }
+        if (configPage9.oilTemperatureEnable == 1) {
+          pinMode(configPage9.oilTemperaturePin, INPUT);
+          attachInterrupt(digitalPinToInterrupt(configPage9.oilTemperaturePin), oilSensorInterrupt, CHANGE);
+        }
+      }
+      
+    }
     /*
     ***********************************************************************************************************
     * BOOST and VVT

--- a/speeduino/board_teensy35.ino
+++ b/speeduino/board_teensy35.ino
@@ -83,21 +83,21 @@ void initBoard()
     */
     if (configPage10.oilPressureEnable == 1 && configPage9.oilTemperatureEnable == 1)
     {
-      if (configPage9.oilTemperaturePin == configPage10.oilPressurePin)
+      if (configPage9.oilTemperaturePin == pinOilPressure)
       {
-          pinMode(configPage10.oilPressurePin, INPUT);
-          attachInterrupt(digitalPinToInterrupt(configPage10.oilPressurePin), oilSensorInterrupt, CHANGE);
+          pinMode(pinOilPressure, INPUT);
+          attachInterrupt(digitalPinToInterrupt(pinOilPressure), oilSensorInterrupt, CHANGE);
       } 
       else
       {
-        if (configPage10.oilPressureEnable == 1 && (configPage10.oilPressurePin == 51 || configPage10.oilPressurePin == 52)) 
+        if (configPage10.oilPressureEnable == 1 && (pinOilPressure == 51 || pinOilPressure == 52)) 
         {
-          pinMode(configPage10.oilPressurePin, INPUT);
-          attachInterrupt(digitalPinToInterrupt(configPage10.oilPressurePin), oilSensorInterrupt, CHANGE);
+          pinMode(pinOilPressure, INPUT);
+          attachInterrupt(digitalPinToInterrupt(pinOilPressure), oilSensorInterrupt, CHANGE);
         }
         if (configPage9.oilTemperatureEnable == 1) {
-          pinMode(configPage9.oilTemperaturePin, INPUT);
-          attachInterrupt(digitalPinToInterrupt(configPage9.oilTemperaturePin), oilSensorInterrupt, CHANGE);
+          pinMode(pinOilTemperature, INPUT);
+          attachInterrupt(digitalPinToInterrupt(pinOilTemperature), oilSensorInterrupt, CHANGE);
         }
       }
       

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -636,7 +636,7 @@ void updateFullStatus()
   fullStatus[113] = currentStatus.fuelTempCorrection; //Fuel temperature Correction (%)
   fullStatus[114] = currentStatus.advance1; //advance 1 (%)
   fullStatus[115] = currentStatus.advance2; //advance 2 (%)
-  fullStatus[116] = 0; //Currently unused
+  fullStatus[116] = currentStatus.oilTemperature; // Hella OPS+T Oil Temperature
 
   //Each new inclusion here need to be added on speeduino.ini@L78, only list first byte of an integer and second byte as "INVALID"
   //Every integer added here should have it's lowByte index added to fsIntIndex array on globals.ino@L116

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -625,6 +625,7 @@ struct statuses {
   byte gear; /**< Current gear (Calculated from vss) */
   byte fuelPressure; /**< Fuel pressure in PSI */
   byte oilPressure; /**< Oil pressure in PSI */
+  byte oilTemperature; /* Oil Temperature in Celsius */
   byte engineProtectStatus;
   byte wmiPW;
   bool wmiEmpty;
@@ -1005,9 +1006,13 @@ struct config9 {
   uint8_t canoutput_param_start_byte[8];
   byte canoutput_param_num_bytes[8];
 
-  byte unused10_110;
-  byte unused10_111;
-  byte unused10_112;
+  byte oilTemperatureEnable : 1;
+  byte oilTemperaturePin : 4;
+  byte oilTemperatureFault : 1;
+  byte unused10_110 : 2;
+  int8_t oilTemperatureMin;
+  byte oilTemperatureMax;
+
   byte unused10_113;
   byte speeduino_tsCanId:4;         //speeduino TS canid (0-14)
   uint16_t true_address;            //speeduino 11bit can address
@@ -1189,6 +1194,7 @@ struct config10 {
 
   byte oilPressureProtRPM[4];
   byte oilPressureProtMins[4];
+  
 
   byte wmiEnabled : 1; // Byte 149
   byte wmiMode : 6;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1026,7 +1026,9 @@ struct config9 {
 
   byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
 
-  byte unused10_155;
+  byte oilSensorOPStPin : 6;
+
+  byte unused10_155 : 2;
   byte unused10_156;
   byte unused10_157;
   byte unused10_158;
@@ -1180,12 +1182,12 @@ struct config10 {
   byte crankingEnrichTaper; //Byte 134
 
   byte fuelPressureEnable : 1;
-  byte oilPressureEnable : 1;
+  byte oilPressureEnable : 2;
   byte oilPressureProtEnbl : 1;
-  byte unused10_135 : 5;
+  byte unused10_136 : 4;
 
   byte fuelPressurePin : 4;
-  byte unused10_136 : 4;
+  byte oilPressurePin : 4;
 
   int8_t fuelPressureMin;
   byte fuelPressureMax;
@@ -1243,9 +1245,7 @@ struct config10 {
   byte spark2InputPolarity : 1;
   byte spark2InputPullup : 1;
 
-  byte oilPressurePin;
-
-  byte unused10_191; //Bytes 187-191
+  byte unused10_190_191[2];
 
 #if defined(CORE_AVR)
   };
@@ -1356,7 +1356,7 @@ extern byte pinBaro; //Pin that an external barometric pressure sensor is attach
 extern byte pinResetControl; // Output pin used control resetting the Arduino
 extern byte pinFuelPressure;
 extern byte pinOilPressure;
-extern byte pinOilTemperature;
+extern byte pinOilSensorOPSt;
 extern byte pinWMIEmpty; // Water tank empty sensor
 extern byte pinWMIIndicator; // No water indicator bulb
 extern byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1185,7 +1185,7 @@ struct config10 {
   byte unused10_135 : 5;
 
   byte fuelPressurePin : 4;
-  byte oilPressurePin : 4;
+  byte unused10_136 : 4;
 
   int8_t fuelPressureMin;
   byte fuelPressureMax;
@@ -1243,7 +1243,9 @@ struct config10 {
   byte spark2InputPolarity : 1;
   byte spark2InputPullup : 1;
 
-  byte unused11_187_191[2]; //Bytes 187-191
+  byte oilPressurePin;
+
+  byte unused10_191; //Bytes 187-191
 
 #if defined(CORE_AVR)
   };
@@ -1354,6 +1356,7 @@ extern byte pinBaro; //Pin that an external barometric pressure sensor is attach
 extern byte pinResetControl; // Output pin used control resetting the Arduino
 extern byte pinFuelPressure;
 extern byte pinOilPressure;
+extern byte pinOilTemperature;
 extern byte pinWMIEmpty; // Water tank empty sensor
 extern byte pinWMIIndicator; // No water indicator bulb
 extern byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -442,6 +442,9 @@ extern volatile PINMASK_TYPE triggerPri_pin_mask;
 extern volatile PORT_TYPE *triggerSec_pin_port;
 extern volatile PINMASK_TYPE triggerSec_pin_mask;
 
+extern volatile PORT_TYPE *oilSensorOPSt_pin_port;
+extern volatile PINMASK_TYPE oilSensorOPSt_pin_mask;
+
 //These need to be here as they are used in both speeduino.ino and scheduler.ino
 extern bool channel1InjEnabled;
 extern bool channel2InjEnabled;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -221,7 +221,7 @@ byte pinBaro; //Pin that an al barometric pressure sensor is attached to (If use
 byte pinResetControl; // Output pin used control resetting the Arduino
 byte pinFuelPressure;
 byte pinOilPressure;
-byte pinOilTemperature;
+byte pinOilSensorOPSt;
 byte pinWMIEmpty; // Water tank empty sensor
 byte pinWMIIndicator; // No water indicator bulb
 byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -92,6 +92,9 @@ volatile PINMASK_TYPE triggerPri_pin_mask;
 volatile PORT_TYPE *triggerSec_pin_port;
 volatile PINMASK_TYPE triggerSec_pin_mask;
 
+volatile PORT_TYPE *oilSensorOPSt_pin_port;
+volatile PINMASK_TYPE oilSensorOPSt_pin_mask;
+
 //These need to be here as they are used in both speeduino.ino and scheduler.ino
 bool channel1InjEnabled = true;
 bool channel2InjEnabled = false;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -221,6 +221,7 @@ byte pinBaro; //Pin that an al barometric pressure sensor is attached to (If use
 byte pinResetControl; // Output pin used control resetting the Arduino
 byte pinFuelPressure;
 byte pinOilPressure;
+byte pinOilTemperature;
 byte pinWMIEmpty; // Water tank empty sensor
 byte pinWMIIndicator; // No water indicator bulb
 byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2348,11 +2348,13 @@ void setPinMapping(byte boardID)
   if ( (configPage6.vvt1Pin != 0) && (configPage6.vvt1Pin < BOARD_NR_GPIO_PINS) ) { pinVVT_1 = pinTranslate(configPage6.vvt1Pin); }
   if ( (configPage6.useExtBaro != 0) && (configPage6.baroPin < BOARD_NR_GPIO_PINS) ) { pinBaro = configPage6.baroPin + A0; }
   if ( (configPage6.useEMAP != 0) && (configPage10.EMAPPin < BOARD_NR_GPIO_PINS) ) { pinEMAP = configPage10.EMAPPin + A0; }
+  if ( (configPage9.oilTemperaturePin != 0) && (configPage9.oilTemperaturePin < BOARD_NR_GPIO_PINS) ) { pinOilTemperature = pinTranslate(configPage9.oilTemperaturePin); }
   if ( (configPage10.fuel2InputPin != 0) && (configPage10.fuel2InputPin < BOARD_NR_GPIO_PINS) ) { pinFuel2Input = pinTranslate(configPage10.fuel2InputPin); }
   if ( (configPage10.spark2InputPin != 0) && (configPage10.spark2InputPin < BOARD_NR_GPIO_PINS) ) { pinSpark2Input = pinTranslate(configPage10.spark2InputPin); }
   if ( (configPage2.vssPin != 0) && (configPage2.vssPin < BOARD_NR_GPIO_PINS) ) { pinVSS = pinTranslate(configPage2.vssPin); }
   if ( (configPage10.fuelPressurePin != 0) && (configPage10.fuelPressurePin < BOARD_NR_GPIO_PINS) ) { pinFuelPressure = configPage10.fuelPressurePin + A0; }
-  if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = configPage10.oilPressurePin + A0; }
+  //if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = configPage10.oilPressurePin + A0; }
+  if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = pinTranslate(configPage10.oilPressurePin); }
   
   if ( (configPage10.wmiEmptyPin != 0) && (configPage10.wmiEmptyPin < BOARD_NR_GPIO_PINS) ) { pinWMIEmpty = pinTranslate(configPage10.wmiEmptyPin); }
   if ( (configPage10.wmiIndicatorPin != 0) && (configPage10.wmiIndicatorPin < BOARD_NR_GPIO_PINS) ) { pinWMIIndicator = pinTranslate(configPage10.wmiIndicatorPin); }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2348,14 +2348,12 @@ void setPinMapping(byte boardID)
   if ( (configPage6.vvt1Pin != 0) && (configPage6.vvt1Pin < BOARD_NR_GPIO_PINS) ) { pinVVT_1 = pinTranslate(configPage6.vvt1Pin); }
   if ( (configPage6.useExtBaro != 0) && (configPage6.baroPin < BOARD_NR_GPIO_PINS) ) { pinBaro = configPage6.baroPin + A0; }
   if ( (configPage6.useEMAP != 0) && (configPage10.EMAPPin < BOARD_NR_GPIO_PINS) ) { pinEMAP = configPage10.EMAPPin + A0; }
-  if ( (configPage9.oilTemperaturePin != 0) && (configPage9.oilTemperaturePin < BOARD_NR_GPIO_PINS) ) { pinOilTemperature = pinTranslate(configPage9.oilTemperaturePin); }
   if ( (configPage10.fuel2InputPin != 0) && (configPage10.fuel2InputPin < BOARD_NR_GPIO_PINS) ) { pinFuel2Input = pinTranslate(configPage10.fuel2InputPin); }
   if ( (configPage10.spark2InputPin != 0) && (configPage10.spark2InputPin < BOARD_NR_GPIO_PINS) ) { pinSpark2Input = pinTranslate(configPage10.spark2InputPin); }
   if ( (configPage2.vssPin != 0) && (configPage2.vssPin < BOARD_NR_GPIO_PINS) ) { pinVSS = pinTranslate(configPage2.vssPin); }
   if ( (configPage10.fuelPressurePin != 0) && (configPage10.fuelPressurePin < BOARD_NR_GPIO_PINS) ) { pinFuelPressure = configPage10.fuelPressurePin + A0; }
-  //if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = configPage10.oilPressurePin + A0; }
-  if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = pinTranslate(configPage10.oilPressurePin); }
-  
+  if ( (configPage10.oilPressurePin != 0) && (configPage10.oilPressurePin < BOARD_NR_GPIO_PINS) ) { pinOilPressure = configPage10.oilPressurePin + A0; }
+  if ( (configPage9.oilSensorOPStPin != 0) && (configPage9.oilSensorOPStPin < BOARD_NR_GPIO_PINS)) { pinOilSensorOPSt = configPage9.oilSensorOPStPin; }  
   if ( (configPage10.wmiEmptyPin != 0) && (configPage10.wmiEmptyPin < BOARD_NR_GPIO_PINS) ) { pinWMIEmpty = pinTranslate(configPage10.wmiEmptyPin); }
   if ( (configPage10.wmiIndicatorPin != 0) && (configPage10.wmiIndicatorPin < BOARD_NR_GPIO_PINS) ) { pinWMIIndicator = pinTranslate(configPage10.wmiIndicatorPin); }
   if ( (configPage10.wmiEnabledPin != 0) && (configPage10.wmiEnabledPin < BOARD_NR_GPIO_PINS) ) { pinWMIEnabled = pinTranslate(configPage10.wmiEnabledPin); }
@@ -2558,9 +2556,13 @@ void setPinMapping(byte boardID)
   {
     pinMode(pinFuelPressure, INPUT);
   }
-  if(configPage10.oilPressureEnable > 0)
+  if(configPage10.oilPressureEnable == 1)
   {
     pinMode(pinOilPressure, INPUT);
+  } 
+  else if (configPage10.oilPressureEnable == 2)
+  {
+    pinMode(pinOilSensorOPSt, INPUT);   
   }
   if(configPage10.wmiEnabled > 0)
   {

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2586,6 +2586,8 @@ void setPinMapping(byte boardID)
   triggerSec_pin_mask = digitalPinToBitMask(pinTrigger2);
   flex_pin_port = portInputRegister(digitalPinToPort(pinFlex));
   flex_pin_mask = digitalPinToBitMask(pinFlex);
+  oilSensorOPSt_pin_port = portInputRegister(digitalPinToPort(pinOilSensorOPSt));
+  oilSensorOPSt_pin_mask = digitalPinToBitMask(pinOilSensorOPSt);
 
 }
 

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -159,6 +159,12 @@ ISR(ADC_vect)
 }
 #endif
 
+#if defined(CORE_AVR)
+  #define READ_OPST_TRIGGER() ((*oilSensorOPSt_pin_port & oilSensorOPSt_pin_mask) ? true : false)
+#else
+  #define READ_OPST_TRIGGER() digitalRead(pinOilSensorOPSt)
+#endif
+
 static inline void oilSensorOPStISR();
 
 volatile struct oilSensorOPStPulse {
@@ -167,16 +173,15 @@ volatile struct oilSensorOPStPulse {
   unsigned long offTime; // Time duration of the LOW level
   unsigned long totalTime; // Time duration of the whole symbol
   unsigned long curEvent; // micros() time of current ISR call
-  unsigned long lastEvent; // micros() time of last ISR call
-  uint8_t value;
-  byte lastLevel; // last level
-  byte gotSync; // Have we synced to the pulse sequence ?
+  unsigned long lastEvent; // micros() time of the last ISR call
+  uint8_t lastLevel; // last level
+  uint8_t gotSync; // Have we synced to the pulse sequence ?
 } oilSensorOPStPulse;
 
 volatile struct oilSensorOPStData {
-  double temperature; // Celsius temperature representation of the relative (error corrected) pulse according to the datasheet
-  double pressure; // Pressure representation of the relative (error corrected) pulse according to the datasheet
-  double status; // Diagnostic pulse, containing its (error corrected) value
+  int16_t temperature; // Celsius temperature + 40 C to avoid problems with negative values 
+  int16_t pressure; // Pressure in PSI
+  uint8_t status; // Diagnostic pulse, containing its (error corrected) value
 } oilSensorOPStData;
 
 #endif // SENSORS_H

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -24,6 +24,8 @@
 #define VSS_GEAR_HYSTERESIS 10
 #define VSS_SAMPLES         4 //Must be a power of 2 and smaller than 255
 
+#define OILSENSOR_REFRESHRATE 10 // Oil sensor refresh rate, number of samples taken per second
+
 /*
 #if defined(CORE_AVR)
   #define ANALOG_ISR
@@ -157,4 +159,26 @@ ISR(ADC_vect)
 }
 #endif
 
+#if defined(CORE_TEENSY) && defined(CORE_TEENSY35)
+  static inline void oilSensorInterrupt();
+  
+  struct oilSensorPulse {
+    uint8_t index = 0; // Index of the pulse we are on, frame is composed by three pulses
+    unsigned long lastSample; // Time in uS from last sample, useful to obey refresh rate
+    unsigned long onTime; // Time duration of the HIGH level 
+    unsigned long offTime; // Time duration of the LOW level
+    unsigned long totalTime; // Time duration of the whole symbol
+    unsigned long curEvent; // micros() time of current ISR call
+    unsigned long lastEvent; // micros() time of last ISR call
+    uint8_t value;
+    byte lastLevel; // last level
+    byte gotSync; // Have we synced to the pulse sequence ?
+  } oilSensorPulse;
+
+  struct oilSensorData {
+    double temperature; // Celsius temperature representation of the relative (error corrected) pulse according to the datasheet
+    double pressure; // Pressure representation of the relative (error corrected) pulse according to the datasheet
+    double status; // Diagnostic pulse, containing its (error corrected) value
+  } oilSensorData;
+#endif
 #endif // SENSORS_H

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -749,16 +749,16 @@ void readOPSt () {
       {
         oilSensorOPStPulse.index++;
         oilSensorOPStPulse.gotSync = 1; 
-        oilSensorOPStData.status = (1024.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime;
+        oilSensorOPStData.status = ((1024UL*oilSensorOPStPulse.onTime)/oilSensorOPStPulse.totalTime)/4; // 640uS max, making it fit uint8
       } 
       else if (oilSensorOPStPulse.index == 1 && oilSensorOPStPulse.gotSync == 1) 
       {
-        oilSensorOPStData.temperature = ((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime-128)/19.2;
+        oilSensorOPStData.temperature = fastMap((4096UL*oilSensorOPStPulse.onTime)/oilSensorOPStPulse.totalTime, 128, 3968, 0, 200);
         oilSensorOPStPulse.index++;
       } 
       else if (oilSensorOPStPulse.index == 2 && oilSensorOPStPulse.gotSync == 1) 
       {
-        oilSensorOPStData.pressure = ((((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime)-128)/26.475+7.25); 
+        oilSensorOPStData.pressure = fastMap((4096UL*oilSensorOPStPulse.onTime)/oilSensorOPStPulse.totalTime, 128, 3968, 7, 152);
         oilSensorOPStPulse.index = 0;
         detachInterrupt(digitalPinToInterrupt(pinOilSensorOPSt));       
       } 

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -617,7 +617,7 @@ byte getOilTemperature()
 
   if( configPage10.oilPressureEnable == 2 ) // Enabling OPS+T sensor will also enable temperature readings from it
   {
-    tempOilTemperature = oilSensorOPStData.temperature + 40; // Adding 40 to handle negative values
+    tempOilTemperature = oilSensorOPStData.temperature; 
   }
   //Sanity check
   // TODO if(tempOilTemperature > configPage9.oilTemperatureMax) { tempOilTemperature = configPage9.oilTemperatureMax; }
@@ -643,7 +643,7 @@ byte getOilPressure()
   } 
   else if (configPage10.oilPressureEnable == 2)
   {
-    tempOilPressure = oilSensorOPStData.pressure*14.5037;
+    tempOilPressure = oilSensorOPStData.pressure;
   }
   //Sanity check
   if(tempOilPressure > configPage10.oilPressureMax) { tempOilPressure = configPage10.oilPressureMax; }
@@ -739,7 +739,7 @@ void readOPSt () {
 {
   oilSensorOPStPulse.curEvent = micros();
 
-  if(oilSensorOPStPulse.lastLevel == 0 && digitalRead(pinOilSensorOPSt) ) // Last event was LOW and we have got a rising edge
+  if(oilSensorOPStPulse.lastLevel == 0 && READ_OPST_TRIGGER()) // Last event was LOW and we have got a rising edge
   {
       oilSensorOPStPulse.offTime = oilSensorOPStPulse.curEvent - oilSensorOPStPulse.lastEvent;
       oilSensorOPStPulse.totalTime = oilSensorOPStPulse.offTime + oilSensorOPStPulse.onTime;
@@ -753,12 +753,12 @@ void readOPSt () {
       } 
       else if (oilSensorOPStPulse.index == 1 && oilSensorOPStPulse.gotSync == 1) 
       {
-        oilSensorOPStData.temperature = ((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime-128)/19.2-40;
+        oilSensorOPStData.temperature = ((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime-128)/19.2;
         oilSensorOPStPulse.index++;
       } 
       else if (oilSensorOPStPulse.index == 2 && oilSensorOPStPulse.gotSync == 1) 
       {
-        oilSensorOPStData.pressure = (((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime)-128)/384.0+0.5;
+        oilSensorOPStData.pressure = ((((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime)-128)/26.475+7.25); 
         oilSensorOPStPulse.index = 0;
         detachInterrupt(digitalPinToInterrupt(pinOilSensorOPSt));       
       } 
@@ -768,7 +768,7 @@ void readOPSt () {
         oilSensorOPStPulse.gotSync = 0;
       }
   } 
-  else if(oilSensorOPStPulse.lastLevel == 1 && !digitalRead(pinOilSensorOPSt) ) // Last event was HIGH and we have got a falling edge 
+  else if(oilSensorOPStPulse.lastLevel == 1 && !READ_OPST_TRIGGER()) // Last event was HIGH and we have got a falling edge 
   { 
       oilSensorOPStPulse.onTime = oilSensorOPStPulse.curEvent - oilSensorOPStPulse.lastEvent;
       oilSensorOPStPulse.lastLevel = 0;

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -617,7 +617,7 @@ byte getOilTemperature()
   int16_t tempOilTemperature = 0;
   //uint16_t tempReading;
 
-  if(configPage9.oilTemperatureEnable > 0 && (configPage9.oilTemperaturePin != 51 || configPage9.oilTemperaturePin != 52))
+  if(configPage9.oilTemperatureEnable > 0 && (pinOilTemperature != 51 || pinOilTemperature != 52))
   {
     tempOilTemperature = oilSensorData.temperature + 40; // Adding 40 to handle negative values
   }
@@ -743,11 +743,11 @@ uint16_t readAuxdigital(uint8_t digitalPin)
   } 
   else 
   {
-    oilSensorPulse.gotSync = 0;
+    //oilSensorPulse.gotSync = 0;
   }
   
   // Last event was LOW and we have got a rising edge
-  if(oilSensorPulse.lastLevel == 0 && digitalRead(configPage10.oilPressurePin) ) 
+  if(oilSensorPulse.lastLevel == 0 && digitalRead(pinOilTemperature) ) 
   {
       digitalToggle(LED_BUILTIN);
       oilSensorPulse.offTime = oilSensorPulse.curEvent - oilSensorPulse.lastEvent;

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -611,30 +611,27 @@ byte getFuelPressure()
   return (byte)tempFuelPressure;
 }
 
-#if defined(CORE_TEENSY) && defined(CORE_TEENSY35)
 byte getOilTemperature()
 {
   int16_t tempOilTemperature = 0;
-  //uint16_t tempReading;
 
-  if(configPage9.oilTemperatureEnable > 0 && (pinOilTemperature != 51 || pinOilTemperature != 52))
+  if( configPage10.oilPressureEnable == 2 ) // Enabling OPS+T sensor will also enable temperature readings from it
   {
-    tempOilTemperature = oilSensorData.temperature + 40; // Adding 40 to handle negative values
+    tempOilTemperature = oilSensorOPStData.temperature + 40; // Adding 40 to handle negative values
   }
   //Sanity check
-  if(tempOilTemperature > configPage9.oilTemperatureMax) { tempOilTemperature = configPage9.oilTemperatureMax; }
+  // TODO if(tempOilTemperature > configPage9.oilTemperatureMax) { tempOilTemperature = configPage9.oilTemperatureMax; }
   if(tempOilTemperature < 0 ) { tempOilTemperature = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
 
   return (byte)tempOilTemperature;
 }
-#endif
 
 byte getOilPressure()
 {
   int16_t tempOilPressure = 0;
   uint16_t tempReading;
 
-  if(configPage10.oilPressureEnable > 0 && (configPage10.oilPressurePin != 51 || configPage10.oilPressurePin != 52))
+  if(configPage10.oilPressureEnable == 1)
   {
     //Perform ADC read
     tempReading = analogRead(pinOilPressure);
@@ -644,12 +641,10 @@ byte getOilPressure()
     tempOilPressure = fastMap10Bit(tempReading, configPage10.oilPressureMin, configPage10.oilPressureMax);
     tempOilPressure = ADC_FILTER(tempOilPressure, 150, currentStatus.oilPressure); //Apply speed smoothing factor
   } 
-#if defined(CORE_TEENSY) && defined(CORE_TEENSY35)
-  else if (configPage10.oilPressureEnable > 0)
+  else if (configPage10.oilPressureEnable == 2)
   {
-    tempOilPressure = oilSensorData.pressure*14.5037;
+    tempOilPressure = oilSensorOPStData.pressure*14.5037;
   }
-#endif
   //Sanity check
   if(tempOilPressure > configPage10.oilPressureMax) { tempOilPressure = configPage10.oilPressureMax; }
   if(tempOilPressure < 0 ) { tempOilPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
@@ -731,53 +726,52 @@ uint16_t readAuxdigital(uint8_t digitalPin)
   return tempReading;
 } 
 
-// ISR to decode PPM data from HELLA oil temperature and pressure sensor
-#if defined(CORE_TEENSY) && defined(CORE_TEENSY35)
-  static inline void oilSensorInterrupt() //Most ARM chips can simply call a function
-{
-  oilSensorPulse.curEvent = micros();
+/*
+ * Called by the 4 hz hardware timer, enables OPS+T interrupt
+ * when timer clicks, ISR will detach itself when it has got readings
+*/
+void readOPSt () {
+  attachInterrupt(digitalPinToInterrupt(pinOilSensorOPSt), oilSensorOPStISR, CHANGE);       
+}
 
-  if (oilSensorPulse.gotSync && oilSensorPulse.lastSample - oilSensorPulse.curEvent <= 1000000/OILSENSOR_REFRESHRATE) // Return if it's not time to run
+// ISR to decode PPM data from HELLA oil temperature and pressure sensor
+  static inline void oilSensorOPStISR() //Most ARM chips can simply call a function
+{
+  oilSensorOPStPulse.curEvent = micros();
+
+  if(oilSensorOPStPulse.lastLevel == 0 && digitalRead(pinOilSensorOPSt) ) // Last event was LOW and we have got a rising edge
   {
-    return;
+      oilSensorOPStPulse.offTime = oilSensorOPStPulse.curEvent - oilSensorOPStPulse.lastEvent;
+      oilSensorOPStPulse.totalTime = oilSensorOPStPulse.offTime + oilSensorOPStPulse.onTime;
+      oilSensorOPStPulse.lastLevel = 1;
+      oilSensorOPStPulse.lastEvent = oilSensorOPStPulse.curEvent;
+      if (oilSensorOPStPulse.totalTime <= 1024 && oilSensorOPStPulse.index == 0) 
+      {
+        oilSensorOPStPulse.index++;
+        oilSensorOPStPulse.gotSync = 1; 
+        oilSensorOPStData.status = (1024.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime;
+      } 
+      else if (oilSensorOPStPulse.index == 1 && oilSensorOPStPulse.gotSync == 1) 
+      {
+        oilSensorOPStData.temperature = ((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime-128)/19.2-40;
+        oilSensorOPStPulse.index++;
+      } 
+      else if (oilSensorOPStPulse.index == 2 && oilSensorOPStPulse.gotSync == 1) 
+      {
+        oilSensorOPStData.pressure = (((4096.0/oilSensorOPStPulse.totalTime)*oilSensorOPStPulse.onTime)-128)/384.0+0.5;
+        oilSensorOPStPulse.index = 0;
+        detachInterrupt(digitalPinToInterrupt(pinOilSensorOPSt));       
+      } 
+      else 
+      {
+        oilSensorOPStPulse.index = 0;
+        oilSensorOPStPulse.gotSync = 0;
+      }
   } 
-  else 
-  {
-    //oilSensorPulse.gotSync = 0;
-  }
-  
-  // Last event was LOW and we have got a rising edge
-  if(oilSensorPulse.lastLevel == 0 && digitalRead(pinOilTemperature) ) 
-  {
-      digitalToggle(LED_BUILTIN);
-      oilSensorPulse.offTime = oilSensorPulse.curEvent - oilSensorPulse.lastEvent;
-      oilSensorPulse.totalTime = oilSensorPulse.offTime + oilSensorPulse.onTime;
-      oilSensorPulse.lastLevel = 1;
-      oilSensorPulse.lastEvent = oilSensorPulse.curEvent;
-      if (oilSensorPulse.totalTime <= 1024 && oilSensorPulse.index == 0) 
-      {
-        oilSensorPulse.index++;
-        oilSensorPulse.gotSync = 1; 
-        oilSensorData.status = (1024.0/oilSensorPulse.totalTime)*oilSensorPulse.onTime;
-      } 
-      else if (oilSensorPulse.index == 1) 
-      {
-        oilSensorData.temperature = ((4096.0/oilSensorPulse.totalTime)*oilSensorPulse.onTime-128)/19.2-40;
-        oilSensorPulse.index++;
-      } 
-      else if (oilSensorPulse.index == 2) 
-      {
-        oilSensorData.pressure = (((4096.0/oilSensorPulse.totalTime)*oilSensorPulse.onTime)-128)/384.0+0.5;
-        oilSensorPulse.index = 0;
-        oilSensorPulse.lastSample = micros();
-      } 
-  } 
-  else if(oilSensorPulse.lastLevel == 1 && !digitalRead(configPage10.oilPressurePin) ) // Last event was HIGH and we have got a falling edge 
+  else if(oilSensorOPStPulse.lastLevel == 1 && !digitalRead(pinOilSensorOPSt) ) // Last event was HIGH and we have got a falling edge 
   { 
-      oilSensorPulse.onTime = oilSensorPulse.curEvent - oilSensorPulse.lastEvent;
-      oilSensorPulse.lastLevel = 0;
-      oilSensorPulse.lastEvent = oilSensorPulse.curEvent;
+      oilSensorOPStPulse.onTime = oilSensorOPStPulse.curEvent - oilSensorOPStPulse.lastEvent;
+      oilSensorOPStPulse.lastLevel = 0;
+      oilSensorOPStPulse.lastEvent = oilSensorOPStPulse.curEvent;
   }
 }  
-
-#endif

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -276,6 +276,12 @@ void loop()
       nitrousControl();
       idleControl(); //Perform any idle related actions. Even at higher frequencies, running 4x per second is sufficient.
       
+      if (configPage10.oilPressureEnable == 2) { // Hella OPS+T Sensor is enabled
+        currentStatus.oilTemperature = getOilTemperature(); // Get oil temp previous reading
+        readOPSt(); // Activate the sensor PPM reading interrupt
+        //The sensor provider pressure too, but pressure reading could be coming from analog inputs, s nothing to do here about it
+    } 
+
       currentStatus.vss = getSpeed();
       currentStatus.gear = getGear();
       currentStatus.fuelPressure = getFuelPressure();
@@ -344,7 +350,7 @@ void loop()
     {
       BIT_CLEAR(TIMER_mask, BIT_TIMER_1HZ);
       readBaro(); //Infrequent baro readings are not an issue.
-
+      
       if ( (configPage10.wmiEnabled > 0) && (configPage10.wmiIndicatorEnabled > 0) )
       {
         // water tank empty


### PR DESCRIPTION
I recently discovered this OPS+T cheap and powerful Oil temperature + pressure sensor from Hella:

https://www.hella.com/municipal/assets/media_global/KI_OPS_T_HELLA_EN.pdf

I'm trying speeduino for the first time for a custom motorcycle project and being able to monitor oil temperature and pressure looks like a good catch. Instead of relying solely on the OEM on/off pressure switch with this 30€ sensor one can evaluate oil pump efficiency, relief valve status, oil cooling circuit behaviour and more.

**Core implementation:**
The sensor outputs a pretty fast (3khz) PPM signal made of three pulses, a diagnostic one and two for the data.

The implementation I made relies on triggering an interrupt by both edges of each pulse, timing them, discovering the first one (the shorter) and using it to sync to the pulse stream. 

The interrupt is activated from the existing 4hz timer and deactivated by the ISR itself so the impact on the MCU should be minimal. I appeal to your own experience if there's a more efficient way of doing this.

**TunerStudio integration:**
I've added interfacing of this sensor to the Fuel/oil pressure menu item.
The user can select it as an alternative to the analog oil pressure sensor. Choosing it will enable the necessary routines. As it will also make oil temperature readings available i've added a note in its section into the panel to inform the user. 
As it will populate the existing oilPressure variable all the existing features regarding oil pressure, logging alarms etc are functional as before.

Oil temperature is available in its own gauge.

**TODOs and known problems:**

It would be nice to implement alarms limits and tables as per the (existing) oil pressure for the oil temperature too.
I had some troubles catching the digital pin 52 in the teensy by using the existing methods (pinTranslate), using it drove to an erratic behaviour. I avoided using pinTranslate as it will be interfaced to digital pins exclusively.
The total number of pins defined for the teensy in its header was 34, the same as the number of the digital pins, I discovered this while trying to understand why my pin assignment from pinOilSensorOPSt in init.ino wasnt working. It's just an error or I'm missing something ?
Theres to rationalize the selectable pins for the sensor into its selector into its configuration panel as I just avoided the crucial ones and made available all the others for full compatibility; it can be useless and eventually dangerous (?).

I started with many clauses which would have made available this addition to the teensy only, however at the end I realized that it should work on other platforms too, I tried to compile it for the mega2560 and it compiled, soon i'll try to connect the sensor to a mega and see if everything is really ok.

Waiting for your feedback.

Kind regards.
Giacomo.