### PR TITLE
Allow 2stroke to use sequential ignition/injection with missing tooth primary trigger (Needs HW test)

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2443,9 +2443,9 @@ menuDialog = main
     dialog = triggerSettings,"Trigger Settings",4
         topicHelp = "https://wiki.speeduino.com/en/decoders"
         field = "Trigger Pattern",                TrigPattern
-        field = "Primary base teeth",             numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 }
+        field = "Primary trigger base teeth",     numTeeth,       { TrigPattern == 0 || TrigPattern == 2 || TrigPattern == 11 || TrigPattern == 18 || TrigPattern == 19 }
+        field = "Primary trigger missing teeth",  missingTeeth,   { TrigPattern == 0 }
         field = "Primary trigger speed",          TrigSpeed,      { TrigPattern == 0 }
-        field = "Missing teeth",                  missingTeeth,   { TrigPattern == 0 }
         field = "Trigger angle multiplier",       TrigAngMul,     { TrigPattern == 11 }
         field = "Trigger Angle ",                 TrigAng
         field = "This number represents the angle ATDC when "
@@ -2454,12 +2454,12 @@ menuDialog = main
         field = "Skip Revolutions",              SkipCycles
         field = "Note: This is the number of revolutions that will be skipped during"
         field = "cranking before the injectors and coils are fired"
-        field = "Trigger edge",                   TrigEdge      { TrigPattern != 4 } ;4G63 uses both edges
-        field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec != 2) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 } ;Missing tooth, dual wheel and Miata 9905, weber-marelli, ST170
-        field = "Missing Tooth Secondary type"    trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) }
-        field = "Level for 1st phase"             PollLevelPol,   { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec == 2) }
-        field = "Trigger Filter",                 TrigFilter,   { TrigPattern != 13 }
-        field = "Re-sync every cycle",            useResync,    { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05, weber-marelli
+        field = "Primary trigger edge",           TrigEdge        { TrigPattern != 4 } ;4G63 uses both edges
+        field = "Secondary trigger edge",         TrigEdgeSec,    { (twoStroke != 1) && ((TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec != 2) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20) } ;Missing tooth, dual wheel and Miata 9905, weber-marelli, ST170
+        field = "Secondary trigger type",         trigPatternSec, { (twoStroke != 1) && (TrigPattern == 0 && TrigSpeed == 0) }
+        field = "Level for 1st phase",            PollLevelPol,   { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec == 2) }
+        field = "Trigger Filter",                 TrigFilter,     { TrigPattern != 13 }
+        field = "Re-sync every cycle",            useResync,      { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05, weber-marelli
 
     dialog = lockSparkSettings, "Locked timing"
         field = "Enabled Fixed/Locked timing",  fixAngEnable

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -426,8 +426,8 @@ void triggerPri_missingTooth()
                 //if Sequential fuel or ignition is in use, further checks are needed before determining sync
                 if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) || (configPage2.injLayout == INJ_SEQUENTIAL) )
                 {
-                  //If either fuel or ignition is sequential, only declare sync if the cam tooth has been seen OR if the missing wheel is on the cam
-                  if( (secondaryToothCount > 0) || (configPage4.TrigSpeed == CAM_SPEED) || (configPage4.trigPatternSec == SEC_TRIGGER_POLL) )
+                  //If either fuel or ignition is sequential, only declare sync if the cam tooth has been seen OR if the missing wheel is on the cam. two stroke doesnt require cam input for full sync
+                  if( (secondaryToothCount > 0) || (configPage4.TrigSpeed == CAM_SPEED) || (configPage4.trigPatternSec == SEC_TRIGGER_POLL) || (configPage2.strokes == TWO_STROKE) )
                   {
                     currentStatus.hasSync = true;
                     BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); //the engine is fully synced so clear the Half Sync bit


### PR DESCRIPTION
it doesn't require a secondary trigger for full sync, before it was only possible to reach 'half-sync'