### PR TITLE
Restore the 'translate' attribute for iacStepHyster to  0

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -653,7 +653,7 @@ page = 6
   #endif
 
       iacStepHome  = scalar, U08,     118,             "Steps",         3,    0,    0, 765,   0
-      iacStepHyster= scalar, U08,     119,             "Steps",         1,  1.0,  1.0,  10,   0
+      iacStepHyster= scalar, U08,     119,             "Steps",         1,  0,  1.0,  10,   0
 
       ; Begin fan control vairables
       fanInv       = bits,   U08,     120, [0:0], "No",        "Yes"


### PR DESCRIPTION
Fixes #498 by preventing the value sent from TS to the firmware from being zero when a value of 1 is selected in the dropdown. Note the original change set the minimum value to 1; this has been retained.