### PR TITLE
STM32F401 build fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,7 @@ framework = arduino
 board = blackpill_f401cc
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
-build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_RTC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED
+build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -128,7 +128,7 @@ monitor_speed = 115200
 src_dir=speeduino
 default_envs = megaatmega2560
 ;The following lines are for testing / experimentation only. Comment the line above to try them out
-;default_envs = black_F407VE
+default_envs = black_F407VE
 ;default_envs = teensy35
 ;default_envs = teensy40
 ;env_default = LaunchPad_tm4c1294ncpdt

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ monitor_speed = 115200
 src_dir=speeduino
 default_envs = megaatmega2560
 ;The following lines are for testing / experimentation only. Comment the line above to try them out
-default_envs = black_F407VE
+;default_envs = black_F407VE
 ;default_envs = teensy35
 ;default_envs = teensy40
 ;env_default = LaunchPad_tm4c1294ncpdt


### PR DESCRIPTION
Very small fix, now RTC is included in master the disable RTC must be removed for building the STM32F401. Had been removed to save program memory but that is not necessary anymore.