### PR TITLE
RTC fixes and changes

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -400,10 +400,8 @@ page = 1
 
       iacTPSlimit               = scalar, U08,  121,        "%",   1,         0,     0,        100,      0               
       iacRPMlimitHysteresis     = scalar, U08,  122,        "RPM"  10,        0      10      2500,     0
-
-      rtc_trim        = scalar,  S08,    123,               "ppm",      1, 0, -127, +127, 0
-      
-      unused2-95    = array,  U08,      124, [4],   "%",        1.0,       0.0,   0.0,     255,      0
+     
+      unused2-95    = array,  U08,      123, [5],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -3918,13 +3916,9 @@ menuDialog = main
     field = "Select Rule Number",  prgm_out_selection
     panel = prgm_out_rules_master
 
-  dialog = rtc_setup, "Real Time Clock"
-       field = "Real Time Clock mode", rtc_mode
-       field = "Real Time Clock Trim +/-", rtc_trim, {rtc_mode}
-
-   dialog = rtc_settings, "Real Time Clock"
-       panel = rtc_setup
-       panel = std_ms3Rtc
+  dialog = rtc_settings, "Real Time Clock"
+      field = "Mode", rtc_mode
+      panel = std_ms3Rtc {rtc_mode}
 
 
 ;-------------------------------------------------------------------------------

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -26,7 +26,6 @@
 #define micros_safe() micros() //timer5 method is not used on anything but AVR, the micros_safe() macro is simply an alias for the normal micros()
 #define TIMER_RESOLUTION 4
 
-#define RTC_ENABLED
 #define USE_SERIAL3
 
 //When building for Black board Serial1 is instanciated,building generic STM32F4x7 has serial2 and serial 1 must be done here
@@ -122,6 +121,12 @@ extern "C" char* sbrk(int incr);
 #endif
 
 #define RTC_LIB_H "STM32RTC.h"
+
+/*
+***********************************************************************************************************
+* Real Time clock for datalogging/time stamping
+*/
+#define RTC_ENABLED
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -6,7 +6,9 @@
 #include "scheduler.h"
 #include "HardwareTimer.h"
 
+#ifdef RTC_ENABLED
 STM32RTC& rtc = STM32RTC::getInstance();
+#endif
 
   void initBoard()
   {
@@ -23,10 +25,11 @@ STM32RTC& rtc = STM32RTC::getInstance();
      ***********************************************************************************************************
      * Real Time clock for datalogging/time stamping
      */
-     
+     #ifdef RTC_ENABLED
      rtc.setClockSource(STM32RTC::LSE_CLOCK); //Initialize external clock for RTC. That is the only clock running of VBAT
      rtc.begin(); // initialize RTC 24H format
-
+     #endif
+     
     /*
     ***********************************************************************************************************
     * Idle

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -552,22 +552,20 @@ void command()
       break;
 
     case 'w':
-      uint32_t StartTime;
-      StartTime = micros();
-      //wait for 7 RTC bytes or 30 milliseconds timeout
-      while((Serial.available() <= 7) & (micros()-StartTime <= 30000)) {}
-        
-      byte offset1, offset2, length1, length2;
+      if(Serial.available() >= 7)
+        {
+          byte offset1, offset2, length1, length2;
 
-      Serial.read(); // First byte of the page identifier can be ignored. It's always 0
-      currentPage = Serial.read();
-      //currentPage = 1;
-      offset1 = Serial.read();
-      offset2 = Serial.read();
-      valueOffset = word(offset2, offset1);
-      length1 = Serial.read();
-      length2 = Serial.read();
-      chunkSize = word(length2, length1);
+          Serial.read(); // First byte of the page identifier can be ignored. It's always 0
+          currentPage = Serial.read();
+          //currentPage = 1;
+          offset1 = Serial.read();
+          offset2 = Serial.read();
+          valueOffset = word(offset2, offset1);
+          length1 = Serial.read();
+          length2 = Serial.read();
+          chunkSize = word(length2, length1);
+        }
 
 #ifdef RTC_ENABLED
       if(currentPage == SD_READWRITE_PAGE)

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -552,20 +552,23 @@ void command()
       break;
 
     case 'w':
-      if(Serial.available() >= 7)
-        {
-          byte offset1, offset2, length1, length2;
+      uint32_t StartTime;
+      StartTime = micros();
+      //wait for 7 RTC bytes or 30 milliseconds timeout
+      while((Serial.available() <= 7) & (micros()-StartTime <= 30000)) {}
+        
+      byte offset1, offset2, length1, length2;
 
-          Serial.read(); // First byte of the page identifier can be ignored. It's always 0
-          currentPage = Serial.read();
-          //currentPage = 1;
-          offset1 = Serial.read();
-          offset2 = Serial.read();
-          valueOffset = word(offset2, offset1);
-          length1 = Serial.read();
-          length2 = Serial.read();
-          chunkSize = word(length2, length1);
-        }
+      Serial.read(); // First byte of the page identifier can be ignored. It's always 0
+      currentPage = Serial.read();
+      //currentPage = 1;
+      offset1 = Serial.read();
+      offset2 = Serial.read();
+      valueOffset = word(offset2, offset1);
+      length1 = Serial.read();
+      length2 = Serial.read();
+      chunkSize = word(length2, length1);
+
 #ifdef RTC_ENABLED
       if(currentPage == SD_READWRITE_PAGE)
         { 
@@ -639,6 +642,8 @@ void command()
             byte month = Serial.read();
             uint16_t year = Serial.read();
             year = word(Serial.read(), year);
+            //Note comms from rtc applet are in big endian, 32 bit processors speeduino are little endian so need byte swap 
+            year = (year<<8) | (year>>8);
             Serial.read(); //Final byte is unused (Always has value 0x5a)
             rtc_setTime(second, minute, hour, day, month, year);
           }

--- a/speeduino/rtc_common.ino
+++ b/speeduino/rtc_common.ino
@@ -94,7 +94,8 @@ uint16_t rtc_getYear()
   #if defined(CORE_TEENSY)
     tempYear = year();
   #elif defined(CORE_STM32)
-    tempYear = rtc.getYear();
+    //year in stm32 rtc is a byte. So add year 2000 to make it correct
+    tempYear = (2000+rtc.getYear());
   #endif
 #endif
   return tempYear;
@@ -107,7 +108,8 @@ void rtc_setTime(byte second, byte minute, byte hour, byte day, byte month, uint
     setTime(second, minute, hour, day, month, year);
   #elif defined(CORE_STM32)
     rtc.setTime(hour, minute, second);
-    rtc.setDate(day, month, year);
+    //year in stm32 rtc is a byte. so substract year 2000 to fit
+    rtc.setDate(day, month, (year-2000));
   #endif
 #endif
 }


### PR DESCRIPTION
Fixed RTC stuff for STM32 and some other fixes/upgrades
1. Remove rtc trim as it is not used (for now)
2. Cleaned up RTC setting time applet a bit (remove rtc trim)
3. The RTC applet and 'w' command did not work correctly on linux with STM32. Now it waits for RTC bytes OR times out
4. The year is communicated big endian by the RTC applet (at least by me) needs changing to little endian
5. Use correct year for STM32 rtc (2020 must be 20 etc)