### PR TITLE
Fix for no O2 selected + incorporate AFR enabled

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -555,14 +555,18 @@ PID (Best suited to wideband sensors):
 byte correctionAFRClosedLoop()
 {
   byte AFRValue = 100;
-  if( configPage6.egoType > 0 ) //egoType of 0 means no O2 sensor
+  
+  if( (configPage6.egoType > 0) || (configPage2.incorporateAFR == true) ) //afrTarget value lookup must be done if O2 sensor is enabled, and always if incorporateAFR is enabled
   {
     currentStatus.afrTarget = currentStatus.O2; //Catch all incase the below doesn't run. This prevents the Include AFR option from doing crazy things if the AFR target conditions aren't met. This value is changed again below if all conditions are met.
 
     //Determine whether the Y axis of the AFR target table tshould be MAP (Speed-Density) or TPS (Alpha-N)
     //Note that this should only run after the sensor warmup delay when using Include AFR option, but on Incorporate AFR option it needs to be done at all times
     if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
-
+  }
+  
+  if( configPage6.egoType > 0 ) //egoType of 0 means no O2 sensor
+  {
     AFRValue = currentStatus.egoCorrection; //Need to record this here, just to make sure the correction stays 'on' even if the nextCycle count isn't ready
     
     if(ignitionCount >= AFRnextCycle)


### PR DESCRIPTION
Lookup afrTarget value must also be done in case O2 sensor is disabled, but incorporate AFR is enabled. If the lookup is not done, afrTarget remains zero and causes a division by zero in PW-function. Regardless of whether any type of O2 sensor is actually used, the incorporate AFR-function can be used.

Thanks for spotting this @ric355 