### PR TITLE
created table3D_impl structs that contain table3D memory

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -360,19 +360,19 @@ extern const byte data_structure_version; //This identifies the data structure w
 extern const uint16_t npage_size[NUM_PAGES]; /**< This array stores the size (in bytes) of each configuration page */
 #define MAP_PAGE_SIZE 288
 
-extern struct table3D fuelTable; //16x16 fuel map
-extern struct table3D fuelTable2; //16x16 fuel map
-extern struct table3D ignitionTable; //16x16 ignition map
-extern struct table3D ignitionTable2; //16x16 ignition map
-extern struct table3D afrTable; //16x16 afr target map
-extern struct table3D stagingTable; //8x8 fuel staging table
-extern struct table3D boostTable; //8x8 boost map
-extern struct table3D vvtTable; //8x8 vvt map
-extern struct table3D wmiTable; //8x8 wmi map
-extern struct table3D trim1Table; //6x6 Fuel trim 1 map
-extern struct table3D trim2Table; //6x6 Fuel trim 2 map
-extern struct table3D trim3Table; //6x6 Fuel trim 3 map
-extern struct table3D trim4Table; //6x6 Fuel trim 4 map
+extern struct table3D_impl<16> fuelTable; //16x16 fuel map
+extern struct table3D_impl<16> fuelTable2; //16x16 fuel map
+extern struct table3D_impl<16> ignitionTable; //16x16 ignition map
+extern struct table3D_impl<16> ignitionTable2; //16x16 ignition map
+extern struct table3D_impl<16> afrTable; //16x16 afr target map
+extern struct table3D_impl<8> stagingTable; //8x8 fuel staging table
+extern struct table3D_impl<8> boostTable; //8x8 boost map
+extern struct table3D_impl<8> vvtTable; //8x8 vvt map
+extern struct table3D_impl<8> wmiTable; //8x8 wmi map
+extern struct table3D_impl<6> trim1Table; //6x6 Fuel trim 1 map
+extern struct table3D_impl<6> trim2Table; //6x6 Fuel trim 2 map
+extern struct table3D_impl<6> trim3Table; //6x6 Fuel trim 3 map
+extern struct table3D_impl<6> trim4Table; //6x6 Fuel trim 4 map
 extern struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
 extern struct table2D maeTable;
 extern struct table2D WUETable; //10 bin Warm Up Enrichment map (2D)

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -5,19 +5,19 @@ const char TSfirmwareVersion[] PROGMEM = "Speeduino";
 const byte data_structure_version = 2; //This identifies the data structure when reading / writing.
 const uint16_t npage_size[NUM_PAGES] = {0,128,288,288,128,288,128,240,192,192,192,288,192,128,288}; /**< This array stores the size (in bytes) of each configuration page */
 
-struct table3D fuelTable; //16x16 fuel map
-struct table3D fuelTable2; //16x16 fuel map
-struct table3D ignitionTable; //16x16 ignition map
-struct table3D ignitionTable2; //16x16 ignition map
-struct table3D afrTable; //16x16 afr target map
-struct table3D stagingTable; //8x8 fuel staging table
-struct table3D boostTable; //8x8 boost map
-struct table3D vvtTable; //8x8 vvt map
-struct table3D wmiTable; //8x8 wmi map
-struct table3D trim1Table; //6x6 Fuel trim 1 map
-struct table3D trim2Table; //6x6 Fuel trim 2 map
-struct table3D trim3Table; //6x6 Fuel trim 3 map
-struct table3D trim4Table; //6x6 Fuel trim 4 map
+struct table3D_impl<16> fuelTable; //16x16 fuel map
+struct table3D_impl<16> fuelTable2; //16x16 fuel map
+struct table3D_impl<16> ignitionTable; //16x16 ignition map
+struct table3D_impl<16> ignitionTable2; //16x16 ignition map
+struct table3D_impl<16> afrTable; //16x16 afr target map
+struct table3D_impl<8> stagingTable; //8x8 fuel staging table
+struct table3D_impl<8> boostTable; //8x8 boost map
+struct table3D_impl<8> vvtTable; //8x8 vvt map
+struct table3D_impl<8> wmiTable; //8x8 wmi map
+struct table3D_impl<6> trim1Table; //6x6 Fuel trim 1 map
+struct table3D_impl<6> trim2Table; //6x6 Fuel trim 2 map
+struct table3D_impl<6> trim3Table; //6x6 Fuel trim 3 map
+struct table3D_impl<6> trim4Table; //6x6 Fuel trim 4 map
 struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
 struct table2D maeTable;
 struct table2D WUETable; //10 bin Warm Up Enrichment map (2D)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -29,19 +29,6 @@ void initialiseAll()
 
     pinMode(LED_BUILTIN, OUTPUT);
     digitalWrite(LED_BUILTIN, LOW);
