### PR TITLE
Add Ford ST170 Decoder

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -130,6 +130,8 @@
     #define trigger_ThirtySixMinus222   = 16
     #define trigger_ThirtySixMinus21    = 17
     #define trigger_420a                = 18
+    #define trigger_Webber              = 19
+    #define trigger_FordST170           = 20
 
 [Constants]
 
@@ -433,7 +435,7 @@ page = 4
       TrigEdge   = bits,   U08,      5,[0:0],    "RISING", "FALLING"
       TrigSpeed  = bits,   U08,      5,[1:1],    "Crank Speed", "Cam Speed"
       IgInv      = bits,   U08,      5,[2:2],    "Going Low",        "Going High"
-      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      TrigPattern= bits,   U08,      5,[3:7],    "Missing Tooth", "Basic Distributor", "Dual Wheel", "GM 7X", "4G63 / Miata / 3000GT", "GM 24X", "Jeep 2000", "Audi 135", "Honda D17", "Miata 99-05", "Mazda AU", "Non-360 Dual", "Nissan 360", "Subaru 6/7", "Daihatsu +1", "Harley EVO", "36-2-2-2", "36-2-1", "DSM 420a", "Weber-Marelli", "Ford ST170", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       TrigEdgeSec= bits,   U08,      6,[0:0],    "RISING", "FALLING"
       fuelPumpPin= bits  , U08,      6,[1:6],    "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "INVALID"
       useResync  = bits,   U08,      6,[7:7],    "No",        "Yes"
@@ -2495,7 +2497,7 @@ menuDialog = main
         field = "Note: This is the number of revolutions that will be skipped during"
         field = "cranking before the injectors and coils are fired"
         field = "Trigger edge",                   TrigEdge      { TrigPattern != 4 } ;4G63 uses both edges
-        field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 19 } ;Missing tooth, dual wheel and Miata 9905, weber-marelli
+        field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 } ;Missing tooth, dual wheel and Miata 9905, weber-marelli, ST170
         field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) }
         field = "Trigger Filter",                 TrigFilter,   { TrigPattern != 13 }
         field = "Re-sync every cycle",            useResync,    { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05, weber-marelli

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -31,6 +31,7 @@
 #define DECODER_36_2_1            17
 #define DECODER_420A              18
 #define DECODER_WEBER             19
+#define DECODER_ST170             20
 
 static inline void addToothLogEntry(unsigned long, bool);
 void loggerPrimaryISR();
@@ -177,6 +178,13 @@ void triggerSetEndTeeth_420a();
 
 void triggerPri_Webber();
 void triggerSec_Webber();
+
+void triggerSetup_FordST170();
+void triggerSec_FordST170();
+uint16_t getRPM_FordST170();
+int getCrankAngle_FordST170();
+void triggerSetEndTeeth_FordST170();
+
 
 extern void (*triggerHandler)(); //Pointer for the trigger function (Gets pointed to the relevant decoder)
 extern void (*triggerSecondaryHandler)(); //Pointer for the secondary trigger function (Gets pointed to the relevant decoder)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -3029,6 +3029,25 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
+    case DECODER_ST170:
+      //Ford ST170
+      triggerSetup_FordST170();
+      triggerHandler = triggerPri_missingTooth;
+      triggerSecondaryHandler = triggerSec_FordST170;
+      decoderHasSecondary = true;
+      getRPM = getRPM_FordST170;
+      getCrankAngle = getCrankAngle_FordST170;
+      triggerSetEndTeeth = triggerSetEndTeeth_FordST170;
+
+      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+      else { primaryTriggerEdge = FALLING; }
+      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
+      else { secondaryTriggerEdge = FALLING; }
+
+      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
+      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
+
+      break;
 
     default:
       triggerHandler = triggerPri_missingTooth;


### PR DESCRIPTION
This adds a decoder for the Ford ST170 engine.
This setup uses a 36-1 primary and a unique 8-3 secondary trigger.
The existing missing tooth decoder with fixed parameters is used as the primary to reduce duplication.

This has been tested on the bench on 2 separate boards.
A logic analyser was used to make sure it the outputs were consistently aligned with the reference tooth on the secondary at startup.

Some testing has been done on my personal car, see video on Facebook.
Angle tracking was confirmed with another ECU brand that already supports this pattern.