### PR TITLE
Make sure we use the same size data types on all platforms (Needs split/rework)

### DIFF
--- a/speeduino/TS_CommandButtonHandler.h
+++ b/speeduino/TS_CommandButtonHandler.h
@@ -68,4 +68,4 @@
 #define TS_CMD_VSS_RATIO5 39173
 #define TS_CMD_VSS_RATIO6 39174
 
-void TS_CommandButtonsHandler(int);
+void TS_CommandButtonsHandler(int16_t);

--- a/speeduino/TS_CommandButtonHandler.ino
+++ b/speeduino/TS_CommandButtonHandler.ino
@@ -19,7 +19,7 @@
  * 
  * @param buttonCommand The command number of the button that was clicked. See TS_CommendButtonHandler.h for a list of button IDs
  */
-void TS_CommandButtonsHandler(int buttonCommand)
+void TS_CommandButtonsHandler(int16_t buttonCommand)
 {
   switch (buttonCommand)
   {

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -58,8 +58,8 @@ volatile PORT_TYPE *n2o_arming_pin_port;
 volatile PINMASK_TYPE n2o_arming_pin_mask;
 
 volatile bool boost_pwm_state;
-unsigned int boost_pwm_max_count; //Used for variable PWM frequency
-volatile unsigned int boost_pwm_cur_value;
+uint16_t boost_pwm_max_count; //Used for variable PWM frequency
+volatile uint16_t boost_pwm_cur_value;
 long boost_pwm_target_value;
 long boost_cl_target_boost;
 uint8_t boostCounter;
@@ -73,9 +73,9 @@ volatile bool vvt2_pwm_state;
 volatile bool vvt1_max_pwm;
 volatile bool vvt2_max_pwm;
 volatile char nextVVT;
-unsigned int vvt_pwm_max_count; //Used for variable PWM frequency
-volatile unsigned int vvt1_pwm_cur_value;
-volatile unsigned int vvt2_pwm_cur_value;
+uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
+volatile uint16_t vvt1_pwm_cur_value;
+volatile uint16_t vvt2_pwm_cur_value;
 long vvt1_pwm_value;
 long vvt2_pwm_value;
 long vvt_pid_target_angle;

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -60,8 +60,8 @@ volatile PINMASK_TYPE n2o_arming_pin_mask;
 volatile bool boost_pwm_state;
 uint16_t boost_pwm_max_count; //Used for variable PWM frequency
 volatile uint16_t boost_pwm_cur_value;
-long boost_pwm_target_value;
-long boost_cl_target_boost;
+int32_t boost_pwm_target_value;
+int32_t boost_cl_target_boost;
 uint8_t boostCounter;
 uint8_t vvtCounter;
 
@@ -76,10 +76,10 @@ volatile char nextVVT;
 uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
 volatile uint16_t vvt1_pwm_cur_value;
 volatile uint16_t vvt2_pwm_cur_value;
-long vvt1_pwm_value;
-long vvt2_pwm_value;
-long vvt_pid_target_angle;
-//long vvt_pid_current_angle;
+int32_t vvt1_pwm_value;
+int32_t vvt2_pwm_value;
+int32_t vvt_pid_target_angle;
+//int32_t vvt_pid_current_angle;
 static inline void boostInterrupt();
 static inline void vvtInterrupt();
 

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -62,11 +62,11 @@ unsigned int boost_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int boost_pwm_cur_value;
 long boost_pwm_target_value;
 long boost_cl_target_boost;
-byte boostCounter;
-byte vvtCounter;
+uint8_t boostCounter;
+uint8_t vvtCounter;
 
-byte fanHIGH = HIGH;             // Used to invert the cooling fan output
-byte fanLOW = LOW;               // Used to invert the cooling fan output
+uint8_t fanHIGH = HIGH;             // Used to invert the cooling fan output
+uint8_t fanLOW = LOW;               // Used to invert the cooling fan output
 
 volatile bool vvt1_pwm_state;
 volatile bool vvt2_pwm_state;

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -32,8 +32,8 @@ void fanControl()
 {
   if( configPage6.fanEnable == 1 )
   {
-    int onTemp = (int)configPage6.fanSP - CALIBRATION_TEMPERATURE_OFFSET;
-    int offTemp = onTemp - configPage6.fanHyster;
+    int16_t onTemp = (int16_t)configPage6.fanSP - CALIBRATION_TEMPERATURE_OFFSET;
+    int16_t offTemp = onTemp - configPage6.fanHyster;
     bool fanPermit = false;
 
     if ( configPage2.fanWhenOff == true) { fanPermit = true; }
@@ -383,7 +383,7 @@ void nitrousControl()
 // Water methanol injection control
 void wmiControl()
 {
-  int wmiPW = 0;
+  int16_t wmiPW = 0;
   
   // wmi can only work when vvt is disabled 
   if( (configPage6.vvtEnabled == 0) && (configPage10.wmiEnabled >= 1) )
@@ -409,7 +409,7 @@ void wmiControl()
           break;
         case WMI_MODE_CLOSEDLOOP:
           // Mapped closed loop - Output PWM follows injector duty cycle with 2D correction map applied (RPM vs MAP). Cell value contains correction value% [nom 100%] 
-          wmiPW = max(0, ((int)currentStatus.PW1 + configPage10.wmiOffset)) * get3DTableValue(&wmiTable, currentStatus.MAP, currentStatus.RPM) / 100;
+          wmiPW = max(0, ((int16_t)currentStatus.PW1 + configPage10.wmiOffset)) * get3DTableValue(&wmiTable, currentStatus.MAP, currentStatus.RPM) / 100;
           break;
         default:
           // Wrong mode

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -155,7 +155,7 @@ void boostControl()
       if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
       else
       {
-        boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
+        boost_pwm_target_value = ((uint32_t)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
         ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
       }
     }
@@ -191,7 +191,7 @@ void boostControl()
           {
             if(PIDcomputed == true)
             {
-              boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
+              boost_pwm_target_value = ((uint32_t)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
               ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
             }
           }
@@ -517,7 +517,7 @@ void boostDisable()
   {
     if(nextVVT == 0)
     {
-      if(vvt1_pwm_value < (long)vvt_pwm_max_count) //Don't toggle if at 100%
+      if(vvt1_pwm_value < (int32_t)vvt_pwm_max_count) //Don't toggle if at 100%
       {
         VVT1_PIN_OFF();
         vvt1_pwm_state = false;
@@ -534,7 +534,7 @@ void boostDisable()
     }
     else if (nextVVT == 1)
     {
-      if(vvt2_pwm_value < (long)vvt_pwm_max_count) //Don't toggle if at 100%
+      if(vvt2_pwm_value < (int32_t)vvt_pwm_max_count) //Don't toggle if at 100%
       {
         VVT2_PIN_OFF();
         vvt2_pwm_state = false;
@@ -551,7 +551,7 @@ void boostDisable()
     }
     else
     {
-      if(vvt1_pwm_value < (long)vvt_pwm_max_count) //Don't toggle if at 100%
+      if(vvt1_pwm_value < (int32_t)vvt_pwm_max_count) //Don't toggle if at 100%
       {
         VVT1_PIN_OFF();
         vvt1_pwm_state = false;
@@ -559,7 +559,7 @@ void boostDisable()
         VVT_TIMER_COMPARE = VVT_TIMER_COUNTER + (vvt_pwm_max_count - vvt1_pwm_cur_value);
       }
       else { vvt1_max_pwm = true; }
-      if(vvt2_pwm_value < (long)vvt_pwm_max_count) //Don't toggle if at 100%
+      if(vvt2_pwm_value < (int32_t)vvt_pwm_max_count) //Don't toggle if at 100%
       {
         VVT1_PIN_OFF();
         vvt2_pwm_state = false;

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -27,7 +27,7 @@
   #if defined(TIMER5_MICROS)
     /*#define micros() (((timer5_overflow_count << 16) + TCNT5) * 4) */ //Fast version of micros() that uses the 4uS tick of timer5. See timers.ino for the overflow ISR of timer5
     #define millis() (ms_counter) //Replaces the standard millis() function with this macro. It is both faster and more accurate. See timers.ino for its counter increment.
-    static inline unsigned long micros_safe(); //A version of micros() that is interrupt safe
+    static inline uint32_t micros_safe(); //A version of micros() that is interrupt safe
   #else
     #define micros_safe() micros() //If the timer5 method is not used, the micros_safe() macro is simply an alias for the normal micros()
   #endif

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -117,9 +117,9 @@ ISR(TIMER5_OVF_vect)
     ++timer5_overflow_count;
 }
 
-static inline unsigned long micros_safe()
+static inline uint32_t micros_safe()
 {
-  unsigned long newMicros;
+  uint32_t newMicros;
   noInterrupts();
   newMicros = (((timer5_overflow_count << 16) + TCNT5) * 4);
   interrupts();

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -96,14 +96,14 @@ void initBoard()
 uint16_t freeRam()
 {
     extern int __heap_start, *__brkval;
-    int currentVal;
+    int16_t currentVal;
     uint16_t v;
 
-    if(__brkval == 0) { currentVal = (int) &__heap_start; }
-    else { currentVal = (int) __brkval; }
+    if(__brkval == 0) { currentVal = (int16_t) &__heap_start; }
+    else { currentVal = (int16_t) __brkval; }
 
     //Old version:
-    //return (uint16_t) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
+    //return (uint16_t) &v - (__brkval == 0 ? (int16_t) &__heap_start : (int16_t) __brkval);
     /* cppcheck-suppress misra-c2012-11.4 ; DEVIATION(D3) */
     return (uint16_t) &v - currentVal; //cppcheck-suppress misra-c2012-11.4
 }

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -40,7 +40,7 @@ void initBoard();
 uint16_t freeRam();
 void doSystemReset();
 void jumpToBootloader();
-extern "C" char* sbrk(int incr);
+extern "C" char* sbrk(int16_t incr);
 
 #if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_BLUEPILL_F103CB) \
  || defined(ARDUINO_BLACKPILL_F401CC) || defined(ARDUINO_BLACKPILL_F411CE)

--- a/speeduino/cancomms.h
+++ b/speeduino/cancomms.h
@@ -33,7 +33,7 @@ bool canCmdPending = false;
 #endif
 
 void secondserial_Command();//This is the heart of the Command Line Interpeter.  All that needed to be done was to make it human readable.
-void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum);
+void sendcanValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t portNum);
 void can_Command();
 void sendCancommand(uint8_t cmdtype , uint16_t canadddress, uint8_t candata1, uint8_t candata2, uint16_t sourcecanAddress);
 void obd_response(uint8_t therequestedPID , uint8_t therequestedPIDlow, uint8_t therequestedPIDhigh);

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -33,7 +33,7 @@ void secondserial_Command()
         break;
 
     case 'G': // this is the reply command sent by the Can interface
-       byte destcaninchannel;
+       uint8_t destcaninchannel;
       if (CANSerial.available() >= 9)
       {
         canCmdPending = false;
@@ -41,7 +41,7 @@ void secondserial_Command()
         destcaninchannel = CANSerial.read();  // the input channel that requested the data value
         if (cancmdfail != 0)
            {                                 // read all 8 bytes of data.
-            for (byte Gx = 0; Gx < 8; Gx++) // first two are the can address the data is from. next two are the can address the data is for.then next 1 or two bytes of data
+            for (uint8_t Gx = 0; Gx < 8; Gx++) // first two are the can address the data is from. next two are the can address the data is for.then next 1 or two bytes of data
               {
                 Gdata[Gx] = CANSerial.read();
               }
@@ -103,7 +103,7 @@ void secondserial_Command()
         break;
 
     case 'r': //New format for the optimised OutputChannels over CAN
-      byte Cmd;
+      uint8_t Cmd;
       if (CANSerial.available() >= 6)
       {
         CANSerial.read(); //Read the $tsCanId
@@ -112,7 +112,7 @@ void secondserial_Command()
         uint16_t offset, length;
         if( (Cmd == 0x30) || ( (Cmd >= 0x40) && (Cmd <0x50) ) ) //Send output channels command 0x30 is 48dec, 0x40(64dec)-0x4F(79dec) are external can request
         {
-          byte tmp;
+          uint8_t tmp;
           tmp = CANSerial.read();
           offset = word(CANSerial.read(), tmp);
           tmp = CANSerial.read();
@@ -157,9 +157,9 @@ void secondserial_Command()
   }
   #endif
 }
-void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portType)
+void sendcanValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t portType)
 {
-  byte fullStatus[NEW_CAN_PACKET_SIZE];    // this must be set to the maximum number of data fullstatus must read in
+  uint8_t fullStatus[NEW_CAN_PACKET_SIZE];    // this must be set to the maximum number of data fullstatus must read in
 
     //CAN serial
     #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)|| defined(CORE_STM32) || defined (CORE_TEENSY) //ATmega2561 does not have Serial3
@@ -270,7 +270,7 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portTy
   fullStatus[73] = currentStatus.tpsADC;
   fullStatus[74] = getNextError();
 
-  for(byte x=0; x<packetLength; x++)
+  for(uint8_t x=0; x<packetLength; x++)
   {
     #if defined(CANSerial_AVAILABLE)
       if (portType == 1){ CANSerial.write(fullStatus[offset+x]); }

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -142,7 +142,7 @@ void secondserial_Command()
       
     case 'Q': // send code version
        //for (unsigned int revn = 0; revn < sizeof( TSfirmwareVersion) - 1; revn++)
-       for (unsigned int revn = 0; revn < 10 - 1; revn++)
+       for (uint16_t revn = 0; revn < 10 - 1; revn++)
        {
          CANSerial.write( TSfirmwareVersion[revn]);
        }
@@ -285,7 +285,7 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t 
 
 void can_Command()
 {
- //int currentcanCommand = inMsg.id;
+ //int16_t currentcanCommand = inMsg.id;
  #if defined (NATIVE_CAN_AVAILABLE)
       // currentStatus.canin[12] = (inMsg.id);
  if ( (inMsg.id == uint16_t(configPage9.obd_address + 0x100))  || (inMsg.id == 0x7DF))      

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -50,18 +50,18 @@
 #define SD_RTC_READ_LENGTH  0x0800
 
 
-byte currentPage = 1;//Not the same as the speeduino config page numbers
+uint8_t currentPage = 1;//Not the same as the speeduino config page numbers
 bool isMap = true; /**< Whether or not the currentPage contains only a 3D map that would require translation */
 unsigned long requestCount = 0; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
-byte currentCommand; /**< The serial command that is currently being processed. This is only useful when cmdPending=True */
+uint8_t currentCommand; /**< The serial command that is currently being processed. This is only useful when cmdPending=True */
 bool cmdPending = false; /**< Whether or not a serial request has only been partially received. This occurs when a command character has been received in the serial buffer, but not all of its arguments have yet been received. If true, the active command will be stored in the currentCommand variable */
 bool chunkPending = false; /**< Whether or not the current chucnk write is complete or not */
 uint16_t chunkComplete = 0; /**< The number of bytes in a chunk write that have been written so far */
 uint16_t chunkSize = 0; /**< The complete size of the requested chunk write */
 int valueOffset; /**< THe memory offset within a given page for a value to be read from or written to. Note that we cannot use 'offset' as a variable name, it is a reserved word for several teensy libraries */
-byte tsCanId = 0;     // current tscanid requested
-byte inProgressOffset;
-byte inProgressLength;
+uint8_t tsCanId = 0;     // current tscanid requested
+uint8_t inProgressOffset;
+uint8_t inProgressLength;
 uint32_t inProgressCompositeTime;
 bool serialInProgress = false;
 bool toothLogSendInProgress = false;
@@ -86,18 +86,18 @@ const char pageTitles[] PROGMEM //This is being stored in the avr flash instead 
   };
 
 void command();//This is the heart of the Command Line Interpeter.  All that needed to be done was to make it human readable.
-void sendValues(uint16_t, uint16_t,byte, byte);
+void sendValues(uint16_t, uint16_t,uint8_t, uint8_t);
 void sendValuesLegacy();
-void receiveValue(uint16_t, byte);
+void receiveValue(uint16_t, uint8_t);
 void saveConfig();
 void sendPage();
 void sendPageASCII();
-void receiveCalibration(byte);
+void receiveCalibration(uint8_t);
 void sendToothLog(uint8_t);
 void testComm();
 void commandButtons(int16_t);
 void sendCompositeLog(uint8_t);
-byte getPageValue(byte, uint16_t);
-byte getStatusEntry(uint16_t);
+uint8_t getPageValue(uint8_t, uint16_t);
+uint8_t getStatusEntry(uint16_t);
 
 #endif // COMMS_H

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -52,7 +52,7 @@
 
 uint8_t currentPage = 1;//Not the same as the speeduino config page numbers
 bool isMap = true; /**< Whether or not the currentPage contains only a 3D map that would require translation */
-unsigned long requestCount = 0; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
+uint32_t requestCount = 0; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
 uint8_t currentCommand; /**< The serial command that is currently being processed. This is only useful when cmdPending=True */
 bool cmdPending = false; /**< Whether or not a serial request has only been partially received. This occurs when a command character has been received in the serial buffer, but not all of its arguments have yet been received. If true, the active command will be stored in the currentCommand variable */
 bool chunkPending = false; /**< Whether or not the current chucnk write is complete or not */

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -92,8 +92,8 @@ void command()
 
       if(Serial.available() >= 2)
       {
-        byte cmdGroup = Serial.read();
-        byte cmdValue = Serial.read();
+        uint8_t cmdGroup = Serial.read();
+        uint8_t cmdValue = Serial.read();
         uint16_t cmdCombined = word(cmdGroup, cmdValue);
 
         if ( ((cmdCombined >= TS_CMD_INJ1_ON) && (cmdCombined <= TS_CMD_IGN8_50PC)) || (cmdCombined == TS_CMD_TEST_ENBL) || (cmdCombined == TS_CMD_TEST_DSBL) )
@@ -233,9 +233,9 @@ void command()
       //2 - Length
       if(Serial.available() >= 6)
       {
-        byte offset1, offset2, length1, length2;
+        uint8_t offset1, offset2, length1, length2;
         int length;
-        byte tempPage;
+        uint8_t tempPage;
 
         Serial.read(); // First byte of the page identifier can be ignored. It's always 0
         tempPage = Serial.read();
@@ -261,14 +261,14 @@ void command()
 
     case 'r': //New format for the optimised OutputChannels
       cmdPending = true;
-      byte cmd;
+      uint8_t cmd;
       if (Serial.available() >= 6)
       {
         tsCanId = Serial.read(); //Read the $tsCanId
         cmd = Serial.read(); // read the command
 
         uint16_t offset, length;
-        byte tmp;
+        uint8_t tmp;
         tmp = Serial.read();
         offset = word(Serial.read(), tmp);
         tmp = Serial.read();
@@ -285,7 +285,7 @@ void command()
           packetSize = 15;
           Serial.write(highByte(packetSize));
           Serial.write(lowByte(packetSize));
-          byte packet[length+1];
+          uint8_t packet[length+1];
 
           packet[0] = 0;
           packet[1] = length;
@@ -299,7 +299,7 @@ void command()
           Serial.write(packet, 9);
 
           FastCRC32 CRC32;
-          uint32_t CRC32_val = CRC32.crc32((byte *)packet, sizeof(packet) );;
+          uint32_t CRC32_val = CRC32.crc32((uint8_t *)packet, sizeof(packet) );;
       
           //Split the 4 bytes of the CRC32 value into individual bytes and send
           Serial.write( ((CRC32_val >> 24) & 255) );
@@ -359,7 +359,7 @@ void command()
             Serial.write(lowByte(23));
             Serial.write(highByte(23));
 
-            byte packet[17];
+            uint8_t packet[17];
             packet[0] = 0;
             packet[1] = 5;
             packet[2] = 0;
@@ -385,7 +385,7 @@ void command()
 
             Serial.write(packet, 17);
             FastCRC32 CRC32;
-            uint32_t CRC32_val = CRC32.crc32((byte *)packet, sizeof(packet) );;
+            uint32_t CRC32_val = CRC32.crc32((uint8_t *)packet, sizeof(packet) );;
         
             //Split the 4 bytes of the CRC32 value into individual bytes and send
             Serial.write( ((CRC32_val >> 24) & 255) );
@@ -443,8 +443,8 @@ void command()
       break;
 
     case 't': // receive new Calibration info. Command structure: "t", <tble_idx> <data array>.
-      byte tableID;
-      //byte canID;
+      uint8_t tableID;
+      //uint8_t canID;
 
       //The first 2 bytes sent represent the canID and tableID
       while (Serial.available() == 0) { }
@@ -484,7 +484,7 @@ void command()
       {
         if(Serial.available() >= 3) // 1 additional byte is required on the MAP pages which are larger than 255 bytes
         {
-          byte offset1, offset2;
+          uint8_t offset1, offset2;
           offset1 = Serial.read();
           offset2 = Serial.read();
           valueOffset = word(offset2, offset1);
@@ -517,7 +517,7 @@ void command()
         //1 - 1st New value
         if(Serial.available() >= 7)
         {
-          byte offset1, offset2, length1, length2;
+          uint8_t offset1, offset2, length1, length2;
 
           Serial.read(); // First byte of the page identifier can be ignored. It's always 0
           currentPage = Serial.read();
@@ -549,7 +549,7 @@ void command()
     case 'w':
       if(Serial.available() >= 7)
         {
-          byte offset1, offset2, length1, length2;
+          uint8_t offset1, offset2, length1, length2;
 
           Serial.read(); // First byte of the page identifier can be ignored. It's always 0
           currentPage = Serial.read();
@@ -627,12 +627,12 @@ void command()
             //Set the RTC date/time
             //Need to ensure there are 9 more bytes with the new values
             while(Serial.available() < 9) {} //Terrible hack, but RTC values should not be set with the engine running anyway
-            byte second = Serial.read();
-            byte minute = Serial.read();
-            byte hour = Serial.read();
-            byte dow = Serial.read();
-            byte day = Serial.read();
-            byte month = Serial.read();
+            uint8_t second = Serial.read();
+            uint8_t minute = Serial.read();
+            uint8_t hour = Serial.read();
+            uint8_t dow = Serial.read();
+            uint8_t day = Serial.read();
+            uint8_t month = Serial.read();
             uint16_t year = Serial.read();
             year = word(Serial.read(), year);
             Serial.read(); //Final byte is unused (Always has value 0x5a)
@@ -728,9 +728,9 @@ void command()
   }
 }
 
-byte getStatusEntry(uint16_t byteNum)
+uint8_t getStatusEntry(uint16_t byteNum)
 {
-  byte statusValue = 0;
+  uint8_t statusValue = 0;
 
   switch(byteNum)
   {
@@ -740,8 +740,8 @@ byte getStatusEntry(uint16_t byteNum)
     case 3: statusValue = currentStatus.syncLossCounter; break;
     case 4: statusValue = lowByte(currentStatus.MAP); break; //2 bytes for MAP
     case 5: statusValue = highByte(currentStatus.MAP); break;
-    case 6: statusValue = (byte)(currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); break; //mat
-    case 7: statusValue = (byte)(currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); break; //Coolant ADC
+    case 6: statusValue = (uint8_t)(currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); break; //mat
+    case 7: statusValue = (uint8_t)(currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); break; //Coolant ADC
     case 8: statusValue = currentStatus.batCorrection; break; //Battery voltage correction (%)
     case 9: statusValue = currentStatus.battery10; break; //battery voltage
     case 10: statusValue = currentStatus.O2; break; //O2
@@ -750,7 +750,7 @@ byte getStatusEntry(uint16_t byteNum)
     case 13: statusValue = currentStatus.wueCorrection; break; //Warmup enrichment (%)
     case 14: statusValue = lowByte(currentStatus.RPM); break; //rpm HB
     case 15: statusValue = highByte(currentStatus.RPM); break; //rpm LB
-    case 16: statusValue = (byte)(currentStatus.AEamount >> 1); break; //TPS acceleration enrichment (%) divided by 2 (Can exceed 255)
+    case 16: statusValue = (uint8_t)(currentStatus.AEamount >> 1); break; //TPS acceleration enrichment (%) divided by 2 (Can exceed 255)
     case 17: statusValue = lowByte(currentStatus.corrections); break; //Total GammaE (%)
     case 18: statusValue = highByte(currentStatus.corrections); break; //Total GammaE (%)
     case 19: statusValue = currentStatus.VE1; break; //VE 1 (%)
@@ -778,8 +778,8 @@ byte getStatusEntry(uint16_t byteNum)
       statusValue = highByte(currentStatus.freeRAM); 
       break;
 
-    case 29: statusValue = (byte)(currentStatus.boostTarget >> 1); break; //Divide boost target by 2 to fit in a byte
-    case 30: statusValue = (byte)(currentStatus.boostDuty / 100); break;
+    case 29: statusValue = (uint8_t)(currentStatus.boostTarget >> 1); break; //Divide boost target by 2 to fit in a byte
+    case 30: statusValue = (uint8_t)(currentStatus.boostDuty / 100); break;
     case 31: statusValue = currentStatus.spark; break; //Spark related bitfield
 
     //rpmDOT must be sent as a signed integer
@@ -886,8 +886,8 @@ byte getStatusEntry(uint16_t byteNum)
 /*
 This function returns the current values of a fixed group of variables
 */
-//void sendValues(int packetlength, byte portNum)
-void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
+//void sendValues(int packetlength, uint8_t portNum)
+void sendValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t portNum)
 {  
   if (portNum == 3)
   {
@@ -909,7 +909,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
 
   currentStatus.spark ^= (-currentStatus.hasSync ^ currentStatus.spark) & (1U << BIT_SPARK_SYNC); //Set the sync bit of the Spark variable to match the hasSync variable
 
-  for(byte x=0; x<packetLength; x++)
+  for(uint8_t x=0; x<packetLength; x++)
   {
     if (portNum == 0) { Serial.write(getStatusEntry(offset+x)); }
     #if defined(CANSerial_AVAILABLE)
@@ -1058,7 +1058,7 @@ void sendValuesLegacy()
   }
 }
 
-void receiveValue(uint16_t valueOffset, byte newValue)
+void receiveValue(uint16_t valueOffset, uint8_t newValue)
 {
 
   void* pnt_configPage;//This only stores the address of the value that it's pointing to and not the max size
@@ -1098,7 +1098,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[veSetPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1130,7 +1130,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[ignSetPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1163,7 +1163,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[afrSetPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1245,7 +1245,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[currentPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1254,7 +1254,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[currentPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1305,7 +1305,7 @@ void receiveValue(uint16_t valueOffset, byte newValue)
       //For some reason, TunerStudio is sending offsets greater than the maximum page size. I'm not sure if it's their bug or mine, but the fix is to only update the config page if the offset is less than the maximum size
       if (valueOffset < npage_size[currentPage])
       {
-        *((byte *)pnt_configPage + (byte)valueOffset) = newValue;
+        *((uint8_t *)pnt_configPage + (uint8_t)valueOffset) = newValue;
       }
       break;
 
@@ -1379,48 +1379,48 @@ void sendPage()
     case boostvvtPage:
     {
       //Need to perform a translation of the values[MAP/TPS][RPM] into the MS expected format
-      byte response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
+      uint8_t response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
 
       //Boost table
       for (int x = 0; x < 64; x++) { response[x] = boostTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = byte(boostTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = byte(boostTable.axisY[7 - (y - 72)]); }
-      Serial.write((byte *)&response, 80);
+      for (int x = 64; x < 72; x++) { response[x] = uint8_t(boostTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 72; y < 80; y++) { response[y] = uint8_t(boostTable.axisY[7 - (y - 72)]); }
+      Serial.write((uint8_t *)&response, 80);
       //VVT table
       for (int x = 0; x < 64; x++) { response[x] = vvtTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = byte(vvtTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = byte(vvtTable.axisY[7 - (y - 72)]); }
-      Serial.write((byte *)&response, 80);
+      for (int x = 64; x < 72; x++) { response[x] = uint8_t(vvtTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 72; y < 80; y++) { response[y] = uint8_t(vvtTable.axisY[7 - (y - 72)]); }
+      Serial.write((uint8_t *)&response, 80);
       //Staging table
       for (int x = 0; x < 64; x++) { response[x] = stagingTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = byte(stagingTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = byte(stagingTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
-      Serial.write((byte *)&response, 80);
+      for (int x = 64; x < 72; x++) { response[x] = uint8_t(stagingTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 72; y < 80; y++) { response[y] = uint8_t(stagingTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
+      Serial.write((uint8_t *)&response, 80);
       sendComplete = true;
       break;
     }
     case seqFuelPage:
     {
       //Need to perform a translation of the values[MAP/TPS][RPM] into the MS expected format
-      byte response[192]; //Bit hacky, but the size is: (6x6 + 6 + 6) * 4 = 192
+      uint8_t response[192]; //Bit hacky, but the size is: (6x6 + 6 + 6) * 4 = 192
 
       //trim1 table
       for (int x = 0; x < 36; x++) { response[x] = trim1Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x] = byte(trim1Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y] = byte(trim1Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int x = 36; x < 42; x++) { response[x] = uint8_t(trim1Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 42; y < 48; y++) { response[y] = uint8_t(trim1Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim2 table
       for (int x = 0; x < 36; x++) { response[x + 48] = trim2Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 48] = byte(trim2Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 48] = byte(trim2Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int x = 36; x < 42; x++) { response[x + 48] = uint8_t(trim2Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 42; y < 48; y++) { response[y + 48] = uint8_t(trim2Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim3 table
       for (int x = 0; x < 36; x++) { response[x + 96] = trim3Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 96] = byte(trim3Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 96] = byte(trim3Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int x = 36; x < 42; x++) { response[x + 96] = uint8_t(trim3Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 42; y < 48; y++) { response[y + 96] = uint8_t(trim3Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim4 table
       for (int x = 0; x < 36; x++) { response[x + 144] = trim4Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 144] = byte(trim4Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 144] = byte(trim4Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
-      Serial.write((byte *)&response, sizeof(response));
+      for (int x = 36; x < 42; x++) { response[x + 144] = uint8_t(trim4Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 42; y < 48; y++) { response[y + 144] = uint8_t(trim4Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      Serial.write((uint8_t *)&response, sizeof(response));
       sendComplete = true;
       break;
     }
@@ -1439,13 +1439,13 @@ void sendPage()
     case wmiMapPage:
     {
       //Need to perform a translation of the values[MAP/TPS][RPM] into the MS expected format
-      byte response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
+      uint8_t response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
 
       //Boost table
       for (int x = 0; x < 64; x++) { response[x] = wmiTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = byte(wmiTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = byte(wmiTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
-      Serial.write((byte *)&response, 80);
+      for (int x = 64; x < 72; x++) { response[x] = uint8_t(wmiTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int y = 72; y < 80; y++) { response[y] = uint8_t(wmiTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
+      Serial.write((uint8_t *)&response, 80);
       break;
     }
       
@@ -1473,25 +1473,25 @@ void sendPage()
     {
         //Need to perform a translation of the values[yaxis][xaxis] into the MS expected format
         //MS format has origin (0,0) in the bottom left corner, we use the top left for efficiency reasons
-        byte response[MAP_PAGE_SIZE];
+        uint8_t response[MAP_PAGE_SIZE];
 
         for (int x = 0; x < 256; x++) { response[x] = currentTable.values[15 - (x / 16)][x % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
         //loop();
-        for (int x = 256; x < 272; x++) { response[x] = byte(currentTable.axisX[(x - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        for (int x = 256; x < 272; x++) { response[x] = uint8_t(currentTable.axisX[(x - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
         //loop();
-        for (int y = 272; y < 288; y++) { response[y] = byte(currentTable.axisY[15 - (y - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        for (int y = 272; y < 288; y++) { response[y] = uint8_t(currentTable.axisY[15 - (y - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         //loop();
-        Serial.write((byte *)&response, sizeof(response));
+        Serial.write((uint8_t *)&response, sizeof(response));
     } //is map
     else
     {
-      for (byte x = 0; x < npage_size[currentPage]; x++)
+      for (uint8_t x = 0; x < npage_size[currentPage]; x++)
       {
-        //response[x] = *((byte *)pnt_configPage + x);
-        Serial.write(*((byte *)pnt_configPage + x)); //Each byte is simply the location in memory of the configPage + the offset + the variable number (x)
+        //response[x] = *((uint8_t *)pnt_configPage + x);
+        Serial.write(*((uint8_t *)pnt_configPage + x)); //Each byte is simply the location in memory of the configPage + the offset + the variable number (x)
       }
 
-      //Serial.write((byte *)&response, npage_size[currentPage]);
+      //Serial.write((uint8_t *)&response, npage_size[currentPage]);
       // }
     } //isMap
   } //sendComplete
@@ -1506,7 +1506,7 @@ void sendPageASCII()
 {
   void* pnt_configPage = &configPage2; //Default value is for safety only. Will be changed below if needed.
   struct table3D currentTable = fuelTable; //Default value is for safety only. Will be changed below if needed.
-  byte currentTitleIndex = 0;// This corresponds to the count up to the first char of a string in pageTitles
+  uint8_t currentTitleIndex = 0;// This corresponds to the count up to the first char of a string in pageTitles
   bool sendComplete = false; //Used to track whether all send operations are complete
 
   switch (currentPage)
@@ -1522,25 +1522,25 @@ void sendPageASCII()
       // When casting to the __FlashStringHelper type Serial.println uses the same subroutine as when using the F macro
       Serial.println((const __FlashStringHelper *)&pageTitles[27]);//27 is the index to the first char in the second sting in pageTitles
       // The following loop displays in human readable form of all byte values in config page 1 up to but not including the first array.
-      // incrementing void pointers is cumbersome. Thus we have "pnt_configPage = (byte *)pnt_configPage + 1"
-      for (pnt_configPage = (byte *)&configPage2; pnt_configPage < &configPage2.wueValues[0]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
-      for (byte x = 10; x; x--)// The x between the ';' has the same representation as the "x != 0" test or comparision
+      // incrementing void pointers is cumbersome. Thus we have "pnt_configPage = (uint8_t *)pnt_configPage + 1"
+      for (pnt_configPage = (uint8_t *)&configPage2; pnt_configPage < &configPage2.wueValues[0]; pnt_configPage = (uint8_t *)pnt_configPage + 1) { Serial.println(*((uint8_t *)pnt_configPage)); }
+      for (uint8_t x = 10; x; x--)// The x between the ';' has the same representation as the "x != 0" test or comparision
       {
         Serial.print(configPage2.wueValues[10 - x]);// This displays the values horizantially on the screen
         Serial.print(F(" "));
       }
       Serial.println();
-      for (pnt_configPage = (byte *)&configPage2.wueValues[9] + 1; pnt_configPage < &configPage2.injAng; pnt_configPage = (byte *)pnt_configPage + 1) {
-        Serial.println(*((byte *)pnt_configPage));// This displays all the byte values between the last array up to but not including the first unsigned int on config page 1
+      for (pnt_configPage = (uint8_t *)&configPage2.wueValues[9] + 1; pnt_configPage < &configPage2.injAng; pnt_configPage = (uint8_t *)pnt_configPage + 1) {
+        Serial.println(*((uint8_t *)pnt_configPage));// This displays all the byte values between the last array up to but not including the first unsigned int on config page 1
       }
       // The following loop displays four unsigned ints
       for (pnt16_configPage = (uint16_t *)&configPage2.injAng; pnt16_configPage < (uint16_t*)&configPage2.injAng + 9; pnt16_configPage = (uint16_t*)pnt16_configPage + 1)
       { Serial.println(*((uint16_t *)pnt16_configPage)); }
       // Following loop displays byte values between the unsigned ints
-      for (pnt_configPage = (uint16_t *)&configPage2.injAng + 9; pnt_configPage < &configPage2.mapMax; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
+      for (pnt_configPage = (uint16_t *)&configPage2.injAng + 9; pnt_configPage < &configPage2.mapMax; pnt_configPage = (uint8_t *)pnt_configPage + 1) { Serial.println(*((uint8_t *)pnt_configPage)); }
       Serial.println(configPage2.mapMax);
       // Following loop displays remaining byte values of the page
-      for (pnt_configPage = (uint16_t *)&configPage2.mapMax + 1; pnt_configPage < (byte *)&configPage2 + npage_size[veSetPage]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
+      for (pnt_configPage = (uint16_t *)&configPage2.mapMax + 1; pnt_configPage < (uint8_t *)&configPage2 + npage_size[veSetPage]; pnt_configPage = (uint8_t *)pnt_configPage + 1) { Serial.println(*((uint8_t *)pnt_configPage)); }
       sendComplete = true;
       break;
 
@@ -1554,10 +1554,10 @@ void sendPageASCII()
       Serial.println((const __FlashStringHelper *)&pageTitles[56]);
       Serial.println(configPage4.triggerAngle);// configPsge2.triggerAngle is an int so just display it without complication
       // Following loop displays byte values after that first int up to but not including the first array in config page 2
-      for (pnt_configPage = (byte *)&configPage4 + 1; pnt_configPage < &configPage4.taeBins[0]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
-      for (byte y = 2; y; y--)// Displaying two equal sized arrays
+      for (pnt_configPage = (uint8_t *)&configPage4 + 1; pnt_configPage < &configPage4.taeBins[0]; pnt_configPage = (uint8_t *)pnt_configPage + 1) { Serial.println(*((uint8_t *)pnt_configPage)); }
+      for (uint8_t y = 2; y; y--)// Displaying two equal sized arrays
       {
-        byte * currentVar;// A placeholder for each array
+        uint8_t * currentVar;// A placeholder for each array
         if (y == 2) {
           currentVar = configPage4.taeBins;
         }
@@ -1565,29 +1565,29 @@ void sendPageASCII()
           currentVar = configPage4.taeValues;
         }
 
-        for (byte j = 4; j; j--)
+        for (uint8_t j = 4; j; j--)
         {
           Serial.print(currentVar[4 - j]);
           Serial.print(' ');
         }
         Serial.println();
       }
-      for (byte x = 10; x ; x--)
+      for (uint8_t x = 10; x ; x--)
       {
         Serial.print(configPage4.wueBins[10 - x]);//Displaying array horizontally across screen
         Serial.print(' ');
       }
       Serial.println();
       Serial.println(configPage4.dwellLimit);// Little lonely byte stuck between two arrays. No complications just display it.
-      for (byte x = 6; x; x--)
+      for (uint8_t x = 6; x; x--)
       {
         Serial.print(configPage4.dwellCorrectionValues[6 - x]);
         Serial.print(' ');
       }
       Serial.println();
-      for (pnt_configPage = (byte *)&configPage4.dwellCorrectionValues[5] + 1; pnt_configPage < (byte *)&configPage4 + npage_size[ignSetPage]; pnt_configPage = (byte *)pnt_configPage + 1)
+      for (pnt_configPage = (uint8_t *)&configPage4.dwellCorrectionValues[5] + 1; pnt_configPage < (uint8_t *)&configPage4 + npage_size[ignSetPage]; pnt_configPage = (uint8_t *)pnt_configPage + 1)
       {
-        Serial.println(*((byte *)pnt_configPage));// Displaying remaining byte values of the page
+        Serial.println(*((uint8_t *)pnt_configPage));// Displaying remaining byte values of the page
       }
       sendComplete = true;
       break;
@@ -1601,30 +1601,30 @@ void sendPageASCII()
       //currentTitleIndex = 91;
       //To Display Values from Config Page 3
       Serial.println((const __FlashStringHelper *)&pageTitles[91]);//special typecasting to enable suroutine that the F macro uses
-      for (pnt_configPage = (byte *)&configPage6; pnt_configPage < &configPage6.voltageCorrectionBins[0]; pnt_configPage = (byte *)pnt_configPage + 1)
+      for (pnt_configPage = (uint8_t *)&configPage6; pnt_configPage < &configPage6.voltageCorrectionBins[0]; pnt_configPage = (uint8_t *)pnt_configPage + 1)
       {
-        Serial.println(*((byte *)pnt_configPage));// Displaying byte values of config page 3 up to but not including the first array
+        Serial.println(*((uint8_t *)pnt_configPage));// Displaying byte values of config page 3 up to but not including the first array
       }
-      for (byte y = 2; y; y--)// Displaying two equally sized arrays that are next to each other
+      for (uint8_t y = 2; y; y--)// Displaying two equally sized arrays that are next to each other
       {
-        byte * currentVar;
+        uint8_t * currentVar;
         if (y == 2) { currentVar = configPage6.voltageCorrectionBins; }
         else { currentVar = configPage6.injVoltageCorrectionValues; }
 
-        for (byte i = 6; i; i--)
+        for (uint8_t i = 6; i; i--)
         {
           Serial.print(currentVar[6 - i]);
           Serial.print(' ');
         }
         Serial.println();
       }
-      for (byte y = 2; y; y--)// and again
+      for (uint8_t y = 2; y; y--)// and again
       {
-        byte* currentVar;
+        uint8_t* currentVar;
         if (y == 2) { currentVar = configPage6.airDenBins; }
         else { currentVar = configPage6.airDenRates; }
 
-        for (byte i = 9; i; i--)
+        for (uint8_t i = 9; i; i--)
         {
           Serial.print(currentVar[9 - i]);
           Serial.print(' ');
@@ -1632,18 +1632,18 @@ void sendPageASCII()
         Serial.println();
       }
       // Following loop displays the remaining byte values of the page
-      for (pnt_configPage = (byte *)&configPage6.airDenRates[8] + 1; pnt_configPage < (byte *)&configPage6 + npage_size[afrSetPage]; pnt_configPage = (byte *)pnt_configPage + 1)
+      for (pnt_configPage = (uint8_t *)&configPage6.airDenRates[8] + 1; pnt_configPage < (uint8_t *)&configPage6 + npage_size[afrSetPage]; pnt_configPage = (uint8_t *)pnt_configPage + 1)
       {
-        Serial.println(*((byte *)pnt_configPage));
+        Serial.println(*((uint8_t *)pnt_configPage));
       }
       sendComplete = true;
 
       //Old configPage4 STARTED HERE!
       //currentTitleIndex = 106;
       Serial.println((const __FlashStringHelper *)&pageTitles[106]);// F macro hack
-      for (byte y = 4; y; y--)// Display four equally sized arrays
+      for (uint8_t y = 4; y; y--)// Display four equally sized arrays
       {
-        byte * currentVar;
+        uint8_t * currentVar;
         switch (y)
         {
           case 1: currentVar = configPage6.iacBins; break;
@@ -1652,16 +1652,16 @@ void sendPageASCII()
           case 4: currentVar = configPage6.iacCLValues; break;
           default: break;
         }
-        for (byte i = 10; i; i--)
+        for (uint8_t i = 10; i; i--)
         {
           Serial.print(currentVar[10 - i]);
           Serial.print(' ');
         }
         Serial.println();
       }
-      for (byte y = 3; y; y--)// Three equally sized arrays
+      for (uint8_t y = 3; y; y--)// Three equally sized arrays
       {
-        byte * currentVar;
+        uint8_t * currentVar;
         switch (y)
         {
           case 1: currentVar = configPage6.iacCrankBins; break;
@@ -1669,7 +1669,7 @@ void sendPageASCII()
           case 3: currentVar = configPage6.iacCrankSteps; break;
           default: break;
         }
-        for (byte i = 4; i; i--)
+        for (uint8_t i = 4; i; i--)
         {
           Serial.print(currentVar[4 - i]);
           Serial.print(' ');
@@ -1677,7 +1677,7 @@ void sendPageASCII()
         Serial.println();
       }
       // Following loop is for remaining byte value of page
-      for (pnt_configPage = (byte *)&configPage6.iacCrankBins[3] + 1; pnt_configPage < (byte *)&configPage6 + npage_size[afrSetPage]; pnt_configPage = (byte *)pnt_configPage + 1) { Serial.println(*((byte *)pnt_configPage)); }
+      for (pnt_configPage = (uint8_t *)&configPage6.iacCrankBins[3] + 1; pnt_configPage < (uint8_t *)&configPage6 + npage_size[afrSetPage]; pnt_configPage = (uint8_t *)pnt_configPage + 1) { Serial.println(*((uint8_t *)pnt_configPage)); }
       sendComplete = true;
       break;
 
@@ -1690,7 +1690,7 @@ void sendPageASCII()
       currentTable = trim1Table;
       for (int y = 0; y < currentTable.ySize; y++)
       {
-        byte axisY = byte(currentTable.axisY[y]);
+        uint8_t axisY = uint8_t(currentTable.axisY[y]);
         if (axisY < 100)
         {
           Serial.write(" ");
@@ -1703,7 +1703,7 @@ void sendPageASCII()
         Serial.write(" ");
         for (int i = 0; i < currentTable.xSize; i++)
         {
-          byte value = currentTable.values[y][i];
+          uint8_t value = currentTable.values[y][i];
           if (value < 100)
           {
             Serial.write(" ");
@@ -1724,9 +1724,9 @@ void sendPageASCII()
       //currentTitleIndex = 141;
       //To Display Values from Config Page 10
       Serial.println((const __FlashStringHelper *)&pageTitles[103]);//special typecasting to enable suroutine that the F macro uses
-      for (pnt_configPage = &configPage9; pnt_configPage < ( (byte *)&configPage9 + npage_size[canbusPage]); pnt_configPage = (byte *)pnt_configPage + 1)
+      for (pnt_configPage = &configPage9; pnt_configPage < ( (uint8_t *)&configPage9 + npage_size[canbusPage]); pnt_configPage = (uint8_t *)pnt_configPage + 1)
       {
-        Serial.println(*((byte *)pnt_configPage));// Displaying byte values of config page 9 up to but not including the first array
+        Serial.println(*((uint8_t *)pnt_configPage));// Displaying byte values of config page 9 up to but not including the first array
       }
       sendComplete = true;
       break;
@@ -1779,7 +1779,7 @@ void sendPageASCII()
         Serial.println();
         for (int y = 0; y < currentTable.ySize; y++)
         {
-          byte axisY = byte(currentTable.axisY[y]);
+          uint8_t axisY = uint8_t(currentTable.axisY[y]);
           if (axisY < 100)
           {
             Serial.write(spaceChar);
@@ -1792,7 +1792,7 @@ void sendPageASCII()
           Serial.write(spaceChar);
           for (int i = 0; i < currentTable.xSize; i++)
           {
-            byte value = currentTable.values[y][i];
+            uint8_t value = currentTable.values[y][i];
             if (value < 100)
             {
               Serial.write(spaceChar);
@@ -1809,7 +1809,7 @@ void sendPageASCII()
         Serial.print(F("    "));
         for (int x = 0; x < currentTable.xSize; x++)// Horizontal bins
         {
-          byte axisX = byte(currentTable.axisX[x] / 100);
+          uint8_t axisX = uint8_t(currentTable.axisX[x] / 100);
           if (axisX < 100)
           {
             Serial.write(spaceChar);
@@ -1840,16 +1840,16 @@ void sendPageASCII()
         currentTitleIndex++;
        }
        Serial.println();
-       for(byte x=0;x<page_size;x++) Serial.println(*((byte *)pnt_configPage + x));
+       for(uint8_t x=0;x<page_size;x++) Serial.println(*((uint8_t *)pnt_configPage + x));
       }
       else
       {*/
       //All other bytes can simply be copied from the config table
-      //byte response[npage_size[currentPage]];
-      for (byte x = 0; x < npage_size[currentPage]; x++)
+      //uint8_t response[npage_size[currentPage]];
+      for (uint8_t x = 0; x < npage_size[currentPage]; x++)
       {
-        //response[x] = *((byte *)pnt_configPage + x);
-        Serial.write(*((byte *)pnt_configPage + x)); //Each byte is simply the location in memory of the configPage + the offset + the variable number (x)
+        //response[x] = *((uint8_t *)pnt_configPage + x);
+        Serial.write(*((uint8_t *)pnt_configPage + x)); //Each byte is simply the location in memory of the configPage + the offset + the variable number (x)
       }
     } //isMap
   } //sendComplete
@@ -1862,45 +1862,45 @@ void sendPageASCII()
  * @param valueAddress The address in the page that should be returned. This is as per the page definition in the ini
  * @return byte The requested value
  */
-byte getPageValue(byte page, uint16_t valueAddress)
+uint8_t getPageValue(uint8_t page, uint16_t valueAddress)
 {
   void* pnt_configPage = &configPage2; //Default value is for safety only. Will be changed below if needed.
   uint16_t tempAddress;
-  byte returnValue = 0;
+  uint8_t returnValue = 0;
 
   switch (page)
   {
     case veMapPage:
         if( valueAddress < 256) { returnValue = fuelTable.values[15 - (valueAddress / 16)][valueAddress % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
-        else if(valueAddress < 272) { returnValue =  byte(fuelTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
-        else if (valueAddress < 288) { returnValue = byte(fuelTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        else if(valueAddress < 272) { returnValue =  uint8_t(fuelTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        else if (valueAddress < 288) { returnValue = uint8_t(fuelTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         break;
 
     case veSetPage:
         pnt_configPage = &configPage2; //Create a pointer to Page 1 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case ignMapPage:
         if( valueAddress < 256) { returnValue = ignitionTable.values[15 - (valueAddress / 16)][valueAddress % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
-        else if(valueAddress < 272) { returnValue =  byte(ignitionTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
-        else if (valueAddress < 288) { returnValue = byte(ignitionTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        else if(valueAddress < 272) { returnValue =  uint8_t(ignitionTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        else if (valueAddress < 288) { returnValue = uint8_t(ignitionTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         break;
 
     case ignSetPage:
         pnt_configPage = &configPage4; //Create a pointer to Page 2 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case afrMapPage:
         if( valueAddress < 256) { returnValue = afrTable.values[15 - (valueAddress / 16)][valueAddress % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
-        else if(valueAddress < 272) { returnValue =  byte(afrTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
-        else if (valueAddress < 288) { returnValue = byte(afrTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        else if(valueAddress < 272) { returnValue =  uint8_t(afrTable.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        else if (valueAddress < 288) { returnValue = uint8_t(afrTable.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         break;
 
     case afrSetPage:
         pnt_configPage = &configPage6; //Create a pointer to Page 3 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case boostvvtPage:
@@ -1911,24 +1911,24 @@ byte getPageValue(byte page, uint16_t valueAddress)
           {
             //Boost table
             if(valueAddress < 64) { returnValue = boostTable.values[7 - (valueAddress / 8)][valueAddress % 8]; }
-            else if(valueAddress < 72) { returnValue = byte(boostTable.axisX[(valueAddress - 64)] / TABLE_RPM_MULTIPLIER); }
-            else if(valueAddress < 80) { returnValue = byte(boostTable.axisY[7 - (valueAddress - 72)]); }
+            else if(valueAddress < 72) { returnValue = uint8_t(boostTable.axisX[(valueAddress - 64)] / TABLE_RPM_MULTIPLIER); }
+            else if(valueAddress < 80) { returnValue = uint8_t(boostTable.axisY[7 - (valueAddress - 72)]); }
           }
           else if(valueAddress < 160)
           {
             tempAddress = valueAddress - 80;
             //VVT table
             if(tempAddress < 64) { returnValue = vvtTable.values[7 - (tempAddress / 8)][tempAddress % 8]; }
-            else if(tempAddress < 72) { returnValue = byte(vvtTable.axisX[(tempAddress - 64)] / TABLE_RPM_MULTIPLIER); }
-            else if(tempAddress < 80) { returnValue = byte(vvtTable.axisY[7 - (tempAddress - 72)]); }
+            else if(tempAddress < 72) { returnValue = uint8_t(vvtTable.axisX[(tempAddress - 64)] / TABLE_RPM_MULTIPLIER); }
+            else if(tempAddress < 80) { returnValue = uint8_t(vvtTable.axisY[7 - (tempAddress - 72)]); }
           }
           else
           {
             tempAddress = valueAddress - 160;
             //Staging table
             if(tempAddress < 64) { returnValue = stagingTable.values[7 - (tempAddress / 8)][tempAddress % 8]; }
-            else if(tempAddress < 72) { returnValue = byte(stagingTable.axisX[(tempAddress - 64)] / TABLE_RPM_MULTIPLIER); }
-            else if(tempAddress < 80) { returnValue = byte(stagingTable.axisY[7 - (tempAddress - 72)] / TABLE_LOAD_MULTIPLIER); }
+            else if(tempAddress < 72) { returnValue = uint8_t(stagingTable.axisX[(tempAddress - 64)] / TABLE_RPM_MULTIPLIER); }
+            else if(tempAddress < 80) { returnValue = uint8_t(stagingTable.axisY[7 - (tempAddress - 72)] / TABLE_LOAD_MULTIPLIER); }
           }
         }
         break;
@@ -1941,70 +1941,70 @@ byte getPageValue(byte page, uint16_t valueAddress)
           {
             //trim1 table
             if(valueAddress < 36) { returnValue = trim1Table.values[5 - (valueAddress / 6)][valueAddress % 6]; }
-            else if(valueAddress < 42) { returnValue = byte(trim1Table.axisX[(valueAddress - 36)] / TABLE_RPM_MULTIPLIER); }
-            else if(valueAddress < 48) { returnValue = byte(trim1Table.axisY[5 - (valueAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
+            else if(valueAddress < 42) { returnValue = uint8_t(trim1Table.axisX[(valueAddress - 36)] / TABLE_RPM_MULTIPLIER); }
+            else if(valueAddress < 48) { returnValue = uint8_t(trim1Table.axisY[5 - (valueAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
           }
           else if(valueAddress < 96)
           {
             tempAddress = valueAddress - 48;
             //trim2 table
             if(tempAddress < 36) { returnValue = trim2Table.values[5 - (tempAddress / 6)][tempAddress % 6]; }
-            else if(tempAddress < 42) { returnValue = byte(trim2Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
-            else if(tempAddress < 48) { returnValue = byte(trim2Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
+            else if(tempAddress < 42) { returnValue = uint8_t(trim2Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
+            else if(tempAddress < 48) { returnValue = uint8_t(trim2Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
           }
           else if(valueAddress < 144)
           {
             tempAddress = valueAddress - 96;
             //trim3 table
             if(tempAddress < 36) { returnValue = trim3Table.values[5 - (tempAddress / 6)][tempAddress % 6]; }
-            else if(tempAddress < 42) { returnValue = byte(trim3Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
-            else if(tempAddress < 48) { returnValue = byte(trim3Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
+            else if(tempAddress < 42) { returnValue = uint8_t(trim3Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
+            else if(tempAddress < 48) { returnValue = uint8_t(trim3Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
           }
           else if(valueAddress < 192)
           {
             tempAddress = valueAddress - 144;
             //trim4 table
             if(tempAddress < 36) { returnValue = trim4Table.values[5 - (tempAddress / 6)][tempAddress % 6]; }
-            else if(tempAddress < 42) { returnValue = byte(trim4Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
-            else if(tempAddress < 48) { returnValue = byte(trim4Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
+            else if(tempAddress < 42) { returnValue = uint8_t(trim4Table.axisX[(tempAddress - 36)] / TABLE_RPM_MULTIPLIER); }
+            else if(tempAddress < 48) { returnValue = uint8_t(trim4Table.axisY[5 - (tempAddress - 42)] / TABLE_LOAD_MULTIPLIER); }
           }
         }
         break;
 
     case canbusPage:
         pnt_configPage = &configPage9; //Create a pointer to Page 10 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case warmupPage:
         pnt_configPage = &configPage10; //Create a pointer to Page 11 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case fuelMap2Page:
         if( valueAddress < 256) { returnValue = fuelTable2.values[15 - (valueAddress / 16)][valueAddress % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
-        else if(valueAddress < 272) { returnValue =  byte(fuelTable2.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
-        else if (valueAddress < 288) { returnValue = byte(fuelTable2.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        else if(valueAddress < 272) { returnValue =  uint8_t(fuelTable2.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        else if (valueAddress < 288) { returnValue = uint8_t(fuelTable2.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         break;
         
     case wmiMapPage:
         if(valueAddress < 80)
         {
           if(valueAddress < 64) { returnValue = wmiTable.values[7 - (valueAddress / 8)][valueAddress % 8]; }
-          else if(valueAddress < 72) { returnValue = byte(wmiTable.axisX[(valueAddress - 64)] / TABLE_RPM_MULTIPLIER); }
-          else if(valueAddress < 80) { returnValue = byte(wmiTable.axisY[7 - (valueAddress - 72)] / TABLE_LOAD_MULTIPLIER); }
+          else if(valueAddress < 72) { returnValue = uint8_t(wmiTable.axisX[(valueAddress - 64)] / TABLE_RPM_MULTIPLIER); }
+          else if(valueAddress < 80) { returnValue = uint8_t(wmiTable.axisY[7 - (valueAddress - 72)] / TABLE_LOAD_MULTIPLIER); }
         }
         break;
 
     case progOutsPage:
         pnt_configPage = &configPage13; //Create a pointer to Page 13 in memory
-        returnValue = *((byte *)pnt_configPage + valueAddress);
+        returnValue = *((uint8_t *)pnt_configPage + valueAddress);
         break;
 
     case ignMap2Page:
         if( valueAddress < 256) { returnValue = ignitionTable2.values[15 - (valueAddress / 16)][valueAddress % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
-        else if(valueAddress < 272) { returnValue =  byte(ignitionTable2.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
-        else if (valueAddress < 288) { returnValue = byte(ignitionTable2.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        else if(valueAddress < 272) { returnValue =  uint8_t(ignitionTable2.axisX[(valueAddress - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        else if (valueAddress < 288) { returnValue = uint8_t(ignitionTable2.axisY[15 - (valueAddress - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         break;
       
     default:
@@ -2023,7 +2023,7 @@ byte getPageValue(byte page, uint16_t valueAddress)
  * 
  * @param tableID Which calibration table to process. 0 = Coolant Sensor. 1 = IAT Sensor. 2 = O2 Sensor.
  */
-void receiveCalibration(byte tableID)
+void receiveCalibration(uint8_t tableID)
 {
   void* pnt_TargetTable_values; //Pointer that will be used to point to the required target table values
   uint16_t* pnt_TargetTable_bins;   //Pointer that will be used to point to the required target table bins
@@ -2047,7 +2047,7 @@ void receiveCalibration(byte tableID)
       break;
     case 2:
       //O2 table
-      //pnt_TargetTable = (byte *)&o2CalibrationTable;
+      //pnt_TargetTable = (uint8_t *)&o2CalibrationTable;
       pnt_TargetTable_values = (uint8_t *)&o2Calibration_values;
       pnt_TargetTable_bins = (uint16_t *)&o2Calibration_bins;
       OFFSET = 0;
@@ -2063,7 +2063,7 @@ void receiveCalibration(byte tableID)
   }
 
   int16_t tempValue;
-  byte tempBuffer[2];
+  uint8_t tempBuffer[2];
 
   if(tableID == 2)
   {
@@ -2075,7 +2075,7 @@ void receiveCalibration(byte tableID)
 
       if( (x % 32) == 0)
       {
-        ((uint8_t*)pnt_TargetTable_values)[(x/32)] = (byte)tempValue; //O2 table stores 8 bit values
+        ((uint8_t*)pnt_TargetTable_values)[(x/32)] = (uint8_t)tempValue; //O2 table stores 8 bit values
         pnt_TargetTable_bins[(x/32)] = (x);
       }
       
@@ -2113,7 +2113,7 @@ Send 256 tooth log entries
  * if useChar is true, the values are sent as chars to be printed out by a terminal emulator
  * if useChar is false, the values are sent as a 2 byte integer which is readable by TunerStudios tooth logger
 */
-void sendToothLog(byte startOffset)
+void sendToothLog(uint8_t startOffset)
 {
   //We need TOOTH_LOG_SIZE number of records to send to TunerStudio. If there aren't that many in the buffer then we just return and wait for the next call
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_TOOTHLOG1READY)) //Sanity check. Flagging system means this should always be true
@@ -2147,13 +2147,13 @@ void sendToothLog(byte startOffset)
     //TunerStudio has timed out, send a LOG of all 0s
     for(int x = 0; x < (4*TOOTH_LOG_SIZE); x++)
     {
-      Serial.write(static_cast<byte>(0x00)); //GCC9 fix
+      Serial.write(static_cast<uint8_t>(0x00)); //GCC9 fix
     }
     cmdPending = false; 
   } 
 }
 
-void sendCompositeLog(byte startOffset)
+void sendCompositeLog(uint8_t startOffset)
 {
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_TOOTHLOG1READY)) //Sanity check. Flagging system means this should always be true
   {
@@ -2194,7 +2194,7 @@ void sendCompositeLog(byte startOffset)
     //TunerStudio has timed out, send a LOG of all 0s
     for(int x = 0; x < (5*TOOTH_LOG_SIZE); x++)
     {
-      Serial.write(static_cast<byte>(0x00)); //GCC9 fix
+      Serial.write(static_cast<uint8_t>(0x00)); //GCC9 fix
     }
     cmdPending = false; 
   } 

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -234,7 +234,7 @@ void command()
       if(Serial.available() >= 6)
       {
         uint8_t offset1, offset2, length1, length2;
-        int length;
+        int16_t length;
         uint8_t tempPage;
 
         Serial.read(); // First byte of the page identifier can be ignored. It's always 0
@@ -246,7 +246,7 @@ void command()
         length1 = Serial.read();
         length2 = Serial.read();
         length = word(length2, length1);
-        for(int i = 0; i < length; i++)
+        for(int16_t i = 0; i < length; i++)
         {
           Serial.write( getPageValue(tempPage, valueOffset + i) );
         }
@@ -644,28 +644,28 @@ void command()
     case 'Z': //Totally non-standard testing function. Will be removed once calibration testing is completed. This function takes 1.5kb of program space! :S
     #ifndef SMALL_FLASH_MODE
       Serial.println(F("Coolant"));
-      for (int x = 0; x < 32; x++)
+      for (int16_t x = 0; x < 32; x++)
       {
         Serial.print(cltCalibration_bins[x]);
         Serial.print(", ");
         Serial.println(cltCalibration_values[x]);
       }
       Serial.println(F("Inlet temp"));
-      for (int x = 0; x < 32; x++)
+      for (int16_t x = 0; x < 32; x++)
       {
         Serial.print(iatCalibration_bins[x]);
         Serial.print(", ");
         Serial.println(iatCalibration_values[x]);
       }
       Serial.println(F("O2"));
-      for (int x = 0; x < 32; x++)
+      for (int16_t x = 0; x < 32; x++)
       {
         Serial.print(o2Calibration_bins[x]);
         Serial.print(", ");
         Serial.println(o2Calibration_values[x]);
       }
       Serial.println(F("WUE"));
-      for (int x = 0; x < 10; x++)
+      for (int16_t x = 0; x < 10; x++)
       {
         Serial.print(configPage4.wueBins[x]);
         Serial.print(F(", "));
@@ -886,7 +886,7 @@ uint8_t getStatusEntry(uint16_t byteNum)
 /*
 This function returns the current values of a fixed group of variables
 */
-//void sendValues(int packetlength, uint8_t portNum)
+//void sendValues(int16_t packetlength, uint8_t portNum)
 void sendValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t portNum)
 {  
   if (portNum == 3)
@@ -936,7 +936,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, uint8_t cmd, uint8_t por
 void sendValuesLegacy()
 {
   uint16_t temp;
-  int bytestosend = 114;
+  int16_t bytestosend = 114;
 
   bytestosend -= Serial.write(currentStatus.secl>>8);
   bytestosend -= Serial.write(currentStatus.secl);
@@ -1051,7 +1051,7 @@ void sendValuesLegacy()
   bytestosend -= Serial.write(temp>>8);
   bytestosend -= Serial.write(temp);
 
-  for(int i = 0; i < bytestosend; i++)
+  for(int16_t i = 0; i < bytestosend; i++)
   {
     // send dummy data to fill remote's buffer
     Serial.write(99);
@@ -1062,7 +1062,7 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
 {
 
   void* pnt_configPage;//This only stores the address of the value that it's pointing to and not the max size
-  int tempOffset;
+  int16_t tempOffset;
 
   switch (currentPage)
   {
@@ -1077,13 +1077,13 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
         if (valueOffset < 272)
         {
           //X Axis
-          fuelTable.axisX[(valueOffset - 256)] = ((int)(newValue) * TABLE_RPM_MULTIPLIER); //The RPM values sent by megasquirt are divided by 100, need to multiple it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+          fuelTable.axisX[(valueOffset - 256)] = ((int16_t)(newValue) * TABLE_RPM_MULTIPLIER); //The RPM values sent by megasquirt are divided by 100, need to multiple it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
         }
         else if(valueOffset < 288)
         {
           //Y Axis
           tempOffset = 15 - (valueOffset - 272); //Need to do a translation to flip the order (Due to us using (0,0) in the top left rather than bottom right
-          fuelTable.axisY[tempOffset] = (int)(newValue) * TABLE_LOAD_MULTIPLIER;
+          fuelTable.axisY[tempOffset] = (int16_t)(newValue) * TABLE_LOAD_MULTIPLIER;
         }
         else
         {
@@ -1113,13 +1113,13 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
         if (valueOffset < 272)
         {
           //X Axis
-          ignitionTable.axisX[(valueOffset - 256)] = (int)(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiple it back by 100 to make it correct
+          ignitionTable.axisX[(valueOffset - 256)] = (int16_t)(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiple it back by 100 to make it correct
         }
         else if(valueOffset < 288)
         {
           //Y Axis
           tempOffset = 15 - (valueOffset - 272); //Need to do a translation to flip the order
-          ignitionTable.axisY[tempOffset] = (int)(newValue) * TABLE_LOAD_MULTIPLIER;
+          ignitionTable.axisY[tempOffset] = (int16_t)(newValue) * TABLE_LOAD_MULTIPLIER;
         }
       }
       ignitionTable.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
@@ -1145,13 +1145,13 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
         if (valueOffset < 272)
         {
           //X Axis
-          afrTable.axisX[(valueOffset - 256)] = int(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+          afrTable.axisX[(valueOffset - 256)] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
         }
         else
         {
           //Y Axis
           tempOffset = 15 - (valueOffset - 272); //Need to do a translation to flip the order
-          afrTable.axisY[tempOffset] = int(newValue) * TABLE_LOAD_MULTIPLIER;
+          afrTable.axisY[tempOffset] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER;
 
         }
       }
@@ -1174,11 +1174,11 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
       }
       else if (valueOffset < 72) //New value is on the X (RPM) axis of the boost table
       {
-        boostTable.axisX[(valueOffset - 64)] = int(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+        boostTable.axisX[(valueOffset - 64)] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
       }
       else if (valueOffset < 80) //New value is on the Y (TPS) axis of the boost table
       {
-        boostTable.axisY[(7 - (valueOffset - 72))] = int(newValue); //TABLE_LOAD_MULTIPLIER is NOT used for boost as it is TPS based (0-100)
+        boostTable.axisY[(7 - (valueOffset - 72))] = int16_t(newValue); //TABLE_LOAD_MULTIPLIER is NOT used for boost as it is TPS based (0-100)
       }
       //End of boost table
       else if (valueOffset < 144) //New value is part of the vvt map
@@ -1189,12 +1189,12 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
       else if (valueOffset < 152) //New value is on the X (RPM) axis of the vvt table
       {
         tempOffset = valueOffset - 144;
-        vvtTable.axisX[tempOffset] = int(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+        vvtTable.axisX[tempOffset] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
       }
       else if (valueOffset < 160) //New value is on the Y (Load) axis of the vvt table
       {
         tempOffset = valueOffset - 152;
-        vvtTable.axisY[(7 - tempOffset)] = int(newValue); //TABLE_LOAD_MULTIPLIER is NOT used for vvt as it is TPS based (0-100)
+        vvtTable.axisY[(7 - tempOffset)] = int16_t(newValue); //TABLE_LOAD_MULTIPLIER is NOT used for vvt as it is TPS based (0-100)
       }
       //End of vvt table
       else if (valueOffset < 224) //New value is part of the staging map
@@ -1205,12 +1205,12 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
       else if (valueOffset < 232) //New value is on the X (RPM) axis of the staging table
       {
         tempOffset = valueOffset - 224;
-        stagingTable.axisX[tempOffset] = int(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+        stagingTable.axisX[tempOffset] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
       }
       else if (valueOffset < 240) //New value is on the Y (Load) axis of the staging table
       {
         tempOffset = valueOffset - 232;
-        stagingTable.axisY[(7 - tempOffset)] = int(newValue) * TABLE_LOAD_MULTIPLIER;
+        stagingTable.axisY[(7 - tempOffset)] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER;
       }
       boostTable.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
       vvtTable.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
@@ -1219,20 +1219,20 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
 
     case seqFuelPage:
       if (valueOffset < 36) { trim1Table.values[5 - (valueOffset / 6)][valueOffset % 6] = newValue; } //Trim1 values
-      else if (valueOffset < 42) { trim1Table.axisX[(valueOffset - 36)] = int(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the trim1 table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
-      else if (valueOffset < 48) { trim1Table.axisY[(5 - (valueOffset - 42))] = int(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (TPS) axis of the boost table
+      else if (valueOffset < 42) { trim1Table.axisX[(valueOffset - 36)] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the trim1 table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+      else if (valueOffset < 48) { trim1Table.axisY[(5 - (valueOffset - 42))] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (TPS) axis of the boost table
       //Trim table 2
       else if (valueOffset < 84) { tempOffset = valueOffset - 48; trim2Table.values[5 - (tempOffset / 6)][tempOffset % 6] = newValue; } //New value is part of the trim2 map
-      else if (valueOffset < 90) { tempOffset = valueOffset - 84; trim2Table.axisX[tempOffset] = int(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
-      else if (valueOffset < 96) { tempOffset = valueOffset - 90; trim2Table.axisY[(5 - tempOffset)] = int(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
+      else if (valueOffset < 90) { tempOffset = valueOffset - 84; trim2Table.axisX[tempOffset] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+      else if (valueOffset < 96) { tempOffset = valueOffset - 90; trim2Table.axisY[(5 - tempOffset)] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
       //Trim table 3
       else if (valueOffset < 132) { tempOffset = valueOffset - 96; trim3Table.values[5 - (tempOffset / 6)][tempOffset % 6] = newValue; } //New value is part of the trim3 map
-      else if (valueOffset < 138) { tempOffset = valueOffset - 132; trim3Table.axisX[tempOffset] = int(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
-      else if (valueOffset < 144) { tempOffset = valueOffset - 138; trim3Table.axisY[(5 - tempOffset)] = int(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
+      else if (valueOffset < 138) { tempOffset = valueOffset - 132; trim3Table.axisX[tempOffset] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+      else if (valueOffset < 144) { tempOffset = valueOffset - 138; trim3Table.axisY[(5 - tempOffset)] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
       //Trim table 4
       else if (valueOffset < 180) { tempOffset = valueOffset - 144; trim4Table.values[5 - (tempOffset / 6)][tempOffset % 6] = newValue; } //New value is part of the trim4 map
-      else if (valueOffset < 186) { tempOffset = valueOffset - 180; trim4Table.axisX[tempOffset] = int(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
-      else if (valueOffset < 192) { tempOffset = valueOffset - 186; trim4Table.axisY[(5 - tempOffset)] = int(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
+      else if (valueOffset < 186) { tempOffset = valueOffset - 180; trim4Table.axisX[tempOffset] = int16_t(newValue) * TABLE_RPM_MULTIPLIER; } //New value is on the X (RPM) axis of the table. The RPM values sent by TunerStudio are divided by 100, need to multiply it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+      else if (valueOffset < 192) { tempOffset = valueOffset - 186; trim4Table.axisY[(5 - tempOffset)] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER; } //New value is on the Y (Load) axis of the table
 
       trim1Table.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
       trim2Table.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
@@ -1269,13 +1269,13 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
         if (valueOffset < 272)
         {
           //X Axis
-          fuelTable2.axisX[(valueOffset - 256)] = ((int)(newValue) * TABLE_RPM_MULTIPLIER); //The RPM values sent by megasquirt are divided by 100, need to multiple it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
+          fuelTable2.axisX[(valueOffset - 256)] = ((int16_t)(newValue) * TABLE_RPM_MULTIPLIER); //The RPM values sent by megasquirt are divided by 100, need to multiple it back by 100 to make it correct (TABLE_RPM_MULTIPLIER)
         }
         else if(valueOffset < 288)
         {
           //Y Axis
           tempOffset = 15 - (valueOffset - 272); //Need to do a translation to flip the order (Due to us using (0,0) in the top left rather than bottom right
-          fuelTable2.axisY[tempOffset] = (int)(newValue) * TABLE_LOAD_MULTIPLIER;
+          fuelTable2.axisY[tempOffset] = (int16_t)(newValue) * TABLE_LOAD_MULTIPLIER;
         }
         else
         {
@@ -1292,11 +1292,11 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
       }
       else if (valueOffset < 72) //New value is on the X (RPM) axis of the wmi table
       {
-        wmiTable.axisX[(valueOffset - 64)] = int(newValue) * TABLE_RPM_MULTIPLIER;
+        wmiTable.axisX[(valueOffset - 64)] = int16_t(newValue) * TABLE_RPM_MULTIPLIER;
       }
       else if (valueOffset < 80) //New value is on the Y (MAP) axis of the boost table
       {
-        wmiTable.axisY[(7 - (valueOffset - 72))] = int(newValue) * TABLE_LOAD_MULTIPLIER;
+        wmiTable.axisY[(7 - (valueOffset - 72))] = int16_t(newValue) * TABLE_LOAD_MULTIPLIER;
       }
       break;
       
@@ -1323,13 +1323,13 @@ void receiveValue(uint16_t valueOffset, uint8_t newValue)
         if (valueOffset < 272)
         {
           //X Axis
-          ignitionTable2.axisX[(valueOffset - 256)] = (int)(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiple it back by 100 to make it correct
+          ignitionTable2.axisX[(valueOffset - 256)] = (int16_t)(newValue) * TABLE_RPM_MULTIPLIER; //The RPM values sent by TunerStudio are divided by 100, need to multiple it back by 100 to make it correct
         }
         else if(valueOffset < 288)
         {
           //Y Axis
           tempOffset = 15 - (valueOffset - 272); //Need to do a translation to flip the order
-          ignitionTable2.axisY[tempOffset] = (int)(newValue) * TABLE_LOAD_MULTIPLIER;
+          ignitionTable2.axisY[tempOffset] = (int16_t)(newValue) * TABLE_LOAD_MULTIPLIER;
         }
       }
       ignitionTable2.cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
@@ -1382,19 +1382,19 @@ void sendPage()
       uint8_t response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
 
       //Boost table
-      for (int x = 0; x < 64; x++) { response[x] = boostTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = uint8_t(boostTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = uint8_t(boostTable.axisY[7 - (y - 72)]); }
+      for (int16_t x = 0; x < 64; x++) { response[x] = boostTable.values[7 - (x / 8)][x % 8]; }
+      for (int16_t x = 64; x < 72; x++) { response[x] = uint8_t(boostTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 72; y < 80; y++) { response[y] = uint8_t(boostTable.axisY[7 - (y - 72)]); }
       Serial.write((uint8_t *)&response, 80);
       //VVT table
-      for (int x = 0; x < 64; x++) { response[x] = vvtTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = uint8_t(vvtTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = uint8_t(vvtTable.axisY[7 - (y - 72)]); }
+      for (int16_t x = 0; x < 64; x++) { response[x] = vvtTable.values[7 - (x / 8)][x % 8]; }
+      for (int16_t x = 64; x < 72; x++) { response[x] = uint8_t(vvtTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 72; y < 80; y++) { response[y] = uint8_t(vvtTable.axisY[7 - (y - 72)]); }
       Serial.write((uint8_t *)&response, 80);
       //Staging table
-      for (int x = 0; x < 64; x++) { response[x] = stagingTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = uint8_t(stagingTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = uint8_t(stagingTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 64; x++) { response[x] = stagingTable.values[7 - (x / 8)][x % 8]; }
+      for (int16_t x = 64; x < 72; x++) { response[x] = uint8_t(stagingTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 72; y < 80; y++) { response[y] = uint8_t(stagingTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
       Serial.write((uint8_t *)&response, 80);
       sendComplete = true;
       break;
@@ -1405,21 +1405,21 @@ void sendPage()
       uint8_t response[192]; //Bit hacky, but the size is: (6x6 + 6 + 6) * 4 = 192
 
       //trim1 table
-      for (int x = 0; x < 36; x++) { response[x] = trim1Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x] = uint8_t(trim1Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y] = uint8_t(trim1Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 36; x++) { response[x] = trim1Table.values[5 - (x / 6)][x % 6]; }
+      for (int16_t x = 36; x < 42; x++) { response[x] = uint8_t(trim1Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 42; y < 48; y++) { response[y] = uint8_t(trim1Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim2 table
-      for (int x = 0; x < 36; x++) { response[x + 48] = trim2Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 48] = uint8_t(trim2Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 48] = uint8_t(trim2Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 36; x++) { response[x + 48] = trim2Table.values[5 - (x / 6)][x % 6]; }
+      for (int16_t x = 36; x < 42; x++) { response[x + 48] = uint8_t(trim2Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 42; y < 48; y++) { response[y + 48] = uint8_t(trim2Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim3 table
-      for (int x = 0; x < 36; x++) { response[x + 96] = trim3Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 96] = uint8_t(trim3Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 96] = uint8_t(trim3Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 36; x++) { response[x + 96] = trim3Table.values[5 - (x / 6)][x % 6]; }
+      for (int16_t x = 36; x < 42; x++) { response[x + 96] = uint8_t(trim3Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 42; y < 48; y++) { response[y + 96] = uint8_t(trim3Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       //trim4 table
-      for (int x = 0; x < 36; x++) { response[x + 144] = trim4Table.values[5 - (x / 6)][x % 6]; }
-      for (int x = 36; x < 42; x++) { response[x + 144] = uint8_t(trim4Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 42; y < 48; y++) { response[y + 144] = uint8_t(trim4Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 36; x++) { response[x + 144] = trim4Table.values[5 - (x / 6)][x % 6]; }
+      for (int16_t x = 36; x < 42; x++) { response[x + 144] = uint8_t(trim4Table.axisX[(x - 36)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 42; y < 48; y++) { response[y + 144] = uint8_t(trim4Table.axisY[5 - (y - 42)] / TABLE_LOAD_MULTIPLIER); }
       Serial.write((uint8_t *)&response, sizeof(response));
       sendComplete = true;
       break;
@@ -1442,9 +1442,9 @@ void sendPage()
       uint8_t response[80]; //Bit hacky, but send 1 map at a time (Each map is 8x8, so 64 + 8 + 8)
 
       //Boost table
-      for (int x = 0; x < 64; x++) { response[x] = wmiTable.values[7 - (x / 8)][x % 8]; }
-      for (int x = 64; x < 72; x++) { response[x] = uint8_t(wmiTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
-      for (int y = 72; y < 80; y++) { response[y] = uint8_t(wmiTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
+      for (int16_t x = 0; x < 64; x++) { response[x] = wmiTable.values[7 - (x / 8)][x % 8]; }
+      for (int16_t x = 64; x < 72; x++) { response[x] = uint8_t(wmiTable.axisX[(x - 64)] / TABLE_RPM_MULTIPLIER); }
+      for (int16_t y = 72; y < 80; y++) { response[y] = uint8_t(wmiTable.axisY[7 - (y - 72)] / TABLE_LOAD_MULTIPLIER); }
       Serial.write((uint8_t *)&response, 80);
       break;
     }
@@ -1475,11 +1475,11 @@ void sendPage()
         //MS format has origin (0,0) in the bottom left corner, we use the top left for efficiency reasons
         uint8_t response[MAP_PAGE_SIZE];
 
-        for (int x = 0; x < 256; x++) { response[x] = currentTable.values[15 - (x / 16)][x % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
+        for (int16_t x = 0; x < 256; x++) { response[x] = currentTable.values[15 - (x / 16)][x % 16]; } //This is slightly non-intuitive, but essentially just flips the table vertically (IE top line becomes the bottom line etc). Columns are unchanged. Every 16 loops, manually call loop() to avoid potential misses
         //loop();
-        for (int x = 256; x < 272; x++) { response[x] = uint8_t(currentTable.axisX[(x - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
+        for (int16_t x = 256; x < 272; x++) { response[x] = uint8_t(currentTable.axisX[(x - 256)] / TABLE_RPM_MULTIPLIER); }  //RPM Bins for VE table (Need to be dvidied by 100)
         //loop();
-        for (int y = 272; y < 288; y++) { response[y] = uint8_t(currentTable.axisY[15 - (y - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
+        for (int16_t y = 272; y < 288; y++) { response[y] = uint8_t(currentTable.axisY[15 - (y - 272)] / TABLE_LOAD_MULTIPLIER); } //MAP or TPS bins for VE table
         //loop();
         Serial.write((uint8_t *)&response, sizeof(response));
     } //is map
@@ -1688,7 +1688,7 @@ void sendPageASCII()
 
     case seqFuelPage:
       currentTable = trim1Table;
-      for (int y = 0; y < currentTable.ySize; y++)
+      for (int16_t y = 0; y < currentTable.ySize; y++)
       {
         uint8_t axisY = uint8_t(currentTable.axisY[y]);
         if (axisY < 100)
@@ -1701,7 +1701,7 @@ void sendPageASCII()
         }
         Serial.print(axisY);// Vertical Bins
         Serial.write(" ");
-        for (int i = 0; i < currentTable.xSize; i++)
+        for (int16_t i = 0; i < currentTable.xSize; i++)
         {
           uint8_t value = currentTable.values[y][i];
           if (value < 100)
@@ -1777,7 +1777,7 @@ void sendPageASCII()
 
         Serial.println((const __FlashStringHelper *)&pageTitles[currentTitleIndex]);// F macro hack
         Serial.println();
-        for (int y = 0; y < currentTable.ySize; y++)
+        for (int16_t y = 0; y < currentTable.ySize; y++)
         {
           uint8_t axisY = uint8_t(currentTable.axisY[y]);
           if (axisY < 100)
@@ -1790,7 +1790,7 @@ void sendPageASCII()
           }
           Serial.print(axisY);// Vertical Bins
           Serial.write(spaceChar);
-          for (int i = 0; i < currentTable.xSize; i++)
+          for (int16_t i = 0; i < currentTable.xSize; i++)
           {
             uint8_t value = currentTable.values[y][i];
             if (value < 100)
@@ -1807,7 +1807,7 @@ void sendPageASCII()
           Serial.println();
         }
         Serial.print(F("    "));
-        for (int x = 0; x < currentTable.xSize; x++)// Horizontal bins
+        for (int16_t x = 0; x < currentTable.xSize; x++)// Horizontal bins
         {
           uint8_t axisX = uint8_t(currentTable.axisX[x] / 100);
           if (axisX < 100)
@@ -2027,7 +2027,7 @@ void receiveCalibration(uint8_t tableID)
 {
   void* pnt_TargetTable_values; //Pointer that will be used to point to the required target table values
   uint16_t* pnt_TargetTable_bins;   //Pointer that will be used to point to the required target table bins
-  int OFFSET, DIVISION_FACTOR;
+  int16_t OFFSET, DIVISION_FACTOR;
 
   switch (tableID)
   {
@@ -2068,7 +2068,7 @@ void receiveCalibration(uint8_t tableID)
   if(tableID == 2)
   {
     //O2 calibration. Comes through as 1024 8-bit values of which we use every 32nd
-    for (int x = 0; x < 1024; x++)
+    for (int16_t x = 0; x < 1024; x++)
     {
       while ( Serial.available() < 1 ) {}
       tempValue = Serial.read();
@@ -2118,7 +2118,7 @@ void sendToothLog(uint8_t startOffset)
   //We need TOOTH_LOG_SIZE number of records to send to TunerStudio. If there aren't that many in the buffer then we just return and wait for the next call
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_TOOTHLOG1READY)) //Sanity check. Flagging system means this should always be true
   {
-      for (int x = startOffset; x < TOOTH_LOG_SIZE; x++)
+      for (int16_t x = startOffset; x < TOOTH_LOG_SIZE; x++)
       {
         //Check whether the tx buffer still has space
         if(Serial.availableForWrite() < 4) 
@@ -2145,7 +2145,7 @@ void sendToothLog(uint8_t startOffset)
   else 
   { 
     //TunerStudio has timed out, send a LOG of all 0s
-    for(int x = 0; x < (4*TOOTH_LOG_SIZE); x++)
+    for(int16_t x = 0; x < (4*TOOTH_LOG_SIZE); x++)
     {
       Serial.write(static_cast<uint8_t>(0x00)); //GCC9 fix
     }
@@ -2158,7 +2158,7 @@ void sendCompositeLog(uint8_t startOffset)
   if (BIT_CHECK(currentStatus.status1, BIT_STATUS1_TOOTHLOG1READY)) //Sanity check. Flagging system means this should always be true
   {
       if(startOffset == 0) { inProgressCompositeTime = 0; }
-      for (int x = startOffset; x < TOOTH_LOG_SIZE; x++)
+      for (int16_t x = startOffset; x < TOOTH_LOG_SIZE; x++)
       {
         //Check whether the tx buffer still has space
         if(Serial.availableForWrite() < 4) 
@@ -2192,7 +2192,7 @@ void sendCompositeLog(uint8_t startOffset)
   else 
   { 
     //TunerStudio has timed out, send a LOG of all 0s
-    for(int x = 0; x < (5*TOOTH_LOG_SIZE); x++)
+    for(int16_t x = 0; x < (5*TOOTH_LOG_SIZE); x++)
     {
       Serial.write(static_cast<uint8_t>(0x00)); //GCC9 fix
     }

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -39,8 +39,8 @@ int8_t correctionKnock(int8_t);
 
 uint16_t correctionsDwell(uint16_t dwell);
 
-extern int MAP_rateOfChange;
-extern int TPS_rateOfChange;
+extern int16_t MAP_rateOfChange;
+extern int16_t TPS_rateOfChange;
 extern uint8_t activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
 extern uint8_t activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
 

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -8,18 +8,18 @@ All functions in the gamma file return
 void initialiseCorrections();
 
 uint16_t correctionsFuel();
-byte correctionWUE(); //Warmup enrichment
+uint8_t correctionWUE(); //Warmup enrichment
 uint16_t correctionCranking(); //Cranking enrichment
-byte correctionASE(); //After Start Enrichment
+uint8_t correctionASE(); //After Start Enrichment
 uint16_t correctionAccel(); //Acceleration Enrichment
-byte correctionFloodClear(); //Check for flood clear on cranking
-byte correctionAFRClosedLoop(); //Closed loop AFR adjustment
-byte correctionFlex(); //Flex fuel adjustment
-byte correctionFuelTemp(); //Fuel temp correction
-byte correctionBatVoltage(); //Battery voltage correction
-byte correctionIATDensity(); //Inlet temp density correction
-byte correctionBaro(); //Barometric pressure correction
-byte correctionLaunch(); //Launch control correction
+uint8_t correctionFloodClear(); //Check for flood clear on cranking
+uint8_t correctionAFRClosedLoop(); //Closed loop AFR adjustment
+uint8_t correctionFlex(); //Flex fuel adjustment
+uint8_t correctionFuelTemp(); //Fuel temp correction
+uint8_t correctionBatVoltage(); //Battery voltage correction
+uint8_t correctionIATDensity(); //Inlet temp density correction
+uint8_t correctionBaro(); //Barometric pressure correction
+uint8_t correctionLaunch(); //Launch control correction
 bool correctionDFCO(); //Decelleration fuel cutoff
 
 
@@ -41,12 +41,12 @@ uint16_t correctionsDwell(uint16_t dwell);
 
 extern int MAP_rateOfChange;
 extern int TPS_rateOfChange;
-extern byte activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
-extern byte activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
+extern uint8_t activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
+extern uint8_t activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
 
 extern uint16_t AFRnextCycle;
 extern unsigned long knockStartTime;
-extern byte lastKnockCount;
+extern uint8_t lastKnockCount;
 extern int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 extern int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid
 extern uint16_t aseTaperStart;

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -45,7 +45,7 @@ extern uint8_t activateMAPDOT; //The mapDOT value seen when the MAE was activate
 extern uint8_t activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
 
 extern uint16_t AFRnextCycle;
-extern unsigned long knockStartTime;
+extern uint32_t knockStartTime;
 extern uint8_t lastKnockCount;
 extern int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 extern int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -24,8 +24,8 @@ Flood clear mode etc.
 long PID_O2, PID_output, PID_AFRTarget;
 PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
 
-int MAP_rateOfChange;
-int TPS_rateOfChange;
+int16_t MAP_rateOfChange;
+int16_t TPS_rateOfChange;
 uint8_t activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
 uint8_t activateTPSDOT; //The tpsDOT value seen when the MAE was activated.
 
@@ -360,10 +360,10 @@ uint16_t correctionAccel()
           }
 
           //Apply AE cold coolant modifier, if CLT is less than taper end temperature
-          if ( currentStatus.coolant < (int)(configPage2.aeColdTaperMax - CALIBRATION_TEMPERATURE_OFFSET) )
+          if ( currentStatus.coolant < (int16_t)(configPage2.aeColdTaperMax - CALIBRATION_TEMPERATURE_OFFSET) )
           {
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
-            if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
+            if ( currentStatus.coolant <= (int16_t)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
               uint16_t accelValue_uint = (uint16_t) accelValue * configPage2.aeColdPct / 100;
               accelValue = (int16_t) accelValue_uint;
@@ -372,7 +372,7 @@ uint16_t correctionAccel()
             else
             {
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
-              int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
+              int16_t taperPercent = (int16_t)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
               uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
               accelValue = (int16_t) accelValue_uint;
@@ -419,10 +419,10 @@ uint16_t correctionAccel()
           }
 
           //Apply AE cold coolant modifier, if CLT is less than taper end temperature
-          if ( currentStatus.coolant < (int)(configPage2.aeColdTaperMax - CALIBRATION_TEMPERATURE_OFFSET) )
+          if ( currentStatus.coolant < (int16_t)(configPage2.aeColdTaperMax - CALIBRATION_TEMPERATURE_OFFSET) )
           {
             //If CLT is less than taper min temp, apply full modifier on top of accelValue
-            if ( currentStatus.coolant <= (int)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
+            if ( currentStatus.coolant <= (int16_t)(configPage2.aeColdTaperMin - CALIBRATION_TEMPERATURE_OFFSET) )
             {
               uint16_t accelValue_uint = (uint16_t) accelValue * configPage2.aeColdPct / 100;
               accelValue = (int16_t) accelValue_uint;
@@ -431,7 +431,7 @@ uint16_t correctionAccel()
             else
             {
               int16_t taperRange = (int16_t) configPage2.aeColdTaperMax - configPage2.aeColdTaperMin;
-              int16_t taperPercent = (int)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
+              int16_t taperPercent = (int16_t)((currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET - configPage2.aeColdTaperMin) * 100) / taperRange;
               int16_t coldPct = (int16_t) 100+ percentage((100-taperPercent), configPage2.aeColdPct-100);
               uint16_t accelValue_uint = (uint16_t) accelValue * coldPct / 100; //Potential overflow (if AE is large) without using uint16_t
               accelValue = (int16_t) accelValue_uint;
@@ -528,7 +528,7 @@ bool correctionDFCO()
     }
     else 
     {
-      if ( ( currentStatus.coolant >= (int)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET) ) && ( currentStatus.RPM > (unsigned int)( (configPage4.dfcoRPM * 10) + configPage4.dfcoHyster) ) && ( currentStatus.TPS < configPage4.dfcoTPSThresh ) )
+      if ( ( currentStatus.coolant >= (int16_t)(configPage2.dfcoMinCLT - CALIBRATION_TEMPERATURE_OFFSET) ) && ( currentStatus.RPM > (uint16_t)( (configPage4.dfcoRPM * 10) + configPage4.dfcoHyster) ) && ( currentStatus.TPS < configPage4.dfcoTPSThresh ) )
       {
         if ( dfcoStart == 0 ) { dfcoStart = runSecsX10; }
         if( (runSecsX10 - dfcoStart) > configPage2.dfcoDelay ) { DFCOValue = true; }
@@ -603,7 +603,7 @@ uint8_t correctionAFRClosedLoop()
       AFRnextCycle = ignitionCount + configPage6.egoCount; //Set the target ignition event for the next calculation
         
       //Check all other requirements for closed loop adjustments
-      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS < configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) )
+      if( (currentStatus.coolant > (int16_t)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (uint16_t)(configPage6.egoRPM * 100)) && (currentStatus.TPS < configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) )
       {
 
         //Check which algorithm is used, simple or PID
@@ -750,13 +750,13 @@ int8_t correctionIdleAdvance(int8_t advance)
     // Limit idle rpm delta between -500rpm - 500rpm
     if(idleRPMdelta > 100) { idleRPMdelta = 100; }
     if(idleRPMdelta < 0) { idleRPMdelta = 0; }
-    if( (configPage2.idleAdvAlgorithm == 0) && ((currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100)) && (currentStatus.TPS < configPage2.idleAdvTPS))) // TPS based idle state
+    if( (configPage2.idleAdvAlgorithm == 0) && ((currentStatus.RPM < (uint16_t)(configPage2.idleAdvRPM * 100)) && (currentStatus.TPS < configPage2.idleAdvTPS))) // TPS based idle state
     {
       int8_t advanceIdleAdjust = (int16_t)(table2D_getValue(&idleAdvanceTable, idleRPMdelta)) - 15;
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }
       else if(configPage2.idleAdvEnabled == 2) { ignIdleValue = advanceIdleAdjust; }
     }
-    else if( (configPage2.idleAdvAlgorithm == 1) && (currentStatus.RPM < (unsigned int)(configPage2.idleAdvRPM * 100) && (currentStatus.CTPSActive == 1) )) // closed throttle position sensor (CTPS) based idle state
+    else if( (configPage2.idleAdvAlgorithm == 1) && (currentStatus.RPM < (uint16_t)(configPage2.idleAdvRPM * 100) && (currentStatus.CTPSActive == 1) )) // closed throttle position sensor (CTPS) based idle state
     {
       int8_t advanceIdleAdjust = (int16_t)(table2D_getValue(&idleAdvanceTable, idleRPMdelta)) - 15;
       if(configPage2.idleAdvEnabled == 1) { ignIdleValue = (advance + advanceIdleAdjust); }
@@ -770,7 +770,7 @@ int8_t correctionSoftRevLimit(int8_t advance)
 {
   uint8_t ignSoftRevValue = advance;
   BIT_CLEAR(currentStatus.spark, BIT_SPARK_SFTLIM);
-  if (currentStatus.RPM > ((unsigned int)(configPage4.SoftRevLim) * 100) ) //Softcut RPM limit
+  if (currentStatus.RPM > ((uint16_t)(configPage4.SoftRevLim) * 100) ) //Softcut RPM limit
   {
     BIT_SET(currentStatus.spark, BIT_SPARK_SFTLIM);
     if (configPage2.SoftLimitMode == SOFT_LIMIT_RELATIVE) { ignSoftRevValue = ignSoftRevValue - configPage4.SoftLimRetard; } //delay timing by configured number of degrees in relative mode
@@ -805,7 +805,7 @@ int8_t correctionSoftLaunch(int8_t advance)
 {
   uint8_t ignSoftLaunchValue = advance;
   //SoftCut rev limit for 2-step launch control.
-  if (configPage6.launchEnabled && clutchTrigger && (currentStatus.clutchEngagedRPM < ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > ((unsigned int)(configPage6.lnchSoftLim) * 100)) && (currentStatus.TPS >= configPage10.lnchCtrlTPS) )
+  if (configPage6.launchEnabled && clutchTrigger && (currentStatus.clutchEngagedRPM < ((uint16_t)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > ((uint16_t)(configPage6.lnchSoftLim) * 100)) && (currentStatus.TPS >= configPage10.lnchCtrlTPS) )
   {
     currentStatus.launchingSoft = true;
     BIT_SET(currentStatus.spark, BIT_SPARK_SLAUNCH);
@@ -824,7 +824,7 @@ int8_t correctionSoftFlatShift(int8_t advance)
 {
   uint8_t ignSoftFlatValue = advance;
 
-  if(configPage6.flatSEnable && clutchTrigger && (currentStatus.clutchEngagedRPM > ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > (currentStatus.clutchEngagedRPM-configPage6.flatSSoftWin) ) )
+  if(configPage6.flatSEnable && clutchTrigger && (currentStatus.clutchEngagedRPM > ((uint16_t)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > (currentStatus.clutchEngagedRPM-configPage6.flatSSoftWin) ) )
   {
     BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
     ignSoftFlatValue = configPage6.flatSRetard;

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -26,12 +26,12 @@ PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.
 
 int MAP_rateOfChange;
 int TPS_rateOfChange;
-byte activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
-byte activateTPSDOT; //The tpsDOT value seen when the MAE was activated.
+uint8_t activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
+uint8_t activateTPSDOT; //The tpsDOT value seen when the MAE was activated.
 
 uint16_t AFRnextCycle;
 unsigned long knockStartTime;
-byte lastKnockCount;
+uint8_t lastKnockCount;
 int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid
 uint16_t aseTaperStart;
@@ -55,7 +55,7 @@ uint16_t correctionsFuel()
 {
   #define MAX_CORRECTIONS 3 //The maximum number of corrections allowed before the sum is reprocessed
   uint32_t sumCorrections = 100;
-  byte activeCorrections = 0;
+  uint8_t activeCorrections = 0;
   uint16_t result; //temporary variable to store the result of each corrections function
 
   //The values returned by each of the correction functions are multipled together and then divided back to give a single 0-255 value.
@@ -127,10 +127,10 @@ uint16_t correctionsFuel()
 correctionsTotal() calls all the other corrections functions and combines their results.
 This is the only function that should be called from anywhere outside the file
 */
-static inline byte correctionsFuel_new()
+static inline uint8_t correctionsFuel_new()
 {
   uint32_t sumCorrections = 100;
-  byte numCorrections = 0;
+  uint8_t numCorrections = 0;
 
   //The values returned by each of the correction functions are multipled together and then divided back to give a single 0-255 value.
   currentStatus.wueCorrection = correctionWUE(); numCorrections++;
@@ -167,9 +167,9 @@ static inline byte correctionsFuel_new()
 Warm Up Enrichment (WUE)
 Uses a 2D enrichment table (WUETable) where the X axis is engine temp and the Y axis is the amount of extra fuel to add
 */
-byte correctionWUE()
+uint8_t correctionWUE()
 {
-  byte WUEValue;
+  uint8_t WUEValue;
   //Possibly reduce the frequency this runs at (Costs about 50 loops per second)
   //if (currentStatus.coolant > (WUETable.axisX[9] - CALIBRATION_TEMPERATURE_OFFSET))
   if (currentStatus.coolant > (table2D_getAxisValue(&WUETable, 9) - CALIBRATION_TEMPERATURE_OFFSET))
@@ -222,7 +222,7 @@ uint16_t correctionCranking()
  * 
  * @return uint8_t The After Start Enrichment modifier as a %. 100% = No modification. 
  */
-byte correctionASE()
+uint8_t correctionASE()
 {
   int16_t ASEValue;
   //Two checks are requiredL:
@@ -254,7 +254,7 @@ byte correctionASE()
     //Safety checks
     if(ASEValue > 255) { ASEValue = 255; }
     if(ASEValue < 0) { ASEValue = 0; }
-    currentStatus.ASEValue = (byte)ASEValue;
+    currentStatus.ASEValue = (uint8_t)ASEValue;
   }
   return currentStatus.ASEValue;
 }
@@ -451,9 +451,9 @@ uint16_t correctionAccel()
 Simple check to see whether we are cranking with the TPS above the flood clear threshold
 This function always returns either 100 or 0
 */
-byte correctionFloodClear()
+uint8_t correctionFloodClear()
 {
-  byte floodValue = 100;
+  uint8_t floodValue = 100;
   if( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) )
   {
     //Engine is currently cranking, check what the TPS is
@@ -470,9 +470,9 @@ byte correctionFloodClear()
 Battery Voltage correction
 Uses a 2D enrichment table (WUETable) where the X axis is engine temp and the Y axis is the amount of extra fuel to add
 */
-byte correctionBatVoltage()
+uint8_t correctionBatVoltage()
 {
-  byte batValue = 100;
+  uint8_t batValue = 100;
   batValue = table2D_getValue(&injectorVCorrectionTable, currentStatus.battery10);
   return batValue;
 }
@@ -481,9 +481,9 @@ byte correctionBatVoltage()
 Simple temperature based corrections lookup based on the inlet air temperature.
 This corrects for changes in air density from movement of the temperature
 */
-byte correctionIATDensity()
+uint8_t correctionIATDensity()
 {
-  byte IATValue = 100;
+  uint8_t IATValue = 100;
   IATValue = table2D_getValue(&IATDensityCorrectionTable, currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); //currentStatus.IAT is the actual temperature, values in IATDensityCorrectionTable.axisX are temp+offset
 
   return IATValue;
@@ -493,9 +493,9 @@ byte correctionIATDensity()
  * @brief 
  * @returns A percentage value indicating the amount the fueling should be changed based on the barometric reading. 100 = No change. 110 = 10% increase. 90 = 10% decrease
  */
-byte correctionBaro()
+uint8_t correctionBaro()
 {
-  byte baroValue = 100;
+  uint8_t baroValue = 100;
   baroValue = table2D_getValue(&baroFuelTable, currentStatus.baro);
 
   return baroValue;
@@ -505,9 +505,9 @@ byte correctionBaro()
 Launch control has a setting to increase the fuel load to assist in bringing up boost
 This simple check applies the extra fuel if we're currently launching
 */
-byte correctionLaunch()
+uint8_t correctionLaunch()
 {
-  byte launchValue = 100;
+  uint8_t launchValue = 100;
   if(currentStatus.launchingHard || currentStatus.launchingSoft) { launchValue = (100 + configPage6.lnchFuelAdd); }
 
   return launchValue;
@@ -543,9 +543,9 @@ bool correctionDFCO()
  * Flex fuel adjustment to vary fuel based on ethanol content
  * The amount of extra fuel required is a linear relationship based on the % of ethanol.
 */
-byte correctionFlex()
+uint8_t correctionFlex()
 {
-  byte flexValue = 100;
+  uint8_t flexValue = 100;
 
   if (configPage2.flexEnabled == 1)
   {
@@ -557,9 +557,9 @@ byte correctionFlex()
 /*
  * Fuel temperature adjustment to vary fuel based on fuel temperature reading
 */
-byte correctionFuelTemp()
+uint8_t correctionFuelTemp()
 {
-  byte fuelTempValue = 100;
+  uint8_t fuelTempValue = 100;
 
   if (configPage2.flexEnabled == 1)
   {
@@ -581,9 +581,9 @@ This continues until either:
 PID (Best suited to wideband sensors):
 
 */
-byte correctionAFRClosedLoop()
+uint8_t correctionAFRClosedLoop()
 {
-  byte AFRValue = 100;
+  uint8_t AFRValue = 100;
   
   if( (configPage6.egoType > 0) || (configPage2.incorporateAFR == true) ) //afrTarget value lookup must be done if O2 sensor is enabled, and always if incorporateAFR is enabled
   {
@@ -687,7 +687,7 @@ int8_t correctionFixedTiming(int8_t advance)
 
 int8_t correctionCrankingFixedTiming(int8_t advance)
 {
-  byte ignCrankFixValue = advance;
+  uint8_t ignCrankFixValue = advance;
   if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) ) { ignCrankFixValue = configPage4.CrankAng; } //Use the fixed cranking ignition angle
   return ignCrankFixValue;
 }
@@ -718,7 +718,7 @@ int8_t correctionWMITiming(int8_t advance)
 
 int8_t correctionIATretard(int8_t advance)
 {
-  byte ignIATValue = advance;
+  uint8_t ignIATValue = advance;
   //Adjust the advance based on IAT. If the adjustment amount is greater than the current advance, just set advance to 0
   int8_t advanceIATadjust = table2D_getValue(&IATRetardTable, currentStatus.IAT);
   int tempAdvance = (advance - advanceIATadjust);
@@ -745,7 +745,7 @@ int8_t correctionIdleAdvance(int8_t advance)
   //Adjust the advance based on idle target rpm.
   if( (configPage2.idleAdvEnabled >= 1) && (currentStatus.runSecs >= configPage2.IdleAdvDelay))
   {
-    currentStatus.CLIdleTarget = (byte)table2D_getValue(&idleTargetTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
+    currentStatus.CLIdleTarget = (uint8_t)table2D_getValue(&idleTargetTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
     int idleRPMdelta = (currentStatus.CLIdleTarget - (currentStatus.RPM / 10) ) + 50;
     // Limit idle rpm delta between -500rpm - 500rpm
     if(idleRPMdelta > 100) { idleRPMdelta = 100; }
@@ -768,7 +768,7 @@ int8_t correctionIdleAdvance(int8_t advance)
 
 int8_t correctionSoftRevLimit(int8_t advance)
 {
-  byte ignSoftRevValue = advance;
+  uint8_t ignSoftRevValue = advance;
   BIT_CLEAR(currentStatus.spark, BIT_SPARK_SFTLIM);
   if (currentStatus.RPM > ((unsigned int)(configPage4.SoftRevLim) * 100) ) //Softcut RPM limit
   {
@@ -783,7 +783,7 @@ int8_t correctionSoftRevLimit(int8_t advance)
 
 int8_t correctionNitrous(int8_t advance)
 {
-  byte ignNitrous = advance;
+  uint8_t ignNitrous = advance;
   //Check if nitrous is currently active
   if(configPage10.n2o_enable > 0)
   {
@@ -803,7 +803,7 @@ int8_t correctionNitrous(int8_t advance)
 
 int8_t correctionSoftLaunch(int8_t advance)
 {
-  byte ignSoftLaunchValue = advance;
+  uint8_t ignSoftLaunchValue = advance;
   //SoftCut rev limit for 2-step launch control.
   if (configPage6.launchEnabled && clutchTrigger && (currentStatus.clutchEngagedRPM < ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > ((unsigned int)(configPage6.lnchSoftLim) * 100)) && (currentStatus.TPS >= configPage10.lnchCtrlTPS) )
   {
@@ -822,7 +822,7 @@ int8_t correctionSoftLaunch(int8_t advance)
 
 int8_t correctionSoftFlatShift(int8_t advance)
 {
-  byte ignSoftFlatValue = advance;
+  uint8_t ignSoftFlatValue = advance;
 
   if(configPage6.flatSEnable && clutchTrigger && (currentStatus.clutchEngagedRPM > ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > (currentStatus.clutchEngagedRPM-configPage6.flatSSoftWin) ) )
   {
@@ -836,7 +836,7 @@ int8_t correctionSoftFlatShift(int8_t advance)
 
 int8_t correctionKnock(int8_t advance)
 {
-  byte knockRetard = 0;
+  uint8_t knockRetard = 0;
 
   //First check is to do the window calculations (ASsuming knock is enabled)
   if( configPage10.knock_mode != KNOCK_MODE_OFF )

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -15,8 +15,8 @@
 #define ignitionLimits(angle) ( (((int16_t)(angle)) >= CRANK_ANGLE_MAX_IGN) ? ((angle) - CRANK_ANGLE_MAX_IGN) : ( ((int16_t)(angle) < 0) ? ((angle) + CRANK_ANGLE_MAX_IGN) : (angle)) )
 
 
-unsigned long angleToTime(int16_t, byte);
-uint16_t timeToAngle(unsigned long, byte);
+unsigned long angleToTime(int16_t, uint8_t);
+uint16_t timeToAngle(unsigned long, uint8_t);
 void doCrankSpeedCalcs();
 
 volatile uint16_t timePerDegree;
@@ -25,7 +25,7 @@ volatile uint16_t degreesPeruSx2048;
 volatile unsigned long degreesPeruSx32768;
 
 //These are only part of the experimental 2nd deriv calcs
-byte deltaToothCount = 0; //The last tooth that was used with the deltaV calc
+uint8_t deltaToothCount = 0; //The last tooth that was used with the deltaV calc
 int rpmDelta;
 
 #endif

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -7,22 +7,22 @@
 #define CRANKMATH_METHOD_ALPHA_BETA        3
 #define CRANKMATH_METHOD_2ND_DERIVATIVE    4
 
-//#define fastDegreesToUS(targetDegrees) ((targetDegrees) * (unsigned long)timePerDegree)
-#define fastDegreesToUS(targetDegrees) (((targetDegrees) * (unsigned long)timePerDegreex16) >> 4)
-/*#define fastTimeToAngle(time) (((unsigned long)time * degreesPeruSx2048) / 2048) */ //Divide by 2048 will be converted at compile time to bitshift
-#define fastTimeToAngle(time) (((unsigned long)(time) * degreesPeruSx32768) / 32768) //Divide by 32768 will be converted at compile time to bitshift
+//#define fastDegreesToUS(targetDegrees) ((targetDegrees) * (uint32_t)timePerDegree)
+#define fastDegreesToUS(targetDegrees) (((targetDegrees) * (uint32_t)timePerDegreex16) >> 4)
+/*#define fastTimeToAngle(time) (((uint32_t)time * degreesPeruSx2048) / 2048) */ //Divide by 2048 will be converted at compile time to bitshift
+#define fastTimeToAngle(time) (((uint32_t)(time) * degreesPeruSx32768) / 32768) //Divide by 32768 will be converted at compile time to bitshift
 
 #define ignitionLimits(angle) ( (((int16_t)(angle)) >= CRANK_ANGLE_MAX_IGN) ? ((angle) - CRANK_ANGLE_MAX_IGN) : ( ((int16_t)(angle) < 0) ? ((angle) + CRANK_ANGLE_MAX_IGN) : (angle)) )
 
 
-unsigned long angleToTime(int16_t, uint8_t);
-uint16_t timeToAngle(unsigned long, uint8_t);
+uint32_t angleToTime(int16_t, uint8_t);
+uint16_t timeToAngle(uint32_t, uint8_t);
 void doCrankSpeedCalcs();
 
 volatile uint16_t timePerDegree;
 volatile uint16_t timePerDegreex16;
 volatile uint16_t degreesPeruSx2048;
-volatile unsigned long degreesPeruSx32768;
+volatile uint32_t degreesPeruSx32768;
 
 //These are only part of the experimental 2nd deriv calcs
 uint8_t deltaToothCount = 0; //The last tooth that was used with the deltaV calc

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -26,6 +26,6 @@ volatile unsigned long degreesPeruSx32768;
 
 //These are only part of the experimental 2nd deriv calcs
 uint8_t deltaToothCount = 0; //The last tooth that was used with the deltaV calc
-int rpmDelta;
+int16_t rpmDelta;
 
 #endif

--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -100,7 +100,7 @@ void doCrankSpeedCalcs()
         //if (deltaToothCount != toothCurrentCount)
         {
           deltaToothCount = toothCurrentCount;
-          int angle1, angle2; //These represent the crank angles that are travelled for the last 2 pulses
+          int16_t angle1, angle2; //These represent the crank angles that are travelled for the last 2 pulses
           if(configPage4.TrigPattern == 4)
           {
             //Special case for 70/110 pattern on 4g63

--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -15,14 +15,14 @@
 * 3) Closed loop error correction (Alpha-beta filter) 
 * 4) 2nd derivative prediction (Speed + acceleration)
 */
-unsigned long angleToTime(int16_t angle, uint8_t method)
+uint32_t angleToTime(int16_t angle, uint8_t method)
 {
-    unsigned long returnTime = 0;
+    uint32_t returnTime = 0;
 
     if( (method == CRANKMATH_METHOD_INTERVAL_REV) || (method == CRANKMATH_METHOD_INTERVAL_DEFAULT) )
     {
         returnTime = ((angle * revolutionTime) / 360);
-        //returnTime = angle * (unsigned long)timePerDegree;
+        //returnTime = angle * (uint32_t)timePerDegree;
     }
     else if (method == CRANKMATH_METHOD_INTERVAL_TOOTH)
     {
@@ -30,7 +30,7 @@ unsigned long angleToTime(int16_t angle, uint8_t method)
         if(triggerToothAngleIsCorrect == true)
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          uint32_t toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
           interrupts();
           
           returnTime = ( (toothTime / triggerToothAngle) * angle );
@@ -49,7 +49,7 @@ unsigned long angleToTime(int16_t angle, uint8_t method)
 * 3) Closed loop error correction (Alpha-beta filter) 
 * 4) 2nd derivative prediction (Speed + acceleration)
 */
-uint16_t timeToAngle(unsigned long time, uint8_t method)
+uint16_t timeToAngle(uint32_t time, uint8_t method)
 {
     uint16_t returnAngle = 0;
 
@@ -65,10 +65,10 @@ uint16_t timeToAngle(unsigned long time, uint8_t method)
         if(triggerToothAngleIsCorrect == true)
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          uint32_t toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
           interrupts();
 
-          returnAngle = ( (unsigned long)(time * triggerToothAngle) / toothTime );
+          returnAngle = ( (uint32_t)(time * triggerToothAngle) / toothTime );
         }
         else { returnAngle = timeToAngle(time, CRANKMATH_METHOD_INTERVAL_REV); } //Safety check. This can occur if the last tooth seen was outside the normal pattern etc
     }
@@ -119,7 +119,7 @@ void doCrankSpeedCalcs()
 
           uint32_t toothDeltaV = (1000000L * angle2 / toothHistory[toothHistoryIndex]) - (1000000L * angle1 / toothHistory[toothHistoryIndex-1]);
           uint32_t toothDeltaT = toothHistory[toothHistoryIndex];
-          //long timeToLastTooth = micros() - toothLastToothTime;
+          //int32_t timeToLastTooth = micros() - toothLastToothTime;
 
           rpmDelta = (toothDeltaV << 10) / (6 * toothDeltaT);
         }
@@ -134,20 +134,20 @@ void doCrankSpeedCalcs()
         if( (triggerToothAngleIsCorrect == true) && (toothLastToothTime > toothLastMinusOneToothTime) && (abs(currentStatus.rpmDOT) > 30) )
         {
           //noInterrupts();
-          unsigned long tempToothLastToothTime = toothLastToothTime;
-          unsigned long tempToothLastMinusOneToothTime = toothLastMinusOneToothTime;
+          uint32_t tempToothLastToothTime = toothLastToothTime;
+          uint32_t tempToothLastMinusOneToothTime = toothLastMinusOneToothTime;
           uint16_t tempTriggerToothAngle = triggerToothAngle;
           interrupts();
-          timePerDegreex16 = (unsigned long)( (tempToothLastToothTime - tempToothLastMinusOneToothTime)*16) / tempTriggerToothAngle;
+          timePerDegreex16 = (uint32_t)( (tempToothLastToothTime - tempToothLastMinusOneToothTime)*16) / tempTriggerToothAngle;
           timePerDegree = timePerDegreex16 / 16;
         }
         else
         {
-          //long timeThisRevolution = (micros_safe() - toothOneTime);
+          //int32_t timeThisRevolution = (micros_safe() - toothOneTime);
           interrupts();
           //Take into account any likely accleration that has occurred since the last full revolution completed:
-          //long rpm_adjust = (timeThisRevolution * (long)currentStatus.rpmDOT) / 1000000; 
-          long rpm_adjust = 0;
+          //int32_t rpm_adjust = (timeThisRevolution * (int32_t)currentStatus.rpmDOT) / 1000000; 
+          int32_t rpm_adjust = 0;
           timePerDegreex16 = ldiv( 2666656L, currentStatus.RPM + rpm_adjust).quot; //The use of a x16 value gives accuracy down to 0.1 of a degree and can provide noticably better timing results on low res triggers
           timePerDegree = timePerDegreex16 / 16;
         }

--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -15,7 +15,7 @@
 * 3) Closed loop error correction (Alpha-beta filter) 
 * 4) 2nd derivative prediction (Speed + acceleration)
 */
-unsigned long angleToTime(int16_t angle, byte method)
+unsigned long angleToTime(int16_t angle, uint8_t method)
 {
     unsigned long returnTime = 0;
 
@@ -49,7 +49,7 @@ unsigned long angleToTime(int16_t angle, byte method)
 * 3) Closed loop error correction (Alpha-beta filter) 
 * 4) 2nd derivative prediction (Speed + acceleration)
 */
-uint16_t timeToAngle(unsigned long time, byte method)
+uint16_t timeToAngle(unsigned long time, uint8_t method)
 {
     uint16_t returnAngle = 0;
 

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -16,7 +16,7 @@ void loggerPrimaryISR();
 void loggerSecondaryISR();
 static inline uint16_t stdGetRPM(uint16_t);
 static inline void setFilter(unsigned long);
-static inline int crankingGetRPM(byte);
+static inline int crankingGetRPM(uint8_t);
 //static inline void doPerToothTiming(uint16_t);
 
 //All of the below are the 6 required functions for each decoder / pattern
@@ -173,7 +173,7 @@ extern volatile unsigned long compositeLastToothTime;
 
 extern unsigned long MAX_STALL_TIME; //The maximum time (in uS) that the system will continue to function before the engine is considered stalled/stopped. This is unique to each decoder, depending on the number of teeth etc. 500000 (half a second) is used as the default value, most decoders will be much less.
 extern volatile uint16_t toothCurrentCount; //The current number of teeth (Onec sync has been achieved, this can never actually be 0
-extern volatile byte toothSystemCount; //Used for decoders such as Audi 135 where not every tooth is used for calculating crank angle. This variable stores the actual number of teeth, not the number being used to calculate crank angle
+extern volatile uint8_t toothSystemCount; //Used for decoders such as Audi 135 where not every tooth is used for calculating crank angle. This variable stores the actual number of teeth, not the number being used to calculate crank angle
 extern volatile unsigned long toothSystemLastToothTime; //As below, but used for decoders where not every tooth count is used for calculation
 extern volatile unsigned long toothLastToothTime; //The time (micros()) that the last tooth was registered
 extern volatile unsigned long toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
@@ -203,7 +203,7 @@ extern bool decoderIsSequential; //Whether or not the decoder supports sequentia
 extern bool decoderIsLowRes; //Is set true, certain extra calculations are performed for better timing accuracy
 extern bool decoderHasSecondary; //Whether or not the pattern uses a secondary input
 extern bool decoderHasFixedCrankingTiming; //Whether or not the decoder supports fixed cranking timing
-extern byte checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
+extern uint8_t checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
 extern unsigned long elapsedTime;
 extern unsigned long lastCrankAngleCalc;
 extern int16_t lastToothCalcAdvance; //Invalid value here forces calculation of this on first main loop

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -16,7 +16,7 @@ void loggerPrimaryISR();
 void loggerSecondaryISR();
 static inline uint16_t stdGetRPM(uint16_t);
 static inline void setFilter(unsigned long);
-static inline int crankingGetRPM(uint8_t);
+static inline int16_t crankingGetRPM(uint8_t);
 //static inline void doPerToothTiming(uint16_t);
 
 //All of the below are the 6 required functions for each decoder / pattern
@@ -24,134 +24,134 @@ void triggerSetup_missingTooth();
 void triggerPri_missingTooth();
 void triggerSec_missingTooth();
 uint16_t getRPM_missingTooth();
-int getCrankAngle_missingTooth();
+int16_t getCrankAngle_missingTooth();
 extern void triggerSetEndTeeth_missingTooth();
 
 void triggerSetup_DualWheel();
 void triggerPri_DualWheel();
 void triggerSec_DualWheel();
 uint16_t getRPM_DualWheel();
-int getCrankAngle_DualWheel();
+int16_t getCrankAngle_DualWheel();
 void triggerSetEndTeeth_DualWheel();
 
 void triggerSetup_BasicDistributor();
 void triggerPri_BasicDistributor();
 void triggerSec_BasicDistributor();
 uint16_t getRPM_BasicDistributor();
-int getCrankAngle_BasicDistributor();
+int16_t getCrankAngle_BasicDistributor();
 void triggerSetEndTeeth_BasicDistributor();
 
 void triggerSetup_GM7X();
 void triggerPri_GM7X();
 void triggerSec_GM7X();
 uint16_t getRPM_GM7X();
-int getCrankAngle_GM7X();
+int16_t getCrankAngle_GM7X();
 void triggerSetEndTeeth_GM7X();
 
 void triggerSetup_4G63();
 void triggerPri_4G63();
 void triggerSec_4G63();
 uint16_t getRPM_4G63();
-int getCrankAngle_4G63();
+int16_t getCrankAngle_4G63();
 void triggerSetEndTeeth_4G63();
 
 void triggerSetup_24X();
 void triggerPri_24X();
 void triggerSec_24X();
 uint16_t getRPM_24X();
-int getCrankAngle_24X();
+int16_t getCrankAngle_24X();
 void triggerSetEndTeeth_24X();
 
 void triggerSetup_Jeep2000();
 void triggerPri_Jeep2000();
 void triggerSec_Jeep2000();
 uint16_t getRPM_Jeep2000();
-int getCrankAngle_Jeep2000();
+int16_t getCrankAngle_Jeep2000();
 void triggerSetEndTeeth_Jeep2000();
 
 void triggerSetup_Audi135();
 void triggerPri_Audi135();
 void triggerSec_Audi135();
 uint16_t getRPM_Audi135();
-int getCrankAngle_Audi135();
+int16_t getCrankAngle_Audi135();
 void triggerSetEndTeeth_Audi135();
 
 void triggerSetup_HondaD17();
 void triggerPri_HondaD17();
 void triggerSec_HondaD17();
 uint16_t getRPM_HondaD17();
-int getCrankAngle_HondaD17();
+int16_t getCrankAngle_HondaD17();
 void triggerSetEndTeeth_HondaD17();
 
 void triggerSetup_Miata9905();
 void triggerPri_Miata9905();
 void triggerSec_Miata9905();
 uint16_t getRPM_Miata9905();
-int getCrankAngle_Miata9905();
+int16_t getCrankAngle_Miata9905();
 void triggerSetEndTeeth_Miata9905();
-int getCamAngle_Miata9905();
+int16_t getCamAngle_Miata9905();
 
 void triggerSetup_MazdaAU();
 void triggerPri_MazdaAU();
 void triggerSec_MazdaAU();
 uint16_t getRPM_MazdaAU();
-int getCrankAngle_MazdaAU();
+int16_t getCrankAngle_MazdaAU();
 void triggerSetEndTeeth_MazdaAU();
 
 void triggerSetup_non360();
 void triggerPri_non360();
 void triggerSec_non360();
 uint16_t getRPM_non360();
-int getCrankAngle_non360();
+int16_t getCrankAngle_non360();
 void triggerSetEndTeeth_non360();
 
 void triggerSetup_Nissan360();
 void triggerPri_Nissan360();
 void triggerSec_Nissan360();
 uint16_t getRPM_Nissan360();
-int getCrankAngle_Nissan360();
+int16_t getCrankAngle_Nissan360();
 void triggerSetEndTeeth_Nissan360();
 
 void triggerSetup_Subaru67();
 void triggerPri_Subaru67();
 void triggerSec_Subaru67();
 uint16_t getRPM_Subaru67();
-int getCrankAngle_Subaru67();
+int16_t getCrankAngle_Subaru67();
 void triggerSetEndTeeth_Subaru67();
 
 void triggerSetup_Daihatsu();
 void triggerPri_Daihatsu();
 void triggerSec_Daihatsu();
 uint16_t getRPM_Daihatsu();
-int getCrankAngle_Daihatsu();
+int16_t getCrankAngle_Daihatsu();
 void triggerSetEndTeeth_Daihatsu();
 
 void triggerSetup_Harley();
 void triggerPri_Harley();
 void triggerSec_Harley();
 uint16_t getRPM_Harley();
-int getCrankAngle_Harley();
+int16_t getCrankAngle_Harley();
 void triggerSetEndTeeth_Harley();
 
 void triggerSetup_ThirtySixMinus222();
 void triggerPri_ThirtySixMinus222();
 void triggerSec_ThirtySixMinus222();
 uint16_t getRPM_ThirtySixMinus222();
-int getCrankAngle_ThirtySixMinus222();
+int16_t getCrankAngle_ThirtySixMinus222();
 void triggerSetEndTeeth_ThirtySixMinus222();
 
 void triggerSetup_ThirtySixMinus21();
 void triggerPri_ThirtySixMinus21();
 void triggerSec_ThirtySixMinus21();
 uint16_t getRPM_ThirtySixMinus21();
-int getCrankAngle_ThirtySixMinus21();
+int16_t getCrankAngle_ThirtySixMinus21();
 void triggerSetEndTeeth_ThirtySixMinus21();
 
 void triggerSetup_420a();
 void triggerPri_420a();
 void triggerSec_420a();
 uint16_t getRPM_420a();
-int getCrankAngle_420a();
+int16_t getCrankAngle_420a();
 void triggerSetEndTeeth_420a();
 
 void triggerPri_Webber();
@@ -160,7 +160,7 @@ void triggerSec_Webber();
 extern void (*triggerHandler)(); //Pointer for the trigger function (Gets pointed to the relevant decoder)
 extern void (*triggerSecondaryHandler)(); //Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
 extern uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to the relevant decoder)
-extern int (*getCrankAngle)(); //Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
+extern int16_t (*getCrankAngle)(); //Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
 extern void (*triggerSetEndTeeth)(); //Pointer to the triggerSetEndTeeth function of each decoder
 
 extern volatile unsigned long curTime;
@@ -187,7 +187,7 @@ extern volatile unsigned long toothOneTime; //The time (micros()) that tooth 1 l
 extern volatile unsigned long toothOneMinusOneTime; //The 2nd to last time (micros()) that tooth 1 last triggered
 extern volatile bool revolutionOne; // For sequential operation, this tracks whether the current revolution is 1 or 2 (not 1)
 
-extern volatile unsigned int secondaryToothCount; //Used for identifying the current secondary (Usually cam) tooth for patterns with multiple secondary teeth
+extern volatile uint16_t secondaryToothCount; //Used for identifying the current secondary (Usually cam) tooth for patterns with multiple secondary teeth
 extern volatile unsigned long secondaryLastToothTime; //The time (micros()) that the last tooth was registered (Cam input)
 extern volatile unsigned long secondaryLastToothTime1; //The time (micros()) that the last tooth was registered (Cam input)
 
@@ -195,7 +195,7 @@ extern volatile uint16_t triggerActualTeeth;
 extern volatile unsigned long triggerFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering)
 extern volatile unsigned long triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
 extern volatile bool validTrigger; //Is set true when the last trigger (Primary or secondary) was valid (ie passed filters)
-extern unsigned int triggerSecFilterTime_duration; // The shortest valid time (in uS) pulse DURATION
+extern uint16_t triggerSecFilterTime_duration; // The shortest valid time (in uS) pulse DURATION
 extern volatile uint16_t triggerToothAngle; //The number of crank degrees that elapse per tooth
 extern volatile bool triggerToothAngleIsCorrect; //Whether or not the triggerToothAngle variable is currently accurate. Some patterns have times when the triggerToothAngle variable cannot be accurately set.
 extern bool secondDerivEnabled; //The use of the 2nd derivative calculation is limited to certain decoders. This is set to either true or false in each decoders setup routine

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -11,11 +11,11 @@
   #define READ_SEC_TRIGGER() digitalRead(pinTrigger2)
 #endif
 
-static inline void addToothLogEntry(unsigned long, bool);
+static inline void addToothLogEntry(uint32_t, bool);
 void loggerPrimaryISR();
 void loggerSecondaryISR();
 static inline uint16_t stdGetRPM(uint16_t);
-static inline void setFilter(unsigned long);
+static inline void setFilter(uint32_t);
 static inline int16_t crankingGetRPM(uint8_t);
 //static inline void doPerToothTiming(uint16_t);
 
@@ -163,37 +163,37 @@ extern uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to t
 extern int16_t (*getCrankAngle)(); //Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
 extern void (*triggerSetEndTeeth)(); //Pointer to the triggerSetEndTeeth function of each decoder
 
-extern volatile unsigned long curTime;
-extern volatile unsigned long curGap;
-extern volatile unsigned long curTime2;
-extern volatile unsigned long curGap2;
-extern volatile unsigned long lastGap;
-extern volatile unsigned long targetGap;
-extern volatile unsigned long compositeLastToothTime;
+extern volatile uint32_t curTime;
+extern volatile uint32_t curGap;
+extern volatile uint32_t curTime2;
+extern volatile uint32_t curGap2;
+extern volatile uint32_t lastGap;
+extern volatile uint32_t targetGap;
+extern volatile uint32_t compositeLastToothTime;
 
-extern unsigned long MAX_STALL_TIME; //The maximum time (in uS) that the system will continue to function before the engine is considered stalled/stopped. This is unique to each decoder, depending on the number of teeth etc. 500000 (half a second) is used as the default value, most decoders will be much less.
+extern uint32_t MAX_STALL_TIME; //The maximum time (in uS) that the system will continue to function before the engine is considered stalled/stopped. This is unique to each decoder, depending on the number of teeth etc. 500000 (half a second) is used as the default value, most decoders will be much less.
 extern volatile uint16_t toothCurrentCount; //The current number of teeth (Onec sync has been achieved, this can never actually be 0
 extern volatile uint8_t toothSystemCount; //Used for decoders such as Audi 135 where not every tooth is used for calculating crank angle. This variable stores the actual number of teeth, not the number being used to calculate crank angle
-extern volatile unsigned long toothSystemLastToothTime; //As below, but used for decoders where not every tooth count is used for calculation
-extern volatile unsigned long toothLastToothTime; //The time (micros()) that the last tooth was registered
-extern volatile unsigned long toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
-extern volatile unsigned long toothLastMinusOneToothTime; //The time (micros()) that the tooth before the last tooth was registered
+extern volatile uint32_t toothSystemLastToothTime; //As below, but used for decoders where not every tooth count is used for calculation
+extern volatile uint32_t toothLastToothTime; //The time (micros()) that the last tooth was registered
+extern volatile uint32_t toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
+extern volatile uint32_t toothLastMinusOneToothTime; //The time (micros()) that the tooth before the last tooth was registered
 #ifndef SMALL_FLASH_MODE
-extern volatile unsigned long toothLastMinusOneSecToothTime; //The time (micros()) that the tooth before the last tooth was registered on secondary input
-extern volatile unsigned long targetGap2;
+extern volatile uint32_t toothLastMinusOneSecToothTime; //The time (micros()) that the tooth before the last tooth was registered on secondary input
+extern volatile uint32_t targetGap2;
 #endif
 
-extern volatile unsigned long toothOneTime; //The time (micros()) that tooth 1 last triggered
-extern volatile unsigned long toothOneMinusOneTime; //The 2nd to last time (micros()) that tooth 1 last triggered
+extern volatile uint32_t toothOneTime; //The time (micros()) that tooth 1 last triggered
+extern volatile uint32_t toothOneMinusOneTime; //The 2nd to last time (micros()) that tooth 1 last triggered
 extern volatile bool revolutionOne; // For sequential operation, this tracks whether the current revolution is 1 or 2 (not 1)
 
 extern volatile uint16_t secondaryToothCount; //Used for identifying the current secondary (Usually cam) tooth for patterns with multiple secondary teeth
-extern volatile unsigned long secondaryLastToothTime; //The time (micros()) that the last tooth was registered (Cam input)
-extern volatile unsigned long secondaryLastToothTime1; //The time (micros()) that the last tooth was registered (Cam input)
+extern volatile uint32_t secondaryLastToothTime; //The time (micros()) that the last tooth was registered (Cam input)
+extern volatile uint32_t secondaryLastToothTime1; //The time (micros()) that the last tooth was registered (Cam input)
 
 extern volatile uint16_t triggerActualTeeth;
-extern volatile unsigned long triggerFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering)
-extern volatile unsigned long triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
+extern volatile uint32_t triggerFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering)
+extern volatile uint32_t triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
 extern volatile bool validTrigger; //Is set true when the last trigger (Primary or secondary) was valid (ie passed filters)
 extern uint16_t triggerSecFilterTime_duration; // The shortest valid time (in uS) pulse DURATION
 extern volatile uint16_t triggerToothAngle; //The number of crank degrees that elapse per tooth
@@ -204,10 +204,10 @@ extern bool decoderIsLowRes; //Is set true, certain extra calculations are perfo
 extern bool decoderHasSecondary; //Whether or not the pattern uses a secondary input
 extern bool decoderHasFixedCrankingTiming; //Whether or not the decoder supports fixed cranking timing
 extern uint8_t checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
-extern unsigned long elapsedTime;
-extern unsigned long lastCrankAngleCalc;
+extern uint32_t elapsedTime;
+extern uint32_t lastCrankAngleCalc;
 extern int16_t lastToothCalcAdvance; //Invalid value here forces calculation of this on first main loop
-extern unsigned long lastVVTtime; //The time between the vvt reference pulse and the last crank pulse
+extern uint32_t lastVVTtime; //The time between the vvt reference pulse and the last crank pulse
 
 extern uint16_t ignition1EndTooth;
 extern uint16_t ignition2EndTooth;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -44,7 +44,7 @@ volatile unsigned long compositeLastToothTime;
 
 unsigned long MAX_STALL_TIME = 500000UL; //The maximum time (in uS) that the system will continue to function before the engine is considered stalled/stopped. This is unique to each decoder, depending on the number of teeth etc. 500000 (half a second) is used as the default value, most decoders will be much less.
 volatile uint16_t toothCurrentCount = 0; //The current number of teeth (Onec sync has been achieved, this can never actually be 0
-volatile byte toothSystemCount = 0; //Used for decoders such as Audi 135 where not every tooth is used for calculating crank angle. This variable stores the actual number of teeth, not the number being used to calculate crank angle
+volatile uint8_t toothSystemCount = 0; //Used for decoders such as Audi 135 where not every tooth is used for calculating crank angle. This variable stores the actual number of teeth, not the number being used to calculate crank angle
 volatile unsigned long toothSystemLastToothTime = 0; //As below, but used for decoders where not every tooth count is used for calculation
 volatile unsigned long toothLastToothTime = 0; //The time (micros()) that the last tooth was registered
 volatile unsigned long toothLastSecToothTime = 0; //The time (micros()) that the last tooth was registered on the secondary input
@@ -73,7 +73,7 @@ bool decoderIsSequential; //Whether or not the decoder supports sequential opera
 bool decoderIsLowRes = false; //Is set true, certain extra calculations are performed for better timing accuracy
 bool decoderHasSecondary = false; //Whether or not the pattern uses a secondary input
 bool decoderHasFixedCrankingTiming = false; //Whether or not the decoder supports fixed cranking timing
-byte checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
+uint8_t checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
 unsigned long elapsedTime;
 unsigned long lastCrankAngleCalc;
 int16_t lastToothCalcAdvance = 99; //Invalid value here forces calculation of this on first main loop
@@ -250,7 +250,7 @@ This gives much more volatile reading, but is quite useful during cranking, part
 It can only be used on patterns where the teeth are evently spaced
 It takes an argument of the full (COMPLETE) number of teeth per revolution. For a missing tooth wheel, this is the number if the tooth had NOT been missing (Eg 36-1 = 36)
 */
-static inline int crankingGetRPM(byte totalTeeth)
+static inline int crankingGetRPM(uint8_t totalTeeth)
 {
   uint16_t tempRPM = 0;
   if( (currentStatus.startRevolutions >= configPage4.StgCycles) && (currentStatus.hasSync == true) )
@@ -575,7 +575,7 @@ int getCrankAngle_missingTooth()
 
 void triggerSetEndTeeth_missingTooth()
 {
-  byte toothAdder = 0;
+  uint8_t toothAdder = 0;
   if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage4.TrigSpeed == CRANK_SPEED) ) { toothAdder = configPage4.triggerTeeth; }
 
   //Temp variables are used here to avoid potential issues if a trigger interrupt occurs part way through this function
@@ -780,7 +780,7 @@ int getCrankAngle_DualWheel()
 void triggerSetEndTeeth_DualWheel()
 {
   //The toothAdder variable is used for when a setup is running sequentially, but the primary wheel is running at crank speed. This way the count of teeth will go up to 2* the number of primary teeth to allow for a sequential count. 
-  byte toothAdder = 0;
+  uint8_t toothAdder = 0;
   if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (configPage4.TrigSpeed == CRANK_SPEED) ) { toothAdder = configPage4.triggerTeeth; }
 
   int16_t tempIgnition1EndTooth;
@@ -1373,7 +1373,7 @@ void triggerPri_4G63()
 }
 void triggerSec_4G63()
 {
-  //byte crankState = READ_PRI_TRIGGER();
+  //uint8_t crankState = READ_PRI_TRIGGER();
   //First filter is a duration based one to ensure the pulse was of sufficient length (time)
   //if(READ_SEC_TRIGGER()) { secondaryLastToothTime1 = micros(); return; }
   if(currentStatus.hasSync == true)
@@ -2570,7 +2570,7 @@ void triggerSec_Nissan360()
 
 
   //Calculate number of primary teeth that this window has been active for
-  byte trigEdge;
+  uint8_t trigEdge;
   if(configPage4.TrigEdgeSec == 0) { trigEdge = LOW; }
   else { trigEdge = HIGH; }
 
@@ -2578,7 +2578,7 @@ void triggerSec_Nissan360()
   else
   {
     //If we reach here, we are at the end of a secondary window
-    byte secondaryDuration = toothCurrentCount - secondaryToothCount; //How many primary teeth have passed during the duration of this secondary window
+    uint8_t secondaryDuration = toothCurrentCount - secondaryToothCount; //How many primary teeth have passed during the duration of this secondary window
 
     if(currentStatus.hasSync == false)
     {
@@ -2713,7 +2713,7 @@ int getCrankAngle_Nissan360()
 void triggerSetEndTeeth_Nissan360()
 {
   //This uses 4 prior teeth, just to ensure there is sufficient time to set the schedule etc
-  byte offset_teeth = 4;
+  uint8_t offset_teeth = 4;
   if((ignition1EndAngle - offset_teeth) > configPage4.triggerAngle) { ignition1EndTooth = ( (ignition1EndAngle - configPage4.triggerAngle) / 2 ) - offset_teeth; }
   else { ignition1EndTooth = ( (ignition1EndAngle + 720 - configPage4.triggerAngle) / 2 ) - offset_teeth; }
   if((ignition2EndAngle - offset_teeth) > configPage4.triggerAngle) { ignition2EndTooth = ( (ignition2EndAngle - configPage4.triggerAngle) / 2 ) - offset_teeth; }

--- a/speeduino/display.ino
+++ b/speeduino/display.ino
@@ -187,8 +187,8 @@ void updateDisplay()
       break;
   }
 
-  int barWidth = ldiv(((unsigned long)currentStatus.RPM * 128), 9000).quot;
-  //int barWidth = map(currentStatus.RPM, 0, 9000, 0, 128);
+  int16_t barWidth = ldiv(((unsigned long)currentStatus.RPM * 128), 9000).quot;
+  //int16_t barWidth = map(currentStatus.RPM, 0, 9000, 0, 128);
   display.fillRect(0, 20, barWidth, 10, 1);
 
   display.display();

--- a/speeduino/display.ino
+++ b/speeduino/display.ino
@@ -187,7 +187,7 @@ void updateDisplay()
       break;
   }
 
-  int16_t barWidth = ldiv(((unsigned long)currentStatus.RPM * 128), 9000).quot;
+  int16_t barWidth = ldiv(((uint32_t)currentStatus.RPM * 128), 9000).quot;
   //int16_t barWidth = map(currentStatus.RPM, 0, 9000, 0, 128);
   display.fillRect(0, 20, barWidth, 10, 1);
 

--- a/speeduino/engineProtection.h
+++ b/speeduino/engineProtection.h
@@ -1,9 +1,5 @@
-
-
-
-
-byte checkEngineProtect();
-byte checkRevLimit();
-byte checkBoostLimit();
-byte checkOilPressureLimit();
-byte checkAFRLimit();
+uint8_t checkEngineProtect();
+uint8_t checkRevLimit();
+uint8_t checkBoostLimit();
+uint8_t checkOilPressureLimit();
+uint8_t checkAFRLimit();

--- a/speeduino/engineProtection.ino
+++ b/speeduino/engineProtection.ino
@@ -2,9 +2,9 @@
 #include "globals.h"
 #include "engineProtection.h"
 
-byte checkEngineProtect()
+uint8_t checkEngineProtect()
 {
-  byte protectActive = 0;
+  uint8_t protectActive = 0;
   if(checkRevLimit() || checkBoostLimit() || checkOilPressureLimit() || checkAFRLimit())
   {
     if(currentStatus.RPM > (configPage4.engineProtectMaxRPM*100U)) { protectActive = 1; }
@@ -13,10 +13,10 @@ byte checkEngineProtect()
   return protectActive;
 }
 
-byte checkRevLimit()
+uint8_t checkRevLimit()
 {
   //Hardcut RPM limit
-  byte revLimiterActive = 0;
+  uint8_t revLimiterActive = 0;
   BIT_CLEAR(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_RPM);
 
   if (currentStatus.RPM > ((unsigned int)(configPage4.HardRevLim) * 100) )
@@ -30,9 +30,9 @@ byte checkRevLimit()
   return revLimiterActive;
 }
 
-byte checkBoostLimit()
+uint8_t checkBoostLimit()
 {
-  byte boostLimitActive = 0;
+  uint8_t boostLimitActive = 0;
   //Boost cutoff is very similar to launchControl, but with a check against MAP rather than a switch
   if( (configPage6.boostCutEnabled > 0) && (currentStatus.MAP > (configPage6.boostLimit * 2)) ) //The boost limit is divided by 2 to allow a limit up to 511kPa
   {
@@ -70,14 +70,14 @@ byte checkBoostLimit()
   return boostLimitActive;
 }
 
-byte checkOilPressureLimit()
+uint8_t checkOilPressureLimit()
 {
-  byte oilProtectActive = 0;
+  uint8_t oilProtectActive = 0;
   BIT_CLEAR(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_OIL); //Will be set true below if required
 
   if( (configPage10.oilPressureProtEnbl == true) && (configPage10.oilPressureEnable == true) )
   {
-    byte oilLimit = table2D_getValue(&oilPressureProtectTable, currentStatus.RPMdiv100);
+    uint8_t oilLimit = table2D_getValue(&oilPressureProtectTable, currentStatus.RPMdiv100);
     if(currentStatus.oilPressure < oilLimit)
     {
       BIT_SET(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_OIL);
@@ -88,9 +88,9 @@ byte checkOilPressureLimit()
   return oilProtectActive;
 }
 
-byte checkAFRLimit()
+uint8_t checkAFRLimit()
 {
-  byte checkAFRLimitActive = 0;
+  uint8_t checkAFRLimitActive = 0;
 
   return checkAFRLimitActive;
 }

--- a/speeduino/engineProtection.ino
+++ b/speeduino/engineProtection.ino
@@ -19,7 +19,7 @@ uint8_t checkRevLimit()
   uint8_t revLimiterActive = 0;
   BIT_CLEAR(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_RPM);
 
-  if (currentStatus.RPM > ((unsigned int)(configPage4.HardRevLim) * 100) )
+  if (currentStatus.RPM > ((uint16_t)(configPage4.HardRevLim) * 100) )
   { 
     BIT_SET(currentStatus.spark, BIT_SPARK_HRDLIM); //Legacy and likely to be removed at some point
     BIT_SET(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_RPM);

--- a/speeduino/errors.h
+++ b/speeduino/errors.h
@@ -42,15 +42,15 @@
  */
 struct packedError
 {
-  byte errorNum : 2;
-  byte errorID  : 6;
+  uint8_t errorNum : 2;
+  uint8_t errorID  : 6;
 };
 
-byte getNextError();
-byte setError(byte);
+uint8_t getNextError();
+uint8_t setError(uint8_t);
 
-byte errorCount = 0;
-byte errorCodes[4];
+uint8_t errorCount = 0;
+uint8_t errorCodes[4];
 
 
 #endif

--- a/speeduino/errors.ino
+++ b/speeduino/errors.ino
@@ -11,7 +11,7 @@ A full copy of the license may be found in the projects root directory
 #include "globals.h"
 #include "errors.h"
 
-byte setError(byte errorID)
+uint8_t setError(uint8_t errorID)
 {
   if(errorCount < MAX_ERRORS)
   {
@@ -22,9 +22,9 @@ byte setError(byte errorID)
   return errorCount;
 }
 
-void clearError(byte errorID)
+void clearError(uint8_t errorID)
 {
-  byte clearedError = 255;
+  uint8_t clearedError = 255;
 
   if (errorID == errorCodes[0]) { clearedError = 0; }
   else if(errorID == errorCodes[1]) { clearedError = 1; }
@@ -35,7 +35,7 @@ void clearError(byte errorID)
   {
     errorCodes[clearedError] = ERR_NONE;
     //Clear the required error and move any from above it 'down' in the error array
-    for (byte x=clearedError; x < (errorCount-1); x++)
+    for (uint8_t x=clearedError; x < (errorCount-1); x++)
     {
       errorCodes[x] = errorCodes[x+1];
       errorCodes[x+1] = ERR_NONE;
@@ -46,10 +46,10 @@ void clearError(byte errorID)
   }
 }
 
-byte getNextError()
+uint8_t getNextError()
 {
   packedError currentError;
-  byte currentErrorNum = 0;
+  uint8_t currentErrorNum = 0;
 
   if(errorCount > 0)
   {
@@ -66,5 +66,5 @@ byte getNextError()
   }
 
 
-  return *(byte*)&currentError; //Ugly, but this forces the cast of the currentError struct to a byte.
+  return *(uint8_t*)&currentError; //Ugly, but this forces the cast of the currentError struct to a byte.
 }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -480,9 +480,9 @@ extern const uint8_t PROGMEM fsIntIndex[31];
 extern bool initialisationComplete; //Tracks whether the setup() function has run completely
 extern uint8_t fpPrimeTime; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
 extern volatile uint16_t mainLoopCount;
-extern unsigned long revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
-extern volatile unsigned long timer5_overflow_count; //Increments every time counter 5 overflows. Used for the fast version of micros()
-extern volatile unsigned long ms_counter; //A counter that increments once per ms
+extern uint32_t revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
+extern volatile uint32_t timer5_overflow_count; //Increments every time counter 5 overflows. Used for the fast version of micros()
+extern volatile uint32_t ms_counter; //A counter that increments once per ms
 extern uint16_t fixedCrankingOverride;
 extern bool clutchTrigger;
 extern bool previousClutchTrigger;
@@ -491,8 +491,8 @@ extern volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 extern volatile bool fpPrimed; //Tracks whether or not the fuel pump priming has been completed yet
 extern volatile uint16_t toothHistoryIndex;
 extern volatile uint8_t toothHistorySerialIndex;
-extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
-extern unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
+extern uint32_t currentLoopTime; /**< The time (in uS) that the current mainloop started */
+extern uint32_t previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 extern uint8_t primaryTriggerEdge;
 extern uint8_t secondaryTriggerEdge;
@@ -525,10 +525,10 @@ struct statuses {
   volatile bool hasSync;
   uint16_t RPM;
   uint8_t RPMdiv100;
-  long longRPM;
+  int32_t longRPM;
   int16_t mapADC;
   int16_t baroADC;
-  long MAP; //Has to be a long for PID calcs (Boost control)
+  int32_t MAP; //Has to be a long for PID calcs (Boost control)
   int16_t EMAP;
   int16_t EMAPADC;
   uint8_t baro; //Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
@@ -574,7 +574,7 @@ struct statuses {
   bool fanOn; /**< Whether or not the fan is turned on */
   volatile uint8_t ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   volatile int8_t fuelTemp;
-  unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
+  uint32_t AEEndTime; /**< The target end time used whenever AE is turned on */
   volatile uint8_t status1;
   volatile uint8_t spark;
   volatile uint8_t spark2;
@@ -619,7 +619,7 @@ struct statuses {
   bool toothLogEnabled;
   bool compositeLogEnabled;
   //int8_t vvt1Angle;
-  long vvt1Angle;
+  int32_t vvt1Angle;
   uint8_t vvt1TargetAngle;
   uint8_t vvt1Duty;
   uint16_t injAngle;
@@ -632,7 +632,7 @@ struct statuses {
   uint8_t engineProtectStatus;
   uint8_t wmiPW;
   bool wmiEmpty;
-  long vvt2Angle;
+  int32_t vvt2Angle;
   uint8_t vvt2TargetAngle;
   uint8_t vvt2Duty;
   uint8_t outputsStatus;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -355,7 +355,7 @@
 
 extern const char TSfirmwareVersion[] PROGMEM;
 
-extern const byte data_structure_version; //This identifies the data structure when reading / writing.
+extern const uint8_t data_structure_version; //This identifies the data structure when reading / writing.
 #define NUM_PAGES     15
 extern const uint16_t npage_size[NUM_PAGES]; /**< This array stores the size (in bytes) of each configuration page */
 #define MAP_PAGE_SIZE 288
@@ -476,9 +476,9 @@ extern int ignition7StartAngle;
 extern int ignition8StartAngle;
 
 //These are variables used across multiple files
-extern const byte PROGMEM fsIntIndex[31];
+extern const uint8_t PROGMEM fsIntIndex[31];
 extern bool initialisationComplete; //Tracks whether the setup() function has run completely
-extern byte fpPrimeTime; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
+extern uint8_t fpPrimeTime; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
 extern volatile uint16_t mainLoopCount;
 extern unsigned long revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
 extern volatile unsigned long timer5_overflow_count; //Increments every time counter 5 overflows. Used for the fast version of micros()
@@ -490,27 +490,27 @@ extern volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
 extern volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 extern volatile bool fpPrimed; //Tracks whether or not the fuel pump priming has been completed yet
 extern volatile unsigned int toothHistoryIndex;
-extern volatile byte toothHistorySerialIndex;
+extern volatile uint8_t toothHistorySerialIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-extern byte primaryTriggerEdge;
-extern byte secondaryTriggerEdge;
+extern uint8_t primaryTriggerEdge;
+extern uint8_t secondaryTriggerEdge;
 extern int CRANK_ANGLE_MAX;
 extern int CRANK_ANGLE_MAX_IGN;
 extern int CRANK_ANGLE_MAX_INJ; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 extern volatile uint32_t runSecsX10; /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
 extern volatile uint32_t seclx10; /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */
-extern volatile byte HWTest_INJ; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
-extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
-extern volatile byte HWTest_IGN; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
-extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
+extern volatile uint8_t HWTest_INJ; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
+extern volatile uint8_t HWTest_INJ_50pc; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
+extern volatile uint8_t HWTest_IGN; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
+extern volatile uint8_t HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
 
 //This needs to be here because using the config page directly can prevent burning the setting
-extern byte resetControl;
+extern uint8_t resetControl;
 
-extern volatile byte TIMER_mask;
-extern volatile byte LOOP_TIMER;
+extern volatile uint8_t TIMER_mask;
+extern volatile uint8_t LOOP_TIMER;
 
 //These functions all do checks on a pin to determine if it is already in use by another (higher importance) function
 #define pinIsInjector(pin)  ( ((pin) == pinInjector1) || ((pin) == pinInjector2) || ((pin) == pinInjector3) || ((pin) == pinInjector4) || ((pin) == pinInjector5) || ((pin) == pinInjector6) || ((pin) == pinInjector7) || ((pin) == pinInjector8) )
@@ -524,24 +524,24 @@ extern volatile byte LOOP_TIMER;
 struct statuses {
   volatile bool hasSync;
   uint16_t RPM;
-  byte RPMdiv100;
+  uint8_t RPMdiv100;
   long longRPM;
   int mapADC;
   int baroADC;
   long MAP; //Has to be a long for PID calcs (Boost control)
   int16_t EMAP;
   int16_t EMAPADC;
-  byte baro; //Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
-  byte TPS; /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
-  byte tpsADC; /**< 0-255 byte representation of the TPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
-  byte tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
-  byte mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
+  uint8_t baro; //Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
+  uint8_t TPS; /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
+  uint8_t tpsADC; /**< 0-255 byte representation of the TPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
+  uint8_t tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
+  uint8_t mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
   volatile int rpmDOT;
-  byte VE; /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both */
-  byte VE1; /**< The VE value from fuel table 1 */
-  byte VE2; /**< The VE value from fuel table 2, if in use (and required conditions are met) */
-  byte O2;
-  byte O2_2;
+  uint8_t VE; /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both */
+  uint8_t VE1; /**< The VE value from fuel table 1 */
+  uint8_t VE2; /**< The VE value from fuel table 2, if in use (and required conditions are met) */
+  uint8_t O2;
+  uint8_t O2_2;
   int coolant;
   int cltADC;
   int IAT;
@@ -550,34 +550,34 @@ struct statuses {
   int O2ADC;
   int O2_2ADC;
   int dwell;
-  byte dwellCorrection; /**< The amount of correction being applied to the dwell time. */
-  byte battery10; /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
+  uint8_t dwellCorrection; /**< The amount of correction being applied to the dwell time. */
+  uint8_t battery10; /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
   int8_t advance; /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
   int8_t advance1; /**< The advance value from ignition table 1 */
   int8_t advance2; /**< The advance value from ignition table 2 */
   uint16_t corrections; /**< The total current corrections % amount */
   uint16_t AEamount; /**< The amount of accleration enrichment currently being applied. 100=No change. Varies above 255 */
-  byte egoCorrection; /**< The amount of closed loop AFR enrichment currently being applied */
-  byte wueCorrection; /**< The amount of warmup enrichment currently being applied */
-  byte batCorrection; /**< The amount of battery voltage enrichment currently being applied */
-  byte iatCorrection; /**< The amount of inlet air temperature adjustment currently being applied */
-  byte baroCorrection; /**< The amount of correction being applied for the current baro reading */
-  byte launchCorrection; /**< The amount of correction being applied if launch control is active */
-  byte flexCorrection; /**< Amount of correction being applied to compensate for ethanol content */
-  byte fuelTempCorrection; /**< Amount of correction being applied to compensate for fuel temperature */
+  uint8_t egoCorrection; /**< The amount of closed loop AFR enrichment currently being applied */
+  uint8_t wueCorrection; /**< The amount of warmup enrichment currently being applied */
+  uint8_t batCorrection; /**< The amount of battery voltage enrichment currently being applied */
+  uint8_t iatCorrection; /**< The amount of inlet air temperature adjustment currently being applied */
+  uint8_t baroCorrection; /**< The amount of correction being applied for the current baro reading */
+  uint8_t launchCorrection; /**< The amount of correction being applied if launch control is active */
+  uint8_t flexCorrection; /**< Amount of correction being applied to compensate for ethanol content */
+  uint8_t fuelTempCorrection; /**< Amount of correction being applied to compensate for fuel temperature */
   int8_t flexIgnCorrection; /**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
-  byte afrTarget;
-  byte idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
-  byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
+  uint8_t afrTarget;
+  uint8_t idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
+  uint8_t CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
   bool CTPSActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
   bool fanOn; /**< Whether or not the fan is turned on */
-  volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
+  volatile uint8_t ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   volatile int8_t fuelTemp;
   unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
-  volatile byte status1;
-  volatile byte spark;
-  volatile byte spark2;
+  volatile uint8_t status1;
+  volatile uint8_t spark;
+  volatile uint8_t spark2;
   uint8_t engine;
   unsigned int PW1; //In uS
   unsigned int PW2; //In uS
@@ -587,8 +587,8 @@ struct statuses {
   unsigned int PW6; //In uS
   unsigned int PW7; //In uS
   unsigned int PW8; //In uS
-  volatile byte runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
-  volatile byte secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
+  volatile uint8_t runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
+  volatile uint8_t secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
   volatile uint32_t loopsPerSecond; /**< A performance indicator showing the number of main loops that are being executed each second */ 
   bool launchingSoft; /**< Indicator showing whether soft launch control adjustments are active */
   bool launchingHard; /**< Indicator showing whether hard launch control adjustments are active */
@@ -597,46 +597,46 @@ struct statuses {
   bool flatShiftingHard;
   volatile uint32_t startRevolutions; /**< A counter for how many revolutions have been completed since sync was achieved. */
   uint16_t boostTarget;
-  byte testOutputs;
+  uint8_t testOutputs;
   bool testActive;
   uint16_t boostDuty; //Percentage value * 100 to give 2 points of precision
-  byte idleLoad; /**< Either the current steps or current duty cycle for the idle control. */
+  uint8_t idleLoad; /**< Either the current steps or current duty cycle for the idle control. */
   uint16_t canin[16];   //16bit raw value of selected canin data for channel 0-15
   uint8_t current_caninchannel = 0; /**< Current CAN channel, defaults to 0 */
   uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it everytime it's used (Config page value is stored divided by 10) */
-  volatile byte status3;
+  volatile uint8_t status3;
   int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
-  byte nitrous_status;
-  byte nSquirts;
-  byte nChannels; /**< Number of fuel and ignition channels.  */
+  uint8_t nitrous_status;
+  uint8_t nSquirts;
+  uint8_t nChannels; /**< Number of fuel and ignition channels.  */
   int16_t fuelLoad;
   int16_t fuelLoad2;
   int16_t ignLoad;
   bool fuelPumpOn; /**< Indicator showing the current status of the fuel pump */
-  byte syncLossCounter;
-  byte knockRetard;
+  uint8_t syncLossCounter;
+  uint8_t knockRetard;
   bool knockActive;
   bool toothLogEnabled;
   bool compositeLogEnabled;
   //int8_t vvt1Angle;
   long vvt1Angle;
-  byte vvt1TargetAngle;
-  byte vvt1Duty;
+  uint8_t vvt1TargetAngle;
+  uint8_t vvt1Duty;
   uint16_t injAngle;
-  byte ASEValue;
+  uint8_t ASEValue;
   uint16_t vss; /**< Current speed reading. Natively stored in kph and converted to mph in TS if required */
   bool idleUpOutputActive; /**< Whether the idle up output is currently active */
-  byte gear; /**< Current gear (Calculated from vss) */
-  byte fuelPressure; /**< Fuel pressure in PSI */
-  byte oilPressure; /**< Oil pressure in PSI */
-  byte engineProtectStatus;
-  byte wmiPW;
+  uint8_t gear; /**< Current gear (Calculated from vss) */
+  uint8_t fuelPressure; /**< Fuel pressure in PSI */
+  uint8_t oilPressure; /**< Oil pressure in PSI */
+  uint8_t engineProtectStatus;
+  uint8_t wmiPW;
   bool wmiEmpty;
   long vvt2Angle;
-  byte vvt2TargetAngle;
-  byte vvt2Duty;
-  byte outputsStatus;
-  byte TS_SD_Status; //TunerStudios SD card status
+  uint8_t vvt2TargetAngle;
+  uint8_t vvt2Duty;
+  uint8_t outputsStatus;
+  uint8_t TS_SD_Status; //TunerStudios SD card status
 };
 
 /**
@@ -647,96 +647,96 @@ struct statuses {
  */
 struct config2 {
 
-  byte aseTaperTime;
-  byte aeColdPct;  //AE cold clt modifier %
-  byte aeColdTaperMin; //AE cold modifier, taper start temp (full modifier), was ASE in early versions
-  byte aeMode : 2; /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */
-  byte battVCorMode : 1;
-  byte SoftLimitMode : 1;
-  byte useTachoSweep : 1;
-  byte aeApplyMode : 1; //0 = Multiply | 1 = Add
-  byte multiplyMAP : 2; //0 = off | 1 = baro | 2 = 100
-  byte wueValues[10]; //Warm up enrichment array (10 bytes)
-  byte crankingPct; //Cranking enrichment
-  byte pinMapping; // The board / ping mapping to be used
-  byte tachoPin : 6; //Custom pin setting for tacho output
-  byte tachoDiv : 2; //Whether to change the tacho speed
-  byte tachoDuration; //The duration of the tacho pulse in mS
-  byte maeThresh; /**< The MAPdot threshold that must be exceeded before AE is engaged */
-  byte taeThresh; /**< The TPSdot threshold that must be exceeded before AE is engaged */
-  byte aeTime;
+  uint8_t aseTaperTime;
+  uint8_t aeColdPct;  //AE cold clt modifier %
+  uint8_t aeColdTaperMin; //AE cold modifier, taper start temp (full modifier), was ASE in early versions
+  uint8_t aeMode : 2; /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */
+  uint8_t battVCorMode : 1;
+  uint8_t SoftLimitMode : 1;
+  uint8_t useTachoSweep : 1;
+  uint8_t aeApplyMode : 1; //0 = Multiply | 1 = Add
+  uint8_t multiplyMAP : 2; //0 = off | 1 = baro | 2 = 100
+  uint8_t wueValues[10]; //Warm up enrichment array (10 bytes)
+  uint8_t crankingPct; //Cranking enrichment
+  uint8_t pinMapping; // The board / ping mapping to be used
+  uint8_t tachoPin : 6; //Custom pin setting for tacho output
+  uint8_t tachoDiv : 2; //Whether to change the tacho speed
+  uint8_t tachoDuration; //The duration of the tacho pulse in mS
+  uint8_t maeThresh; /**< The MAPdot threshold that must be exceeded before AE is engaged */
+  uint8_t taeThresh; /**< The TPSdot threshold that must be exceeded before AE is engaged */
+  uint8_t aeTime;
 
   //Display config bits
-  byte displayType : 3; //21
-  byte display1 : 3;
-  byte display2 : 2;
+  uint8_t displayType : 3; //21
+  uint8_t display1 : 3;
+  uint8_t display2 : 2;
 
-  byte display3 : 3;    //22
-  byte display4 : 2;
-  byte display5 : 3;
+  uint8_t display3 : 3;    //22
+  uint8_t display4 : 2;
+  uint8_t display5 : 3;
 
-  byte displayB1 : 4;   //23
-  byte displayB2 : 4;
+  uint8_t displayB1 : 4;   //23
+  uint8_t displayB2 : 4;
 
-  byte reqFuel;       //24
-  byte divider;
-  byte injTiming : 1;
-  byte multiplyMAP_old : 1;
-  byte includeAFR : 1;
-  byte hardCutType : 1;
-  byte ignAlgorithm : 3;
-  byte indInjAng : 1;
-  byte injOpen; //Injector opening time (ms * 10)
+  uint8_t reqFuel;       //24
+  uint8_t divider;
+  uint8_t injTiming : 1;
+  uint8_t multiplyMAP_old : 1;
+  uint8_t includeAFR : 1;
+  uint8_t hardCutType : 1;
+  uint8_t ignAlgorithm : 3;
+  uint8_t indInjAng : 1;
+  uint8_t injOpen; //Injector opening time (ms * 10)
   uint16_t injAng[4];
 
   //config1 in ini
-  byte mapSample : 2;
-  byte strokes : 1;
-  byte injType : 1;
-  byte nCylinders : 4; //Number of cylinders
+  uint8_t mapSample : 2;
+  uint8_t strokes : 1;
+  uint8_t injType : 1;
+  uint8_t nCylinders : 4; //Number of cylinders
 
   //config2 in ini
-  byte fuelAlgorithm : 3;
-  byte fixAngEnable : 1; //Whether fixed/locked timing is enabled
-  byte nInjectors : 4; //Number of injectors
+  uint8_t fuelAlgorithm : 3;
+  uint8_t fixAngEnable : 1; //Whether fixed/locked timing is enabled
+  uint8_t nInjectors : 4; //Number of injectors
 
 
   //config3 in ini
-  byte engineType : 1;
-  byte flexEnabled : 1;
-  byte legacyMAP  : 1;
-  byte baroCorr : 1;
-  byte injLayout : 2;
-  byte perToothIgn : 1;
-  byte dfcoEnabled : 1; //Whether or not DFCO is turned on
+  uint8_t engineType : 1;
+  uint8_t flexEnabled : 1;
+  uint8_t legacyMAP  : 1;
+  uint8_t baroCorr : 1;
+  uint8_t injLayout : 2;
+  uint8_t perToothIgn : 1;
+  uint8_t dfcoEnabled : 1; //Whether or not DFCO is turned on
 
-  byte aeColdTaperMax;  //AE cold modifier, taper end temp (no modifier applied), was primePulse in early versions
-  byte dutyLim;
-  byte flexFreqLow; //Lowest valid frequency reading from the flex sensor
-  byte flexFreqHigh; //Highest valid frequency reading from the flex sensor
+  uint8_t aeColdTaperMax;  //AE cold modifier, taper end temp (no modifier applied), was primePulse in early versions
+  uint8_t dutyLim;
+  uint8_t flexFreqLow; //Lowest valid frequency reading from the flex sensor
+  uint8_t flexFreqHigh; //Highest valid frequency reading from the flex sensor
 
-  byte boostMaxDuty;
-  byte tpsMin;
-  byte tpsMax;
+  uint8_t boostMaxDuty;
+  uint8_t tpsMin;
+  uint8_t tpsMax;
   int8_t mapMin; //Must be signed
   uint16_t mapMax;
-  byte fpPrime; //Time (In seconds) that the fuel pump should be primed for on power up
-  byte stoich;
+  uint8_t fpPrime; //Time (In seconds) that the fuel pump should be primed for on power up
+  uint8_t stoich;
   uint16_t oddfire2; //The ATDC angle of channel 2 for oddfire
   uint16_t oddfire3; //The ATDC angle of channel 3 for oddfire
   uint16_t oddfire4; //The ATDC angle of channel 4 for oddfire
 
-  byte idleUpPin : 6;
-  byte idleUpPolarity : 1;
-  byte idleUpEnabled : 1;
+  uint8_t idleUpPin : 6;
+  uint8_t idleUpPolarity : 1;
+  uint8_t idleUpEnabled : 1;
 
-  byte idleUpAdder;
-  byte aeTaperMin;
-  byte aeTaperMax;
+  uint8_t idleUpAdder;
+  uint8_t aeTaperMin;
+  uint8_t aeTaperMax;
 
-  byte iacCLminDuty;
-  byte iacCLmaxDuty;
-  byte boostMinDuty;
+  uint8_t iacCLminDuty;
+  uint8_t iacCLmaxDuty;
+  uint8_t boostMinDuty;
 
   int8_t baroMin; //Must be signed
   uint16_t baroMax;
@@ -744,40 +744,40 @@ struct config2 {
   int8_t EMAPMin; //Must be signed
   uint16_t EMAPMax;
 
-  byte fanWhenOff : 1;      // Only run fan when engine is running
-  byte fanWhenCranking : 1;      //**< Setting whether the fan output will stay on when the engine is cranking */ 
-  byte fanUnused : 3;
-  byte rtc_mode : 2;
-  byte incorporateAFR : 1;  //Incorporate AFR
-  byte asePct[4];  //Afterstart enrichment (%)
-  byte aseCount[4]; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
-  byte aseBins[4]; //Afterstart enrichment temp axis
-  byte primePulse[4]; //Priming pulsewidth
-  byte primeBins[4]; //Priming temp axis
+  uint8_t fanWhenOff : 1;      // Only run fan when engine is running
+  uint8_t fanWhenCranking : 1;      //**< Setting whether the fan output will stay on when the engine is cranking */ 
+  uint8_t fanUnused : 3;
+  uint8_t rtc_mode : 2;
+  uint8_t incorporateAFR : 1;  //Incorporate AFR
+  uint8_t asePct[4];  //Afterstart enrichment (%)
+  uint8_t aseCount[4]; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
+  uint8_t aseBins[4]; //Afterstart enrichment temp axis
+  uint8_t primePulse[4]; //Priming pulsewidth
+  uint8_t primeBins[4]; //Priming temp axis
 
-  byte CTPSPin : 6;
-  byte CTPSPolarity : 1;
-  byte CTPSEnabled : 1;
+  uint8_t CTPSPin : 6;
+  uint8_t CTPSPolarity : 1;
+  uint8_t CTPSEnabled : 1;
 
-  byte idleAdvEnabled : 2;
-  byte idleAdvAlgorithm : 1;
-  byte IdleAdvDelay : 5;
+  uint8_t idleAdvEnabled : 2;
+  uint8_t idleAdvAlgorithm : 1;
+  uint8_t IdleAdvDelay : 5;
   
-  byte idleAdvRPM;
-  byte idleAdvTPS;
+  uint8_t idleAdvRPM;
+  uint8_t idleAdvTPS;
 
-  byte injAngRPM[4];
+  uint8_t injAngRPM[4];
 
-  byte idleTaperTime;
-  byte dfcoDelay;
-  byte dfcoMinCLT;
+  uint8_t idleTaperTime;
+  uint8_t dfcoDelay;
+  uint8_t dfcoMinCLT;
 
   //VSS Stuff
-  byte vssMode : 2;
-  byte vssPin : 6;
+  uint8_t vssMode : 2;
+  uint8_t vssPin : 6;
   
   uint16_t vssPulsesPerKm;
-  byte vssSmoothing;
+  uint8_t vssSmoothing;
   uint16_t vssRatio1;
   uint16_t vssRatio2;
   uint16_t vssRatio3;
@@ -785,19 +785,19 @@ struct config2 {
   uint16_t vssRatio5;
   uint16_t vssRatio6;
 
-  byte idleUpOutputEnabled : 1;
-  byte idleUpOutputInv : 1;
-  byte idleUpOutputPin  : 6;
+  uint8_t idleUpOutputEnabled : 1;
+  uint8_t idleUpOutputInv : 1;
+  uint8_t idleUpOutputPin  : 6;
 
-  byte tachoSweepMaxRPM;
-  byte primingDelay;
+  uint8_t tachoSweepMaxRPM;
+  uint8_t primingDelay;
 
-  byte iacTPSlimit;
-  byte iacRPMlimitHysteresis;
+  uint8_t iacTPSlimit;
+  uint8_t iacRPMlimitHysteresis;
 
   int8_t rtc_trim;
 
-  byte unused2_95[4];
+  uint8_t unused2_95[4];
 
 #if defined(CORE_AVR)
   };
@@ -811,83 +811,83 @@ struct config4 {
 
   int16_t triggerAngle;
   int8_t FixAng; //Negative values allowed
-  byte CrankAng;
-  byte TrigAngMul; //Multiplier for non evenly divisible tooth counts.
+  uint8_t CrankAng;
+  uint8_t TrigAngMul; //Multiplier for non evenly divisible tooth counts.
 
-  byte TrigEdge : 1;
-  byte TrigSpeed : 1;
-  byte IgInv : 1;
-  byte TrigPattern : 5;
+  uint8_t TrigEdge : 1;
+  uint8_t TrigSpeed : 1;
+  uint8_t IgInv : 1;
+  uint8_t TrigPattern : 5;
 
-  byte TrigEdgeSec : 1;
-  byte fuelPumpPin : 6;
-  byte useResync : 1;
+  uint8_t TrigEdgeSec : 1;
+  uint8_t fuelPumpPin : 6;
+  uint8_t useResync : 1;
 
-  byte sparkDur; //Spark duration in ms * 10
-  byte trigPatternSec; //Mode for Missing tooth secondary trigger.  Either single tooth cam wheel or 4-1
+  uint8_t sparkDur; //Spark duration in ms * 10
+  uint8_t trigPatternSec; //Mode for Missing tooth secondary trigger.  Either single tooth cam wheel or 4-1
   uint8_t bootloaderCaps; //Capabilities of the bootloader over stock. e.g., 0=Stock, 1=Reset protection, etc.
 
-  byte resetControlConfig : 2; //Which method of reset control to use (0=None, 1=Prevent When Running, 2=Prevent Always, 3=Serial Command)
-  byte resetControlPin : 6;
+  uint8_t resetControlConfig : 2; //Which method of reset control to use (0=None, 1=Prevent When Running, 2=Prevent Always, 3=Serial Command)
+  uint8_t resetControlPin : 6;
 
-  byte StgCycles; //The number of initial cycles before the ignition should fire when first cranking
+  uint8_t StgCycles; //The number of initial cycles before the ignition should fire when first cranking
 
-  byte boostType : 1; //Open or closed loop boost control
-  byte useDwellLim : 1; //Whether the dwell limiter is off or on
-  byte sparkMode : 3; //Spark output mode (Eg Wasted spark, single channel or Wasted COP)
-  byte triggerFilter : 2; //The mode of trigger filter being used (0=Off, 1=Light (Not currently used), 2=Normal, 3=Aggressive)
-  byte ignCranklock : 1; //Whether or not the ignition timing during cranking is locked to a CAS pulse. Only currently valid for Basic distributor and 4G63.
+  uint8_t boostType : 1; //Open or closed loop boost control
+  uint8_t useDwellLim : 1; //Whether the dwell limiter is off or on
+  uint8_t sparkMode : 3; //Spark output mode (Eg Wasted spark, single channel or Wasted COP)
+  uint8_t triggerFilter : 2; //The mode of trigger filter being used (0=Off, 1=Light (Not currently used), 2=Normal, 3=Aggressive)
+  uint8_t ignCranklock : 1; //Whether or not the ignition timing during cranking is locked to a CAS pulse. Only currently valid for Basic distributor and 4G63.
 
-  byte dwellCrank; //Dwell time whilst cranking
-  byte dwellRun; //Dwell time whilst running
-  byte triggerTeeth; //The full count of teeth on the trigger wheel if there were no gaps
-  byte triggerMissingTeeth; //The size of the tooth gap (ie number of missing teeth)
-  byte crankRPM; //RPM below which the engine is considered to be cranking
-  byte floodClear; //TPS value that triggers flood clear mode (No fuel whilst cranking)
-  byte SoftRevLim; //Soft rev limit (RPM/100)
-  byte SoftLimRetard; //Amount soft limit retards (degrees)
-  byte SoftLimMax; //Time the soft limit can run
-  byte HardRevLim; //Hard rev limit (RPM/100)
-  byte taeBins[4]; //TPS based acceleration enrichment bins (%/s)
-  byte taeValues[4]; //TPS based acceleration enrichment rates (% to add)
-  byte wueBins[10]; //Warmup Enrichment bins (Values are in configTable1)
-  byte dwellLimit;
-  byte dwellCorrectionValues[6]; //Correction table for dwell vs battery voltage
-  byte iatRetBins[6]; // Inlet Air Temp timing retard curve bins
-  byte iatRetValues[6]; // Inlet Air Temp timing retard curve values
-  byte dfcoRPM; //RPM at which DFCO turns off/on at
-  byte dfcoHyster; //Hysteris RPM for DFCO
-  byte dfcoTPSThresh; //TPS must be below this figure for DFCO to engage
+  uint8_t dwellCrank; //Dwell time whilst cranking
+  uint8_t dwellRun; //Dwell time whilst running
+  uint8_t triggerTeeth; //The full count of teeth on the trigger wheel if there were no gaps
+  uint8_t triggerMissingTeeth; //The size of the tooth gap (ie number of missing teeth)
+  uint8_t crankRPM; //RPM below which the engine is considered to be cranking
+  uint8_t floodClear; //TPS value that triggers flood clear mode (No fuel whilst cranking)
+  uint8_t SoftRevLim; //Soft rev limit (RPM/100)
+  uint8_t SoftLimRetard; //Amount soft limit retards (degrees)
+  uint8_t SoftLimMax; //Time the soft limit can run
+  uint8_t HardRevLim; //Hard rev limit (RPM/100)
+  uint8_t taeBins[4]; //TPS based acceleration enrichment bins (%/s)
+  uint8_t taeValues[4]; //TPS based acceleration enrichment rates (% to add)
+  uint8_t wueBins[10]; //Warmup Enrichment bins (Values are in configTable1)
+  uint8_t dwellLimit;
+  uint8_t dwellCorrectionValues[6]; //Correction table for dwell vs battery voltage
+  uint8_t iatRetBins[6]; // Inlet Air Temp timing retard curve bins
+  uint8_t iatRetValues[6]; // Inlet Air Temp timing retard curve values
+  uint8_t dfcoRPM; //RPM at which DFCO turns off/on at
+  uint8_t dfcoHyster; //Hysteris RPM for DFCO
+  uint8_t dfcoTPSThresh; //TPS must be below this figure for DFCO to engage
 
-  byte ignBypassEnabled : 1; //Whether or not the ignition bypass is enabled
-  byte ignBypassPin : 6; //Pin the ignition bypass is activated on
-  byte ignBypassHiLo : 1; //Whether this should be active high or low.
+  uint8_t ignBypassEnabled : 1; //Whether or not the ignition bypass is enabled
+  uint8_t ignBypassPin : 6; //Pin the ignition bypass is activated on
+  uint8_t ignBypassHiLo : 1; //Whether this should be active high or low.
 
-  byte ADCFILTER_TPS;
-  byte ADCFILTER_CLT;
-  byte ADCFILTER_IAT;
-  byte ADCFILTER_O2;
-  byte ADCFILTER_BAT;
-  byte ADCFILTER_MAP; //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
-  byte ADCFILTER_BARO;
+  uint8_t ADCFILTER_TPS;
+  uint8_t ADCFILTER_CLT;
+  uint8_t ADCFILTER_IAT;
+  uint8_t ADCFILTER_O2;
+  uint8_t ADCFILTER_BAT;
+  uint8_t ADCFILTER_MAP; //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
+  uint8_t ADCFILTER_BARO;
   
-  byte cltAdvBins[6]; /**< Coolant Temp timing advance curve bins */
-  byte cltAdvValues[6]; /**< Coolant timing advance curve values. These are translated by 15 to allow for negative values */
+  uint8_t cltAdvBins[6]; /**< Coolant Temp timing advance curve bins */
+  uint8_t cltAdvValues[6]; /**< Coolant timing advance curve values. These are translated by 15 to allow for negative values */
 
-  byte maeBins[4]; /**< MAP based AE MAPdot bins */
-  byte maeRates[4]; /**< MAP based AE values */
+  uint8_t maeBins[4]; /**< MAP based AE MAPdot bins */
+  uint8_t maeRates[4]; /**< MAP based AE values */
 
   int8_t batVoltCorrect; /**< Battery voltage calibration offset */
 
-  byte baroFuelBins[8];
-  byte baroFuelValues[8];
+  uint8_t baroFuelBins[8];
+  uint8_t baroFuelValues[8];
 
-  byte idleAdvBins[6];
-  byte idleAdvValues[6];
+  uint8_t idleAdvBins[6];
+  uint8_t idleAdvValues[6];
 
-  byte engineProtectMaxRPM;
+  uint8_t engineProtectMaxRPM;
 
-  byte unused4_120[7];
+  uint8_t unused4_120[7];
 
 #if defined(CORE_AVR)
   };
@@ -899,95 +899,95 @@ struct config4 {
 //This mostly covers off variables that are required for AFR targets and closed loop
 struct config6 {
 
-  byte egoAlgorithm : 2;
-  byte egoType : 2;
-  byte boostEnabled : 1;
-  byte vvtEnabled : 1;
-  byte engineProtectType : 2;
+  uint8_t egoAlgorithm : 2;
+  uint8_t egoType : 2;
+  uint8_t boostEnabled : 1;
+  uint8_t vvtEnabled : 1;
+  uint8_t engineProtectType : 2;
 
-  byte egoKP;
-  byte egoKI;
-  byte egoKD;
-  byte egoTemp; //The temperature above which closed loop functions
-  byte egoCount; //The number of ignition cylces per step
-  byte vvtMode : 2; //Valid VVT modes are 'on/off', 'open loop' and 'closed loop'
-  byte vvtLoadSource : 2; //Load source for VVT (TPS or MAP)
-  byte vvtPWMdir : 1; //VVT direction (normal or reverse)
-  byte vvtCLUseHold : 1; //Whether or not to use a hold duty cycle (Most cases are Yes)
-  byte vvtCLAlterFuelTiming : 1;
-  byte boostCutEnabled : 1;
-  byte egoLimit; //Maximum amount the closed loop will vary the fueling
-  byte ego_min; //AFR must be above this for closed loop to function
-  byte ego_max; //AFR must be below this for closed loop to function
-  byte ego_sdelay; //Time in seconds after engine starts that closed loop becomes available
-  byte egoRPM; //RPM must be above this for closed loop to function
-  byte egoTPSMax; //TPS must be below this for closed loop to function
-  byte vvt1Pin : 6;
-  byte useExtBaro : 1;
-  byte boostMode : 1; //Simple of full boost control
-  byte boostPin : 6;
-  byte VVTasOnOff : 1; //Whether or not to use the VVT table as an on/off map
-  byte useEMAP : 1;
-  byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
-  byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage
-  byte airDenBins[9];
-  byte airDenRates[9];
-  byte boostFreq; //Frequency of the boost PWM valve
-  byte vvtFreq; //Frequency of the vvt PWM valve
-  byte idleFreq;
+  uint8_t egoKP;
+  uint8_t egoKI;
+  uint8_t egoKD;
+  uint8_t egoTemp; //The temperature above which closed loop functions
+  uint8_t egoCount; //The number of ignition cylces per step
+  uint8_t vvtMode : 2; //Valid VVT modes are 'on/off', 'open loop' and 'closed loop'
+  uint8_t vvtLoadSource : 2; //Load source for VVT (TPS or MAP)
+  uint8_t vvtPWMdir : 1; //VVT direction (normal or reverse)
+  uint8_t vvtCLUseHold : 1; //Whether or not to use a hold duty cycle (Most cases are Yes)
+  uint8_t vvtCLAlterFuelTiming : 1;
+  uint8_t boostCutEnabled : 1;
+  uint8_t egoLimit; //Maximum amount the closed loop will vary the fueling
+  uint8_t ego_min; //AFR must be above this for closed loop to function
+  uint8_t ego_max; //AFR must be below this for closed loop to function
+  uint8_t ego_sdelay; //Time in seconds after engine starts that closed loop becomes available
+  uint8_t egoRPM; //RPM must be above this for closed loop to function
+  uint8_t egoTPSMax; //TPS must be below this for closed loop to function
+  uint8_t vvt1Pin : 6;
+  uint8_t useExtBaro : 1;
+  uint8_t boostMode : 1; //Simple of full boost control
+  uint8_t boostPin : 6;
+  uint8_t VVTasOnOff : 1; //Whether or not to use the VVT table as an on/off map
+  uint8_t useEMAP : 1;
+  uint8_t voltageCorrectionBins[6]; //X axis bins for voltage correction tables
+  uint8_t injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage
+  uint8_t airDenBins[9];
+  uint8_t airDenRates[9];
+  uint8_t boostFreq; //Frequency of the boost PWM valve
+  uint8_t vvtFreq; //Frequency of the vvt PWM valve
+  uint8_t idleFreq;
 
-  byte launchPin : 6;
-  byte launchEnabled : 1;
-  byte launchHiLo : 1;
+  uint8_t launchPin : 6;
+  uint8_t launchEnabled : 1;
+  uint8_t launchHiLo : 1;
 
-  byte lnchSoftLim;
+  uint8_t lnchSoftLim;
   int8_t lnchRetard; //Allow for negative advance value (ATDC)
-  byte lnchHardLim;
-  byte lnchFuelAdd;
+  uint8_t lnchHardLim;
+  uint8_t lnchFuelAdd;
 
   //PID values for idle needed to go here as out of room in the idle page
-  byte idleKP;
-  byte idleKI;
-  byte idleKD;
+  uint8_t idleKP;
+  uint8_t idleKI;
+  uint8_t idleKD;
 
-  byte boostLimit; //Is divided by 2, allowing kPa values up to 511
-  byte boostKP;
-  byte boostKI;
-  byte boostKD;
+  uint8_t boostLimit; //Is divided by 2, allowing kPa values up to 511
+  uint8_t boostKP;
+  uint8_t boostKI;
+  uint8_t boostKD;
 
-  byte lnchPullRes : 2;
-  byte fuelTrimEnabled : 1;
-  byte flatSEnable : 1;
-  byte baroPin : 4;
-  byte flatSSoftWin;
-  byte flatSRetard;
-  byte flatSArm;
+  uint8_t lnchPullRes : 2;
+  uint8_t fuelTrimEnabled : 1;
+  uint8_t flatSEnable : 1;
+  uint8_t baroPin : 4;
+  uint8_t flatSSoftWin;
+  uint8_t flatSRetard;
+  uint8_t flatSArm;
 
-  byte iacCLValues[10]; //Closed loop target RPM value
-  byte iacOLStepVal[10]; //Open loop step values for stepper motors
-  byte iacOLPWMVal[10]; //Open loop duty values for PMWM valves
-  byte iacBins[10]; //Temperature Bins for the above 3 curves
-  byte iacCrankSteps[4]; //Steps to use when cranking (Stepper motor)
-  byte iacCrankDuty[4]; //Duty cycle to use on PWM valves when cranking
-  byte iacCrankBins[4]; //Temperature Bins for the above 2 curves
+  uint8_t iacCLValues[10]; //Closed loop target RPM value
+  uint8_t iacOLStepVal[10]; //Open loop step values for stepper motors
+  uint8_t iacOLPWMVal[10]; //Open loop duty values for PMWM valves
+  uint8_t iacBins[10]; //Temperature Bins for the above 3 curves
+  uint8_t iacCrankSteps[4]; //Steps to use when cranking (Stepper motor)
+  uint8_t iacCrankDuty[4]; //Duty cycle to use on PWM valves when cranking
+  uint8_t iacCrankBins[4]; //Temperature Bins for the above 2 curves
 
-  byte iacAlgorithm : 3; //Valid values are: "None", "On/Off", "PWM", "PWM Closed Loop", "Stepper", "Stepper Closed Loop"
-  byte iacStepTime : 3; //How long to pulse the stepper for to ensure the step completes (ms)
-  byte iacChannels : 1; //How many outputs to use in PWM mode (0 = 1 channel, 1 = 2 channels)
-  byte iacPWMdir : 1; //Direction of the PWM valve. 0 = Normal = Higher RPM with more duty. 1 = Reverse = Lower RPM with more duty
+  uint8_t iacAlgorithm : 3; //Valid values are: "None", "On/Off", "PWM", "PWM Closed Loop", "Stepper", "Stepper Closed Loop"
+  uint8_t iacStepTime : 3; //How long to pulse the stepper for to ensure the step completes (ms)
+  uint8_t iacChannels : 1; //How many outputs to use in PWM mode (0 = 1 channel, 1 = 2 channels)
+  uint8_t iacPWMdir : 1; //Direction of the PWM valve. 0 = Normal = Higher RPM with more duty. 1 = Reverse = Lower RPM with more duty
 
-  byte iacFastTemp; //Fast idle temp when using a simple on/off valve
+  uint8_t iacFastTemp; //Fast idle temp when using a simple on/off valve
 
-  byte iacStepHome; //When using a stepper motor, the number of steps to be taken on startup to home the motor
-  byte iacStepHyster; //Hysteresis temperature (*10). Eg 2.2C = 22
+  uint8_t iacStepHome; //When using a stepper motor, the number of steps to be taken on startup to home the motor
+  uint8_t iacStepHyster; //Hysteresis temperature (*10). Eg 2.2C = 22
 
-  byte fanInv : 1;        // Fan output inversion bit
-  byte fanEnable : 1;     // Fan enable bit. 0=Off, 1=On/Off
-  byte fanPin : 6;
-  byte fanSP;             // Cooling fan start temperature
-  byte fanHyster;         // Fan hysteresis
-  byte fanFreq;           // Fan PWM frequency
-  byte fanPWMBins[4];     //Temperature Bins for the PWM fan control
+  uint8_t fanInv : 1;        // Fan output inversion bit
+  uint8_t fanEnable : 1;     // Fan enable bit. 0=Off, 1=On/Off
+  uint8_t fanPin : 6;
+  uint8_t fanSP;             // Cooling fan start temperature
+  uint8_t fanHyster;         // Fan hysteresis
+  uint8_t fanFreq;           // Fan PWM frequency
+  uint8_t fanPWMBins[4];     //Temperature Bins for the PWM fan control
 
 #if defined(CORE_AVR)
   };
@@ -998,74 +998,74 @@ struct config6 {
 //Page 9 of the config mostly deals with CANBUS control
 //See ini file for further info (Config Page 10 in the ini)
 struct config9 {
-  byte enable_secondarySerial:1;            //enable secondary serial
-  byte intcan_available:1;                     //enable internal can module
-  byte enable_intcan:1;
-  byte caninput_sel[16];                    //bit status on/Can/analog_local/digtal_local if input is enabled
+  uint8_t enable_secondarySerial:1;            //enable secondary serial
+  uint8_t intcan_available:1;                     //enable internal can module
+  uint8_t enable_intcan:1;
+  uint8_t caninput_sel[16];                    //bit status on/Can/analog_local/digtal_local if input is enabled
   uint16_t caninput_source_can_address[16];        //u16 [15] array holding can address of input
   uint8_t caninput_source_start_byte[16];     //u08 [15] array holds the start byte number(value of 0-7)
   uint16_t caninput_source_num_bytes;     //u16 bit status of the number of bytes length 1 or 2
-  byte unused10_67;
-  byte unused10_68;
-  byte enable_candata_out : 1;
-  byte canoutput_sel[8];
+  uint8_t unused10_67;
+  uint8_t unused10_68;
+  uint8_t enable_candata_out : 1;
+  uint8_t canoutput_sel[8];
   uint16_t canoutput_param_group[8];
   uint8_t canoutput_param_start_byte[8];
-  byte canoutput_param_num_bytes[8];
+  uint8_t canoutput_param_num_bytes[8];
 
-  byte unused10_110;
-  byte unused10_111;
-  byte unused10_112;
-  byte unused10_113;
-  byte speeduino_tsCanId:4;         //speeduino TS canid (0-14)
+  uint8_t unused10_110;
+  uint8_t unused10_111;
+  uint8_t unused10_112;
+  uint8_t unused10_113;
+  uint8_t speeduino_tsCanId:4;         //speeduino TS canid (0-14)
   uint16_t true_address;            //speeduino 11bit can address
   uint16_t realtime_base_address;   //speeduino 11 bit realtime base address
   uint16_t obd_address;             //speeduino OBD diagnostic address
   uint8_t Auxinpina[16];            //analog  pin number when internal aux in use
   uint8_t Auxinpinb[16];            // digital pin number when internal aux in use
 
-  byte iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
-  byte iacCoolTime : 3; // how long to wait for the stepper to cool between steps
+  uint8_t iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
+  uint8_t iacCoolTime : 3; // how long to wait for the stepper to cool between steps
 
-  byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
+  uint8_t iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
 
-  byte unused10_155;
-  byte unused10_156;
-  byte unused10_157;
-  byte unused10_158;
-  byte unused10_159;
-  byte unused10_160;
-  byte unused10_161;
-  byte unused10_162;
-  byte unused10_163;
-  byte unused10_164;
-  byte unused10_165;
-  byte unused10_166;
-  byte unused10_167;
-  byte unused10_168;
-  byte unused10_169;
-  byte unused10_170;
-  byte unused10_171;
-  byte unused10_172;
-  byte unused10_173;
-  byte unused10_174;
-  byte unused10_175;
-  byte unused10_176;
-  byte unused10_177;
-  byte unused10_178;
-  byte unused10_179;
-  byte unused10_180;
-  byte unused10_181;
-  byte unused10_182;
-  byte unused10_183;
-  byte unused10_184;
-  byte unused10_185;
-  byte unused10_186;
-  byte unused10_187;
-  byte unused10_188;
-  byte unused10_189;
-  byte unused10_190;
-  byte unused10_191;
+  uint8_t unused10_155;
+  uint8_t unused10_156;
+  uint8_t unused10_157;
+  uint8_t unused10_158;
+  uint8_t unused10_159;
+  uint8_t unused10_160;
+  uint8_t unused10_161;
+  uint8_t unused10_162;
+  uint8_t unused10_163;
+  uint8_t unused10_164;
+  uint8_t unused10_165;
+  uint8_t unused10_166;
+  uint8_t unused10_167;
+  uint8_t unused10_168;
+  uint8_t unused10_169;
+  uint8_t unused10_170;
+  uint8_t unused10_171;
+  uint8_t unused10_172;
+  uint8_t unused10_173;
+  uint8_t unused10_174;
+  uint8_t unused10_175;
+  uint8_t unused10_176;
+  uint8_t unused10_177;
+  uint8_t unused10_178;
+  uint8_t unused10_179;
+  uint8_t unused10_180;
+  uint8_t unused10_181;
+  uint8_t unused10_182;
+  uint8_t unused10_183;
+  uint8_t unused10_184;
+  uint8_t unused10_185;
+  uint8_t unused10_186;
+  uint8_t unused10_187;
+  uint8_t unused10_188;
+  uint8_t unused10_189;
+  uint8_t unused10_190;
+  uint8_t unused10_191;
   
 #if defined(CORE_AVR)
   };
@@ -1079,23 +1079,23 @@ Page 10 - No specific purpose. Created initially for the cranking enrich curve
 See ini file for further info (Config Page 11 in the ini)
 */
 struct config10 {
-  byte crankingEnrichBins[4]; //Bytes 0-4
-  byte crankingEnrichValues[4]; //Bytes 4-7
+  uint8_t crankingEnrichBins[4]; //Bytes 0-4
+  uint8_t crankingEnrichValues[4]; //Bytes 4-7
 
   //Byte 8
-  byte rotaryType : 2;
-  byte stagingEnabled : 1;
-  byte stagingMode : 1;
-  byte EMAPPin : 4;
+  uint8_t rotaryType : 2;
+  uint8_t stagingEnabled : 1;
+  uint8_t stagingMode : 1;
+  uint8_t EMAPPin : 4;
 
-  byte rotarySplitValues[8]; //Bytes 9-16
-  byte rotarySplitBins[8]; //Bytes 17-24
+  uint8_t rotarySplitValues[8]; //Bytes 9-16
+  uint8_t rotarySplitBins[8]; //Bytes 17-24
 
   uint16_t boostSens; //Bytes 25-26
-  byte boostIntv; //Byte 27
+  uint8_t boostIntv; //Byte 27
   uint16_t stagedInjSizePri; //Bytes 28-29
   uint16_t stagedInjSizeSec; //Bytes 30-31
-  byte lnchCtrlTPS; //Byte 32
+  uint8_t lnchCtrlTPS; //Byte 32
 
   uint8_t flexBoostBins[6]; //Byets 33-38
   int16_t flexBoostAdj[6];  //kPa to be added to the boost target @ current ethanol (negative values allowed). Bytes 39-50
@@ -1107,145 +1107,145 @@ struct config10 {
                             //Bytes 69-74
 
   //Byte 75
-  byte n2o_enable : 2;
-  byte n2o_arming_pin : 6;
-  byte n2o_minCLT; //Byte 76
-  byte n2o_maxMAP; //Byte 77
-  byte n2o_minTPS; //Byte 78
-  byte n2o_maxAFR; //Byte 79
+  uint8_t n2o_enable : 2;
+  uint8_t n2o_arming_pin : 6;
+  uint8_t n2o_minCLT; //Byte 76
+  uint8_t n2o_maxMAP; //Byte 77
+  uint8_t n2o_minTPS; //Byte 78
+  uint8_t n2o_maxAFR; //Byte 79
 
   //Byte 80
-  byte n2o_stage1_pin : 6;
-  byte n2o_pin_polarity : 1;
-  byte n2o_stage1_unused : 1;
-  byte n2o_stage1_minRPM; //Byte 81
-  byte n2o_stage1_maxRPM; //Byte 82
-  byte n2o_stage1_adderMin; //Byte 83
-  byte n2o_stage1_adderMax; //Byte 84
-  byte n2o_stage1_retard; //Byte 85
+  uint8_t n2o_stage1_pin : 6;
+  uint8_t n2o_pin_polarity : 1;
+  uint8_t n2o_stage1_unused : 1;
+  uint8_t n2o_stage1_minRPM; //Byte 81
+  uint8_t n2o_stage1_maxRPM; //Byte 82
+  uint8_t n2o_stage1_adderMin; //Byte 83
+  uint8_t n2o_stage1_adderMax; //Byte 84
+  uint8_t n2o_stage1_retard; //Byte 85
 
   //Byte 86
-  byte n2o_stage2_pin : 6;
-  byte n2o_stage2_unused : 2;
-  byte n2o_stage2_minRPM; //Byte 87
-  byte n2o_stage2_maxRPM; //Byte 88
-  byte n2o_stage2_adderMin; //Byte 89
-  byte n2o_stage2_adderMax; //Byte 90
-  byte n2o_stage2_retard; //Byte 91
+  uint8_t n2o_stage2_pin : 6;
+  uint8_t n2o_stage2_unused : 2;
+  uint8_t n2o_stage2_minRPM; //Byte 87
+  uint8_t n2o_stage2_maxRPM; //Byte 88
+  uint8_t n2o_stage2_adderMin; //Byte 89
+  uint8_t n2o_stage2_adderMax; //Byte 90
+  uint8_t n2o_stage2_retard; //Byte 91
 
   //Byte 92
-  byte knock_mode : 2;
-  byte knock_pin : 6;
+  uint8_t knock_mode : 2;
+  uint8_t knock_pin : 6;
 
   //Byte 93
-  byte knock_trigger : 1;
-  byte knock_pullup : 1;
-  byte knock_limiterDisable : 1;
-  byte knock_unused : 2;
-  byte knock_count : 3;
+  uint8_t knock_trigger : 1;
+  uint8_t knock_pullup : 1;
+  uint8_t knock_limiterDisable : 1;
+  uint8_t knock_unused : 2;
+  uint8_t knock_count : 3;
 
-  byte knock_threshold; //Byte 94
-  byte knock_maxMAP; //Byte 95
-  byte knock_maxRPM; //Byte 96
-  byte knock_window_rpms[6]; //Bytes 97-102
-  byte knock_window_angle[6]; //Bytes 103-108
-  byte knock_window_dur[6]; //Bytes 109-114
+  uint8_t knock_threshold; //Byte 94
+  uint8_t knock_maxMAP; //Byte 95
+  uint8_t knock_maxRPM; //Byte 96
+  uint8_t knock_window_rpms[6]; //Bytes 97-102
+  uint8_t knock_window_angle[6]; //Bytes 103-108
+  uint8_t knock_window_dur[6]; //Bytes 109-114
 
-  byte knock_maxRetard; //Byte 115
-  byte knock_firstStep; //Byte 116
-  byte knock_stepSize; //Byte 117
-  byte knock_stepTime; //Byte 118
+  uint8_t knock_maxRetard; //Byte 115
+  uint8_t knock_firstStep; //Byte 116
+  uint8_t knock_stepSize; //Byte 117
+  uint8_t knock_stepTime; //Byte 118
         
-  byte knock_duration; //Time after knock retard starts that it should start recovering. Byte 119
-  byte knock_recoveryStepTime; //Byte 120
-  byte knock_recoveryStep; //Byte 121
+  uint8_t knock_duration; //Time after knock retard starts that it should start recovering. Byte 119
+  uint8_t knock_recoveryStepTime; //Byte 120
+  uint8_t knock_recoveryStep; //Byte 121
 
   //Byte 122
-  byte fuel2Algorithm : 3;
-  byte fuel2Mode : 3;
-  byte fuel2SwitchVariable : 2;
+  uint8_t fuel2Algorithm : 3;
+  uint8_t fuel2Mode : 3;
+  uint8_t fuel2SwitchVariable : 2;
 
   //Bytes 123-124
   uint16_t fuel2SwitchValue;
 
   //Byte 125
-  byte fuel2InputPin : 6;
-  byte fuel2InputPolarity : 1;
-  byte fuel2InputPullup : 1;
+  uint8_t fuel2InputPin : 6;
+  uint8_t fuel2InputPolarity : 1;
+  uint8_t fuel2InputPullup : 1;
 
-  byte vvtCLholdDuty; //Byte 126
-  byte vvtCLKP; //Byte 127
-  byte vvtCLKI; //Byte 128
-  byte vvtCLKD; //Byte 129
+  uint8_t vvtCLholdDuty; //Byte 126
+  uint8_t vvtCLKP; //Byte 127
+  uint8_t vvtCLKI; //Byte 128
+  uint8_t vvtCLKD; //Byte 129
   int16_t vvtCLMinAng; //Bytes 130-131
   int16_t vvtCLMaxAng; //Bytes 132-133
 
-  byte crankingEnrichTaper; //Byte 134
+  uint8_t crankingEnrichTaper; //Byte 134
 
-  byte fuelPressureEnable : 1;
-  byte oilPressureEnable : 1;
-  byte oilPressureProtEnbl : 1;
-  byte unused10_135 : 5;
+  uint8_t fuelPressureEnable : 1;
+  uint8_t oilPressureEnable : 1;
+  uint8_t oilPressureProtEnbl : 1;
+  uint8_t unused10_135 : 5;
 
-  byte fuelPressurePin : 4;
-  byte oilPressurePin : 4;
+  uint8_t fuelPressurePin : 4;
+  uint8_t oilPressurePin : 4;
 
   int8_t fuelPressureMin;
-  byte fuelPressureMax;
+  uint8_t fuelPressureMax;
   int8_t oilPressureMin;
-  byte oilPressureMax;
+  uint8_t oilPressureMax;
 
-  byte oilPressureProtRPM[4];
-  byte oilPressureProtMins[4];
+  uint8_t oilPressureProtRPM[4];
+  uint8_t oilPressureProtMins[4];
 
-  byte wmiEnabled : 1; // Byte 149
-  byte wmiMode : 6;
+  uint8_t wmiEnabled : 1; // Byte 149
+  uint8_t wmiMode : 6;
   
-  byte wmiAdvEnabled : 1;
+  uint8_t wmiAdvEnabled : 1;
 
-  byte wmiTPS; // Byte 150
-  byte wmiRPM; // Byte 151
-  byte wmiMAP; // Byte 152
-  byte wmiMAP2; // Byte 153
-  byte wmiIAT; // Byte 154
+  uint8_t wmiTPS; // Byte 150
+  uint8_t wmiRPM; // Byte 151
+  uint8_t wmiMAP; // Byte 152
+  uint8_t wmiMAP2; // Byte 153
+  uint8_t wmiIAT; // Byte 154
   int8_t wmiOffset; // Byte 155
 
-  byte wmiIndicatorEnabled : 1; // 156
-  byte wmiIndicatorPin : 6;
-  byte wmiIndicatorPolarity : 1;
+  uint8_t wmiIndicatorEnabled : 1; // 156
+  uint8_t wmiIndicatorPin : 6;
+  uint8_t wmiIndicatorPolarity : 1;
 
-  byte wmiEmptyEnabled : 1; // 157
-  byte wmiEmptyPin : 6;
-  byte wmiEmptyPolarity : 1;
+  uint8_t wmiEmptyEnabled : 1; // 157
+  uint8_t wmiEmptyPin : 6;
+  uint8_t wmiEmptyPolarity : 1;
 
-  byte wmiEnabledPin; // 158
+  uint8_t wmiEnabledPin; // 158
 
-  byte wmiAdvBins[6]; //Bytes 159-164
-  byte wmiAdvAdj[6];  //Additional advance (in degrees)
+  uint8_t wmiAdvBins[6]; //Bytes 159-164
+  uint8_t wmiAdvAdj[6];  //Additional advance (in degrees)
                       //Bytes 165-170
-  byte vvtCLminDuty;
-  byte vvtCLmaxDuty;
-  byte vvt2Pin : 6;
-  byte unused11_174_1 : 1;
-  byte unused11_174_2 : 1;
+  uint8_t vvtCLminDuty;
+  uint8_t vvtCLmaxDuty;
+  uint8_t vvt2Pin : 6;
+  uint8_t unused11_174_1 : 1;
+  uint8_t unused11_174_2 : 1;
 
-  byte fuelTempBins[6];
-  byte fuelTempValues[6]; //180
+  uint8_t fuelTempBins[6];
+  uint8_t fuelTempValues[6]; //180
 
   //Byte 186
-  byte spark2Algorithm : 3;
-  byte spark2Mode : 3;
-  byte spark2SwitchVariable : 2;
+  uint8_t spark2Algorithm : 3;
+  uint8_t spark2Mode : 3;
+  uint8_t spark2SwitchVariable : 2;
 
   //Bytes 187-188
   uint16_t spark2SwitchValue;
 
   //Byte 189
-  byte spark2InputPin : 6;
-  byte spark2InputPolarity : 1;
-  byte spark2InputPullup : 1;
+  uint8_t spark2InputPin : 6;
+  uint8_t spark2InputPolarity : 1;
+  uint8_t spark2InputPullup : 1;
 
-  byte unused11_187_191[2]; //Bytes 187-191
+  uint8_t unused11_187_191[2]; //Bytes 187-191
 
 #if defined(CORE_AVR)
   };
@@ -1278,7 +1278,7 @@ struct config13 {
 
   uint16_t candID[8]; //Actual CAN ID need 16bits, this is a placeholder
 
-  byte unused12_106_127[22];
+  uint8_t unused12_106_127[22];
 
 #if defined(CORE_AVR)
   };
@@ -1286,83 +1286,83 @@ struct config13 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
-extern byte pinInjector1; //Output pin injector 1
-extern byte pinInjector2; //Output pin injector 2
-extern byte pinInjector3; //Output pin injector 3
-extern byte pinInjector4; //Output pin injector 4
-extern byte pinInjector5; //Output pin injector 5
-extern byte pinInjector6; //Output pin injector 6
-extern byte pinInjector7; //Output pin injector 7
-extern byte pinInjector8; //Output pin injector 8
-extern byte injectorOutputControl; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810
-extern byte pinCoil1; //Pin for coil 1
-extern byte pinCoil2; //Pin for coil 2
-extern byte pinCoil3; //Pin for coil 3
-extern byte pinCoil4; //Pin for coil 4
-extern byte pinCoil5; //Pin for coil 5
-extern byte pinCoil6; //Pin for coil 6
-extern byte pinCoil7; //Pin for coil 7
-extern byte pinCoil8; //Pin for coil 8
-extern byte ignitionOutputControl; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810
-extern byte pinTrigger; //The CAS pin
-extern byte pinTrigger2; //The Cam Sensor pin
-extern byte pinTrigger3;	//the 2nd cam sensor pin
-extern byte pinTPS;//TPS input pin
-extern byte pinMAP; //MAP sensor pin
-extern byte pinEMAP; //EMAP sensor pin
-extern byte pinMAP2; //2nd MAP sensor (Currently unused)
-extern byte pinIAT; //IAT sensor pin
-extern byte pinCLT; //CLS sensor pin
-extern byte pinO2; //O2 Sensor pin
-extern byte pinO2_2; //second O2 pin
-extern byte pinBat; //Battery voltage pin
-extern byte pinDisplayReset; // OLED reset pin
-extern byte pinTachOut; //Tacho output
-extern byte pinFuelPump; //Fuel pump on/off
-extern byte pinIdle1; //Single wire idle control
-extern byte pinIdle2; //2 wire idle control (Not currently used)
-extern byte pinIdleUp; //Input for triggering Idle Up
-extern byte pinIdleUpOutput; //Output that follows (normal or inverted) the idle up pin
-extern byte pinCTPS; //Input for triggering closed throttle state
-extern byte pinFuel2Input; //Input for switching to the 2nd fuel table
-extern byte pinSpark2Input; //Input for switching to the 2nd ignition table
-extern byte pinSpareTemp1; // Future use only
-extern byte pinSpareTemp2; // Future use only
-extern byte pinSpareOut1; //Generic output
-extern byte pinSpareOut2; //Generic output
-extern byte pinSpareOut3; //Generic output
-extern byte pinSpareOut4; //Generic output
-extern byte pinSpareOut5; //Generic output
-extern byte pinSpareOut6; //Generic output
-extern byte pinSpareHOut1; //spare high current output
-extern byte pinSpareHOut2; // spare high current output
-extern byte pinSpareLOut1; // spare low current output
-extern byte pinSpareLOut2; // spare low current output
-extern byte pinSpareLOut3;
-extern byte pinSpareLOut4;
-extern byte pinSpareLOut5;
-extern byte pinBoost;
-extern byte pinVVT_1;		// vvt output 1
-extern byte pinVVT_2;		// vvt output 2
-extern byte pinFan;       // Cooling fan output
-extern byte pinStepperDir; //Direction pin for the stepper motor driver
-extern byte pinStepperStep; //Step pin for the stepper motor driver
-extern byte pinStepperEnable; //Turning the DRV8825 driver on/off
-extern byte pinLaunch;
-extern byte pinIgnBypass; //The pin used for an ignition bypass (Optional)
-extern byte pinFlex; //Pin with the flex sensor attached
-extern byte pinVSS; 
-extern byte pinBaro; //Pin that an external barometric pressure sensor is attached to (If used)
-extern byte pinResetControl; // Output pin used control resetting the Arduino
-extern byte pinFuelPressure;
-extern byte pinOilPressure;
-extern byte pinWMIEmpty; // Water tank empty sensor
-extern byte pinWMIIndicator; // No water indicator bulb
-extern byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 
-extern byte pinMC33810_1_CS;
-extern byte pinMC33810_2_CS;
+extern uint8_t pinInjector1; //Output pin injector 1
+extern uint8_t pinInjector2; //Output pin injector 2
+extern uint8_t pinInjector3; //Output pin injector 3
+extern uint8_t pinInjector4; //Output pin injector 4
+extern uint8_t pinInjector5; //Output pin injector 5
+extern uint8_t pinInjector6; //Output pin injector 6
+extern uint8_t pinInjector7; //Output pin injector 7
+extern uint8_t pinInjector8; //Output pin injector 8
+extern uint8_t injectorOutputControl; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810
+extern uint8_t pinCoil1; //Pin for coil 1
+extern uint8_t pinCoil2; //Pin for coil 2
+extern uint8_t pinCoil3; //Pin for coil 3
+extern uint8_t pinCoil4; //Pin for coil 4
+extern uint8_t pinCoil5; //Pin for coil 5
+extern uint8_t pinCoil6; //Pin for coil 6
+extern uint8_t pinCoil7; //Pin for coil 7
+extern uint8_t pinCoil8; //Pin for coil 8
+extern uint8_t ignitionOutputControl; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810
+extern uint8_t pinTrigger; //The CAS pin
+extern uint8_t pinTrigger2; //The Cam Sensor pin
+extern uint8_t pinTrigger3;	//the 2nd cam sensor pin
+extern uint8_t pinTPS;//TPS input pin
+extern uint8_t pinMAP; //MAP sensor pin
+extern uint8_t pinEMAP; //EMAP sensor pin
+extern uint8_t pinMAP2; //2nd MAP sensor (Currently unused)
+extern uint8_t pinIAT; //IAT sensor pin
+extern uint8_t pinCLT; //CLS sensor pin
+extern uint8_t pinO2; //O2 Sensor pin
+extern uint8_t pinO2_2; //second O2 pin
+extern uint8_t pinBat; //Battery voltage pin
+extern uint8_t pinDisplayReset; // OLED reset pin
+extern uint8_t pinTachOut; //Tacho output
+extern uint8_t pinFuelPump; //Fuel pump on/off
+extern uint8_t pinIdle1; //Single wire idle control
+extern uint8_t pinIdle2; //2 wire idle control (Not currently used)
+extern uint8_t pinIdleUp; //Input for triggering Idle Up
+extern uint8_t pinIdleUpOutput; //Output that follows (normal or inverted) the idle up pin
+extern uint8_t pinCTPS; //Input for triggering closed throttle state
+extern uint8_t pinFuel2Input; //Input for switching to the 2nd fuel table
+extern uint8_t pinSpark2Input; //Input for switching to the 2nd ignition table
+extern uint8_t pinSpareTemp1; // Future use only
+extern uint8_t pinSpareTemp2; // Future use only
+extern uint8_t pinSpareOut1; //Generic output
+extern uint8_t pinSpareOut2; //Generic output
+extern uint8_t pinSpareOut3; //Generic output
+extern uint8_t pinSpareOut4; //Generic output
+extern uint8_t pinSpareOut5; //Generic output
+extern uint8_t pinSpareOut6; //Generic output
+extern uint8_t pinSpareHOut1; //spare high current output
+extern uint8_t pinSpareHOut2; // spare high current output
+extern uint8_t pinSpareLOut1; // spare low current output
+extern uint8_t pinSpareLOut2; // spare low current output
+extern uint8_t pinSpareLOut3;
+extern uint8_t pinSpareLOut4;
+extern uint8_t pinSpareLOut5;
+extern uint8_t pinBoost;
+extern uint8_t pinVVT_1;		// vvt output 1
+extern uint8_t pinVVT_2;		// vvt output 2
+extern uint8_t pinFan;       // Cooling fan output
+extern uint8_t pinStepperDir; //Direction pin for the stepper motor driver
+extern uint8_t pinStepperStep; //Step pin for the stepper motor driver
+extern uint8_t pinStepperEnable; //Turning the DRV8825 driver on/off
+extern uint8_t pinLaunch;
+extern uint8_t pinIgnBypass; //The pin used for an ignition bypass (Optional)
+extern uint8_t pinFlex; //Pin with the flex sensor attached
+extern uint8_t pinVSS; 
+extern uint8_t pinBaro; //Pin that an external barometric pressure sensor is attached to (If used)
+extern uint8_t pinResetControl; // Output pin used control resetting the Arduino
+extern uint8_t pinFuelPressure;
+extern uint8_t pinOilPressure;
+extern uint8_t pinWMIEmpty; // Water tank empty sensor
+extern uint8_t pinWMIIndicator; // No water indicator bulb
+extern uint8_t pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 
+extern uint8_t pinMC33810_1_CS;
+extern uint8_t pinMC33810_2_CS;
 #ifdef USE_SPI_EEPROM
-  extern byte pinSPIFlash_CS;
+  extern uint8_t pinSPIFlash_CS;
 #endif
 
 
@@ -1378,9 +1378,9 @@ extern struct config6 configPage6;
 extern struct config9 configPage9;
 extern struct config10 configPage10;
 extern struct config13 configPage13;
-//extern byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
-//extern byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
-//extern byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
+//extern uint8_t cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
+//extern uint8_t iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
+//extern uint8_t o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
 extern uint16_t cltCalibration_bins[32];
 extern uint16_t cltCalibration_values[32];

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -93,7 +93,7 @@
   #define BOARD_MAX_DIGITAL_PINS NUM_DIGITAL_PINS
   #define BOARD_MAX_IO_PINS NUM_DIGITAL_PINS
   #if __GNUC__ < 7 //Already included on GCC 7
-  extern "C" char* sbrk(int incr); //Used to freeRam
+  extern "C" char* sbrk(int16_t incr); //Used to freeRam
   #endif
   #ifndef digitalPinToInterrupt
   inline uint32_t  digitalPinToInterrupt(uint32_t Interrupt_pin) { return Interrupt_pin; } //This isn't included in the stm32duino libs (yet)
@@ -457,23 +457,23 @@ extern bool channel6InjEnabled;
 extern bool channel7InjEnabled;
 extern bool channel8InjEnabled;
 
-extern int ignition1EndAngle;
-extern int ignition2EndAngle;
-extern int ignition3EndAngle;
-extern int ignition4EndAngle;
-extern int ignition5EndAngle;
-extern int ignition6EndAngle;
-extern int ignition7EndAngle;
-extern int ignition8EndAngle;
+extern int16_t ignition1EndAngle;
+extern int16_t ignition2EndAngle;
+extern int16_t ignition3EndAngle;
+extern int16_t ignition4EndAngle;
+extern int16_t ignition5EndAngle;
+extern int16_t ignition6EndAngle;
+extern int16_t ignition7EndAngle;
+extern int16_t ignition8EndAngle;
 
-extern int ignition1StartAngle;
-extern int ignition2StartAngle;
-extern int ignition3StartAngle;
-extern int ignition4StartAngle;
-extern int ignition5StartAngle;
-extern int ignition6StartAngle;
-extern int ignition7StartAngle;
-extern int ignition8StartAngle;
+extern int16_t ignition1StartAngle;
+extern int16_t ignition2StartAngle;
+extern int16_t ignition3StartAngle;
+extern int16_t ignition4StartAngle;
+extern int16_t ignition5StartAngle;
+extern int16_t ignition6StartAngle;
+extern int16_t ignition7StartAngle;
+extern int16_t ignition8StartAngle;
 
 //These are variables used across multiple files
 extern const uint8_t PROGMEM fsIntIndex[31];
@@ -489,16 +489,16 @@ extern bool previousClutchTrigger;
 extern volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
 extern volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 extern volatile bool fpPrimed; //Tracks whether or not the fuel pump priming has been completed yet
-extern volatile unsigned int toothHistoryIndex;
+extern volatile uint16_t toothHistoryIndex;
 extern volatile uint8_t toothHistorySerialIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 extern uint8_t primaryTriggerEdge;
 extern uint8_t secondaryTriggerEdge;
-extern int CRANK_ANGLE_MAX;
-extern int CRANK_ANGLE_MAX_IGN;
-extern int CRANK_ANGLE_MAX_INJ; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
+extern int16_t CRANK_ANGLE_MAX;
+extern int16_t CRANK_ANGLE_MAX_IGN;
+extern int16_t CRANK_ANGLE_MAX_INJ; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 extern volatile uint32_t runSecsX10; /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
 extern volatile uint32_t seclx10; /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */
 extern volatile uint8_t HWTest_INJ; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
@@ -526,8 +526,8 @@ struct statuses {
   uint16_t RPM;
   uint8_t RPMdiv100;
   long longRPM;
-  int mapADC;
-  int baroADC;
+  int16_t mapADC;
+  int16_t baroADC;
   long MAP; //Has to be a long for PID calcs (Boost control)
   int16_t EMAP;
   int16_t EMAPADC;
@@ -536,20 +536,20 @@ struct statuses {
   uint8_t tpsADC; /**< 0-255 byte representation of the TPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
   uint8_t tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
   uint8_t mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
-  volatile int rpmDOT;
+  volatile int16_t rpmDOT;
   uint8_t VE; /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both */
   uint8_t VE1; /**< The VE value from fuel table 1 */
   uint8_t VE2; /**< The VE value from fuel table 2, if in use (and required conditions are met) */
   uint8_t O2;
   uint8_t O2_2;
-  int coolant;
-  int cltADC;
-  int IAT;
-  int iatADC;
-  int batADC;
-  int O2ADC;
-  int O2_2ADC;
-  int dwell;
+  int16_t coolant;
+  int16_t cltADC;
+  int16_t IAT;
+  int16_t iatADC;
+  int16_t batADC;
+  int16_t O2ADC;
+  int16_t O2_2ADC;
+  int16_t dwell;
   uint8_t dwellCorrection; /**< The amount of correction being applied to the dwell time. */
   uint8_t battery10; /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
   int8_t advance; /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
@@ -579,21 +579,21 @@ struct statuses {
   volatile uint8_t spark;
   volatile uint8_t spark2;
   uint8_t engine;
-  unsigned int PW1; //In uS
-  unsigned int PW2; //In uS
-  unsigned int PW3; //In uS
-  unsigned int PW4; //In uS
-  unsigned int PW5; //In uS
-  unsigned int PW6; //In uS
-  unsigned int PW7; //In uS
-  unsigned int PW8; //In uS
+  uint16_t PW1; //In uS
+  uint16_t PW2; //In uS
+  uint16_t PW3; //In uS
+  uint16_t PW4; //In uS
+  uint16_t PW5; //In uS
+  uint16_t PW6; //In uS
+  uint16_t PW7; //In uS
+  uint16_t PW8; //In uS
   volatile uint8_t runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
   volatile uint8_t secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
   volatile uint32_t loopsPerSecond; /**< A performance indicator showing the number of main loops that are being executed each second */ 
   bool launchingSoft; /**< Indicator showing whether soft launch control adjustments are active */
   bool launchingHard; /**< Indicator showing whether hard launch control adjustments are active */
   uint16_t freeRAM;
-  unsigned int clutchEngagedRPM; /**< The RPM at which the clutch was last depressed. Used for distinguishing between launch control and flat shift */ 
+  uint16_t clutchEngagedRPM; /**< The RPM at which the clutch was last depressed. Used for distinguishing between launch control and flat shift */ 
   bool flatShiftingHard;
   volatile uint32_t startRevolutions; /**< A counter for how many revolutions have been completed since sync was achieved. */
   uint16_t boostTarget;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -102,14 +102,14 @@ bool channel6InjEnabled = false;
 bool channel7InjEnabled = false;
 bool channel8InjEnabled = false;
 
-int ignition1EndAngle = 0;
-int ignition2EndAngle = 0;
-int ignition3EndAngle = 0;
-int ignition4EndAngle = 0;
-int ignition5EndAngle = 0;
-int ignition6EndAngle = 0;
-int ignition7EndAngle = 0;
-int ignition8EndAngle = 0;
+int16_t ignition1EndAngle = 0;
+int16_t ignition2EndAngle = 0;
+int16_t ignition3EndAngle = 0;
+int16_t ignition4EndAngle = 0;
+int16_t ignition5EndAngle = 0;
+int16_t ignition6EndAngle = 0;
+int16_t ignition7EndAngle = 0;
+int16_t ignition8EndAngle = 0;
 
 //These are variables used across multiple files
 const uint8_t PROGMEM fsIntIndex[31] = {4, 14, 25, 27, 32, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 75, 77, 79, 81, 85, 87, 89, 96, 101}; //int indexes in fullStatus array
@@ -125,16 +125,16 @@ bool previousClutchTrigger;
 volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
 volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 volatile bool fpPrimed = false; //Tracks whether or not the fuel pump priming has been completed yet
-volatile unsigned int toothHistoryIndex = 0;
+volatile uint16_t toothHistoryIndex = 0;
 volatile uint8_t toothHistorySerialIndex = 0;
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 uint8_t primaryTriggerEdge;
 uint8_t secondaryTriggerEdge;
-int CRANK_ANGLE_MAX = 720;
-int CRANK_ANGLE_MAX_IGN = 360;
-int CRANK_ANGLE_MAX_INJ = 360; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
+int16_t CRANK_ANGLE_MAX = 720;
+int16_t CRANK_ANGLE_MAX_IGN = 360;
+int16_t CRANK_ANGLE_MAX_INJ = 360; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;
 volatile uint8_t HWTest_INJ = 0; /**< Each bit in this variable represents one of the injector channels and it's HW test status */

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -116,9 +116,9 @@ const uint8_t PROGMEM fsIntIndex[31] = {4, 14, 25, 27, 32, 41, 43, 45, 47, 49, 5
 bool initialisationComplete = false; //Tracks whether the setup() function has run completely
 uint8_t fpPrimeTime = 0; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
 volatile uint16_t mainLoopCount;
-unsigned long revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
-volatile unsigned long timer5_overflow_count = 0; //Increments every time counter 5 overflows. Used for the fast version of micros()
-volatile unsigned long ms_counter = 0; //A counter that increments once per ms
+uint32_t revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
+volatile uint32_t timer5_overflow_count = 0; //Increments every time counter 5 overflows. Used for the fast version of micros()
+volatile uint32_t ms_counter = 0; //A counter that increments once per ms
 uint16_t fixedCrankingOverride = 0;
 bool clutchTrigger;
 bool previousClutchTrigger;
@@ -127,8 +127,8 @@ volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 volatile bool fpPrimed = false; //Tracks whether or not the fuel pump priming has been completed yet
 volatile uint16_t toothHistoryIndex = 0;
 volatile uint8_t toothHistorySerialIndex = 0;
-unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
-unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
+uint32_t currentLoopTime; /**< The time (in uS) that the current mainloop started */
+uint32_t previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 uint8_t primaryTriggerEdge;
 uint8_t secondaryTriggerEdge;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -2,7 +2,7 @@
 
 const char TSfirmwareVersion[] PROGMEM = "Speeduino";
 
-const byte data_structure_version = 2; //This identifies the data structure when reading / writing.
+const uint8_t data_structure_version = 2; //This identifies the data structure when reading / writing.
 const uint16_t npage_size[NUM_PAGES] = {0,128,288,288,128,288,128,240,192,192,192,288,192,128,288}; /**< This array stores the size (in bytes) of each configuration page */
 
 struct table3D fuelTable; //16x16 fuel map
@@ -112,9 +112,9 @@ int ignition7EndAngle = 0;
 int ignition8EndAngle = 0;
 
 //These are variables used across multiple files
-const byte PROGMEM fsIntIndex[31] = {4, 14, 25, 27, 32, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 75, 77, 79, 81, 85, 87, 89, 96, 101}; //int indexes in fullStatus array
+const uint8_t PROGMEM fsIntIndex[31] = {4, 14, 25, 27, 32, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 75, 77, 79, 81, 85, 87, 89, 96, 101}; //int indexes in fullStatus array
 bool initialisationComplete = false; //Tracks whether the setup() function has run completely
-byte fpPrimeTime = 0; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
+uint8_t fpPrimeTime = 0; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
 volatile uint16_t mainLoopCount;
 unsigned long revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
 volatile unsigned long timer5_overflow_count = 0; //Increments every time counter 5 overflows. Used for the fast version of micros()
@@ -126,107 +126,107 @@ volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
 volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 volatile bool fpPrimed = false; //Tracks whether or not the fuel pump priming has been completed yet
 volatile unsigned int toothHistoryIndex = 0;
-volatile byte toothHistorySerialIndex = 0;
+volatile uint8_t toothHistorySerialIndex = 0;
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-byte primaryTriggerEdge;
-byte secondaryTriggerEdge;
+uint8_t primaryTriggerEdge;
+uint8_t secondaryTriggerEdge;
 int CRANK_ANGLE_MAX = 720;
 int CRANK_ANGLE_MAX_IGN = 360;
 int CRANK_ANGLE_MAX_INJ = 360; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;
-volatile byte HWTest_INJ = 0; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
-volatile byte HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
-volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
-volatile byte HWTest_IGN_50pc = 0; 
+volatile uint8_t HWTest_INJ = 0; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
+volatile uint8_t HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
+volatile uint8_t HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
+volatile uint8_t HWTest_IGN_50pc = 0; 
 
 
 //This needs to be here because using the config page directly can prevent burning the setting
-byte resetControl = RESET_CONTROL_DISABLED;
+uint8_t resetControl = RESET_CONTROL_DISABLED;
 
-volatile byte TIMER_mask;
-volatile byte LOOP_TIMER;
+volatile uint8_t TIMER_mask;
+volatile uint8_t LOOP_TIMER;
 
 
-byte pinInjector1; //Output pin injector 1
-byte pinInjector2; //Output pin injector 2
-byte pinInjector3; //Output pin injector 3
-byte pinInjector4; //Output pin injector 4
-byte pinInjector5; //Output pin injector 5
-byte pinInjector6; //Output pin injector 6
-byte pinInjector7; //Output pin injector 7
-byte pinInjector8; //Output pin injector 8
-byte injectorOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
-byte pinCoil1; //Pin for coil 1
-byte pinCoil2; //Pin for coil 2
-byte pinCoil3; //Pin for coil 3
-byte pinCoil4; //Pin for coil 4
-byte pinCoil5; //Pin for coil 5
-byte pinCoil6; //Pin for coil 6
-byte pinCoil7; //Pin for coil 7
-byte pinCoil8; //Pin for coil 8
-byte ignitionOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
-byte pinTrigger; //The CAS pin
-byte pinTrigger2; //The Cam Sensor pin
-byte pinTrigger3;	//the 2nd cam sensor pin
-byte pinTPS;//TPS input pin
-byte pinMAP; //MAP sensor pin
-byte pinEMAP; //EMAP sensor pin
-byte pinMAP2; //2nd MAP sensor (Currently unused)
-byte pinIAT; //IAT sensor pin
-byte pinCLT; //CLS sensor pin
-byte pinO2; //O2 Sensor pin
-byte pinO2_2; //second O2 pin
-byte pinBat; //Battery voltage pin
-byte pinDisplayReset; // OLED reset pin
-byte pinTachOut; //Tacho output
-byte pinFuelPump; //Fuel pump on/off
-byte pinIdle1; //Single wire idle control
-byte pinIdle2; //2 wire idle control (Not currently used)
-byte pinIdleUp; //Input for triggering Idle Up
-byte pinIdleUpOutput; //Output that follows (normal or inverted) the idle up pin
-byte pinCTPS; //Input for triggering closed throttle state
-byte pinFuel2Input; //Input for switching to the 2nd fuel table
-byte pinSpark2Input; //Input for switching to the 2nd ignition table
-byte pinSpareTemp1; // Future use only
-byte pinSpareTemp2; // Future use only
-byte pinSpareOut1; //Generic output
-byte pinSpareOut2; //Generic output
-byte pinSpareOut3; //Generic output
-byte pinSpareOut4; //Generic output
-byte pinSpareOut5; //Generic output
-byte pinSpareOut6; //Generic output
-byte pinSpareHOut1; //spare high current output
-byte pinSpareHOut2; // spare high current output
-byte pinSpareLOut1; // spare low current output
-byte pinSpareLOut2; // spare low current output
-byte pinSpareLOut3;
-byte pinSpareLOut4;
-byte pinSpareLOut5;
-byte pinBoost;
-byte pinVVT_1;		// vvt output 1
-byte pinVVT_2;		// vvt output 2
-byte pinFan;       // Cooling fan output
-byte pinStepperDir; //Direction pin for the stepper motor driver
-byte pinStepperStep; //Step pin for the stepper motor driver
-byte pinStepperEnable; //Turning the DRV8825 driver on/off
-byte pinLaunch;
-byte pinIgnBypass; //The pin used for an ignition bypass (Optional)
-byte pinFlex; //Pin with the flex sensor attached
-byte pinVSS;
-byte pinBaro; //Pin that an al barometric pressure sensor is attached to (If used)
-byte pinResetControl; // Output pin used control resetting the Arduino
-byte pinFuelPressure;
-byte pinOilPressure;
-byte pinWMIEmpty; // Water tank empty sensor
-byte pinWMIIndicator; // No water indicator bulb
-byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 
-byte pinMC33810_1_CS;
-byte pinMC33810_2_CS;
+uint8_t pinInjector1; //Output pin injector 1
+uint8_t pinInjector2; //Output pin injector 2
+uint8_t pinInjector3; //Output pin injector 3
+uint8_t pinInjector4; //Output pin injector 4
+uint8_t pinInjector5; //Output pin injector 5
+uint8_t pinInjector6; //Output pin injector 6
+uint8_t pinInjector7; //Output pin injector 7
+uint8_t pinInjector8; //Output pin injector 8
+uint8_t injectorOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
+uint8_t pinCoil1; //Pin for coil 1
+uint8_t pinCoil2; //Pin for coil 2
+uint8_t pinCoil3; //Pin for coil 3
+uint8_t pinCoil4; //Pin for coil 4
+uint8_t pinCoil5; //Pin for coil 5
+uint8_t pinCoil6; //Pin for coil 6
+uint8_t pinCoil7; //Pin for coil 7
+uint8_t pinCoil8; //Pin for coil 8
+uint8_t ignitionOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
+uint8_t pinTrigger; //The CAS pin
+uint8_t pinTrigger2; //The Cam Sensor pin
+uint8_t pinTrigger3;	//the 2nd cam sensor pin
+uint8_t pinTPS;//TPS input pin
+uint8_t pinMAP; //MAP sensor pin
+uint8_t pinEMAP; //EMAP sensor pin
+uint8_t pinMAP2; //2nd MAP sensor (Currently unused)
+uint8_t pinIAT; //IAT sensor pin
+uint8_t pinCLT; //CLS sensor pin
+uint8_t pinO2; //O2 Sensor pin
+uint8_t pinO2_2; //second O2 pin
+uint8_t pinBat; //Battery voltage pin
+uint8_t pinDisplayReset; // OLED reset pin
+uint8_t pinTachOut; //Tacho output
+uint8_t pinFuelPump; //Fuel pump on/off
+uint8_t pinIdle1; //Single wire idle control
+uint8_t pinIdle2; //2 wire idle control (Not currently used)
+uint8_t pinIdleUp; //Input for triggering Idle Up
+uint8_t pinIdleUpOutput; //Output that follows (normal or inverted) the idle up pin
+uint8_t pinCTPS; //Input for triggering closed throttle state
+uint8_t pinFuel2Input; //Input for switching to the 2nd fuel table
+uint8_t pinSpark2Input; //Input for switching to the 2nd ignition table
+uint8_t pinSpareTemp1; // Future use only
+uint8_t pinSpareTemp2; // Future use only
+uint8_t pinSpareOut1; //Generic output
+uint8_t pinSpareOut2; //Generic output
+uint8_t pinSpareOut3; //Generic output
+uint8_t pinSpareOut4; //Generic output
+uint8_t pinSpareOut5; //Generic output
+uint8_t pinSpareOut6; //Generic output
+uint8_t pinSpareHOut1; //spare high current output
+uint8_t pinSpareHOut2; // spare high current output
+uint8_t pinSpareLOut1; // spare low current output
+uint8_t pinSpareLOut2; // spare low current output
+uint8_t pinSpareLOut3;
+uint8_t pinSpareLOut4;
+uint8_t pinSpareLOut5;
+uint8_t pinBoost;
+uint8_t pinVVT_1;		// vvt output 1
+uint8_t pinVVT_2;		// vvt output 2
+uint8_t pinFan;       // Cooling fan output
+uint8_t pinStepperDir; //Direction pin for the stepper motor driver
+uint8_t pinStepperStep; //Step pin for the stepper motor driver
+uint8_t pinStepperEnable; //Turning the DRV8825 driver on/off
+uint8_t pinLaunch;
+uint8_t pinIgnBypass; //The pin used for an ignition bypass (Optional)
+uint8_t pinFlex; //Pin with the flex sensor attached
+uint8_t pinVSS;
+uint8_t pinBaro; //Pin that an al barometric pressure sensor is attached to (If used)
+uint8_t pinResetControl; // Output pin used control resetting the Arduino
+uint8_t pinFuelPressure;
+uint8_t pinOilPressure;
+uint8_t pinWMIEmpty; // Water tank empty sensor
+uint8_t pinWMIIndicator; // No water indicator bulb
+uint8_t pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 
+uint8_t pinMC33810_1_CS;
+uint8_t pinMC33810_2_CS;
 #ifdef USE_SPI_EEPROM
-  byte pinSPIFlash_CS;
+  uint8_t pinSPIFlash_CS;
 #endif
 
 struct statuses currentStatus; /**< The master global status struct. Contains all values that are updated frequently and used across modules */
@@ -237,9 +237,9 @@ struct config9 configPage9;
 struct config10 configPage10;
 struct config13 configPage13;
 
-//byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
-//byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
-//byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
+//uint8_t cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
+//uint8_t iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
+//uint8_t o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
 uint16_t cltCalibration_bins[32];
 uint16_t cltCalibration_values[32];

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -21,8 +21,8 @@ enum StepperStatus {SOFF, STEPPING, COOLING}; //The 2 statuses that a stepper ca
 
 struct StepperIdle
 {
-  int curIdleStep; //Tracks the current location of the stepper
-  int targetIdleStep; //What the targetted step is
+  int16_t curIdleStep; //Tracks the current location of the stepper
+  int16_t targetIdleStep; //What the targetted step is
   volatile StepperStatus stepperStatus;
   volatile unsigned long stepStartTime; //The time the curren
   uint8_t lessAirDirection;
@@ -39,9 +39,9 @@ struct table2D iacCrankDutyTable;
 struct StepperIdle idleStepper;
 bool idleOn; //Simply tracks whether idle was on last time around
 uint8_t idleInitComplete = 99; //TRacks which idle method was initialised. 99 is a method that will never exist
-unsigned int iacStepTime_uS;
-unsigned int iacCoolTime_uS;
-unsigned int completedHomeSteps;
+uint16_t iacStepTime_uS;
+uint16_t iacCoolTime_uS;
+uint16_t completedHomeSteps;
 
 volatile PORT_TYPE *idle_pin_port;
 volatile PINMASK_TYPE idle_pin_mask;
@@ -51,8 +51,8 @@ volatile PORT_TYPE *idleUpOutput_pin_port;
 volatile PINMASK_TYPE idleUpOutput_pin_mask;
 
 volatile bool idle_pwm_state;
-unsigned int idle_pwm_max_count; //Used for variable PWM frequency
-volatile unsigned int idle_pwm_cur_value;
+uint16_t idle_pwm_max_count; //Used for variable PWM frequency
+volatile uint16_t idle_pwm_cur_value;
 long idle_pid_target_value;
 long FeedForwardTerm;
 unsigned long idle_pwm_target_value;

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -25,8 +25,8 @@ struct StepperIdle
   int targetIdleStep; //What the targetted step is
   volatile StepperStatus stepperStatus;
   volatile unsigned long stepStartTime; //The time the curren
-  byte lessAirDirection;
-  byte moreAirDirection;
+  uint8_t lessAirDirection;
+  uint8_t moreAirDirection;
 };
 
 struct table2D iacClosedLoopTable;
@@ -38,7 +38,7 @@ struct table2D iacCrankDutyTable;
 
 struct StepperIdle idleStepper;
 bool idleOn; //Simply tracks whether idle was on last time around
-byte idleInitComplete = 99; //TRacks which idle method was initialised. 99 is a method that will never exist
+uint8_t idleInitComplete = 99; //TRacks which idle method was initialised. 99 is a method that will never exist
 unsigned int iacStepTime_uS;
 unsigned int iacCoolTime_uS;
 unsigned int completedHomeSteps;
@@ -57,17 +57,17 @@ long idle_pid_target_value;
 long FeedForwardTerm;
 unsigned long idle_pwm_target_value;
 long idle_cl_target_rpm;
-byte idleCounter; //Used for tracking the number of calls to the idle control function
+uint8_t idleCounter; //Used for tracking the number of calls to the idle control function
 
-byte idleUpOutputHIGH = HIGH; // Used to invert the idle Up Output 
-byte idleUpOutputLOW = LOW;   // Used to invert the idle Up Output 
+uint8_t idleUpOutputHIGH = HIGH; // Used to invert the idle Up Output 
+uint8_t idleUpOutputLOW = LOW;   // Used to invert the idle Up Output 
 
 void initialiseIdle();
 void initialiseIdleUpOutput();
 static inline void disableIdle();
 static inline void enableIdle();
-static inline byte isStepperHomed();
-static inline byte checkForStepping();
+static inline uint8_t isStepperHomed();
+static inline uint8_t checkForStepping();
 static inline void doStep();
 static inline void idleInterrupt();
 

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -24,7 +24,7 @@ struct StepperIdle
   int16_t curIdleStep; //Tracks the current location of the stepper
   int16_t targetIdleStep; //What the targetted step is
   volatile StepperStatus stepperStatus;
-  volatile unsigned long stepStartTime; //The time the curren
+  volatile uint32_t stepStartTime; //The time the curren
   uint8_t lessAirDirection;
   uint8_t moreAirDirection;
 };
@@ -53,10 +53,10 @@ volatile PINMASK_TYPE idleUpOutput_pin_mask;
 volatile bool idle_pwm_state;
 uint16_t idle_pwm_max_count; //Used for variable PWM frequency
 volatile uint16_t idle_pwm_cur_value;
-long idle_pid_target_value;
-long FeedForwardTerm;
-unsigned long idle_pwm_target_value;
-long idle_cl_target_rpm;
+int32_t idle_pid_target_value;
+int32_t FeedForwardTerm;
+uint32_t idle_pwm_target_value;
+int32_t idle_cl_target_rpm;
 uint8_t idleCounter; //Used for tracking the number of calls to the idle control function
 
 uint8_t idleUpOutputHIGH = HIGH; // Used to invert the idle Up Output 

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -313,7 +313,7 @@ void idleControl()
             break; 
           }
           BIT_SET(currentStatus.spark, BIT_SPARK_IDLE); //Turn the idle control flag on
-          currentStatus.idleLoad = ((unsigned long)(idle_pwm_target_value * 100UL) / idle_pwm_max_count);
+          currentStatus.idleLoad = ((uint32_t)(idle_pwm_target_value * 100UL) / idle_pwm_max_count);
           if(currentStatus.idleUpActive == true) { currentStatus.idleDuty += configPage2.idleUpAdder; } //Add Idle Up amount if active
 
         }
@@ -356,7 +356,7 @@ void idleControl()
             break; 
           }
           BIT_SET(currentStatus.spark, BIT_SPARK_IDLE); //Turn the idle control flag on
-          currentStatus.idleLoad = ((unsigned long)(idle_pwm_target_value * 100UL) / idle_pwm_max_count);
+          currentStatus.idleLoad = ((uint32_t)(idle_pwm_target_value * 100UL) / idle_pwm_max_count);
           if(currentStatus.idleUpActive == true) { currentStatus.idleDuty += configPage2.idleUpAdder; } //Add Idle Up amount if active
 
         }

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -515,7 +515,7 @@ False: If the motor is ready for another step
 static inline uint8_t checkForStepping()
 {
   bool isStepping = false;
-  unsigned int timeCheck;
+  uint16_t timeCheck;
   
   if( (idleStepper.stepperStatus == STEPPING) || (idleStepper.stepperStatus == COOLING) )
   {

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -298,7 +298,7 @@ void idleControl()
       }
       else
       {
-        currentStatus.CLIdleTarget = (byte)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
+        currentStatus.CLIdleTarget = (uint8_t)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
         idle_cl_target_rpm = (uint16_t)currentStatus.CLIdleTarget * 10; //Multiply the byte target value back out by 10
         if( (idleCounter & 31) == 1) { idlePID.SetTunings(configPage6.idleKP, configPage6.idleKI, configPage6.idleKD); } //This only needs to be run very infrequently, once every 32 calls to idleControl(). This is approx. once per second
 
@@ -338,7 +338,7 @@ void idleControl()
         //Read the OL table as feedforward term
         FeedForwardTerm = percentage(table2D_getValue(&iacPWMTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET), idle_pwm_max_count<<2); //All temps are offset by 40 degrees
     
-        currentStatus.CLIdleTarget = (byte)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
+        currentStatus.CLIdleTarget = (uint8_t)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
         idle_cl_target_rpm = (uint16_t)currentStatus.CLIdleTarget * 10; //Multiply the byte target value back out by 10
         if( (idleCounter & 31) == 1) { idlePID.SetTunings(configPage6.idleKP, configPage6.idleKI, configPage6.idleKD); } //This only needs to be run very infrequently, once every 32 calls to idleControl(). This is approx. once per 9 seconds
         if((currentStatus.RPM - idle_cl_target_rpm > configPage2.iacRPMlimitHysteresis*10) || (currentStatus.TPS > configPage2.iacTPSlimit)){ //reset integeral to zero when TPS is bigger than set value in TS (opening throttle so not idle anymore). OR when RPM higher than Idle Target + RPM Histeresis (comming back from high rpm with throttle closed) 
@@ -454,7 +454,7 @@ void idleControl()
             iacCoolTime_uS = configPage9.iacCoolTime * 1000;
           }
 
-          currentStatus.CLIdleTarget = (byte)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
+          currentStatus.CLIdleTarget = (uint8_t)table2D_getValue(&iacClosedLoopTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
           idle_cl_target_rpm = (uint16_t)currentStatus.CLIdleTarget * 10; //All temps are offset by 40 degrees
           PID_computed = idlePID.Compute(true);
           idleStepper.targetIdleStep = idle_pid_target_value >> 2; //Increase resolution
@@ -489,7 +489,7 @@ Returns:
 True: If the system has been homed. No other action is taken
 False: If the motor has not yet been homed. Will also perform another homing step.
 */
-static inline byte isStepperHomed()
+static inline uint8_t isStepperHomed()
 {
   bool isHomed = true; //As it's the most common scenario, default value is true
   if( completedHomeSteps < (configPage6.iacStepHome * 3) ) //Home steps are divided by 3 from TS
@@ -512,7 +512,7 @@ Returns:
 True: If a step is underway or motor is 'cooling'
 False: If the motor is ready for another step
 */
-static inline byte checkForStepping()
+static inline uint8_t checkForStepping()
 {
   bool isStepping = false;
   unsigned int timeCheck;

--- a/speeduino/init.h
+++ b/speeduino/init.h
@@ -3,6 +3,6 @@
 
 void initialiseAll();
 void initialiseTriggers();
-void setPinMapping(byte);
+void setPinMapping(uint8_t);
 
 #endif

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1167,7 +1167,7 @@ void initialiseAll()
     digitalWrite(LED_BUILTIN, HIGH);
 }
 
-void setPinMapping(byte boardID)
+void setPinMapping(uint8_t boardID)
 {
   //Force set defaults. Will be overwritten below if needed.
   injectorOutputControl = OUTPUT_CONTROL_DIRECT;
@@ -2637,8 +2637,8 @@ void setPinMapping(byte boardID)
 
 void initialiseTriggers()
 {
-  byte triggerInterrupt = 0; // By default, use the first interrupt
-  byte triggerInterrupt2 = 1;
+  uint8_t triggerInterrupt = 0; // By default, use the first interrupt
+  uint8_t triggerInterrupt2 = 1;
 
   #if defined(CORE_AVR)
     switch (pinTrigger) {

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -366,7 +366,7 @@ void initialiseAll()
     currentStatus.syncLossCounter = 0;
     currentStatus.flatShiftingHard = false;
     currentStatus.launchingHard = false;
-    currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10); //Crank RPM limit (Saves us calculating this over and over again. It's updated once per second in timers.ino)
+    currentStatus.crankRPM = ((uint16_t)configPage4.crankRPM * 10); //Crank RPM limit (Saves us calculating this over and over again. It's updated once per second in timers.ino)
     currentStatus.fuelPumpOn = false;
     currentStatus.engineProtectStatus = 0;
     triggerFilterTime = 0; //Trigger filter time is the shortest possible time (in uS) that there can be between crank teeth (ie at max RPM). Any pulses that occur faster than this time will be disgarded as noise. This is simply a default value, the actual values are set in the setup() functinos of each decoder

--- a/speeduino/logger.ino
+++ b/speeduino/logger.ino
@@ -11,8 +11,8 @@ void createLog(uint8_t *logBuffer)
     logBuffer[3] = currentStatus.syncLossCounter;
     logBuffer[4] = lowByte(currentStatus.MAP); //2 bytes for MAP
     logBuffer[5] = highByte(currentStatus.MAP);
-    logBuffer[6] = (byte)(currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); //mat
-    logBuffer[7] = (byte)(currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //Coolant ADC
+    logBuffer[6] = (uint8_t)(currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET); //mat
+    logBuffer[7] = (uint8_t)(currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //Coolant ADC
     logBuffer[8] = currentStatus.batCorrection; //Battery voltage correction (%)
     logBuffer[9] = currentStatus.battery10; //battery voltage
     logBuffer[10] = currentStatus.O2; //O2
@@ -21,7 +21,7 @@ void createLog(uint8_t *logBuffer)
     logBuffer[13] = currentStatus.wueCorrection; //Warmup enrichment (%)
     logBuffer[14] = lowByte(currentStatus.RPM); //rpm HB
     logBuffer[15] = highByte(currentStatus.RPM); //rpm LB
-    logBuffer[16] = (byte)(currentStatus.AEamount >> 1); //TPS acceleration enrichment (%) divided by 2 (Can exceed 255)
+    logBuffer[16] = (uint8_t)(currentStatus.AEamount >> 1); //TPS acceleration enrichment (%) divided by 2 (Can exceed 255)
     logBuffer[17] = currentStatus.corrections; //Total GammaE (%)
     logBuffer[18] = currentStatus.VE; //Current VE (%). Can be equal to VE1 or VE2 or a calculated value from both of them
     logBuffer[19] = currentStatus.VE1; //VE 1 (%)
@@ -37,11 +37,11 @@ void createLog(uint8_t *logBuffer)
 
     //The following can be used to show the amount of free memory
     currentStatus.freeRAM = freeRam();
-    logBuffer[27] = lowByte(currentStatus.freeRAM); //(byte)((currentStatus.loopsPerSecond >> 8) & 0xFF);
+    logBuffer[27] = lowByte(currentStatus.freeRAM); //(uint8_t)((currentStatus.loopsPerSecond >> 8) & 0xFF);
     logBuffer[28] = highByte(currentStatus.freeRAM);
 
-    logBuffer[29] = (byte)(currentStatus.boostTarget >> 1); //Divide boost target by 2 to fit in a byte
-    logBuffer[30] = (byte)(currentStatus.boostDuty / 100);
+    logBuffer[29] = (uint8_t)(currentStatus.boostTarget >> 1); //Divide boost target by 2 to fit in a byte
+    logBuffer[30] = (uint8_t)(currentStatus.boostDuty / 100);
     logBuffer[31] = currentStatus.spark; //Spark related bitfield
 
     //rpmDOT must be sent as a signed integer

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -2,17 +2,17 @@
 #define MATH_H
 
 int16_t fastMap1023toX(int16_t, int16_t);
-unsigned long percentage(uint8_t, unsigned long);
-inline long powint(int16_t, uint16_t);
-int16_t divs100(long);
-unsigned long divu100(unsigned long);
+uint32_t percentage(uint8_t, uint32_t);
+inline int32_t powint(int16_t, uint16_t);
+int16_t divs100(int32_t);
+uint32_t divu100(uint32_t);
 
 #define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) ^ ((d) < 0)) ? (((n) - (d)/2)/(d)) : (((n) + (d)/2)/(d)))
 
 //This is a dedicated function that specifically handles the case of mapping 0-1023 values into a 0 to X range
 //This is a common case because it means converting from a standard 10-bit analog input to a byte or 10-bit analog into 0-511 (Eg the temperature readings)
-#define fastMap1023toX(x, out_max) ( ((unsigned long)x * out_max) >> 10)
+#define fastMap1023toX(x, out_max) ( ((uint32_t)x * out_max) >> 10)
 //This is a new version that allows for out_min
-#define fastMap10Bit(x, out_min, out_max) ( ( ((unsigned long)x * (out_max-out_min)) >> 10 ) + out_min)
+#define fastMap10Bit(x, out_min, out_max) ( ( ((uint32_t)x * (out_max-out_min)) >> 10 ) + out_min)
 
 #endif

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -1,10 +1,10 @@
 #ifndef MATH_H
 #define MATH_H
 
-int fastMap1023toX(int, int);
+int16_t fastMap1023toX(int16_t, int16_t);
 unsigned long percentage(uint8_t, unsigned long);
-inline long powint(int, unsigned int);
-int divs100(long);
+inline long powint(int16_t, uint16_t);
+int16_t divs100(long);
 unsigned long divu100(unsigned long);
 
 #define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) ^ ((d) < 0)) ? (((n) - (d)/2)/(d)) : (((n) + (d)/2)/(d)))

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -2,7 +2,7 @@
 #define MATH_H
 
 int fastMap1023toX(int, int);
-unsigned long percentage(byte, unsigned long);
+unsigned long percentage(uint8_t, unsigned long);
 inline long powint(int, unsigned int);
 int divs100(long);
 unsigned long divu100(unsigned long);

--- a/speeduino/maths.ino
+++ b/speeduino/maths.ino
@@ -2,12 +2,12 @@
 #include "globals.h"
 
 //Replace the standard arduino map() function to use the div function instead
-int fastMap(unsigned long x, int in_min, int in_max, int out_min, int out_max)
+int16_t fastMap(unsigned long x, int16_t in_min, int16_t in_max, int16_t out_min, int16_t out_max)
 {
   unsigned long a = (x - (unsigned long)in_min);
-  int b = (out_max - out_min);
-  int c = (in_max - in_min);
-  int d = (ldiv( (a * (long)b) , (long)c ).quot);
+  int16_t b = (out_max - out_min);
+  int16_t c = (in_max - in_min);
+  int16_t d = (ldiv( (a * (long)b) , (long)c ).quot);
   return d + out_min;
   //return ldiv( ((x - in_min) * (out_max - out_min)) , (in_max - in_min) ).quot + out_min;
   //return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
@@ -19,7 +19,7 @@ Ref: www.hackersdelight.org/divcMore.pdf
 */
 
 //Unsigned divide by 10
-unsigned int divu10(unsigned int n)
+uint16_t divu10(uint16_t n)
 {
   unsigned long q, r;
   q = (n >> 1) + (n >> 2);
@@ -32,7 +32,7 @@ unsigned int divu10(unsigned int n)
 }
 
 //Signed divide by 100
-int divs100(long n)
+int16_t divs100(long n)
 {
   return (n / 100); // Amazingly, gcc is producing a better /divide by 100 function than this
   /*
@@ -71,10 +71,10 @@ unsigned long percentage(uint8_t x, unsigned long y)
 /*
  * Calculates integer power values. Same as pow() but with ints
  */
-inline long powint(int factor, unsigned int exponent)
+inline long powint(int16_t factor, uint16_t exponent)
 {
    long product = 1;
-   unsigned int counter = exponent;
+   uint16_t counter = exponent;
    while ( (counter--) > 0) { product *= factor; }
    return product;
 }

--- a/speeduino/maths.ino
+++ b/speeduino/maths.ino
@@ -2,12 +2,12 @@
 #include "globals.h"
 
 //Replace the standard arduino map() function to use the div function instead
-int16_t fastMap(unsigned long x, int16_t in_min, int16_t in_max, int16_t out_min, int16_t out_max)
+int16_t fastMap(uint32_t x, int16_t in_min, int16_t in_max, int16_t out_min, int16_t out_max)
 {
-  unsigned long a = (x - (unsigned long)in_min);
+  uint32_t a = (x - (uint32_t)in_min);
   int16_t b = (out_max - out_min);
   int16_t c = (in_max - in_min);
-  int16_t d = (ldiv( (a * (long)b) , (long)c ).quot);
+  int16_t d = (ldiv( (a * (int32_t)b) , (int32_t)c ).quot);
   return d + out_min;
   //return ldiv( ((x - in_min) * (out_max - out_min)) , (in_max - in_min) ).quot + out_min;
   //return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
@@ -21,7 +21,7 @@ Ref: www.hackersdelight.org/divcMore.pdf
 //Unsigned divide by 10
 uint16_t divu10(uint16_t n)
 {
-  unsigned long q, r;
+  uint32_t q, r;
   q = (n >> 1) + (n >> 2);
   q = q + (q >> 4);
   q = q + (q >> 8);
@@ -32,11 +32,11 @@ uint16_t divu10(uint16_t n)
 }
 
 //Signed divide by 100
-int16_t divs100(long n)
+int16_t divs100(int32_t n)
 {
   return (n / 100); // Amazingly, gcc is producing a better /divide by 100 function than this
   /*
-  long q, r;
+  int32_t q, r;
   n = n + (n>>31 & 99);
   q = (n >> 1) + (n >> 3) + (n >> 6) - (n >> 10) +
   (n >> 12) + (n >> 13) - (n >> 16);
@@ -48,10 +48,10 @@ int16_t divs100(long n)
 }
 
 //Unsigned divide by 100
-unsigned long divu100(unsigned long n)
+uint32_t divu100(uint32_t n)
 {
   //return (n / 100);
-  unsigned long q, r;
+  uint32_t q, r;
   q = (n >> 1) + (n >> 3) + (n >> 6) - (n >> 10) +
   (n >> 12) + (n >> 13) - (n >> 16);
   q = q + (q >> 20);
@@ -62,7 +62,7 @@ unsigned long divu100(unsigned long n)
 
 //Return x percent of y
 //This is a relatively fast approximation of a percentage value.
-unsigned long percentage(uint8_t x, unsigned long y)
+uint32_t percentage(uint8_t x, uint32_t y)
 {
   return (y * x) / 100; //For some reason this is faster
   //return divu100(y * x);
@@ -71,9 +71,9 @@ unsigned long percentage(uint8_t x, unsigned long y)
 /*
  * Calculates integer power values. Same as pow() but with ints
  */
-inline long powint(int16_t factor, uint16_t exponent)
+inline int32_t powint(int16_t factor, uint16_t exponent)
 {
-   long product = 1;
+   int32_t product = 1;
    uint16_t counter = exponent;
    while ( (counter--) > 0) { product *= factor; }
    return product;

--- a/speeduino/maths.ino
+++ b/speeduino/maths.ino
@@ -62,7 +62,7 @@ unsigned long divu100(unsigned long n)
 
 //Return x percent of y
 //This is a relatively fast approximation of a percentage value.
-unsigned long percentage(byte x, unsigned long y)
+unsigned long percentage(uint8_t x, unsigned long y)
 {
   return (y * x) / 100; //For some reason this is faster
   //return divu100(y * x);

--- a/speeduino/rtc_common.h
+++ b/speeduino/rtc_common.h
@@ -9,7 +9,7 @@ uint8_t rtc_getDay();
 uint8_t rtc_getDOW();
 uint8_t rtc_getMonth();
 uint16_t rtc_getYear();
-void rtc_setTime(byte, byte, byte, byte, byte, uint16_t);
+void rtc_setTime(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint16_t);
 
 
 

--- a/speeduino/rtc_common.ino
+++ b/speeduino/rtc_common.ino
@@ -99,7 +99,7 @@ uint16_t rtc_getYear()
   return tempYear;
 }
 
-void rtc_setTime(byte second, byte minute, byte hour, byte day, byte month, uint16_t year)
+void rtc_setTime(uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year)
 {
 #ifdef RTC_ENABLED
   #if defined(CORE_TEENSY)

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -147,8 +147,8 @@ struct Schedule {
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start
   volatile COMPARE_TYPE endCompare;
 
-  unsigned int nextStartCompare;
-  unsigned int nextEndCompare;
+  uint16_t nextStartCompare;
+  uint16_t nextEndCompare;
   volatile bool hasNextSchedule = false;
   volatile bool endScheduleSetByDecoder = false;
 };
@@ -161,8 +161,8 @@ struct FuelSchedule {
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start
   volatile COMPARE_TYPE endCompare;
 
-  unsigned int nextStartCompare;
-  unsigned int nextEndCompare;
+  uint16_t nextStartCompare;
+  uint16_t nextEndCompare;
   volatile bool hasNextSchedule = false;
 };
 
@@ -190,10 +190,10 @@ extern Schedule ignitionSchedule8;
 
 //IgnitionSchedule nullSchedule; //This is placed at the end of the queue. It's status will always be set to OFF and hence will never perform any action within an ISR
 
-static inline unsigned int setQueue(volatile Schedule *queue[], Schedule *schedule1, Schedule *schedule2, unsigned int CNT)
+static inline uint16_t setQueue(volatile Schedule *queue[], Schedule *schedule1, Schedule *schedule2, uint16_t CNT)
 {
   //Create an array of all the upcoming targets, relative to the current count on the timer
-  unsigned int tmpQueue[4];
+  uint16_t tmpQueue[4];
 
   //Set the initial queue state. This order matches the tmpQueue order
   if(schedule1->Status == OFF)
@@ -230,7 +230,7 @@ static inline unsigned int setQueue(volatile Schedule *queue[], Schedule *schedu
   //Sort the queues. Both queues are kept in sync.
   //This implementes a sorting networking based on the Bose-Nelson sorting network
   //See: pages.ripco.net/~jgamble/nw.html
-  #define SWAP(x,y) if(tmpQueue[y] < tmpQueue[x]) { unsigned int tmp = tmpQueue[x]; tmpQueue[x] = tmpQueue[y]; tmpQueue[y] = tmp; volatile Schedule *tmpS = queue[x]; queue[x] = queue[y]; queue[y] = tmpS; }
+  #define SWAP(x,y) if(tmpQueue[y] < tmpQueue[x]) { uint16_t tmp = tmpQueue[x]; tmpQueue[x] = tmpQueue[y]; tmpQueue[y] = tmp; volatile Schedule *tmpS = queue[x]; queue[x] = queue[y]; queue[y] = tmpS; }
   /*SWAP(0, 1); */ //Likely not needed
   /*SWAP(2, 3); */ //Likely not needed
   SWAP(0, 2);
@@ -246,14 +246,14 @@ static inline unsigned int setQueue(volatile Schedule *queue[], Schedule *schedu
  * The current item (0) is discarded
  * The final queue slot is set to nullSchedule to indicate that no action should be taken
  */
-static inline unsigned int popQueue(volatile Schedule *queue[])
+static inline uint16_t popQueue(volatile Schedule *queue[])
 {
   queue[0] = queue[1];
   queue[1] = queue[2];
   queue[2] = queue[3];
   //queue[3] = &nullSchedule;
 
-  unsigned int returnCompare;
+  uint16_t returnCompare;
   if( queue[0]->Status == PENDING ) { returnCompare = queue[0]->startCompare; }
   else { returnCompare = queue[0]->endCompare; }
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -71,25 +71,25 @@ extern void (*ign8EndFunction)();
 
 void initialiseSchedulers();
 void beginInjectorPriming();
-void setFuelSchedule1(unsigned long timeout, unsigned long duration);
-void setFuelSchedule2(unsigned long timeout, unsigned long duration);
-void setFuelSchedule3(unsigned long timeout, unsigned long duration);
-void setFuelSchedule4(unsigned long timeout, unsigned long duration);
-//void setFuelSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)()); //Schedule 5 remains a special case for now due to the way it's implemented 
-void setFuelSchedule5(unsigned long timeout, unsigned long duration);
-void setFuelSchedule6(unsigned long timeout, unsigned long duration);
-void setFuelSchedule7(unsigned long timeout, unsigned long duration);
-void setFuelSchedule8(unsigned long timeout, unsigned long duration);
-void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
-void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
+void setFuelSchedule1(uint32_t timeout, uint32_t duration);
+void setFuelSchedule2(uint32_t timeout, uint32_t duration);
+void setFuelSchedule3(uint32_t timeout, uint32_t duration);
+void setFuelSchedule4(uint32_t timeout, uint32_t duration);
+//void setFuelSchedule5(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)()); //Schedule 5 remains a special case for now due to the way it's implemented 
+void setFuelSchedule5(uint32_t timeout, uint32_t duration);
+void setFuelSchedule6(uint32_t timeout, uint32_t duration);
+void setFuelSchedule7(uint32_t timeout, uint32_t duration);
+void setFuelSchedule8(uint32_t timeout, uint32_t duration);
+void setIgnitionSchedule1(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule2(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule3(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule4(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule5(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule6(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule7(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
+void setIgnitionSchedule8(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)());
 
-inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((always_inline));
+inline void refreshIgnitionSchedule1(uint32_t timeToEnd) __attribute__((always_inline));
 
 //The ARM cores use seprate functions for their ISRs
 #if defined(ARDUINO_ARCH_STM32) || defined(CORE_TEENSY)
@@ -138,12 +138,12 @@ inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((alw
 enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The 3 statuses that a schedule can have
 
 struct Schedule {
-  volatile unsigned long duration;
+  volatile uint32_t duration;
   volatile ScheduleStatus Status;
   volatile uint8_t schedulesSet; //A counter of how many times the schedule has been set
   void (*StartCallback)(); //Start Callback function for schedule
   void (*EndCallback)(); //Start Callback function for schedule
-  volatile unsigned long startTime; /**< The system time (in uS) that the schedule started, used by the overdwell protection in timers.ino */
+  volatile uint32_t startTime; /**< The system time (in uS) that the schedule started, used by the overdwell protection in timers.ino */
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start
   volatile COMPARE_TYPE endCompare;
 
@@ -155,7 +155,7 @@ struct Schedule {
 
 //Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables. They are removed in this struct to save RAM
 struct FuelSchedule {
-  volatile unsigned long duration;
+  volatile uint32_t duration;
   volatile ScheduleStatus Status;
   volatile uint8_t schedulesSet; //A counter of how many times the schedule has been set
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -140,7 +140,7 @@ enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The 3 statuses that a sch
 struct Schedule {
   volatile unsigned long duration;
   volatile ScheduleStatus Status;
-  volatile byte schedulesSet; //A counter of how many times the schedule has been set
+  volatile uint8_t schedulesSet; //A counter of how many times the schedule has been set
   void (*StartCallback)(); //Start Callback function for schedule
   void (*EndCallback)(); //Start Callback function for schedule
   volatile unsigned long startTime; /**< The system time (in uS) that the schedule started, used by the overdwell protection in timers.ino */
@@ -157,7 +157,7 @@ struct Schedule {
 struct FuelSchedule {
   volatile unsigned long duration;
   volatile ScheduleStatus Status;
-  volatile byte schedulesSet; //A counter of how many times the schedule has been set
+  volatile uint8_t schedulesSet; //A counter of how many times the schedule has been set
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start
   volatile COMPARE_TYPE endCompare;
 

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -121,7 +121,7 @@ endCallback: This function is called once the duration time has been reached
 */
 
 //Experimental new generic function. This is NOT yet ready and functional
-void setFuelSchedule(struct Schedule *targetSchedule, unsigned long timeout, unsigned long duration)
+void setFuelSchedule(struct Schedule *targetSchedule, uint32_t timeout, uint32_t duration)
 {
   if(targetSchedule->Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -156,8 +156,8 @@ void setFuelSchedule(struct Schedule *targetSchedule, unsigned long timeout, uns
 }
 
 
-//void setFuelSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule1(unsigned long timeout, unsigned long duration) //Uses timer 3 compare A
+//void setFuelSchedule1(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
+void setFuelSchedule1(uint32_t timeout, uint32_t duration) //Uses timer 3 compare A
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   //if(timeout < MAX_TIMER_PERIOD)
@@ -200,7 +200,7 @@ void setFuelSchedule1(unsigned long timeout, unsigned long duration) //Uses time
   } //Timeout less than threshold
 }
 
-void setFuelSchedule2(unsigned long timeout, unsigned long duration) //Uses timer 3 compare B
+void setFuelSchedule2(uint32_t timeout, uint32_t duration) //Uses timer 3 compare B
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -237,8 +237,8 @@ void setFuelSchedule2(unsigned long timeout, unsigned long duration) //Uses time
     }
   }
 }
-//void setFuelSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule3(unsigned long timeout, unsigned long duration) //Uses timer 3 compare C
+//void setFuelSchedule3(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
+void setFuelSchedule3(uint32_t timeout, uint32_t duration) //Uses timer 3 compare C
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -275,8 +275,8 @@ void setFuelSchedule3(unsigned long timeout, unsigned long duration) //Uses time
     }
   }
 }
-//void setFuelSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
-void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses timer 4 compare B
+//void setFuelSchedule4(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
+void setFuelSchedule4(uint32_t timeout, uint32_t duration) //Uses timer 4 compare B
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -315,7 +315,7 @@ void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses time
 }
 
 #if INJ_CHANNELS >= 5
-void setFuelSchedule5(unsigned long timeout, unsigned long duration) //Uses timer 4 compare C
+void setFuelSchedule5(uint32_t timeout, uint32_t duration) //Uses timer 4 compare C
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -352,7 +352,7 @@ void setFuelSchedule5(unsigned long timeout, unsigned long duration) //Uses time
 #endif
 
 #if INJ_CHANNELS >= 6
-void setFuelSchedule6(unsigned long timeout, unsigned long duration) //Uses timer 4 compare A
+void setFuelSchedule6(uint32_t timeout, uint32_t duration) //Uses timer 4 compare A
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -389,7 +389,7 @@ void setFuelSchedule6(unsigned long timeout, unsigned long duration) //Uses time
 #endif
 
 #if INJ_CHANNELS >= 7
-void setFuelSchedule7(unsigned long timeout, unsigned long duration) //Uses timer 5 compare C
+void setFuelSchedule7(uint32_t timeout, uint32_t duration) //Uses timer 5 compare C
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -426,7 +426,7 @@ void setFuelSchedule7(unsigned long timeout, unsigned long duration) //Uses time
 #endif
 
 #if INJ_CHANNELS >= 8
-void setFuelSchedule8(unsigned long timeout, unsigned long duration) //Uses timer 5 compare B
+void setFuelSchedule8(uint32_t timeout, uint32_t duration) //Uses timer 5 compare B
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -463,7 +463,7 @@ void setFuelSchedule8(unsigned long timeout, unsigned long duration) //Uses time
 #endif
 
 //Ignition schedulers use Timer 5
-void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule1(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule1.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -500,7 +500,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
   }
 }
 
-inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
+inline void refreshIgnitionSchedule1(uint32_t timeToEnd)
 {
   if( (ignitionSchedule1.Status == RUNNING) && (timeToEnd < ignitionSchedule1.duration) )
   //Must have the threshold check here otherwise it can cause a condition where the compare fires twice, once after the other, both for the end
@@ -513,7 +513,7 @@ inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
   }
 }
 
-void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule2(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule2.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -547,7 +547,7 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule3(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule3.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -582,7 +582,7 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule4(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule4.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -617,7 +617,7 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule5(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule5.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -652,7 +652,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule6(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule6.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -687,7 +687,7 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule7(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule7.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -722,7 +722,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
+void setIgnitionSchedule8(void (*startCallback)(), uint32_t timeout, uint32_t duration, void(*endCallback)())
 {
   if(ignitionSchedule8.Status != RUNNING) //Check that we're not already part way through a schedule
   {
@@ -761,7 +761,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
 extern void beginInjectorPriming()
 {
   //Perform the injector priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
-  unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
+  uint32_t primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
   if( (primingValue > 0) && (currentStatus.TPS < configPage4.floodClear) )
   {
     primingValue = primingValue * 100 * 5; //to acheive long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.

--- a/speeduino/secondaryTables.h
+++ b/speeduino/secondaryTables.h
@@ -1,4 +1,4 @@
 void calculateSecondaryFuel();
 void calculateSecondarySpark();
-byte getVE2();
-byte getAdvance2();
+uint8_t getVE2();
+uint8_t getAdvance2();

--- a/speeduino/secondaryTables.ino
+++ b/speeduino/secondaryTables.ino
@@ -157,9 +157,9 @@ void calculateSecondarySpark()
  * This performs largely the same operations as getVE() however the lookup is of the secondary fuel table and uses the secondary load source
  * @return byte 
  */
-byte getVE2()
+uint8_t getVE2()
 {
-  byte tempVE = 100;
+  uint8_t tempVE = 100;
   if( configPage10.fuel2Algorithm == LOAD_SOURCE_MAP)
   {
     //Speed Density
@@ -186,9 +186,9 @@ byte getVE2()
  * 
  * @return byte The current target advance value in degrees
  */
-byte getAdvance2()
+uint8_t getAdvance2()
 {
-  byte tempAdvance = 0;
+  uint8_t tempAdvance = 0;
   if (configPage2.ignAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
   {
     //Speed Density

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -47,7 +47,7 @@ volatile uint16_t knockAngle;
 
 unsigned long MAPrunningValue; //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
 unsigned long EMAPrunningValue; //As above but for EMAP
-unsigned int MAPcount; //Number of samples taken in the current MAP cycle
+uint16_t MAPcount; //Number of samples taken in the current MAP cycle
 uint32_t MAPcurRev; //Tracks which revolution we're sampling on
 bool auxIsEnabled;
 uint8_t TPSlast; /**< The previous TPS reading */
@@ -95,14 +95,14 @@ void readBat();
 void readBaro();
 
 #if defined(ANALOG_ISR)
-volatile int AnChannel[15];
+volatile int16_t AnChannel[15];
 
 //Analog ISR interrupt routine
 /*
 ISR(ADC_vect)
 {
   uint8_t nChannel;
-  int result = ADCL | (ADCH << 8);
+  int16_t result = ADCL | (ADCH << 8);
 
   //ADCSRA = 0x6E; - ADC disabled by clearing bit 7(ADEN)
   //BIT_CLEAR(ADCSRA, ADIE);
@@ -133,7 +133,7 @@ ISR(ADC_vect)
 ISR(ADC_vect)
 {
   uint8_t nChannel = ADMUX & 0x07;
-  int result = ADCL | (ADCH << 8);
+  int16_t result = ADCL | (ADCH << 8);
 
   BIT_CLEAR(ADCSRA, ADEN); //Disable ADC for Changing Channel (see chapter 26.5 of datasheet)
 

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -32,7 +32,7 @@
 #endif
 */
 
-volatile byte flexCounter = 0;
+volatile uint8_t flexCounter = 0;
 volatile unsigned long flexStartTime;
 volatile unsigned long flexPulseWidth;
 
@@ -42,7 +42,7 @@ volatile unsigned long flexPulseWidth;
   #define READ_FLEX() digitalRead(pinFlex)
 #endif
 
-volatile byte knockCounter = 0;
+volatile uint8_t knockCounter = 0;
 volatile uint16_t knockAngle;
 
 unsigned long MAPrunningValue; //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
@@ -50,22 +50,22 @@ unsigned long EMAPrunningValue; //As above but for EMAP
 unsigned int MAPcount; //Number of samples taken in the current MAP cycle
 uint32_t MAPcurRev; //Tracks which revolution we're sampling on
 bool auxIsEnabled;
-byte TPSlast; /**< The previous TPS reading */
+uint8_t TPSlast; /**< The previous TPS reading */
 unsigned long TPS_time; //The time the TPS sample was taken
 unsigned long TPSlast_time; //The time the previous TPS sample was taken
-byte MAPlast; /**< The previous MAP reading */
+uint8_t MAPlast; /**< The previous MAP reading */
 unsigned long MAP_time; //The time the MAP sample was taken
 unsigned long MAPlast_time; //The time the previous MAP sample was taken
 volatile unsigned long vssLastPulseTime; /**< The time of the last VSS pulse of the VSS */
 volatile unsigned long vssLastMinusOnePulseTime; /**< The time of the last VSS_NUM_SAMPLES pulses of the VSS are stored in this array */
 volatile unsigned long vssTotalTime; /**< Cumulative count of the last VSS_SAMPLES number of pulses */
-volatile byte vssCount;
+volatile uint8_t vssCount;
 
 
 //These variables are used for tracking the number of running sensors values that appear to be errors. Once a threshold is reached, the sensor reading will go to default value and assume the sensor is faulty
-byte mapErrorCount = 0;
-byte iatErrorCount = 0;
-byte cltErrorCount = 0;
+uint8_t mapErrorCount = 0;
+uint8_t iatErrorCount = 0;
+uint8_t cltErrorCount = 0;
 
 /**
  * @brief Simple low pass IIR filter macro for the analog inputs
@@ -83,9 +83,9 @@ void readO2_2();
 void flexPulse();
 void vssPulse();
 uint16_t getSpeed();
-byte getGear();
-byte getFuelPressure();
-byte getOilPressure();
+uint8_t getGear();
+uint8_t getFuelPressure();
+uint8_t getOilPressure();
 uint16_t readAuxanalog(uint8_t analogPin);
 uint16_t readAuxdigital(uint8_t digitalPin);
 void readCLT(bool=true); //Allows the option to override the use of the filter
@@ -101,7 +101,7 @@ volatile int AnChannel[15];
 /*
 ISR(ADC_vect)
 {
-  byte nChannel;
+  uint8_t nChannel;
   int result = ADCL | (ADCH << 8);
 
   //ADCSRA = 0x6E; - ADC disabled by clearing bit 7(ADEN)
@@ -132,7 +132,7 @@ ISR(ADC_vect)
 */
 ISR(ADC_vect)
 {
-  byte nChannel = ADMUX & 0x07;
+  uint8_t nChannel = ADMUX & 0x07;
   int result = ADCL | (ADCH << 8);
 
   BIT_CLEAR(ADCSRA, ADEN); //Disable ADC for Changing Channel (see chapter 26.5 of datasheet)

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -33,8 +33,8 @@
 */
 
 volatile uint8_t flexCounter = 0;
-volatile unsigned long flexStartTime;
-volatile unsigned long flexPulseWidth;
+volatile uint32_t flexStartTime;
+volatile uint32_t flexPulseWidth;
 
 #if defined(CORE_AVR)
   #define READ_FLEX() ((*flex_pin_port & flex_pin_mask) ? true : false)
@@ -45,20 +45,20 @@ volatile unsigned long flexPulseWidth;
 volatile uint8_t knockCounter = 0;
 volatile uint16_t knockAngle;
 
-unsigned long MAPrunningValue; //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
-unsigned long EMAPrunningValue; //As above but for EMAP
+uint32_t MAPrunningValue; //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
+uint32_t EMAPrunningValue; //As above but for EMAP
 uint16_t MAPcount; //Number of samples taken in the current MAP cycle
 uint32_t MAPcurRev; //Tracks which revolution we're sampling on
 bool auxIsEnabled;
 uint8_t TPSlast; /**< The previous TPS reading */
-unsigned long TPS_time; //The time the TPS sample was taken
-unsigned long TPSlast_time; //The time the previous TPS sample was taken
+uint32_t TPS_time; //The time the TPS sample was taken
+uint32_t TPSlast_time; //The time the previous TPS sample was taken
 uint8_t MAPlast; /**< The previous MAP reading */
-unsigned long MAP_time; //The time the MAP sample was taken
-unsigned long MAPlast_time; //The time the previous MAP sample was taken
-volatile unsigned long vssLastPulseTime; /**< The time of the last VSS pulse of the VSS */
-volatile unsigned long vssLastMinusOnePulseTime; /**< The time of the last VSS_NUM_SAMPLES pulses of the VSS are stored in this array */
-volatile unsigned long vssTotalTime; /**< Cumulative count of the last VSS_SAMPLES number of pulses */
+uint32_t MAP_time; //The time the MAP sample was taken
+uint32_t MAPlast_time; //The time the previous MAP sample was taken
+volatile uint32_t vssLastPulseTime; /**< The time of the last VSS pulse of the VSS */
+volatile uint32_t vssLastMinusOnePulseTime; /**< The time of the last VSS_NUM_SAMPLES pulses of the VSS are stored in this array */
+volatile uint32_t vssTotalTime; /**< Cumulative count of the last VSS_SAMPLES number of pulses */
 volatile uint8_t vssCount;
 
 
@@ -72,7 +72,7 @@ uint8_t cltErrorCount = 0;
  * This is effectively implementing the smooth filter from playground.arduino.cc/Main/Smooth
  * But removes the use of floats and uses 8 bits of fixed precision.
  */
-#define ADC_FILTER(input, alpha, prior) (((long)input * (256 - alpha) + ((long)prior * alpha))) >> 8
+#define ADC_FILTER(input, alpha, prior) (((int32_t)input * (256 - alpha) + ((int32_t)prior * alpha))) >> 8
 
 static inline void instanteneousMAPReading() __attribute__((always_inline));
 static inline void readMAP() __attribute__((always_inline));

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -274,7 +274,7 @@ static inline void readMAP()
           //Error check
           if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
           {
-            if( (unsigned long)tempReading < MAPrunningValue ) { MAPrunningValue = (unsigned long)tempReading; } //Check whether the current reading is lower than the running minimum
+            if( (uint32_t)tempReading < MAPrunningValue ) { MAPrunningValue = (uint32_t)tempReading; } //Check whether the current reading is lower than the running minimum
           }
           else { mapErrorCount += 1; }
         }

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -59,7 +59,7 @@ void initialiseADC()
 
   //The following checks the aux inputs and initialises pins if required
   auxIsEnabled = false;
-  for (byte AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
+  for (uint8_t AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
   {
     currentStatus.current_caninchannel = AuxinChan;                   
     if (((configPage9.caninput_sel[currentStatus.current_caninchannel]&12) == 4)
@@ -72,7 +72,7 @@ void initialiseADC()
             || (((configPage9.enable_secondarySerial == 0) && ( (configPage9.enable_intcan == 1) && (configPage9.intcan_available == 0) )) && (configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 2)  
             || (((configPage9.enable_secondarySerial == 0) && (configPage9.enable_intcan == 0)) && ((configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 2)))  
     {  //if current input channel is enabled as analog local pin check caninput_selxb(bits 2:3) with &12 and caninput_selxa(bits 0:1) with &3
-      byte pinNumber = (configPage9.Auxinpina[currentStatus.current_caninchannel]&127);
+      uint8_t pinNumber = (configPage9.Auxinpina[currentStatus.current_caninchannel]&127);
       if( pinIsUsed(pinNumber) )
       {
         //Do nothing here as the pin is already in use.
@@ -90,7 +90,7 @@ void initialiseADC()
             || (((configPage9.enable_secondarySerial == 0) && ( (configPage9.enable_intcan == 1) && (configPage9.intcan_available == 0) )) && (configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 3)
             || (((configPage9.enable_secondarySerial == 0) && (configPage9.enable_intcan == 0)) && ((configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 3)))
     {  //if current input channel is enabled as digital local pin check caninput_selxb(bits 2:3) wih &12 and caninput_selxa(bits 0:1) with &3
-       byte pinNumber = (configPage9.Auxinpinb[currentStatus.current_caninchannel]&127);
+       uint8_t pinNumber = (configPage9.Auxinpinb[currentStatus.current_caninchannel]&127);
        if( pinIsUsed(pinNumber) )
        {
          //Do nothing here as the pin is already in use.
@@ -357,16 +357,16 @@ void readTPS(bool useFilter)
   TPSlast = currentStatus.TPS;
   TPSlast_time = TPS_time;
   #if defined(ANALOG_ISR)
-    byte tempTPS = fastMap1023toX(AnChannel[pinTPS-A0], 255); //Get the current raw TPS ADC value and map it into a byte
+    uint8_t tempTPS = fastMap1023toX(AnChannel[pinTPS-A0], 255); //Get the current raw TPS ADC value and map it into a byte
   #else
     analogRead(pinTPS);
-    byte tempTPS = fastMap1023toX(analogRead(pinTPS), 255); //Get the current raw TPS ADC value and map it into a byte
+    uint8_t tempTPS = fastMap1023toX(analogRead(pinTPS), 255); //Get the current raw TPS ADC value and map it into a byte
   #endif
   //The use of the filter can be overridden if required. This is used on startup to disable priming pulse if flood clear is wanted
   if(useFilter == true) { currentStatus.tpsADC = ADC_FILTER(tempTPS, configPage4.ADCFILTER_TPS, currentStatus.tpsADC); }
   else { currentStatus.tpsADC = tempTPS; }
   //currentStatus.tpsADC = ADC_FILTER(tempTPS, 128, currentStatus.tpsADC);
-  byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
+  uint8_t tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 
   if(configPage2.tpsMax > configPage2.tpsMin)
   {
@@ -569,9 +569,9 @@ uint16_t getSpeed()
   return tempSpeed;
 }
 
-byte getGear()
+uint8_t getGear()
 {
-  byte tempGear = 0; //Unknown gear
+  uint8_t tempGear = 0; //Unknown gear
   if(currentStatus.vss > 0)
   {
     //If the speed is non-zero, default to the last calculated gear
@@ -590,7 +590,7 @@ byte getGear()
   return tempGear;
 }
 
-byte getFuelPressure()
+uint8_t getFuelPressure()
 {
   int16_t tempFuelPressure = 0;
   uint16_t tempReading;
@@ -608,10 +608,10 @@ byte getFuelPressure()
     if(tempFuelPressure < 0 ) { tempFuelPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
   }
 
-  return (byte)tempFuelPressure;
+  return (uint8_t)tempFuelPressure;
 }
 
-byte getOilPressure()
+uint8_t getOilPressure()
 {
   int16_t tempOilPressure = 0;
   uint16_t tempReading;
@@ -631,7 +631,7 @@ byte getOilPressure()
   }
 
 
-  return (byte)tempOilPressure;
+  return (uint8_t)tempOilPressure;
 }
 
 /*

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -155,7 +155,7 @@ static inline void instanteneousMAPReading()
   MAPlast_time = MAP_time;
   MAP_time = micros();
 
-  unsigned int tempReading;
+  uint16_t tempReading;
   //Instantaneous MAP readings
   #if defined(ANALOG_ISR_MAP)
     tempReading = AnChannel[pinMAP-A0];
@@ -178,7 +178,7 @@ static inline void instanteneousMAPReading()
 
 static inline void readMAP()
 {
-  unsigned int tempReading;
+  uint16_t tempReading;
   //MAP Sampling system
   switch(configPage2.mapSample)
   {
@@ -402,7 +402,7 @@ void readTPS(bool useFilter)
 
 void readCLT(bool useFilter)
 {
-  unsigned int tempReading;
+  uint16_t tempReading;
   #if defined(ANALOG_ISR)
     tempReading = fastMap1023toX(AnChannel[pinCLT-A0], 511); //Get the current raw CLT value
   #else
@@ -419,7 +419,7 @@ void readCLT(bool useFilter)
 
 void readIAT()
 {
-  unsigned int tempReading;
+  uint16_t tempReading;
   #if defined(ANALOG_ISR)
     tempReading = fastMap1023toX(AnChannel[pinIAT-A0], 511); //Get the current raw IAT value
   #else
@@ -435,7 +435,7 @@ void readBaro()
 {
   if ( configPage6.useExtBaro != 0 )
   {
-    int tempReading;
+    int16_t tempReading;
     // readings
     #if defined(ANALOG_ISR_MAP)
       tempReading = AnChannel[pinBaro-A0];
@@ -455,7 +455,7 @@ void readO2()
   //An O2 read is only performed if an O2 sensor type is selected. This is to prevent potentially dangerous use of the O2 readings prior to proper setup/calibration
   if(configPage6.egoType > 0)
   {
-    unsigned int tempReading;
+    uint16_t tempReading;
     #if defined(ANALOG_ISR)
       tempReading = fastMap1023toX(AnChannel[pinO2-A0], 511); //Get the current O2 value.
     #else
@@ -479,7 +479,7 @@ void readO2_2()
 {
   //Second O2 currently disabled as its not being used
   //Get the current O2 value.
-  unsigned int tempReading;
+  uint16_t tempReading;
   #if defined(ANALOG_ISR)
     tempReading = fastMap1023toX(AnChannel[pinO2_2-A0], 511); //Get the current O2 value.
   #else
@@ -493,7 +493,7 @@ void readO2_2()
 
 void readBat()
 {
-  int tempReading;
+  int16_t tempReading;
   #if defined(ANALOG_ISR)
     tempReading = fastMap1023toX(AnChannel[pinBat-A0], 245); //Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
   #else
@@ -689,7 +689,7 @@ void vssPulse()
 uint16_t readAuxanalog(uint8_t analogPin)
 {
   //read the Aux analog value for pin set by analogPin 
-  unsigned int tempReading;
+  uint16_t tempReading;
   #if defined(ANALOG_ISR)
     tempReading = fastMap1023toX(AnChannel[analogPin-A0], 1023); //Get the current raw Auxanalog value
   #else
@@ -703,7 +703,7 @@ uint16_t readAuxanalog(uint8_t analogPin)
 uint16_t readAuxdigital(uint8_t digitalPin)
 {
   //read the Aux digital value for pin set by digitalPin 
-  unsigned int tempReading;
+  uint16_t tempReading;
   tempReading = digitalRead(digitalPin); 
   return tempReading;
 } 

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -13,9 +13,9 @@
 #define SPEEDUINO_H
 //#include "globals.h"
 
-uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
-byte getVE1();
-byte getAdvance1();
+uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpen);
+uint8_t getVE1();
+uint8_t getAdvance1();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);
 void calculateIgnitionAngle1(int);
@@ -36,9 +36,9 @@ extern uint16_t inj_opentime_uS; /**< The injector opening time. This is set wit
 extern bool ignitionOn; /**< The current state of the ignition system (on or off) */
 extern bool fuelOn; /**< The current state of the fuel system (on or off) */
 
-extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-extern byte curRollingCut; /**< Rolling rev limiter, current ignition channel being cut */
-extern byte rollingCutCounter; /**< how many times (revolutions) the ignition has been cut in a row */
+extern uint8_t maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
+extern uint8_t curRollingCut; /**< Rolling rev limiter, current ignition channel being cut */
+extern uint8_t rollingCutCounter; /**< how many times (revolutions) the ignition has been cut in a row */
 extern uint32_t rollingCutLastRev; /**< Tracks whether we're on the same or a different rev for the rolling cut */
 
 extern int channel1IgnDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -13,7 +13,7 @@
 #define SPEEDUINO_H
 //#include "globals.h"
 
-uint16_t PW(int16_t REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t injOpen);
+uint16_t PW(int16_t REQ_FUEL, uint8_t VE, int32_t MAP, uint16_t corrections, int16_t injOpen);
 uint8_t getVE1();
 uint8_t getAdvance1();
 

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -13,22 +13,22 @@
 #define SPEEDUINO_H
 //#include "globals.h"
 
-uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpen);
+uint16_t PW(int16_t REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t injOpen);
 uint8_t getVE1();
 uint8_t getAdvance1();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);
-void calculateIgnitionAngle1(int);
-void calculateIgnitionAngle2(int);
-void calculateIgnitionAngle3(int);
-void calculateIgnitionAngle3(int, int);
-void calculateIgnitionAngle4(int);
-void calculateIgnitionAngle4(int, int);
-void calculateIgnitionAngle5(int);
-void calculateIgnitionAngle6(int);
-void calculateIgnitionAngle7(int);
-void calculateIgnitionAngle8(int);
-void calculateIgnitionAngles(int);
+void calculateIgnitionAngle1(int16_t);
+void calculateIgnitionAngle2(int16_t);
+void calculateIgnitionAngle3(int16_t);
+void calculateIgnitionAngle3(int16_t, int16_t);
+void calculateIgnitionAngle4(int16_t);
+void calculateIgnitionAngle4(int16_t, int16_t);
+void calculateIgnitionAngle5(int16_t);
+void calculateIgnitionAngle6(int16_t);
+void calculateIgnitionAngle7(int16_t);
+void calculateIgnitionAngle8(int16_t);
+void calculateIgnitionAngles(int16_t);
 
 extern uint16_t req_fuel_uS; /**< The required fuel variable (As calculated by TunerStudio) in uS */
 extern uint16_t inj_opentime_uS; /**< The injector opening time. This is set within Tuner Studio, but stored here in uS rather than mS */
@@ -41,22 +41,22 @@ extern uint8_t curRollingCut; /**< Rolling rev limiter, current ignition channel
 extern uint8_t rollingCutCounter; /**< how many times (revolutions) the ignition has been cut in a row */
 extern uint32_t rollingCutLastRev; /**< Tracks whether we're on the same or a different rev for the rolling cut */
 
-extern int channel1IgnDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-extern int channel2IgnDegrees; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-extern int channel3IgnDegrees; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-extern int channel4IgnDegrees; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-extern int channel5IgnDegrees; /**< The number of crank degrees until cylinder 5 is at TDC */
-extern int channel6IgnDegrees; /**< The number of crank degrees until cylinder 6 is at TDC */
-extern int channel7IgnDegrees; /**< The number of crank degrees until cylinder 7 is at TDC */
-extern int channel8IgnDegrees; /**< The number of crank degrees until cylinder 8 is at TDC */
-extern int channel1InjDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-extern int channel2InjDegrees; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-extern int channel3InjDegrees; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-extern int channel4InjDegrees; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-extern int channel5InjDegrees; /**< The number of crank degrees until cylinder 5 is at TDC */
-extern int channel6InjDegrees; /**< The number of crank degrees until cylinder 6 is at TDC */
-extern int channel7InjDegrees; /**< The number of crank degrees until cylinder 7 is at TDC */
-extern int channel8InjDegrees; /**< The number of crank degrees until cylinder 8 is at TDC */
+extern int16_t channel1IgnDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
+extern int16_t channel2IgnDegrees; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
+extern int16_t channel3IgnDegrees; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
+extern int16_t channel4IgnDegrees; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
+extern int16_t channel5IgnDegrees; /**< The number of crank degrees until cylinder 5 is at TDC */
+extern int16_t channel6IgnDegrees; /**< The number of crank degrees until cylinder 6 is at TDC */
+extern int16_t channel7IgnDegrees; /**< The number of crank degrees until cylinder 7 is at TDC */
+extern int16_t channel8IgnDegrees; /**< The number of crank degrees until cylinder 8 is at TDC */
+extern int16_t channel1InjDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
+extern int16_t channel2InjDegrees; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
+extern int16_t channel3InjDegrees; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
+extern int16_t channel4InjDegrees; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
+extern int16_t channel5InjDegrees; /**< The number of crank degrees until cylinder 5 is at TDC */
+extern int16_t channel6InjDegrees; /**< The number of crank degrees until cylinder 6 is at TDC */
+extern int16_t channel7InjDegrees; /**< The number of crank degrees until cylinder 7 is at TDC */
+extern int16_t channel8InjDegrees; /**< The number of crank degrees until cylinder 8 is at TDC */
 
 /** @name Staging
  * These values are a percentage of the total (Combined) req_fuel value that would be required for each injector channel to deliver that much fuel.   

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -40,31 +40,31 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "secondaryTables.h"
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
-int ignition1StartAngle = 0;
-int ignition2StartAngle = 0;
-int ignition3StartAngle = 0;
-int ignition4StartAngle = 0;
-int ignition5StartAngle = 0;
-int ignition6StartAngle = 0;
-int ignition7StartAngle = 0;
-int ignition8StartAngle = 0;
+int16_t ignition1StartAngle = 0;
+int16_t ignition2StartAngle = 0;
+int16_t ignition3StartAngle = 0;
+int16_t ignition4StartAngle = 0;
+int16_t ignition5StartAngle = 0;
+int16_t ignition6StartAngle = 0;
+int16_t ignition7StartAngle = 0;
+int16_t ignition8StartAngle = 0;
 
-int channel1IgnDegrees = 0; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-int channel2IgnDegrees = 0; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-int channel3IgnDegrees = 0; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-int channel4IgnDegrees = 0; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-int channel5IgnDegrees = 0; /**< The number of crank degrees until cylinder 5 is at TDC */
-int channel6IgnDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
-int channel7IgnDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
-int channel8IgnDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */
-int channel1InjDegrees = 0; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-int channel2InjDegrees = 0; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-int channel3InjDegrees = 0; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-int channel4InjDegrees = 0; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-int channel5InjDegrees = 0; /**< The number of crank degrees until cylinder 5 is at TDC */
-int channel6InjDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
-int channel7InjDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
-int channel8InjDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */
+int16_t channel1IgnDegrees = 0; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
+int16_t channel2IgnDegrees = 0; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
+int16_t channel3IgnDegrees = 0; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
+int16_t channel4IgnDegrees = 0; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
+int16_t channel5IgnDegrees = 0; /**< The number of crank degrees until cylinder 5 is at TDC */
+int16_t channel6IgnDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
+int16_t channel7IgnDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
+int16_t channel8IgnDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */
+int16_t channel1InjDegrees = 0; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
+int16_t channel2InjDegrees = 0; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
+int16_t channel3InjDegrees = 0; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
+int16_t channel4InjDegrees = 0; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
+int16_t channel5InjDegrees = 0; /**< The number of crank degrees until cylinder 5 is at TDC */
+int16_t channel6InjDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
+int16_t channel7InjDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
+int16_t channel8InjDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */
 
 uint16_t req_fuel_uS = 0; /**< The required fuel variable (As calculated by TunerStudio) in uS */
 uint16_t inj_opentime_uS = 0;
@@ -226,7 +226,7 @@ void loop()
 
       if(previousClutchTrigger != clutchTrigger) { currentStatus.clutchEngagedRPM = currentStatus.RPM; }
 
-      if (configPage6.launchEnabled && clutchTrigger && (currentStatus.clutchEngagedRPM < ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > ((unsigned int)(configPage6.lnchHardLim) * 100)) && (currentStatus.TPS >= configPage10.lnchCtrlTPS) ) 
+      if (configPage6.launchEnabled && clutchTrigger && (currentStatus.clutchEngagedRPM < ((uint16_t)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > ((uint16_t)(configPage6.lnchHardLim) * 100)) && (currentStatus.TPS >= configPage10.lnchCtrlTPS) ) 
       { 
         //HardCut rev limit for 2-step launch control.
         currentStatus.launchingHard = true; 
@@ -239,7 +239,7 @@ void loop()
         BIT_CLEAR(currentStatus.spark, BIT_SPARK_HLAUNCH); 
 
         //If launch is not active, check whether flat shift should be active
-        if(configPage6.flatSEnable && clutchTrigger && (currentStatus.RPM > ((unsigned int)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > currentStatus.clutchEngagedRPM) ) { currentStatus.flatShiftingHard = true; }
+        if(configPage6.flatSEnable && clutchTrigger && (currentStatus.RPM > ((uint16_t)(configPage6.flatSArm) * 100)) && (currentStatus.RPM > currentStatus.clutchEngagedRPM) ) { currentStatus.flatShiftingHard = true; }
         else { currentStatus.flatShiftingHard = false; }
       }
 
@@ -431,7 +431,7 @@ void loop()
         currentStatus.PW1 = currentStatus.PW1 + (configPage10.n2o_stage2_adderMax + percentage(adderPercent, (configPage10.n2o_stage2_adderMin - configPage10.n2o_stage2_adderMax))) * 100; //Calculate the above percentage of the calculated ms value.
       }
 
-      int injector1StartAngle = 0;
+      int16_t injector1StartAngle = 0;
       uint16_t injector2StartAngle = 0;
       uint16_t injector3StartAngle = 0;
       uint16_t injector4StartAngle = 0;
@@ -450,8 +450,8 @@ void loop()
       #endif
       //These are used for comparisons on channels above 1 where the starting angle (for injectors or ignition) can be less than a single loop time
       //(Don't ask why this is needed, it's just there)
-      int tempCrankAngle;
-      int tempStartAngle;
+      int16_t tempCrankAngle;
+      int16_t tempStartAngle;
 
       doCrankSpeedCalcs(); //In crankMaths.ino
 
@@ -520,7 +520,7 @@ void loop()
       //***********************************************************************************************
       //BEGIN INJECTION TIMING
       currentStatus.injAngle = table2D_getValue(&injectorAngleTable, currentStatus.RPM / 100);
-      unsigned int PWdivTimerPerDegree = div(currentStatus.PW1, timePerDegree).quot; //How many crank degrees the calculated PW will take at the current speed
+      uint16_t PWdivTimerPerDegree = div(currentStatus.PW1, timePerDegree).quot; //How many crank degrees the calculated PW will take at the current speed
 
       injector1StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel1InjDegrees);
 
@@ -656,7 +656,7 @@ void loop()
       else { currentStatus.dwell =  (configPage4.dwellRun * 100); }
       currentStatus.dwell = correctionsDwell(currentStatus.dwell);
 
-      int dwellAngle = timeToAngle(currentStatus.dwell, CRANKMATH_METHOD_INTERVAL_REV); //Convert the dwell time to dwell angle based on the current engine speed
+      int16_t dwellAngle = timeToAngle(currentStatus.dwell, CRANKMATH_METHOD_INTERVAL_REV); //Convert the dwell time to dwell angle based on the current engine speed
 
       calculateIgnitionAngles(dwellAngle);
 
@@ -672,7 +672,7 @@ void loop()
       //This may potentially be called a number of times as we get closer and closer to the opening time
 
       //Determine the current crank angle
-      int crankAngle = getCrankAngle();
+      int16_t crankAngle = getCrankAngle();
       while(crankAngle > CRANK_ANGLE_MAX_INJ ) { crankAngle = crankAngle - CRANK_ANGLE_MAX_INJ; } //Continue reducing the crank angle by the max injection amount until it's below the required limit. This will usually only run (at most) once, but in cases where there is sequential ignition and more than 2 squirts per cycle, it may run up to 4 times. 
 
       // if(Serial && false)
@@ -1173,7 +1173,7 @@ void loop()
  * @param injOpen Injector opening time. The time the injector take to open minus the time it takes to close (Both in uS)
  * @return uint16_t The injector pulse width in uS
  */
-uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpen)
+uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t injOpen)
 {
   //Standard float version of the calculation
   //return (REQ_FUEL * (float)(VE/100.0) * (float)(MAP/100.0) * (float)(TPS/100.0) * (float)(corrections/100.0) + injOpen);
@@ -1189,17 +1189,17 @@ uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpe
   if (corrections > 511 ) { bitShift = 6; }
   if (corrections > 1023) { bitShift = 5; }
   
-  iVE = ((unsigned int)VE << 7) / 100;
+  iVE = ((uint16_t)VE << 7) / 100;
 
   //Check whether either of the mutiply MAP modes is turned on
-  if ( configPage2.multiplyMAP == MULTIPLY_MAP_MODE_100) { iMAP = ((unsigned int)MAP << 7) / 100; }
-  else if( configPage2.multiplyMAP == MULTIPLY_MAP_MODE_BARO) { iMAP = ((unsigned int)MAP << 7) / currentStatus.baro; }
+  if ( configPage2.multiplyMAP == MULTIPLY_MAP_MODE_100) { iMAP = ((uint16_t)MAP << 7) / 100; }
+  else if( configPage2.multiplyMAP == MULTIPLY_MAP_MODE_BARO) { iMAP = ((uint16_t)MAP << 7) / currentStatus.baro; }
   
   if ( (configPage2.includeAFR == true) && (configPage6.egoType == 2) && (currentStatus.runSecs > configPage6.ego_sdelay) ) {
-    iAFR = ((unsigned int)currentStatus.O2 << 7) / currentStatus.afrTarget;  //Include AFR (vs target) if enabled
+    iAFR = ((uint16_t)currentStatus.O2 << 7) / currentStatus.afrTarget;  //Include AFR (vs target) if enabled
   }
   if ( (configPage2.incorporateAFR == true) && (configPage2.includeAFR == false) ) {
-    iAFR = ((unsigned int)configPage2.stoich << 7) / currentStatus.afrTarget;  //Incorporate stoich vs target AFR, if enabled.
+    iAFR = ((uint16_t)configPage2.stoich << 7) / currentStatus.afrTarget;  //Incorporate stoich vs target AFR, if enabled.
   }
   iCorrections = (corrections << bitShift) / 100;
 
@@ -1230,7 +1230,7 @@ uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpe
       intermediate = 65535;  //Make sure this won't overflow when we convert to uInt. This means the maximum pulsewidth possible is 65.535mS
     }
   }
-  return (unsigned int)(intermediate);
+  return (uint16_t)(intermediate);
 }
 
 /**
@@ -1302,7 +1302,7 @@ uint16_t calculateInjectorStartAngle(uint16_t PWdivTimerPerDegree, int16_t injCh
   return tempInjectorStartAngle;
 }
 
-void calculateIgnitionAngle1(int dwellAngle)
+void calculateIgnitionAngle1(int16_t dwellAngle)
 {
   ignition1EndAngle = CRANK_ANGLE_MAX_IGN - currentStatus.advance;
   if(ignition1EndAngle > CRANK_ANGLE_MAX_IGN) {ignition1EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1310,7 +1310,7 @@ void calculateIgnitionAngle1(int dwellAngle)
   if(ignition1StartAngle < 0) {ignition1StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle2(int dwellAngle)
+void calculateIgnitionAngle2(int16_t dwellAngle)
 {
   ignition2EndAngle = channel2IgnDegrees - currentStatus.advance;
   if(ignition2EndAngle > CRANK_ANGLE_MAX_IGN) {ignition2EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1318,7 +1318,7 @@ void calculateIgnitionAngle2(int dwellAngle)
   if(ignition2StartAngle < 0) {ignition2StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle3(int dwellAngle)
+void calculateIgnitionAngle3(int16_t dwellAngle)
 {
   ignition3EndAngle = channel3IgnDegrees - currentStatus.advance;
   if(ignition3EndAngle > CRANK_ANGLE_MAX_IGN) {ignition3EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1327,7 +1327,7 @@ void calculateIgnitionAngle3(int dwellAngle)
 }
 
 // ignition 3 for rotary
-void calculateIgnitionAngle3(int dwellAngle, int rotarySplitDegrees)
+void calculateIgnitionAngle3(int16_t dwellAngle, int16_t rotarySplitDegrees)
 {
   ignition3EndAngle = ignition1EndAngle + rotarySplitDegrees;
   ignition3StartAngle = ignition3EndAngle - dwellAngle;
@@ -1335,7 +1335,7 @@ void calculateIgnitionAngle3(int dwellAngle, int rotarySplitDegrees)
   if(ignition3StartAngle < 0) {ignition3StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle4(int dwellAngle)
+void calculateIgnitionAngle4(int16_t dwellAngle)
 {
   ignition4EndAngle = channel4IgnDegrees - currentStatus.advance;
   if(ignition4EndAngle > CRANK_ANGLE_MAX_IGN) {ignition4EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1344,7 +1344,7 @@ void calculateIgnitionAngle4(int dwellAngle)
 }
 
 // ignition 4 for rotary
-void calculateIgnitionAngle4(int dwellAngle, int rotarySplitDegrees)
+void calculateIgnitionAngle4(int16_t dwellAngle, int16_t rotarySplitDegrees)
 {
   ignition4EndAngle = ignition2EndAngle + rotarySplitDegrees;
   ignition4StartAngle = ignition4EndAngle - dwellAngle;
@@ -1352,7 +1352,7 @@ void calculateIgnitionAngle4(int dwellAngle, int rotarySplitDegrees)
   if(ignition4StartAngle < 0) {ignition4StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle5(int dwellAngle)
+void calculateIgnitionAngle5(int16_t dwellAngle)
 {
   ignition5EndAngle = channel5IgnDegrees - currentStatus.advance;
   if(ignition5EndAngle > CRANK_ANGLE_MAX_IGN) {ignition5EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1360,7 +1360,7 @@ void calculateIgnitionAngle5(int dwellAngle)
   if(ignition5StartAngle < 0) {ignition5StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle6(int dwellAngle)
+void calculateIgnitionAngle6(int16_t dwellAngle)
 {
   ignition6EndAngle = channel6IgnDegrees - currentStatus.advance;
   if(ignition6EndAngle > CRANK_ANGLE_MAX_IGN) {ignition6EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1368,7 +1368,7 @@ void calculateIgnitionAngle6(int dwellAngle)
   if(ignition6StartAngle < 0) {ignition6StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle7(int dwellAngle)
+void calculateIgnitionAngle7(int16_t dwellAngle)
 {
   ignition7EndAngle = channel7IgnDegrees - currentStatus.advance;
   if(ignition7EndAngle > CRANK_ANGLE_MAX_IGN) {ignition7EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1376,7 +1376,7 @@ void calculateIgnitionAngle7(int dwellAngle)
   if(ignition7StartAngle < 0) {ignition7StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngle8(int dwellAngle)
+void calculateIgnitionAngle8(int16_t dwellAngle)
 {
   ignition8EndAngle = channel8IgnDegrees - currentStatus.advance;
   if(ignition8EndAngle > CRANK_ANGLE_MAX_IGN) {ignition8EndAngle -= CRANK_ANGLE_MAX_IGN;}
@@ -1384,7 +1384,7 @@ void calculateIgnitionAngle8(int dwellAngle)
   if(ignition8StartAngle < 0) {ignition8StartAngle += CRANK_ANGLE_MAX_IGN;}
 }
 
-void calculateIgnitionAngles(int dwellAngle)
+void calculateIgnitionAngles(int16_t dwellAngle)
 {
   //Calculate start and end angle for each channel
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -72,9 +72,9 @@ uint16_t inj_opentime_uS = 0;
 bool ignitionOn = false; /**< The current state of the ignition system (on or off) */
 bool fuelOn = false; /**< The current state of the fuel system (on or off) */
 
-byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-byte curRollingCut = 0; /**< Rolling rev limiter, current ignition channel being cut */
-byte rollingCutCounter = 0; /**< how many times (revolutions) the ignition has been cut in a row */
+uint8_t maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
+uint8_t curRollingCut = 0; /**< Rolling rev limiter, current ignition channel being cut */
+uint8_t rollingCutCounter = 0; /**< how many times (revolutions) the ignition has been cut in a row */
 uint32_t rollingCutLastRev = 0; /**< Tracks whether we're on the same or a different rev for the rolling cut */
 
 uint16_t staged_req_fuel_mult_pri = 0;
@@ -292,7 +292,7 @@ void loop()
       {
         //TODO dazq to clean this right up :)
         //check through the Aux input channels if enabed for Can or local use
-        for (byte AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
+        for (uint8_t AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
         {
           currentStatus.current_caninchannel = AuxinChan;          
           
@@ -475,7 +475,7 @@ void loop()
         {
           uint32_t tempPW3 = (((unsigned long)currentStatus.PW1 * staged_req_fuel_mult_sec) / 100); //This is ONLY needed in in table mode. Auto mode only calculates the difference.
 
-          byte stagingSplit = get3DTableValue(&stagingTable, currentStatus.MAP, currentStatus.RPM);
+          uint8_t stagingSplit = get3DTableValue(&stagingTable, currentStatus.MAP, currentStatus.RPM);
           currentStatus.PW1 = ((100 - stagingSplit) * tempPW1) / 100;
           currentStatus.PW1 += inj_opentime_uS; 
 
@@ -572,10 +572,10 @@ void loop()
 
             if(configPage6.fuelTrimEnabled > 0)
             {
-              unsigned long pw1percent = 100 + (byte)get3DTableValue(&trim1Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw2percent = 100 + (byte)get3DTableValue(&trim2Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw3percent = 100 + (byte)get3DTableValue(&trim3Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw4percent = 100 + (byte)get3DTableValue(&trim4Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              unsigned long pw1percent = 100 + (uint8_t)get3DTableValue(&trim1Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              unsigned long pw2percent = 100 + (uint8_t)get3DTableValue(&trim2Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              unsigned long pw3percent = 100 + (uint8_t)get3DTableValue(&trim3Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              unsigned long pw4percent = 100 + (uint8_t)get3DTableValue(&trim4Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
 
               if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
               if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
@@ -1173,7 +1173,7 @@ void loop()
  * @param injOpen Injector opening time. The time the injector take to open minus the time it takes to close (Both in uS)
  * @return uint16_t The injector pulse width in uS
  */
-uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
+uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int injOpen)
 {
   //Standard float version of the calculation
   //return (REQ_FUEL * (float)(VE/100.0) * (float)(MAP/100.0) * (float)(TPS/100.0) * (float)(corrections/100.0) + injOpen);
@@ -1185,7 +1185,7 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
   //100% float free version, does sacrifice a little bit of accuracy, but not much.
 
   //If corrections are huge, use less bitshift to avoid overflow. Sacrifices a bit more accuracy (basically only during very cold temp cranking)
-  byte bitShift = 7;
+  uint8_t bitShift = 7;
   if (corrections > 511 ) { bitShift = 6; }
   if (corrections > 1023) { bitShift = 5; }
   
@@ -1238,9 +1238,9 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
  * 
  * @return byte The current VE value
  */
-byte getVE1()
+uint8_t getVE1()
 {
-  byte tempVE = 100;
+  uint8_t tempVE = 100;
   if (configPage2.fuelAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
   {
     //Speed Density
@@ -1267,9 +1267,9 @@ byte getVE1()
  * 
  * @return byte The current target advance value in degrees
  */
-byte getAdvance1()
+uint8_t getAdvance1()
 {
-  byte tempAdvance = 0;
+  uint8_t tempAdvance = 0;
   if (configPage2.ignAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
   {
     //Speed Density
@@ -1419,7 +1419,7 @@ void calculateIgnitionAngles(int dwellAngle)
       }
       else if(configPage4.sparkMode == IGN_MODE_ROTARY)
       {
-        byte splitDegrees = 0;
+        uint8_t splitDegrees = 0;
         if (configPage2.fuelAlgorithm == LOAD_SOURCE_MAP) { splitDegrees = table2D_getValue(&rotarySplitTable, currentStatus.MAP/2); }
         else { splitDegrees = table2D_getValue(&rotarySplitTable, currentStatus.TPS/2); }
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -147,7 +147,7 @@ void loop()
 
     previousLoopTime = currentLoopTime;
     currentLoopTime = micros_safe();
-    unsigned long timeToLastTooth = (currentLoopTime - toothLastToothTime);
+    uint32_t timeToLastTooth = (currentLoopTime - toothLastToothTime);
     if ( (timeToLastTooth < MAX_STALL_TIME) || (toothLastToothTime > currentLoopTime) ) //Check how long ago the last tooth was seen compared to now. If it was more than half a second ago then the engine is probably stopped. toothLastToothTime can be greater than currentLoopTime if a pulse occurs between getting the lastest time and doing the comparison
     {
       currentStatus.longRPM = getRPM(); //Long RPM is included here
@@ -456,7 +456,7 @@ void loop()
       doCrankSpeedCalcs(); //In crankMaths.ino
 
       //Check that the duty cycle of the chosen pulsewidth isn't too high.
-      unsigned long pwLimit = percentage(configPage2.dutyLim, revolutionTime); //The pulsewidth limit is determined to be the duty cycle limit (Eg 85%) by the total time it takes to perform 1 revolution
+      uint32_t pwLimit = percentage(configPage2.dutyLim, revolutionTime); //The pulsewidth limit is determined to be the duty cycle limit (Eg 85%) by the total time it takes to perform 1 revolution
       //Handle multiple squirts per rev
       if (configPage2.strokes == FOUR_STROKE) { pwLimit = pwLimit * 2 / currentStatus.nSquirts; } 
       else { pwLimit = pwLimit / currentStatus.nSquirts; }
@@ -469,11 +469,11 @@ void loop()
       {
         //Scale the 'full' pulsewidth by each of the injector capacities
         currentStatus.PW1 -= inj_opentime_uS; //Subtract the opening time from PW1 as it needs to be multiplied out again by the pri/sec req_fuel values below. It is added on again after that calculation. 
-        uint32_t tempPW1 = (((unsigned long)currentStatus.PW1 * staged_req_fuel_mult_pri) / 100);
+        uint32_t tempPW1 = (((uint32_t)currentStatus.PW1 * staged_req_fuel_mult_pri) / 100);
 
         if(configPage10.stagingMode == STAGING_MODE_TABLE)
         {
-          uint32_t tempPW3 = (((unsigned long)currentStatus.PW1 * staged_req_fuel_mult_sec) / 100); //This is ONLY needed in in table mode. Auto mode only calculates the difference.
+          uint32_t tempPW3 = (((uint32_t)currentStatus.PW1 * staged_req_fuel_mult_sec) / 100); //This is ONLY needed in in table mode. Auto mode only calculates the difference.
 
           uint8_t stagingSplit = get3DTableValue(&stagingTable, currentStatus.MAP, currentStatus.RPM);
           currentStatus.PW1 = ((100 - stagingSplit) * tempPW1) / 100;
@@ -572,10 +572,10 @@ void loop()
 
             if(configPage6.fuelTrimEnabled > 0)
             {
-              unsigned long pw1percent = 100 + (uint8_t)get3DTableValue(&trim1Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw2percent = 100 + (uint8_t)get3DTableValue(&trim2Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw3percent = 100 + (uint8_t)get3DTableValue(&trim3Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
-              unsigned long pw4percent = 100 + (uint8_t)get3DTableValue(&trim4Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              uint32_t pw1percent = 100 + (uint8_t)get3DTableValue(&trim1Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              uint32_t pw2percent = 100 + (uint8_t)get3DTableValue(&trim2Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              uint32_t pw3percent = 100 + (uint8_t)get3DTableValue(&trim3Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
+              uint32_t pw4percent = 100 + (uint8_t)get3DTableValue(&trim4Table, currentStatus.MAP, currentStatus.RPM) - OFFSET_FUELTRIM;
 
               if (pw1percent != 100) { currentStatus.PW1 = (pw1percent * currentStatus.PW1) / 100; }
               if (pw2percent != 100) { currentStatus.PW2 = (pw2percent * currentStatus.PW2) / 100; }
@@ -755,8 +755,8 @@ void loop()
           if (injector1StartAngle > crankAngle)
           {
             setFuelSchedule1(
-                      ((injector1StartAngle - crankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1
+                      ((injector1StartAngle - crankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW1
                       );
           }
         }
@@ -783,8 +783,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule2(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW2
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW2
                       );
           }
         }
@@ -801,8 +801,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule3(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW3
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW3
                       );
           }
         }
@@ -819,8 +819,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule4(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW4
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW4
                       );
           }
         }
@@ -839,14 +839,14 @@ void loop()
             //Note the hacky use of fuel schedule 3 below
             /*
             setFuelSchedule3(openInjector3and5,
-                      ((unsigned long)(tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW1,
+                      ((uint32_t)(tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW1,
                       closeInjector3and5
                     );*/
             
             setFuelSchedule5(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW5
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW5
                       );
           }
         }
@@ -863,8 +863,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule6(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW6
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW6
                       );
           }
         }
@@ -881,8 +881,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule7(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW7
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW7
                       );
           }
         }
@@ -899,8 +899,8 @@ void loop()
           if ( tempStartAngle > tempCrankAngle )
           {
             setFuelSchedule8(
-                      ((tempStartAngle - tempCrankAngle) * (unsigned long)timePerDegree),
-                      (unsigned long)currentStatus.PW8
+                      ((tempStartAngle - tempCrankAngle) * (uint32_t)timePerDegree),
+                      (uint32_t)currentStatus.PW8
                       );
           }
         }
@@ -943,9 +943,9 @@ void loop()
         {
           
           setIgnitionSchedule1(ign1StartFunction,
-                    //((unsigned long)(ignition1StartAngle - crankAngle) * (unsigned long)timePerDegree),
+                    //((uint32_t)(ignition1StartAngle - crankAngle) * (uint32_t)timePerDegree),
                     angleToTime((ignition1StartAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV),
-                    currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
+                    currentStatus.dwell + fixedCrankingOverride, //((uint32_t)((uint32_t)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
                     ign1EndFunction
                     );
         }
@@ -954,7 +954,7 @@ void loop()
 #if defined(USE_IGN_REFRESH)
         if( (ignitionSchedule1.Status == RUNNING) && (ignition1EndAngle > crankAngle) && (configPage4.StgCycles == 0) && (configPage2.perToothIgn != true) )
         {
-          unsigned long uSToEnd = 0;
+          uint32_t uSToEnd = 0;
 
           crankAngle = getCrankAngle(); //Refresh with the latest crank angle
           if (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= 360; }
@@ -979,10 +979,10 @@ void loop()
             tempStartAngle = ignition2StartAngle - channel2IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition2StartTime = 0;
+            uint32_t ignition2StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule2.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition2StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition2StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition2StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition2StartTime = 0; }
 
             if ( (ignition2StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN2_CMD_BIT)) )
@@ -1004,10 +1004,10 @@ void loop()
             tempStartAngle = ignition3StartAngle - channel3IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition3StartTime = 0;
+            uint32_t ignition3StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule3.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition3StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition3StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition3StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition3StartTime = 0; }
 
             if ( (ignition3StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN3_CMD_BIT)) )
@@ -1029,10 +1029,10 @@ void loop()
             tempStartAngle = ignition4StartAngle - channel4IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition4StartTime = 0;
+            uint32_t ignition4StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule4.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition4StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition4StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition4StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition4StartTime = 0; }
 
             if ( (ignition4StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN4_CMD_BIT)) )
@@ -1054,10 +1054,10 @@ void loop()
             tempStartAngle = ignition5StartAngle - channel5IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition5StartTime = 0;
+            uint32_t ignition5StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule5.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition5StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition5StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition5StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition5StartTime = 0; }
 
             if ( (ignition5StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN5_CMD_BIT)) )
@@ -1079,10 +1079,10 @@ void loop()
             tempStartAngle = ignition6StartAngle - channel6IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition6StartTime = 0;
+            uint32_t ignition6StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule6.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition6StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition6StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition6StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition6StartTime = 0; }
 
             if ( (ignition6StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN6_CMD_BIT)) )
@@ -1104,10 +1104,10 @@ void loop()
             tempStartAngle = ignition7StartAngle - channel7IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition7StartTime = 0;
+            uint32_t ignition7StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule7.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition7StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition7StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition7StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition7StartTime = 0; }
 
             if ( (ignition7StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN7_CMD_BIT)) )
@@ -1129,10 +1129,10 @@ void loop()
             tempStartAngle = ignition8StartAngle - channel8IgnDegrees;
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
-            unsigned long ignition8StartTime = 0;
+            uint32_t ignition8StartTime = 0;
             if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule8.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition8StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition8StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
+            //else if (tempStartAngle < tempCrankAngle) { ignition8StartTime = ((int32_t)(360 - tempCrankAngle + tempStartAngle) * (int32_t)timePerDegree); }
             else { ignition8StartTime = 0; }
 
             if ( (ignition8StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN8_CMD_BIT)) )
@@ -1173,7 +1173,7 @@ void loop()
  * @param injOpen Injector opening time. The time the injector take to open minus the time it takes to close (Both in uS)
  * @return uint16_t The injector pulse width in uS
  */
-uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t injOpen)
+uint16_t PW(int REQ_FUEL, uint8_t VE, int32_t MAP, uint16_t corrections, int16_t injOpen)
 {
   //Standard float version of the calculation
   //return (REQ_FUEL * (float)(VE/100.0) * (float)(MAP/100.0) * (float)(TPS/100.0) * (float)(corrections/100.0) + injOpen);
@@ -1204,18 +1204,18 @@ uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t in
   iCorrections = (corrections << bitShift) / 100;
 
 
-  unsigned long intermediate = ((uint32_t)REQ_FUEL * (uint32_t)iVE) >> 7; //Need to use an intermediate value to avoid overflowing the long
-  if ( configPage2.multiplyMAP > 0 ) { intermediate = (intermediate * (unsigned long)iMAP) >> 7; }
+  uint32_t intermediate = ((uint32_t)REQ_FUEL * (uint32_t)iVE) >> 7; //Need to use an intermediate value to avoid overflowing the long
+  if ( configPage2.multiplyMAP > 0 ) { intermediate = (intermediate * (uint32_t)iMAP) >> 7; }
   
   if ( (configPage2.includeAFR == true) && (configPage6.egoType == 2) && (currentStatus.runSecs > configPage6.ego_sdelay) ) {
     //EGO type must be set to wideband and the AFR warmup time must've elapsed for this to be used
-    intermediate = (intermediate * (unsigned long)iAFR) >> 7;  
+    intermediate = (intermediate * (uint32_t)iAFR) >> 7;  
   }
   if ( (configPage2.incorporateAFR == true) && (configPage2.includeAFR == false) ) {
-    intermediate = (intermediate * (unsigned long)iAFR) >> 7;
+    intermediate = (intermediate * (uint32_t)iAFR) >> 7;
   }
   
-  intermediate = (intermediate * (unsigned long)iCorrections) >> bitShift;
+  intermediate = (intermediate * (uint32_t)iCorrections) >> bitShift;
   if (intermediate != 0)
   {
     //If intermeditate is not 0, we need to add the opening time (0 typically indicates that one of the full fuel cuts is active)
@@ -1223,7 +1223,7 @@ uint16_t PW(int REQ_FUEL, uint8_t VE, long MAP, uint16_t corrections, int16_t in
     //AE Adds % of req_fuel
     if ( configPage2.aeApplyMode == AE_MODE_ADDER )
     {
-      intermediate += ( ((unsigned long)REQ_FUEL) * (currentStatus.AEamount - 100) ) / 100;
+      intermediate += ( ((uint32_t)REQ_FUEL) * (currentStatus.AEamount - 100) ) / 100;
     }
     if ( intermediate > 65535)
     {

--- a/speeduino/storage.h
+++ b/speeduino/storage.h
@@ -4,7 +4,7 @@
 #include "globals.h"
 
 void writeAllConfig();
-void writeConfig(byte);
+void writeConfig(uint8_t);
 void loadConfig();
 void loadCalibration();
 void writeCalibration();
@@ -13,13 +13,13 @@ void writeCalibration_new();
 void resetConfigPages();
 
 //These are utility functions that prevent other files from having to use EEPROM.h directly
-byte readLastBaro();
-void storeLastBaro(byte);
-void storeCalibrationValue(uint16_t, byte);
-byte readEEPROMVersion();
-void storeEEPROMVersion(byte);
-void storePageCRC32(byte, uint32_t);
-uint32_t readPageCRC32(byte);
+uint8_t readLastBaro();
+void storeLastBaro(uint8_t);
+void storeCalibrationValue(uint16_t, uint8_t);
+uint8_t readEEPROMVersion();
+void storeEEPROMVersion(uint8_t);
+void storePageCRC32(uint8_t, uint32_t);
+uint32_t readPageCRC32(uint8_t);
 
 #if defined(CORE_STM32) || defined(CORE_TEENSY) & !defined(USE_SPI_EEPROM)
 #define EEPROM_MAX_WRITE_BLOCK 64 //The maximum number of write operations that will be performed in one go. If we try to write to the EEPROM too fast (Each write takes ~3ms) then the rest of the system can hang)

--- a/speeduino/storage.ino
+++ b/speeduino/storage.ino
@@ -34,7 +34,7 @@ void writeAllConfig()
 Takes the current configuration (config pages and maps)
 and writes them to EEPROM as per the layout defined in storage.h
 */
-void writeConfig(byte tableNum)
+void writeConfig(uint8_t tableNum)
 {
   /*
   We only ever write to the EEPROM where the new value is different from the currently stored byte
@@ -44,9 +44,9 @@ void writeConfig(byte tableNum)
   int offset;
   int i, z, y;
   int writeCounter = 0;
-  byte newVal; //Used for tempoerarily storing the new intended value
+  uint8_t newVal; //Used for tempoerarily storing the new intended value
   //Create a pointer to the config page
-  byte* pnt_configPage;
+  uint8_t* pnt_configPage;
 
   switch(tableNum)
   {
@@ -69,7 +69,7 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG1_XBINS;
-        if( EEPROM.read(x) != (byte(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, byte(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if( EEPROM.read(x) != (uint8_t(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, uint8_t(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte 
       }
       //TPS/MAP bins
       for(int x=EEPROM_CONFIG1_YBINS; x<EEPROM_CONFIG2_START; x++)
@@ -88,11 +88,11 @@ void writeConfig(byte tableNum)
       | Config page 2 (See storage.h for data layout)
       | 64 byte long config table
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage2; //Create a pointer to Page 2 in memory
+      pnt_configPage = (uint8_t*)&configPage2; //Create a pointer to Page 2 in memory
       for(int x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG2_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG2_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START))); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -143,11 +143,11 @@ void writeConfig(byte tableNum)
       | Config page 2 (See storage.h for data layout)
       | 64 byte long config table
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage4; //Create a pointer to Page 2 in memory
+      pnt_configPage = (uint8_t*)&configPage4; //Create a pointer to Page 2 in memory
       for(int x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG4_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG4_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START))); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -175,7 +175,7 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG5_XBINS;
-        if(EEPROM.read(x) != byte(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, byte(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(x) != uint8_t(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, uint8_t(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
       for(int x=EEPROM_CONFIG5_YBINS; x<EEPROM_CONFIG6_START; x++)
@@ -195,11 +195,11 @@ void writeConfig(byte tableNum)
       | Config page 3 (See storage.h for data layout)
       | 64 byte long config table
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage6; //Create a pointer to Page 3 in memory
+      pnt_configPage = (uint8_t*)&configPage6; //Create a pointer to Page 3 in memory
       for(int x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG6_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG6_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START))); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -241,11 +241,11 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG7_XBINS1;
-        if(EEPROM.read(x) != byte(boostTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, byte(boostTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(x) != uint8_t(boostTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, uint8_t(boostTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
         offset = y - EEPROM_CONFIG7_XBINS2;
-        if(EEPROM.read(y) != byte(vvtTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(y, byte(vvtTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(y) != uint8_t(vvtTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(y, uint8_t(vvtTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
         offset = z - EEPROM_CONFIG7_XBINS3;
-        if(EEPROM.read(z) != byte(stagingTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(z, byte(stagingTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(z) != uint8_t(stagingTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(z, uint8_t(stagingTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
         y++;
         z++;
       }
@@ -260,7 +260,7 @@ void writeConfig(byte tableNum)
         offset = y - EEPROM_CONFIG7_YBINS2;
         if(EEPROM.read(y) != vvtTable.axisY[offset]) { EEPROM.write(y, vvtTable.axisY[offset]); writeCounter++; } //TABLE_LOAD_MULTIPLIER is NOT used for VVT as it is TPS based (0-100)
         offset = z - EEPROM_CONFIG7_YBINS3;
-        if(EEPROM.read(z) != byte(stagingTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)) { EEPROM.write(z, byte(stagingTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(z) != uint8_t(stagingTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)) { EEPROM.write(z, uint8_t(stagingTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
         y++;
         z++;
       }
@@ -320,13 +320,13 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { eepromWritesPending = true; break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG8_XBINS1;
-        EEPROM.update(x, byte(trim1Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
+        EEPROM.update(x, uint8_t(trim1Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
         offset = y - EEPROM_CONFIG8_XBINS2;
-        EEPROM.update(y, byte(trim2Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
+        EEPROM.update(y, uint8_t(trim2Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
         offset = z - EEPROM_CONFIG8_XBINS3;
-        EEPROM.update(z, byte(trim3Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
+        EEPROM.update(z, uint8_t(trim3Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
         offset = i - EEPROM_CONFIG8_XBINS4;
-        EEPROM.update(i, byte(trim4Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
+        EEPROM.update(i, uint8_t(trim4Table.axisX[offset]/TABLE_RPM_MULTIPLIER)); //RPM bins are divided by 100 and converted to a byte
         y++;
         z++;
         i++;
@@ -360,11 +360,11 @@ void writeConfig(byte tableNum)
       | Config page 10 (See storage.h for data layout)
       | 192 byte long config table
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage9; //Create a pointer to Page 10 in memory
+      pnt_configPage = (uint8_t*)&configPage9; //Create a pointer to Page 10 in memory
       for(int x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG9_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG9_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START))); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -377,12 +377,12 @@ void writeConfig(byte tableNum)
       | Config page 11 (See storage.h for data layout)
       | 192 byte long config table
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage10; //Create a pointer to Page 11 in memory
+      pnt_configPage = (uint8_t*)&configPage10; //Create a pointer to Page 11 in memory
       //As there are no 3d tables in this page, all 192 bytes can simply be read in
       for(int x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG10_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG10_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START))); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -409,7 +409,7 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG11_XBINS;
-        if( EEPROM.read(x) != (byte(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, byte(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if( EEPROM.read(x) != (uint8_t(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, uint8_t(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
       for(int x=EEPROM_CONFIG11_YBINS; x<EEPROM_CONFIG11_END; x++)
@@ -442,14 +442,14 @@ void writeConfig(byte tableNum)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; }
         offset = x - EEPROM_CONFIG12_XBINS;
-        if(EEPROM.read(x) != byte(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, byte(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
+        if(EEPROM.read(x) != uint8_t(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, uint8_t(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //MAP bins
       for(int x=EEPROM_CONFIG12_YBINS; x<EEPROM_CONFIG12_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; }
         offset = x - EEPROM_CONFIG12_YBINS;
-        if(EEPROM.read(x) != byte(wmiTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)) { EEPROM.write(x, byte(wmiTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)); writeCounter++; }
+        if(EEPROM.read(x) != uint8_t(wmiTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)) { EEPROM.write(x, uint8_t(wmiTable.axisY[offset]/TABLE_LOAD_MULTIPLIER)); writeCounter++; }
       }
 
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
@@ -461,12 +461,12 @@ void writeConfig(byte tableNum)
       /*---------------------------------------------------
       | Config page 13 (See storage.h for data layout)
       -----------------------------------------------------*/
-      pnt_configPage = (byte *)&configPage13; //Create a pointer to Page 12 in memory
+      pnt_configPage = (uint8_t*)&configPage13; //Create a pointer to Page 12 in memory
       //As there are no 3d tables in this page, all bytes can simply be read in
       for(int x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
-        if(EEPROM.read(x) != *(pnt_configPage + byte(x - EEPROM_CONFIG13_START))) { EEPROM.write(x, *(pnt_configPage + byte(x - EEPROM_CONFIG13_START))); writeCounter++; }
+        if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START))); writeCounter++; }
       }
       if(writeCounter > EEPROM_MAX_WRITE_BLOCK) { eepromWritesPending = true; }
       else { eepromWritesPending = false; }
@@ -531,7 +531,7 @@ void loadConfig()
   
   int offset;
   //Create a pointer to the config page
-  byte* pnt_configPage;
+  uint8_t* pnt_configPage;
 
   //Fuel table (See storage.h for data layout)
   for(uint16_t x=EEPROM_CONFIG1_MAP; x<EEPROM_CONFIG1_XBINS; x++)
@@ -551,10 +551,10 @@ void loadConfig()
     offset = x - EEPROM_CONFIG1_YBINS;
     fuelTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER;
   }
-  pnt_configPage = (byte *)&configPage2; //Create a pointer to Page 1 in memory
+  pnt_configPage = (uint8_t*)&configPage2; //Create a pointer to Page 1 in memory
   for(int x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG2_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START)) = EEPROM.read(x);
   }
   //That concludes the reading of the VE table
   
@@ -580,10 +580,10 @@ void loadConfig()
     ignitionTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
   }
 
-  pnt_configPage = (byte *)&configPage4; //Create a pointer to Page 4 in memory
+  pnt_configPage = (uint8_t*)&configPage4; //Create a pointer to Page 4 in memory
   for(int x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG4_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
@@ -608,10 +608,10 @@ void loadConfig()
     afrTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
   }
 
-  pnt_configPage = (byte *)&configPage6; //Create a pointer to Page 6 in memory
+  pnt_configPage = (uint8_t*)&configPage6; //Create a pointer to Page 6 in memory
   for(int x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG6_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
@@ -719,20 +719,20 @@ void loadConfig()
   }
   //*********************************************************************************************************************************************************************************
   //canbus control page load
-    pnt_configPage = (byte *)&configPage9; //Create a pointer to Page 10 in memory
+    pnt_configPage = (uint8_t*)&configPage9; //Create a pointer to Page 10 in memory
   for(int x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG9_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
 
   //CONFIG PAGE (10)
-  pnt_configPage = (byte *)&configPage10; //Create a pointer to Page 11 in memory
+  pnt_configPage = (uint8_t*)&configPage10; //Create a pointer to Page 11 in memory
   //All 192 bytes can simply be pulled straight from the configTable
   for(int x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG10_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
@@ -779,11 +779,11 @@ void loadConfig()
   
   //*********************************************************************************************************************************************************************************
   //CONFIG PAGE (13)
-  pnt_configPage = (byte *)&configPage13; //Create a pointer to Page 13 in memory
+  pnt_configPage = (uint8_t*)&configPage13; //Create a pointer to Page 13 in memory
   //All bytes can simply be pulled straight from the configTable
   for(int x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
   {
-    *(pnt_configPage + byte(x - EEPROM_CONFIG13_START)) = EEPROM.read(x);
+    *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
@@ -872,16 +872,16 @@ void writeCalibration()
 Takes a page number and CRC32 value then stores it in the relevant place in EEPROM
 Note: Each pages requires 4 bytes for its CRC32. These are stored in reverse page order (ie the last page is store first in EEPROM)
 */
-void storePageCRC32(byte pageNo, uint32_t crc32_val)
+void storePageCRC32(uint8_t pageNo, uint32_t crc32_val)
 {
   uint16_t address; //Start address for the relevant page
   address = EEPROM_PAGE_CRC32 + ((NUM_PAGES - pageNo) * 4);
 
   //One = Most significant -> Four = Least significant byte
-  byte four = (crc32_val & 0xFF);
-  byte three = ((crc32_val >> 8) & 0xFF);
-  byte two = ((crc32_val >> 16) & 0xFF);
-  byte one = ((crc32_val >> 24) & 0xFF);
+  uint8_t four = (crc32_val & 0xFF);
+  uint8_t three = ((crc32_val >> 8) & 0xFF);
+  uint8_t two = ((crc32_val >> 16) & 0xFF);
+  uint8_t one = ((crc32_val >> 24) & 0xFF);
 
   //Write the 4 bytes into the eeprom memory.
   EEPROM.update(address, four);
@@ -893,7 +893,7 @@ void storePageCRC32(byte pageNo, uint32_t crc32_val)
 /*
 Retrieves and returns the 4 byte CRC32 for a given page from EEPROM
 */
-uint32_t readPageCRC32(byte pageNo)
+uint32_t readPageCRC32(uint8_t pageNo)
 {
   uint16_t address; //Start address for the relevant page
   address = EEPROM_PAGE_CRC32 + ((NUM_PAGES - pageNo) * 4);
@@ -910,8 +910,8 @@ uint32_t readPageCRC32(byte pageNo)
 
 // Utility functions.
 // By having these in this file, it prevents other files from calling EEPROM functions directly. This is useful due to differences in the EEPROM libraries on different devces
-byte readLastBaro() { return EEPROM.read(EEPROM_LAST_BARO); }
-void storeLastBaro(byte newValue) { EEPROM.update(EEPROM_LAST_BARO, newValue); }
-void storeCalibrationValue(uint16_t location, byte value) { EEPROM.update(location, value); } //This is essentially just an abstraction for EEPROM.update()
-byte readEEPROMVersion() { return EEPROM.read(EEPROM_DATA_VERSION); }
-void storeEEPROMVersion(byte newVersion) { EEPROM.update(EEPROM_DATA_VERSION, newVersion); }
+uint8_t readLastBaro() { return EEPROM.read(EEPROM_LAST_BARO); }
+void storeLastBaro(uint8_t newValue) { EEPROM.update(EEPROM_LAST_BARO, newValue); }
+void storeCalibrationValue(uint16_t location, uint8_t value) { EEPROM.update(location, value); } //This is essentially just an abstraction for EEPROM.update()
+uint8_t readEEPROMVersion() { return EEPROM.read(EEPROM_DATA_VERSION); }
+void storeEEPROMVersion(uint8_t newVersion) { EEPROM.update(EEPROM_DATA_VERSION, newVersion); }

--- a/speeduino/storage.ino
+++ b/speeduino/storage.ino
@@ -41,9 +41,9 @@ void writeConfig(uint8_t tableNum)
   This is due to the limited write life of the EEPROM (Approximately 100,000 writes)
   */
 
-  int offset;
-  int i, z, y;
-  int writeCounter = 0;
+  int16_t offset;
+  int16_t i, z, y;
+  int16_t writeCounter = 0;
   uint8_t newVal; //Used for tempoerarily storing the new intended value
   //Create a pointer to the config page
   uint8_t* pnt_configPage;
@@ -57,7 +57,7 @@ void writeConfig(uint8_t tableNum)
       -----------------------------------------------------*/
       if(EEPROM.read(EEPROM_CONFIG1_XSIZE) != fuelTable.xSize) { EEPROM.write(EEPROM_CONFIG1_XSIZE, fuelTable.xSize); writeCounter++; } //Write the VE Tables RPM dimension size
       if(EEPROM.read(EEPROM_CONFIG1_YSIZE) != fuelTable.ySize) { EEPROM.write(EEPROM_CONFIG1_YSIZE, fuelTable.ySize); writeCounter++; } //Write the VE Tables MAP/TPS dimension size
-      for(int x=EEPROM_CONFIG1_MAP; x<EEPROM_CONFIG1_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG1_MAP; x<EEPROM_CONFIG1_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG1_MAP;
@@ -65,14 +65,14 @@ void writeConfig(uint8_t tableNum)
       }
 
       //RPM bins
-      for(int x=EEPROM_CONFIG1_XBINS; x<EEPROM_CONFIG1_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG1_XBINS; x<EEPROM_CONFIG1_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG1_XBINS;
         if( EEPROM.read(x) != (uint8_t(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, uint8_t(fuelTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte 
       }
       //TPS/MAP bins
-      for(int x=EEPROM_CONFIG1_YBINS; x<EEPROM_CONFIG2_START; x++)
+      for(int16_t x=EEPROM_CONFIG1_YBINS; x<EEPROM_CONFIG2_START; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG1_YBINS;
@@ -89,7 +89,7 @@ void writeConfig(uint8_t tableNum)
       | 64 byte long config table
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage2; //Create a pointer to Page 2 in memory
-      for(int x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
+      for(int16_t x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START))); writeCounter++; }
@@ -109,7 +109,7 @@ void writeConfig(uint8_t tableNum)
       if(EEPROM.read(EEPROM_CONFIG3_XSIZE) != ignitionTable.xSize) { EEPROM.write(EEPROM_CONFIG3_XSIZE,ignitionTable.xSize); writeCounter++; } //Write the ignition Table RPM dimension size
       if(EEPROM.read(EEPROM_CONFIG3_YSIZE) != ignitionTable.ySize) { EEPROM.write(EEPROM_CONFIG3_YSIZE,ignitionTable.ySize); writeCounter++; } //Write the ignition Table MAP/TPS dimension size
 
-      for(int x=EEPROM_CONFIG3_MAP; x<EEPROM_CONFIG3_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG3_MAP; x<EEPROM_CONFIG3_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG3_MAP;
@@ -117,7 +117,7 @@ void writeConfig(uint8_t tableNum)
         if(EEPROM.read(x) != newVal) { EEPROM.write(x, newVal); writeCounter++; }  //Write the 16x16 map with translation
       }
       //RPM bins
-      for(int x=EEPROM_CONFIG3_XBINS; x<EEPROM_CONFIG3_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG3_XBINS; x<EEPROM_CONFIG3_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG3_XBINS;
@@ -125,7 +125,7 @@ void writeConfig(uint8_t tableNum)
         if(EEPROM.read(x) != newVal) { EEPROM.write(x, newVal); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
-      for(int x=EEPROM_CONFIG3_YBINS; x<EEPROM_CONFIG4_START; x++)
+      for(int16_t x=EEPROM_CONFIG3_YBINS; x<EEPROM_CONFIG4_START; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG3_YBINS;
@@ -144,7 +144,7 @@ void writeConfig(uint8_t tableNum)
       | 64 byte long config table
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage4; //Create a pointer to Page 2 in memory
-      for(int x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
+      for(int16_t x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START))); writeCounter++; }
@@ -164,21 +164,21 @@ void writeConfig(uint8_t tableNum)
       if(EEPROM.read(EEPROM_CONFIG5_XSIZE) != afrTable.xSize) { EEPROM.write(EEPROM_CONFIG5_XSIZE,afrTable.xSize); writeCounter++; } //Write the ignition Table RPM dimension size
       if(EEPROM.read(EEPROM_CONFIG5_YSIZE) != afrTable.ySize) { EEPROM.write(EEPROM_CONFIG5_YSIZE,afrTable.ySize); writeCounter++; } //Write the ignition Table MAP/TPS dimension size
 
-      for(int x=EEPROM_CONFIG5_MAP; x<EEPROM_CONFIG5_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG5_MAP; x<EEPROM_CONFIG5_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG5_MAP;
         if(EEPROM.read(x) != (afrTable.values[15-(offset/16)][offset%16]) ) { EEPROM.write(x, afrTable.values[15-(offset/16)][offset%16]); writeCounter++; }  //Write the 16x16 map
       }
       //RPM bins
-      for(int x=EEPROM_CONFIG5_XBINS; x<EEPROM_CONFIG5_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG5_XBINS; x<EEPROM_CONFIG5_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG5_XBINS;
         if(EEPROM.read(x) != uint8_t(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, uint8_t(afrTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
-      for(int x=EEPROM_CONFIG5_YBINS; x<EEPROM_CONFIG6_START; x++)
+      for(int16_t x=EEPROM_CONFIG5_YBINS; x<EEPROM_CONFIG6_START; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG5_YBINS;
@@ -196,7 +196,7 @@ void writeConfig(uint8_t tableNum)
       | 64 byte long config table
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage6; //Create a pointer to Page 3 in memory
-      for(int x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
+      for(int16_t x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START))); writeCounter++; }
@@ -222,7 +222,7 @@ void writeConfig(uint8_t tableNum)
 
       y = EEPROM_CONFIG7_MAP2; //We do the 3 maps together in the same loop
       z = EEPROM_CONFIG7_MAP3;
-      for(int x=EEPROM_CONFIG7_MAP1; x<EEPROM_CONFIG7_XBINS1; x++)
+      for(int16_t x=EEPROM_CONFIG7_MAP1; x<EEPROM_CONFIG7_XBINS1; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG7_MAP1;
@@ -237,7 +237,7 @@ void writeConfig(uint8_t tableNum)
       //RPM bins
       y = EEPROM_CONFIG7_XBINS2;
       z = EEPROM_CONFIG7_XBINS3;
-      for(int x=EEPROM_CONFIG7_XBINS1; x<EEPROM_CONFIG7_YBINS1; x++)
+      for(int16_t x=EEPROM_CONFIG7_XBINS1; x<EEPROM_CONFIG7_YBINS1; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG7_XBINS1;
@@ -252,7 +252,7 @@ void writeConfig(uint8_t tableNum)
       //TPS/MAP bins
       y=EEPROM_CONFIG7_YBINS2;
       z=EEPROM_CONFIG7_YBINS3;
-      for(int x=EEPROM_CONFIG7_YBINS1; x<EEPROM_CONFIG7_XSIZE2; x++)
+      for(int16_t x=EEPROM_CONFIG7_YBINS1; x<EEPROM_CONFIG7_XSIZE2; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG7_YBINS1;
@@ -289,7 +289,7 @@ void writeConfig(uint8_t tableNum)
       z = EEPROM_CONFIG8_MAP3; //We do the 4 maps together in the same loop
       i = EEPROM_CONFIG8_MAP4; //We do the 4 maps together in the same loop
 
-      for(int x=EEPROM_CONFIG8_MAP1; x<EEPROM_CONFIG8_XBINS1; x++)
+      for(int16_t x=EEPROM_CONFIG8_MAP1; x<EEPROM_CONFIG8_XBINS1; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG8_MAP1;
@@ -316,7 +316,7 @@ void writeConfig(uint8_t tableNum)
       y = EEPROM_CONFIG8_XBINS2;
       z = EEPROM_CONFIG8_XBINS3;
       i = EEPROM_CONFIG8_XBINS4;
-      for(int x=EEPROM_CONFIG8_XBINS1; x<EEPROM_CONFIG8_YBINS1; x++)
+      for(int16_t x=EEPROM_CONFIG8_XBINS1; x<EEPROM_CONFIG8_YBINS1; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { eepromWritesPending = true; break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG8_XBINS1;
@@ -335,7 +335,7 @@ void writeConfig(uint8_t tableNum)
       y=EEPROM_CONFIG8_YBINS2;
       z=EEPROM_CONFIG8_YBINS3;
       i=EEPROM_CONFIG8_YBINS4;
-      for(int x=EEPROM_CONFIG8_YBINS1; x<EEPROM_CONFIG8_XSIZE2; x++)
+      for(int16_t x=EEPROM_CONFIG8_YBINS1; x<EEPROM_CONFIG8_XSIZE2; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { eepromWritesPending = true; break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG8_YBINS1;
@@ -361,7 +361,7 @@ void writeConfig(uint8_t tableNum)
       | 192 byte long config table
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage9; //Create a pointer to Page 10 in memory
-      for(int x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
+      for(int16_t x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START))); writeCounter++; }
@@ -379,7 +379,7 @@ void writeConfig(uint8_t tableNum)
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage10; //Create a pointer to Page 11 in memory
       //As there are no 3d tables in this page, all 192 bytes can simply be read in
-      for(int x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
+      for(int16_t x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START))); writeCounter++; }
@@ -397,7 +397,7 @@ void writeConfig(uint8_t tableNum)
       -----------------------------------------------------*/
       EEPROM.update(EEPROM_CONFIG11_XSIZE, fuelTable2.xSize); writeCounter++; //Write the VE Tables RPM dimension size
       EEPROM.update(EEPROM_CONFIG11_YSIZE, fuelTable2.ySize); writeCounter++; //Write the VE Tables MAP/TPS dimension size
-      for(int x=EEPROM_CONFIG11_MAP; x<EEPROM_CONFIG11_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG11_MAP; x<EEPROM_CONFIG11_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG11_MAP;
@@ -405,14 +405,14 @@ void writeConfig(uint8_t tableNum)
       }
 
       //RPM bins
-      for(int x=EEPROM_CONFIG11_XBINS; x<EEPROM_CONFIG11_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG11_XBINS; x<EEPROM_CONFIG11_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG11_XBINS;
         if( EEPROM.read(x) != (uint8_t(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)) ) { EEPROM.write(x, uint8_t(fuelTable2.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
-      for(int x=EEPROM_CONFIG11_YBINS; x<EEPROM_CONFIG11_END; x++)
+      for(int16_t x=EEPROM_CONFIG11_YBINS; x<EEPROM_CONFIG11_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG11_YBINS;
@@ -431,21 +431,21 @@ void writeConfig(uint8_t tableNum)
       if(EEPROM.read(EEPROM_CONFIG12_XSIZE) != wmiTable.xSize) { EEPROM.write(EEPROM_CONFIG12_XSIZE,wmiTable.xSize); writeCounter++; } //Write the wmi Table RPM dimension size
       if(EEPROM.read(EEPROM_CONFIG12_YSIZE) != wmiTable.ySize) { EEPROM.write(EEPROM_CONFIG12_YSIZE,wmiTable.ySize); writeCounter++; } //Write the wmi Table MAP dimension size
 
-      for(int x=EEPROM_CONFIG12_MAP; x<EEPROM_CONFIG12_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG12_MAP; x<EEPROM_CONFIG12_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; }
         offset = x - EEPROM_CONFIG12_MAP;
         if(EEPROM.read(x) != (wmiTable.values[7-(offset/8)][offset%8]) ) { EEPROM.write(x, wmiTable.values[7-(offset/8)][offset%8]); writeCounter++; }  //Write the 8x8 map
       }
       //RPM bins
-      for(int x=EEPROM_CONFIG12_XBINS; x<EEPROM_CONFIG12_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG12_XBINS; x<EEPROM_CONFIG12_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; }
         offset = x - EEPROM_CONFIG12_XBINS;
         if(EEPROM.read(x) != uint8_t(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)) { EEPROM.write(x, uint8_t(wmiTable.axisX[offset]/TABLE_RPM_MULTIPLIER)); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //MAP bins
-      for(int x=EEPROM_CONFIG12_YBINS; x<EEPROM_CONFIG12_END; x++)
+      for(int16_t x=EEPROM_CONFIG12_YBINS; x<EEPROM_CONFIG12_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; }
         offset = x - EEPROM_CONFIG12_YBINS;
@@ -463,7 +463,7 @@ void writeConfig(uint8_t tableNum)
       -----------------------------------------------------*/
       pnt_configPage = (uint8_t*)&configPage13; //Create a pointer to Page 12 in memory
       //As there are no 3d tables in this page, all bytes can simply be read in
-      for(int x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
+      for(int16_t x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         if(EEPROM.read(x) != *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START))) { EEPROM.write(x, *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START))); writeCounter++; }
@@ -481,7 +481,7 @@ void writeConfig(uint8_t tableNum)
       if(EEPROM.read(EEPROM_CONFIG14_XSIZE) != ignitionTable2.xSize) { EEPROM.write(EEPROM_CONFIG14_XSIZE,ignitionTable2.xSize); writeCounter++; } //Write the ignition Table RPM dimension size
       if(EEPROM.read(EEPROM_CONFIG14_YSIZE) != ignitionTable2.ySize) { EEPROM.write(EEPROM_CONFIG14_YSIZE,ignitionTable2.ySize); writeCounter++; } //Write the ignition Table MAP/TPS dimension size
 
-      for(int x=EEPROM_CONFIG14_MAP; x<EEPROM_CONFIG14_XBINS; x++)
+      for(int16_t x=EEPROM_CONFIG14_MAP; x<EEPROM_CONFIG14_XBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG14_MAP;
@@ -489,7 +489,7 @@ void writeConfig(uint8_t tableNum)
         if(EEPROM.read(x) != newVal) { EEPROM.write(x, newVal); writeCounter++; }  //Write the 16x16 map with translation
       }
       //RPM bins
-      for(int x=EEPROM_CONFIG14_XBINS; x<EEPROM_CONFIG14_YBINS; x++)
+      for(int16_t x=EEPROM_CONFIG14_XBINS; x<EEPROM_CONFIG14_YBINS; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG14_XBINS;
@@ -497,7 +497,7 @@ void writeConfig(uint8_t tableNum)
         if(EEPROM.read(x) != newVal) { EEPROM.write(x, newVal); writeCounter++; } //RPM bins are divided by 100 and converted to a byte
       }
       //TPS/MAP bins
-      for(int x=EEPROM_CONFIG14_YBINS; x<EEPROM_CONFIG14_END; x++)
+      for(int16_t x=EEPROM_CONFIG14_YBINS; x<EEPROM_CONFIG14_END; x++)
       {
         if( (writeCounter > EEPROM_MAX_WRITE_BLOCK) ) { break; } //This is a safety check to make sure we don't attempt to write too much to the EEPROM at a time.
         offset = x - EEPROM_CONFIG14_YBINS;
@@ -529,7 +529,7 @@ void resetConfigPages()
 void loadConfig()
 {
   
-  int offset;
+  int16_t offset;
   //Create a pointer to the config page
   uint8_t* pnt_configPage;
 
@@ -540,19 +540,19 @@ void loadConfig()
     fuelTable.values[15-(offset/16)][offset%16] = EEPROM.read(x); //Read the 8x8 map
   }
   //RPM bins
-  for(int x=EEPROM_CONFIG1_XBINS; x<EEPROM_CONFIG1_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG1_XBINS; x<EEPROM_CONFIG1_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG1_XBINS;
     fuelTable.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG1_YBINS; x<EEPROM_CONFIG2_START; x++)
+  for(int16_t x=EEPROM_CONFIG1_YBINS; x<EEPROM_CONFIG2_START; x++)
   {
     offset = x - EEPROM_CONFIG1_YBINS;
     fuelTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER;
   }
   pnt_configPage = (uint8_t*)&configPage2; //Create a pointer to Page 1 in memory
-  for(int x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
+  for(int16_t x=EEPROM_CONFIG2_START; x<EEPROM_CONFIG2_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG2_START)) = EEPROM.read(x);
   }
@@ -562,26 +562,26 @@ void loadConfig()
   //IGNITION CONFIG PAGE (2)
 
   //Begin writing the Ignition table, basically the same thing as above
-  for(int x=EEPROM_CONFIG3_MAP; x<EEPROM_CONFIG3_XBINS; x++)
+  for(int16_t x=EEPROM_CONFIG3_MAP; x<EEPROM_CONFIG3_XBINS; x++)
   {
     offset = x - EEPROM_CONFIG3_MAP;
     ignitionTable.values[15-(offset/16)][offset%16] = EEPROM.read(x); //Read the 8x8 map
   }
   //RPM bins
-  for(int x=EEPROM_CONFIG3_XBINS; x<EEPROM_CONFIG3_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG3_XBINS; x<EEPROM_CONFIG3_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG3_XBINS;
     ignitionTable.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG3_YBINS; x<EEPROM_CONFIG4_START; x++)
+  for(int16_t x=EEPROM_CONFIG3_YBINS; x<EEPROM_CONFIG4_START; x++)
   {
     offset = x - EEPROM_CONFIG3_YBINS;
     ignitionTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
   }
 
   pnt_configPage = (uint8_t*)&configPage4; //Create a pointer to Page 4 in memory
-  for(int x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
+  for(int16_t x=EEPROM_CONFIG4_START; x<EEPROM_CONFIG4_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG4_START)) = EEPROM.read(x);
   }
@@ -590,35 +590,35 @@ void loadConfig()
   //AFR TARGET CONFIG PAGE (3)
 
   //Begin writing the Ignition table, basically the same thing as above
-  for(int x=EEPROM_CONFIG5_MAP; x<EEPROM_CONFIG5_XBINS; x++)
+  for(int16_t x=EEPROM_CONFIG5_MAP; x<EEPROM_CONFIG5_XBINS; x++)
   {
     offset = x - EEPROM_CONFIG5_MAP;
     afrTable.values[15-(offset/16)][offset%16] = EEPROM.read(x); //Read the 16x16 map
   }
   //RPM bins
-  for(int x=EEPROM_CONFIG5_XBINS; x<EEPROM_CONFIG5_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG5_XBINS; x<EEPROM_CONFIG5_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG5_XBINS;
     afrTable.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG5_YBINS; x<EEPROM_CONFIG6_START; x++)
+  for(int16_t x=EEPROM_CONFIG5_YBINS; x<EEPROM_CONFIG6_START; x++)
   {
     offset = x - EEPROM_CONFIG5_YBINS;
     afrTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
   }
 
   pnt_configPage = (uint8_t*)&configPage6; //Create a pointer to Page 6 in memory
-  for(int x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
+  for(int16_t x=EEPROM_CONFIG6_START; x<EEPROM_CONFIG6_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG6_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
   // Boost and vvt tables load
-  int y = EEPROM_CONFIG7_MAP2;
-  int z = EEPROM_CONFIG7_MAP3;
-  for(int x=EEPROM_CONFIG7_MAP1; x<EEPROM_CONFIG7_XBINS1; x++)
+  int16_t y = EEPROM_CONFIG7_MAP2;
+  int16_t z = EEPROM_CONFIG7_MAP3;
+  for(int16_t x=EEPROM_CONFIG7_MAP1; x<EEPROM_CONFIG7_XBINS1; x++)
   {
     offset = x - EEPROM_CONFIG7_MAP1;
     boostTable.values[7-(offset/8)][offset%8] = EEPROM.read(x); //Read the 8x8 map
@@ -633,7 +633,7 @@ void loadConfig()
   //RPM bins
   y = EEPROM_CONFIG7_XBINS2;
   z = EEPROM_CONFIG7_XBINS3;
-  for(int x=EEPROM_CONFIG7_XBINS1; x<EEPROM_CONFIG7_YBINS1; x++)
+  for(int16_t x=EEPROM_CONFIG7_XBINS1; x<EEPROM_CONFIG7_YBINS1; x++)
   {
     offset = x - EEPROM_CONFIG7_XBINS1;
     boostTable.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
@@ -648,7 +648,7 @@ void loadConfig()
   //TPS/MAP bins
   y = EEPROM_CONFIG7_YBINS2;
   z = EEPROM_CONFIG7_YBINS3;
-  for(int x=EEPROM_CONFIG7_YBINS1; x<EEPROM_CONFIG7_XSIZE2; x++)
+  for(int16_t x=EEPROM_CONFIG7_YBINS1; x<EEPROM_CONFIG7_XSIZE2; x++)
   {
     offset = x - EEPROM_CONFIG7_YBINS1;
     boostTable.axisY[offset] = EEPROM.read(x); //TABLE_LOAD_MULTIPLIER is NOT used for boost as it is TPS based (0-100)
@@ -664,8 +664,8 @@ void loadConfig()
   // Fuel trim tables load
   y = EEPROM_CONFIG8_MAP2;
   z = EEPROM_CONFIG8_MAP3;
-  int i = EEPROM_CONFIG8_MAP4;
-  for(int x=EEPROM_CONFIG8_MAP1; x<EEPROM_CONFIG8_XBINS1; x++)
+  int16_t i = EEPROM_CONFIG8_MAP4;
+  for(int16_t x=EEPROM_CONFIG8_MAP1; x<EEPROM_CONFIG8_XBINS1; x++)
   {
     offset = x - EEPROM_CONFIG8_MAP1;
     trim1Table.values[5-(offset/6)][offset%6] = EEPROM.read(x); //Read the 6x6 map
@@ -684,7 +684,7 @@ void loadConfig()
   y = EEPROM_CONFIG8_XBINS2;
   z = EEPROM_CONFIG8_XBINS3;
   i = EEPROM_CONFIG8_XBINS4;
-  for(int x=EEPROM_CONFIG8_XBINS1; x<EEPROM_CONFIG8_YBINS1; x++)
+  for(int16_t x=EEPROM_CONFIG8_XBINS1; x<EEPROM_CONFIG8_YBINS1; x++)
   {
     offset = x - EEPROM_CONFIG8_XBINS1;
     trim1Table.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
@@ -703,7 +703,7 @@ void loadConfig()
   y = EEPROM_CONFIG8_YBINS2;
   z = EEPROM_CONFIG8_YBINS3;
   i = EEPROM_CONFIG8_YBINS4;
-  for(int x=EEPROM_CONFIG8_YBINS1; x<EEPROM_CONFIG8_XSIZE2; x++)
+  for(int16_t x=EEPROM_CONFIG8_YBINS1; x<EEPROM_CONFIG8_XSIZE2; x++)
   {
     offset = x - EEPROM_CONFIG8_YBINS1;
     trim1Table.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
@@ -720,7 +720,7 @@ void loadConfig()
   //*********************************************************************************************************************************************************************************
   //canbus control page load
     pnt_configPage = (uint8_t*)&configPage9; //Create a pointer to Page 10 in memory
-  for(int x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
+  for(int16_t x=EEPROM_CONFIG9_START; x<EEPROM_CONFIG9_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG9_START)) = EEPROM.read(x);
   }
@@ -730,26 +730,26 @@ void loadConfig()
   //CONFIG PAGE (10)
   pnt_configPage = (uint8_t*)&configPage10; //Create a pointer to Page 11 in memory
   //All 192 bytes can simply be pulled straight from the configTable
-  for(int x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
+  for(int16_t x=EEPROM_CONFIG10_START; x<EEPROM_CONFIG10_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG10_START)) = EEPROM.read(x);
   }
 
   //*********************************************************************************************************************************************************************************
   //Fuel table 2 (See storage.h for data layout)
-  for(int x=EEPROM_CONFIG11_MAP; x<EEPROM_CONFIG11_XBINS; x++)
+  for(int16_t x=EEPROM_CONFIG11_MAP; x<EEPROM_CONFIG11_XBINS; x++)
   {
     offset = x - EEPROM_CONFIG11_MAP;
     fuelTable2.values[15-(offset/16)][offset%16] = EEPROM.read(x); //Read the 8x8 map
   }
   //RPM bins
-  for(int x=EEPROM_CONFIG11_XBINS; x<EEPROM_CONFIG11_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG11_XBINS; x<EEPROM_CONFIG11_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG11_XBINS;
     fuelTable2.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG11_YBINS; x<EEPROM_CONFIG11_END; x++)
+  for(int16_t x=EEPROM_CONFIG11_YBINS; x<EEPROM_CONFIG11_END; x++)
   {
     offset = x - EEPROM_CONFIG11_YBINS;
     fuelTable2.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER;
@@ -757,21 +757,21 @@ void loadConfig()
 
   //*********************************************************************************************************************************************************************************
   // WMI table load
-  for(int x=EEPROM_CONFIG12_MAP; x<EEPROM_CONFIG12_XBINS; x++)
+  for(int16_t x=EEPROM_CONFIG12_MAP; x<EEPROM_CONFIG12_XBINS; x++)
   {
     offset = x - EEPROM_CONFIG12_MAP;
     wmiTable.values[7-(offset/8)][offset%8] = EEPROM.read(x); //Read the 8x8 map
   }
 
   //RPM bins
-  for(int x=EEPROM_CONFIG12_XBINS; x<EEPROM_CONFIG12_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG12_XBINS; x<EEPROM_CONFIG12_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG12_XBINS;
     wmiTable.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
 
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG12_YBINS; x<EEPROM_CONFIG12_END; x++)
+  for(int16_t x=EEPROM_CONFIG12_YBINS; x<EEPROM_CONFIG12_END; x++)
   {
     offset = x - EEPROM_CONFIG12_YBINS;
     wmiTable.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //TABLE_LOAD_MULTIPLIER is NOT used for boost as it is TPS based (0-100)
@@ -781,7 +781,7 @@ void loadConfig()
   //CONFIG PAGE (13)
   pnt_configPage = (uint8_t*)&configPage13; //Create a pointer to Page 13 in memory
   //All bytes can simply be pulled straight from the configTable
-  for(int x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
+  for(int16_t x=EEPROM_CONFIG13_START; x<EEPROM_CONFIG13_END; x++)
   {
     *(pnt_configPage + uint8_t(x - EEPROM_CONFIG13_START)) = EEPROM.read(x);
   }
@@ -790,19 +790,19 @@ void loadConfig()
   //SECOND IGNITION CONFIG PAGE (14)
 
   //Begin writing the Ignition table, basically the same thing as above
-  for(int x=EEPROM_CONFIG14_MAP; x<EEPROM_CONFIG14_XBINS; x++)
+  for(int16_t x=EEPROM_CONFIG14_MAP; x<EEPROM_CONFIG14_XBINS; x++)
   {
     offset = x - EEPROM_CONFIG14_MAP;
     ignitionTable2.values[15-(offset/16)][offset%16] = EEPROM.read(x); //Read the 8x8 map
   }
   //RPM bins
-  for(int x=EEPROM_CONFIG14_XBINS; x<EEPROM_CONFIG14_YBINS; x++)
+  for(int16_t x=EEPROM_CONFIG14_XBINS; x<EEPROM_CONFIG14_YBINS; x++)
   {
     offset = x - EEPROM_CONFIG14_XBINS;
     ignitionTable2.axisX[offset] = (EEPROM.read(x) * TABLE_RPM_MULTIPLIER); //RPM bins are divided by 100 when stored. Multiply them back now
   }
   //TPS/MAP bins
-  for(int x=EEPROM_CONFIG14_YBINS; x<EEPROM_CONFIG14_END; x++)
+  for(int16_t x=EEPROM_CONFIG14_YBINS; x<EEPROM_CONFIG14_END; x++)
   {
     offset = x - EEPROM_CONFIG14_YBINS;
     ignitionTable2.axisY[offset] = EEPROM.read(x) * TABLE_LOAD_MULTIPLIER; //Table load is divided by 2 (Allows for MAP up to 511)
@@ -820,9 +820,9 @@ This is separate from the config load as the calibrations do not exist as pages 
 void loadCalibration()
 {
 
-  for(int x=0; x<32; x++) //Each calibration table is 32 bytes long
+  for(int16_t x=0; x<32; x++) //Each calibration table is 32 bytes long
   {
-    int y = EEPROM_CALIBRATION_CLT + (x * 2);
+    int16_t y = EEPROM_CALIBRATION_CLT + (x * 2);
     EEPROM.get(y, cltCalibration_bins[x]);
     y += 64; 
     EEPROM.get(y, cltCalibration_values[x]);
@@ -848,9 +848,9 @@ and saves them to the EEPROM.
 void writeCalibration()
 {
 
-  for(int x=0; x<32; x++) //Each calibration table is 32 bytes long
+  for(int16_t x=0; x<32; x++) //Each calibration table is 32 bytes long
   {
-    int y = EEPROM_CALIBRATION_CLT + (x * 2);
+    int16_t y = EEPROM_CALIBRATION_CLT + (x * 2);
     EEPROM.put(y, cltCalibration_bins[x]);
     y += 64; 
     EEPROM.put(y, cltCalibration_values[x]);

--- a/speeduino/table.h
+++ b/speeduino/table.h
@@ -48,9 +48,9 @@ The valueSize variable should be set to either 8 or 16 to indicate this BEFORE t
 */
 struct table2D {
   //Used 5414 RAM with original version
-  byte valueSize;
-  byte axisSize;
-  byte xSize;
+  uint8_t valueSize;
+  uint8_t axisSize;
+  uint8_t xSize;
 
   void *values;
   void *axisX;
@@ -65,37 +65,37 @@ struct table2D {
   //Store the last input and output for caching
   int16_t lastInput;
   int16_t lastOutput;
-  byte cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
+  uint8_t cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
 };
 
-//void table2D_setSize(struct table2D targetTable, byte newSize);
-void table2D_setSize(struct table2D*, byte);
-int16_t table2D_getAxisValue(struct table2D*, byte);
-int16_t table2D_getRawValue(struct table2D*, byte);
+//void table2D_setSize(struct table2D targetTable, uint8_t newSize);
+void table2D_setSize(struct table2D*, uint8_t);
+int16_t table2D_getAxisValue(struct table2D*, uint8_t);
+int16_t table2D_getRawValue(struct table2D*, uint8_t);
 
 struct table3D {
 
   //All tables must be the same size for simplicity
 
-  byte xSize;
-  byte ySize;
+  uint8_t xSize;
+  uint8_t ySize;
 
-  byte **values;
+  uint8_t **values;
   int16_t *axisX;
   int16_t *axisY;
 
   //Store the last X and Y coordinates in the table. This is used to make the next check faster
-  byte lastXMax, lastXMin;
-  byte lastYMax, lastYMin;
+  uint8_t lastXMax, lastXMin;
+  uint8_t lastYMax, lastYMin;
 
   //Store the last input and output values, again for caching purposes
   int16_t lastXInput, lastYInput;
-  byte lastOutput; //This will need changing if we ever have 16-bit table values
+  uint8_t lastOutput; //This will need changing if we ever have 16-bit table values
   bool cacheIsValid; ///< This tracks whether the tables cache should be used. Ordinarily this is true, but is set to false whenever TunerStudio sends a new value for the table
 };
 
-//void table3D_setSize(struct table3D *targetTable, byte);
-void table3D_setSize(struct table3D *targetTable, byte);
+//void table3D_setSize(struct table3D *targetTable, uint8_t);
+void table3D_setSize(struct table3D *targetTable, uint8_t);
 
 /*
 3D Tables have an origin (0,0) in the top left hand corner. Vertical axis is expressed first.

--- a/speeduino/table.h
+++ b/speeduino/table.h
@@ -110,7 +110,7 @@ Eg: 2x2 table
 (1,0) = 1
 
 */
-int get3DTableValue(struct table3D *fromTable, int, int);
-int table2D_getValue(struct table2D *fromTable, int);
+int16_t get3DTableValue(struct table3D *fromTable, int16_t, int16_t);
+int16_t table2D_getValue(struct table2D *fromTable, int16_t);
 
 #endif // TABLE_H

--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -163,7 +163,7 @@ int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
     */
 
     //Non-Float version
-    int16_t yVal = ((long)(m << 6) / n) * (abs(yMax - yMin));
+    int16_t yVal = ((int32_t)(m << 6) / n) * (abs(yMax - yMin));
     yVal = (yVal >> 6);
 
     if (yMax > yMin) { yVal = yMin + yVal; }
@@ -396,20 +396,20 @@ int16_t get3DTableValue(struct table3D *fromTable, int16_t Y_in, int16_t X_in)
 
       //Initial check incase the values were hit straight on
 
-      unsigned long p = (long)X - xMinValue;
+      uint32_t p = (int32_t)X - xMinValue;
       if (xMaxValue == xMinValue) { p = (p << TABLE_SHIFT_FACTOR); }  //This only occurs if the requested X value was equal to one of the X axis bins
       else { p = ( (p << TABLE_SHIFT_FACTOR) / (xMaxValue - xMinValue) ); } //This is the standard case
 
-      unsigned long q;
+      uint32_t q;
       if (yMaxValue == yMinValue)
       {
-        q = (long)Y - yMinValue;
+        q = (int32_t)Y - yMinValue;
         q = (q << TABLE_SHIFT_FACTOR);
       }
       //Standard case
       else
       {
-        q = long(Y) - yMaxValue;
+        q = int32_t(Y) - yMaxValue;
         q = TABLE_SHIFT_POWER - ( (q << TABLE_SHIFT_FACTOR) / (yMinValue - yMaxValue) );
       }
 

--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -12,7 +12,7 @@ Note that this may clear some of the existing values of the table
 #include "globals.h"
 
 /*
-void table2D_setSize(struct table2D* targetTable, byte newSize)
+void table2D_setSize(struct table2D* targetTable, uint8_t newSize)
 {
   //Table resize is ONLY permitted during system initialisation.
   //if(initialisationComplete == false)
@@ -22,8 +22,8 @@ void table2D_setSize(struct table2D* targetTable, byte newSize)
     {
       //The following lines have MISRA suppressions as realloc is otherwise forbidden. These calls have been verified as unable to be executed from anywhere but controlled areas. 
       //cppcheck-suppress misra-21.3
-      targetTable->values = (byte *)realloc(targetTable->values, newSize * sizeof(byte)); //cppcheck-suppress misra_21.3
-      targetTable->axisX = (byte *)realloc(targetTable->axisX, newSize * sizeof(byte));
+      targetTable->values = (uint8_t *)realloc(targetTable->values, newSize * sizeof(uint8_t)); //cppcheck-suppress misra_21.3
+      targetTable->axisX = (uint8_t *)realloc(targetTable->axisX, newSize * sizeof(uint8_t));
       targetTable->xSize = newSize;
     }
     else
@@ -48,16 +48,16 @@ void* heap_alloc(uint16_t size)
  }
 
 
-void table3D_setSize(struct table3D *targetTable, byte newSize)
+void table3D_setSize(struct table3D *targetTable, uint8_t newSize)
 {
   if(initialisationComplete == false)
   {
     /*
-    targetTable->values = (byte **)malloc(newSize * sizeof(byte*));
-    for(byte i = 0; i < newSize; i++) { targetTable->values[i] = (byte *)malloc(newSize * sizeof(byte)); }
+    targetTable->values = (uint8_t **)malloc(newSize * sizeof(uint8_t *));
+    for(uint8_t i = 0; i < newSize; i++) { targetTable->values[i] = (uint8_t *)malloc(newSize * sizeof(uint8_t)); }
     */
-    targetTable->values = (byte **)heap_alloc(newSize * sizeof(byte*));
-    for(byte i = 0; i < newSize; i++) { targetTable->values[i] = (byte *)heap_alloc(newSize * sizeof(byte)); }
+    targetTable->values = (uint8_t **)heap_alloc(newSize * sizeof(uint8_t *));
+    for(uint8_t i = 0; i < newSize; i++) { targetTable->values[i] = (uint8_t *)heap_alloc(newSize * sizeof(uint8_t)); }
 
     /*
     targetTable->axisX = (int16_t *)malloc(newSize * sizeof(int16_t));
@@ -185,7 +185,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
  * @param X_in 
  * @return int16_t 
  */
-int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in)
+int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
 {
   int returnValue = 0;
 
@@ -202,7 +202,7 @@ int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in)
  * @param X_in 
  * @return int16_t 
  */
-int16_t table2D_getRawValue(struct table2D *fromTable, byte X_index)
+int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
 {
   int returnValue = 0;
 
@@ -226,8 +226,8 @@ int get3DTableValue(struct table3D *fromTable, int Y_in, int X_in)
     //      This is because the important tables (fuel and injection) will have the highest RPM at the top of the X axis, so starting there will mean the best case occurs when the RPM is highest (And hence the CPU is needed most)
     int xMinValue = fromTable->axisX[0];
     int xMaxValue = fromTable->axisX[fromTable->xSize-1];
-    byte xMin = 0;
-    byte xMax = 0;
+    uint8_t xMin = 0;
+    uint8_t xMax = 0;
 
     //If the requested X value is greater/small than the maximum/minimum bin, reset X to be that value
     if(X > xMaxValue) { X = xMaxValue; }
@@ -302,8 +302,8 @@ int get3DTableValue(struct table3D *fromTable, int Y_in, int X_in)
     //Loop through the Y axis bins for the min/max pair
     int yMaxValue = fromTable->axisY[0];
     int yMinValue = fromTable->axisY[fromTable->ySize-1];
-    byte yMin = 0;
-    byte yMax = 0;
+    uint8_t yMin = 0;
+    uint8_t yMax = 0;
 
     //If the requested Y value is greater/small than the maximum/minimum bin, reset Y to be that value
     if(Y > yMaxValue) { Y = yMaxValue; }

--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -78,16 +78,16 @@ ie: Given a value on the X axis, it returns a Y value that coresponds to the poi
 This function must take into account whether a table contains 8-bit or 16-bit values.
 Unfortunately this means many of the lines are duplicated depending on this
 */
-int table2D_getValue(struct table2D *fromTable, int X_in)
+int16_t table2D_getValue(struct table2D *fromTable, int16_t X_in)
 {
   //Orig memory usage = 5414
-  int returnValue = 0;
+  int16_t returnValue = 0;
   bool valueFound = false;
 
-  int X = X_in;
-  int xMinValue, xMaxValue;
-  int xMin = 0;
-  int xMax = fromTable->xSize-1;
+  int16_t X = X_in;
+  int16_t xMinValue, xMaxValue;
+  int16_t xMin = 0;
+  int16_t xMax = fromTable->xSize-1;
 
   //Check whether the X input is the same as last time this ran
   if( (X_in == fromTable->lastInput) && (fromTable->cacheTime == currentStatus.secl) )
@@ -123,7 +123,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
     {
       //If we're not in the same bin, loop through to find where we are
       xMaxValue = table2D_getAxisValue(fromTable, fromTable->xSize-1); // init xMaxValue in preparation for loop.
-      for (int x = fromTable->xSize-1; x > 0; x--)
+      for (int16_t x = fromTable->xSize-1; x > 0; x--)
       {
         xMinValue = table2D_getAxisValue(fromTable, x-1); // fetch next Min
 
@@ -159,7 +159,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
 
     //Float version
     /*
-    int yVal = (m / n) * (abs(yMax - yMin));
+    int16_t yVal = (m / n) * (abs(yMax - yMin));
     */
 
     //Non-Float version
@@ -187,7 +187,7 @@ int table2D_getValue(struct table2D *fromTable, int X_in)
  */
 int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
 {
-  int returnValue = 0;
+  int16_t returnValue = 0;
 
   if(fromTable->axisSize == SIZE_INT) { returnValue = ((int16_t*)fromTable->axisX)[X_in]; }
   else if(fromTable->axisSize == SIZE_BYTE) { returnValue = ((uint8_t*)fromTable->axisX)[X_in]; }
@@ -204,7 +204,7 @@ int16_t table2D_getAxisValue(struct table2D *fromTable, uint8_t X_in)
  */
 int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
 {
-  int returnValue = 0;
+  int16_t returnValue = 0;
 
   if(fromTable->valueSize == SIZE_INT) { returnValue = ((int16_t*)fromTable->values)[X_index]; }
   else if(fromTable->valueSize == SIZE_BYTE) { returnValue = ((uint8_t*)fromTable->values)[X_index]; }
@@ -215,17 +215,17 @@ int16_t table2D_getRawValue(struct table2D *fromTable, uint8_t X_index)
 
 //This function pulls a value from a 3D table given a target for X and Y coordinates.
 //It performs a 2D linear interpolation as descibred in: www.megamanual.com/v22manual/ve_tuner.pdf
-int get3DTableValue(struct table3D *fromTable, int Y_in, int X_in)
+int16_t get3DTableValue(struct table3D *fromTable, int16_t Y_in, int16_t X_in)
   {
-    int X = X_in;
-    int Y = Y_in;
+    int16_t X = X_in;
+    int16_t Y = Y_in;
 
-    int tableResult = 0;
+    int16_t tableResult = 0;
     //Loop through the X axis bins for the min/max pair
     //Note: For the X axis specifically, rather than looping from tableAxisX[0] up to tableAxisX[max], we start at tableAxisX[Max] and go down.
     //      This is because the important tables (fuel and injection) will have the highest RPM at the top of the X axis, so starting there will mean the best case occurs when the RPM is highest (And hence the CPU is needed most)
-    int xMinValue = fromTable->axisX[0];
-    int xMaxValue = fromTable->axisX[fromTable->xSize-1];
+    int16_t xMinValue = fromTable->axisX[0];
+    int16_t xMaxValue = fromTable->axisX[fromTable->xSize-1];
     uint8_t xMin = 0;
     uint8_t xMax = 0;
 
@@ -300,8 +300,8 @@ int get3DTableValue(struct table3D *fromTable, int Y_in, int X_in)
     }
 
     //Loop through the Y axis bins for the min/max pair
-    int yMaxValue = fromTable->axisY[0];
-    int yMinValue = fromTable->axisY[fromTable->ySize-1];
+    int16_t yMaxValue = fromTable->axisY[0];
+    int16_t yMinValue = fromTable->axisY[fromTable->ySize-1];
     uint8_t yMin = 0;
     uint8_t yMax = 0;
 
@@ -381,10 +381,10 @@ int get3DTableValue(struct table3D *fromTable, int Y_in, int X_in)
               C          D
 
     */
-    int A = fromTable->values[yMin][xMin];
-    int B = fromTable->values[yMin][xMax];
-    int C = fromTable->values[yMax][xMin];
-    int D = fromTable->values[yMax][xMax];
+    int16_t A = fromTable->values[yMin][xMin];
+    int16_t B = fromTable->values[yMin][xMax];
+    int16_t C = fromTable->values[yMax][xMin];
+    int16_t D = fromTable->values[yMax][xMax];
 
     //Check that all values aren't just the same (This regularly happens with things like the fuel trim maps)
     if( (A == B) && (A == C) && (A == D) ) { tableResult = A; }

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -26,10 +26,10 @@ enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tach
 volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
 volatile TachoOutputStatus tachoOutputFlag;
 
-volatile byte loop33ms;
-volatile byte loop66ms;
-volatile byte loop100ms;
-volatile byte loop250ms;
+volatile uint8_t loop33ms;
+volatile uint8_t loop66ms;
+volatile uint8_t loop100ms;
+volatile uint8_t loop250ms;
 volatile int loopSec;
 
 volatile unsigned int dwellLimit_uS;

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -30,9 +30,9 @@ volatile uint8_t loop33ms;
 volatile uint8_t loop66ms;
 volatile uint8_t loop100ms;
 volatile uint8_t loop250ms;
-volatile int loopSec;
+volatile int16_t loopSec;
 
-volatile unsigned int dwellLimit_uS;
+volatile uint16_t dwellLimit_uS;
 volatile uint16_t lastRPM_100ms; //Need to record this for rpmDOT calculation
 volatile uint16_t last250msLoopCount = 1000; //Set to effectively random number on startup. Just need this to be different to what mainLoopCount equals initially (Probably 0)
 

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -156,7 +156,7 @@ void oneMSInterval() //Most ARM chips can simply call a function
     BIT_SET(TIMER_mask, BIT_TIMER_1HZ);
 
     dwellLimit_uS = (1000 * configPage4.dwellLimit); //Update uS value incase setting has changed
-    currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10);
+    currentStatus.crankRPM = ((uint16_t)configPage4.crankRPM * 10);
 
     //**************************************************************************************************************************************************
     //This updates the runSecs variable

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -52,7 +52,7 @@ void oneMSInterval() //Most ARM chips can simply call a function
   loop250ms++;
   loopSec++;
 
-  unsigned long targetOverdwellTime;
+  uint32_t targetOverdwellTime;
 
   //Overdwell check
   targetOverdwellTime = micros() - dwellLimit_uS; //Set a target time in the past that all coil charging must have begun after. If the coil charge began before this time, it's been running too long
@@ -231,7 +231,7 @@ void oneMSInterval() //Most ARM chips can simply call a function
       //Continental flex sensor fuel temperature can be read with following formula: (Temperature = (41.25 * pulse width(ms)) - 81.25). 1000μs = -40C and 5000μs = 125C
       if(flexPulseWidth > 5000) { flexPulseWidth = 5000; }
       else if(flexPulseWidth < 1000) { flexPulseWidth = 1000; }
-      currentStatus.fuelTemp = (((4224 * (long)flexPulseWidth) >> 10) - 8125) / 100;
+      currentStatus.fuelTemp = (((4224 * (int32_t)flexPulseWidth) >> 10) - 8125) / 100;
     }
 
     //**************************************************************************************************************************************************

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -66,7 +66,7 @@ void doUpdates()
     {
       int endMem = EEPROM_CONFIG10_END - x;
       int startMem = endMem - 128; //
-      byte currentVal = EEPROM.read(startMem);
+      uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
     //The remaining data only has to move back 64 bytes
@@ -74,7 +74,7 @@ void doUpdates()
     {
       int endMem = EEPROM_CONFIG10_END - 1152 - x;
       int startMem = endMem - 64; //
-      byte currentVal = EEPROM.read(startMem);
+      uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
 
@@ -89,7 +89,7 @@ void doUpdates()
     {
       int endMem = EEPROM_CONFIG10_END - x;
       int startMem = endMem - 82; //
-      byte currentVal = EEPROM.read(startMem);
+      uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
 
@@ -147,7 +147,7 @@ void doUpdates()
   {
     //October 2018 set default values for all the aux in variables (These were introduced in Aug, but no defaults were set then)
     //All aux channels set to Off
-    for (byte AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
+    for (uint8_t AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
     {
       configPage9.caninput_sel[AuxinChan] = 0;
     }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -15,9 +15,9 @@ void doUpdates()
   //May 2017 firmware introduced a -40 offset on the ignition table. Update that table to +40
   if(EEPROM.read(EEPROM_DATA_VERSION) == 2)
   {
-    for(int x=0; x<16; x++)
+    for(int16_t x=0; x<16; x++)
     {
-      for(int y=0; y<16; y++)
+      for(int16_t y=0; y<16; y++)
       {
         ignitionTable.values[x][y] = ignitionTable.values[x][y] + 40;
       }
@@ -62,18 +62,18 @@ void doUpdates()
   if(EEPROM.read(EEPROM_DATA_VERSION) == 5)
   {
     //Data after page 4 has to move back 128 bytes
-    for(int x=0; x < 1152; x++)
+    for(int16_t x=0; x < 1152; x++)
     {
-      int endMem = EEPROM_CONFIG10_END - x;
-      int startMem = endMem - 128; //
+      int16_t endMem = EEPROM_CONFIG10_END - x;
+      int16_t startMem = endMem - 128; //
       uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
     //The remaining data only has to move back 64 bytes
-    for(int x=0; x < 352; x++)
+    for(int16_t x=0; x < 352; x++)
     {
-      int endMem = EEPROM_CONFIG10_END - 1152 - x;
-      int startMem = endMem - 64; //
+      int16_t endMem = EEPROM_CONFIG10_END - 1152 - x;
+      int16_t startMem = endMem - 64; //
       uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
@@ -85,10 +85,10 @@ void doUpdates()
   if(EEPROM.read(EEPROM_DATA_VERSION) == 6)
   {
     //Data after page 8 has to move back 82 bytes
-    for(int x=0; x < 529; x++)
+    for(int16_t x=0; x < 529; x++)
     {
-      int endMem = EEPROM_CONFIG10_END - x;
-      int startMem = endMem - 82; //
+      int16_t endMem = EEPROM_CONFIG10_END - x;
+      int16_t startMem = endMem - 82; //
       uint8_t currentVal = EEPROM.read(startMem);
       EEPROM.update(endMem, currentVal);
     }
@@ -326,7 +326,7 @@ void doUpdates()
     configPage2.dfcoMinCLT = 80; //CALIBRATION_TEMPERATURE_OFFSET is 40
 
     //Update flexfuel ignition config values for 40 degrees offset
-    for (int i=0; i<6; i++)
+    for (int16_t i=0; i<6; i++)
     {
       configPage10.flexAdvAdj[i] += 40;
     }
@@ -373,8 +373,8 @@ void doUpdates()
     //202008
 
     //MAJOR update to move the coolant, IAT and O2 calibrations to 2D tables
-    int y;
-    for(int x=0; x<(CALIBRATION_TABLE_SIZE/16); x++) //Each calibration table is 512 bytes long
+    int16_t y;
+    for(int16_t x=0; x<(CALIBRATION_TABLE_SIZE/16); x++) //Each calibration table is 512 bytes long
     {
       y = EEPROM_CALIBRATION_CLT_OLD + (x * 16);
       cltCalibration_values[x] = EEPROM.read(y);
@@ -402,7 +402,7 @@ void doUpdates()
     configPage10.wmiIndicatorEnabled = 0;
     configPage10.wmiEmptyEnabled = 0;
     configPage10.wmiAdvEnabled = 0;
-    for(int i=0; i<6; i++)
+    for(int16_t i=0; i<6; i++)
     {
       configPage10.wmiAdvBins[i] = i*100/2;
       configPage10.wmiAdvAdj[i] = OFFSET_IGNITION;
@@ -439,7 +439,7 @@ void doUpdates()
     
 
     //Fix for wrong placed page 13
-    for(int x=EEPROM_CONFIG14_END; x>=EEPROM_CONFIG13_START; x--)
+    for(int16_t x=EEPROM_CONFIG14_END; x>=EEPROM_CONFIG13_START; x--)
     {
       EEPROM.update(x, EEPROM.read(x-112));
     }

--- a/speeduino/utilities.h
+++ b/speeduino/utilities.h
@@ -26,8 +26,8 @@ uint8_t pinIsValid = 0;
 //uint8_t outputPin[sizeof(configPage13.outputPin)];
 
 void setResetControlPinState();
-byte pinTranslate(byte);
-uint32_t calculateCRC32(byte);
+uint8_t pinTranslate(uint8_t);
+uint32_t calculateCRC32(uint8_t);
 void initialiseProgrammableIO();
 void checkProgrammableIO();
 int16_t ProgrammableIOGetData(uint16_t index);

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -16,9 +16,9 @@ FastCRC32 CRC32;
 //This function performs a translation between the pin list that appears in TS and the actual pin numbers
 //For the digital IO, this will simply return the same number as the rawPin value as those are mapped directly.
 //For analog pins, it will translate them into the currect internal pin number
-byte pinTranslate(byte rawPin)
+uint8_t pinTranslate(uint8_t rawPin)
 {
-  byte outputPin = rawPin;
+  uint8_t outputPin = rawPin;
   if(rawPin > BOARD_MAX_DIGITAL_PINS) { outputPin = A8 + (outputPin - BOARD_MAX_DIGITAL_PINS - 1); }
 
   return outputPin;
@@ -54,10 +54,10 @@ void setResetControlPinState()
 /*
 Calculates and returns the CRC32 value of a given page of memory
 */
-uint32_t calculateCRC32(byte pageNo)
+uint32_t calculateCRC32(uint8_t pageNo)
 {
   uint32_t CRC32_val;
-  byte raw_value;
+  uint8_t raw_value;
   void* pnt_configPage;
 
   //This sucks (again) for all the 3D map pages that have to have a translation performed
@@ -80,7 +80,7 @@ uint32_t calculateCRC32(byte pageNo)
     case veSetPage:
       //Confirmed working
       pnt_configPage = &configPage2; //Create a pointer to Page 1 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage2) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage2) );
       break;
 
     case ignMapPage:
@@ -99,7 +99,7 @@ uint32_t calculateCRC32(byte pageNo)
     case ignSetPage:
       //Confirmed working
       pnt_configPage = &configPage4; //Create a pointer to Page 4 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage4) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage4) );
       break;
 
     case afrMapPage:
@@ -118,7 +118,7 @@ uint32_t calculateCRC32(byte pageNo)
     case afrSetPage:
       //Confirmed working
       pnt_configPage = &configPage6; //Create a pointer to Page 4 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage6) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage6) );
       break;
 
     case boostvvtPage:
@@ -150,13 +150,13 @@ uint32_t calculateCRC32(byte pageNo)
     case canbusPage:
       //Confirmed working
       pnt_configPage = &configPage9; //Create a pointer to Page 9 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage9) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage9) );
       break;
 
     case warmupPage:
       //Confirmed working
       pnt_configPage = &configPage10; //Create a pointer to Page 10 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage10) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage10) );
       break;
 
     case fuelMap2Page:
@@ -189,7 +189,7 @@ uint32_t calculateCRC32(byte pageNo)
     case progOutsPage:
       //Confirmed working
       pnt_configPage = &configPage13; //Create a pointer to Page 10 in memory
-      CRC32_val = CRC32.crc32((byte *)pnt_configPage, sizeof(configPage13) );
+      CRC32_val = CRC32.crc32((uint8_t *)pnt_configPage, sizeof(configPage13) );
       break;
     
     case ignMap2Page:
@@ -241,7 +241,7 @@ void checkProgrammableIO()
     secondCheck = false;
     if ( BIT_CHECK(pinIsValid, y) ) //if outputPin == 0 it is disabled
     { 
-      //byte theIndex = configPage13.firstDataIn[y];
+      //uint8_t theIndex = configPage13.firstDataIn[y];
       data = ProgrammableIOGetData(configPage13.firstDataIn[y]);
       data2 = configPage13.firstTarget[y];
 


### PR DESCRIPTION
For example on AVR int is only 16 bits, but on 32 bit boards it's 32 bits. lets always use int16_t/uint16_t to be sure. long _should_ always be 32 bits but again use int32_t/uint32_t. same with byte int8_t/uint8_t.

This will probably break EEPROM compatibility on 32bit boards, but it's probably already broken in tunerstudio? considering speeduino.ini is based on the EEPROM layout of AVR?