-    table3D_setSize(&fuelTable, 16);
-    table3D_setSize(&fuelTable2, 16);
-    table3D_setSize(&ignitionTable, 16);
-    table3D_setSize(&ignitionTable2, 16);
-    table3D_setSize(&afrTable, 16);
-    table3D_setSize(&stagingTable, 8);
-    table3D_setSize(&boostTable, 8);
-    table3D_setSize(&vvtTable, 8);
-    table3D_setSize(&wmiTable, 8);
-    table3D_setSize(&trim1Table, 6);
-    table3D_setSize(&trim2Table, 6);
-    table3D_setSize(&trim3Table, 6);
-    table3D_setSize(&trim4Table, 6);
 
     #if defined(CORE_STM32)
     configPage9.intcan_available = 1;   // device has internal canbus

--- a/speeduino/table.ino
+++ b/speeduino/table.ino
@@ -4,72 +4,8 @@ Copyright (C) Josh Stewart
 A full copy of the license may be found in the projects root directory
 */
 
-/*
-Because the size of the table is dynamic, this functino is required to reallocate the array sizes
-Note that this may clear some of the existing values of the table
-*/
 #include "table.h"
 #include "globals.h"
-
-/*
-void table2D_setSize(struct table2D* targetTable, byte newSize)
-{
-  //Table resize is ONLY permitted during system initialisation.
-  //if(initialisationComplete == false)
-  {
-    //2D tables can contain either bytes or ints, depending on the value of the valueSize field
-    if(targetTable->valueSize == SIZE_BYTE)
-    {
-      //The following lines have MISRA suppressions as realloc is otherwise forbidden. These calls have been verified as unable to be executed from anywhere but controlled areas. 
-      //cppcheck-suppress misra-21.3
-      targetTable->values = (byte *)realloc(targetTable->values, newSize * sizeof(byte)); //cppcheck-suppress misra_21.3
-      targetTable->axisX = (byte *)realloc(targetTable->axisX, newSize * sizeof(byte));
-      targetTable->xSize = newSize;
-    }
-    else
-    {
-      targetTable->values16 = (int16_t *)realloc(targetTable->values16, newSize * sizeof(int16_t));
-      targetTable->axisX16 = (int16_t *)realloc(targetTable->axisX16, newSize * sizeof(int16_t));
-      targetTable->xSize = newSize;
-    } //Byte or int
-  } //initialisationComplete
-}
-*/
-
-void* heap_alloc(uint16_t size)
- {
-     uint8_t* value = nullptr;
-     if (size < (TABLE_HEAP_SIZE - _heap_pointer))
-     {
-         value = &_3DTable_heap[_heap_pointer];
-         _heap_pointer += size;
-     }
-     return value;
- }
-
-
-void table3D_setSize(struct table3D *targetTable, byte newSize)
-{
-  if(initialisationComplete == false)
-  {
-    /*
-    targetTable->values = (byte **)malloc(newSize * sizeof(byte*));
-    for(byte i = 0; i < newSize; i++) { targetTable->values[i] = (byte *)malloc(newSize * sizeof(byte)); }
-    */
-    targetTable->values = (byte **)heap_alloc(newSize * sizeof(byte*));
-    for(byte i = 0; i < newSize; i++) { targetTable->values[i] = (byte *)heap_alloc(newSize * sizeof(byte)); }
-
-    /*
-    targetTable->axisX = (int16_t *)malloc(newSize * sizeof(int16_t));
-    targetTable->axisY = (int16_t *)malloc(newSize * sizeof(int16_t));
-    */
-    targetTable->axisX = (int16_t *)heap_alloc(newSize * sizeof(int16_t));
-    targetTable->axisY = (int16_t *)heap_alloc(newSize * sizeof(int16_t));
-    targetTable->xSize = newSize;
-    targetTable->ySize = newSize;
-    targetTable->cacheIsValid = false; //Invalid the tables cache to ensure a lookup of new values
-  } //initialisationComplete
-}
 
 /*
 This function pulls a 1D linear interpolated (ie averaged) value from a 2D table


### PR DESCRIPTION
Regarding the merge of #291 and commit 0e80fdf6d84dbe07ca2d91f3eaf94c65d16d87bf.
This is a better solution, again, but templates can be scary for non C++ people. 
I don't use virtual functions, so there is no overhead to using this feature. 

The main thing is, this is much easier to maintain and less error-prone than having multiple `#define`.

It's been a long time since I've been active here, but I hope I can still do relevant improvements.

I tested quickly, all tables are loading correctly, are editable in tunerstudio and keep their values upon reboot. 