### PR TITLE
Fix Warmup Enrichment dialog responsiveness

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1775,6 +1775,7 @@ menuDialog = main
 
   cltAdvValues    = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
 
+  wueRates        = "Final enrichment value must be 100%."
   ;speeduino_tsCanId = "This is the TsCanId that the Speeduino ECU will respond to. This should match the main controller CAN ID in project properties if it is connected directy to TunerStudio, Otherwise the device ID if connected via CAN passthrough"
   true_address    = "This is the 11bit Can address of the Speeduino ECU "
   realtime_base_address = "This is the 11bit CAN address of the realtime data broadcast from the Speeduino ECU. This MUST be at least 0x16 greater than the true address"
@@ -2832,8 +2833,6 @@ menuDialog = main
 
     dialog = warmup, "Warmup Enrichment (WUE) - Percent Multiplier"
         panel = warmup_curve
-        field = "Final enrichment value must be 100%."
-        field = ""
 
     ;Fuel trim composite dialog
     dialog = inj_trim1TblTitle, "Channel #1"


### PR DESCRIPTION
Having extra field in dialog like warmup enrichment breaks ability to properly resize the window. Instead bottom help section can be used for description.

## Before

<img width="1065" alt="before" src="https://user-images.githubusercontent.com/3144291/104132864-4399bc00-5380-11eb-83c8-048d44ea8dea.png">

## After

<img width="1064" alt="after" src="https://user-images.githubusercontent.com/3144291/104132867-4694ac80-5380-11eb-875b-e6877ca43528.png">

