### PR TITLE
Create better support for STM32F401 and STM32F411 blackpills

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,19 @@ framework = arduino
 board = blackpill_f401cc
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
-build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED
+build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
+upload_protocol = dfu
+debug_tool = stlink
+monitor_speed = 115200
+
+;STM32 Official core
+[env:black_F411CE]
+platform = ststm32
+framework = arduino
+board = blackpill_f411ce
+lib_deps = stm32duino/STM32duino RTC
+board_build.core = stm32
+build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -108,13 +108,22 @@ extern "C" char* sbrk(int incr);
   #endif
     InternalSTM32F7_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 
-#elif defined(STM32F401xC)
+#elif defined(STM32F411xE)
   #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #include EEPROM_LIB_H
     EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 131072UL, 4095UL, 0x08040000UL};
     InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 
-#else //default case, internal flash as EEPROM for STM32F4
+#elif defined(STM32F401xC)
+  //when using with internal falsh not enough rom is available so small flash mode is enabled
+  //be carefull that the only 50% of flash is can be used, the other 50% is used for eeprom emulation
+  #define SMALL_FLASH_MODE
+  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
+  #include EEPROM_LIB_H
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 4095UL, 0x08020000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+
+#else //default case, internal flash as EEPROM for STM32F407
   #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #include EEPROM_LIB_H
     EEPROM_Emulation_Config EmulatedEEPROMMconfig{4UL, 131072UL, 2047UL, 0x08080000UL};

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -12,7 +12,7 @@ A full copy of the license may be found in the projects root directory
 #include "decoders.h"
 #include "TS_CommandButtonHandler.h"
 #include "errors.h"
-#include "src/FastCRC/FastCRC.h"
+// #include "src/FastCRC/FastCRC.h"
 #ifdef RTC_ENABLED
   #include "rtc_common.h"
 #endif
@@ -181,7 +181,9 @@ void command()
       break;
 
     case 'L': // List the contents of current page in human readable form
+      #ifndef SMALL_FLASH_MODE
       sendPageASCII();
+      #endif
       break;
 
     case 'm': //Send the current free memory

--- a/speeduino/comms.ino
+++ b/speeduino/comms.ino
@@ -12,7 +12,7 @@ A full copy of the license may be found in the projects root directory
 #include "decoders.h"
 #include "TS_CommandButtonHandler.h"
 #include "errors.h"
-// #include "src/FastCRC/FastCRC.h"
+#include "src/FastCRC/FastCRC.h"
 #ifdef RTC_ENABLED
   #include "rtc_common.h"
 #endif

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -207,10 +207,8 @@ extern volatile unsigned long toothSystemLastToothTime; //As below, but used for
 extern volatile unsigned long toothLastToothTime; //The time (micros()) that the last tooth was registered
 extern volatile unsigned long toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
 extern volatile unsigned long toothLastMinusOneToothTime; //The time (micros()) that the tooth before the last tooth was registered
-#ifndef SMALL_FLASH_MODE
 extern volatile unsigned long toothLastMinusOneSecToothTime; //The time (micros()) that the tooth before the last tooth was registered on secondary input
 extern volatile unsigned long targetGap2;
-#endif
 
 extern volatile unsigned long toothOneTime; //The time (micros()) that tooth 1 last triggered
 extern volatile unsigned long toothOneMinusOneTime; //The 2nd to last time (micros()) that tooth 1 last triggered

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -49,10 +49,8 @@ volatile unsigned long toothSystemLastToothTime = 0; //As below, but used for de
 volatile unsigned long toothLastToothTime = 0; //The time (micros()) that the last tooth was registered
 volatile unsigned long toothLastSecToothTime = 0; //The time (micros()) that the last tooth was registered on the secondary input
 volatile unsigned long toothLastMinusOneToothTime = 0; //The time (micros()) that the tooth before the last tooth was registered
-#ifndef SMALL_FLASH_MODE
 volatile unsigned long toothLastMinusOneSecToothTime = 0; //The time (micros()) that the tooth before the last tooth was registered on secondary input
 volatile unsigned long targetGap2;
-#endif
 volatile unsigned long toothOneTime = 0; //The time (micros()) that tooth 1 last triggered
 volatile unsigned long toothOneMinusOneTime = 0; //The 2nd to last time (micros()) that tooth 1 last triggered
 volatile bool revolutionOne = 0; // For sequential operation, this tracks whether the current revolution is 1 or 2 (not 1)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1470,6 +1470,7 @@ void setPinMapping(byte boardID)
       break;
 
     case 6:
+      #ifndef SMALL_FLASH_MODE
       //Pin mappings as per the 2001-05 MX5 PNP shield
       pinInjector1 = 44; //Output pin injector 1 is on
       pinInjector2 = 46; //Output pin injector 2 is on
@@ -1504,7 +1505,7 @@ void setPinMapping(byte boardID)
       pinLaunch = 12; //Can be overwritten below
       pinFlex = 3; // Flex sensor (Must be external interrupt enabled)
       pinResetControl = 39; //Reset control output
-
+      #endif
       //This is NOT correct. It has not yet been tested with this board
       #if defined(CORE_TEENSY35)
         pinTrigger = 23;
@@ -1522,6 +1523,7 @@ void setPinMapping(byte boardID)
       break;
 
     case 8:
+      #ifndef SMALL_FLASH_MODE
       //Pin mappings as per the 1996-97 MX5 PNP shield
       pinInjector1 = 11; //Output pin injector 1 is on
       pinInjector2 = 10; //Output pin injector 2 is on
@@ -1569,9 +1571,11 @@ void setPinMapping(byte boardID)
         pinFan = 50; //Won't work (No mapping for pin 35)
         pinTachOut = 28; //Done
       #endif
+      #endif
       break;
 
     case 9:
+     #ifndef SMALL_FLASH_MODE
       //Pin mappings as per the 89-95 MX5 PNP shield
       pinInjector1 = 11; //Output pin injector 1 is on
       pinInjector2 = 10; //Output pin injector 2 is on
@@ -1604,7 +1608,7 @@ void setPinMapping(byte boardID)
       pinFlex = 3; // Flex sensor (Must be external interrupt enabled)
       pinResetControl = 44; //Reset control output
       pinVSS = 20;
-
+      #endif
       #if defined(CORE_TEENSY35)
         pinTrigger = 23;
         pinTrigger2 = 36;
@@ -1736,6 +1740,7 @@ void setPinMapping(byte boardID)
       break;
 
     case 31:
+     #ifndef SMALL_FLASH_MODE
       //Pin mappings for the BMW PnP PCBs by pazi88. This is an AVR only module. At least for now
       pinInjector1 = 8; //Output pin injector 1
       pinInjector2 = 9; //Output pin injector 2
@@ -1774,9 +1779,11 @@ void setPinMapping(byte boardID)
       pinFlex = 2; // Flex sensor
       pinResetControl = 43; //Reset control output
       pinVSS = 3; //VSS input pin
+      #endif
       break;
 
     case 40:
+     #ifndef SMALL_FLASH_MODE
       //Pin mappings as per the NO2C shield
       pinInjector1 = 8; //Output pin injector 1 is on
       pinInjector2 = 9; //Output pin injector 2 is on
@@ -1816,6 +1823,7 @@ void setPinMapping(byte boardID)
       pinSpareLOut2 = 34; //low current output spare2 - ONLY WITH DB
       pinSpareLOut3 = 36; //low current output spare3 - ONLY WITH DB
       pinResetControl = 26; //Reset control output
+      #endif
       break;
 
     case 41:
@@ -2212,7 +2220,39 @@ void setPinMapping(byte boardID)
         pinInjector8 = PE13; //
         pinInjector7 = PE14; //
         // = PE15;  //
-       
+     #elif (defined(STM32F411xE) || defined(STM32F401xC))
+        //@VitroBoss please define the pinsout here
+        pinInjector1 = PB7; //Output pin injector 1 is on
+        pinInjector2 = PB6; //Output pin injector 2 is on
+        pinInjector3 = PB5; //Output pin injector 3 is on
+        pinInjector4 = PB4; //Output pin injector 4 is on
+        pinCoil1 = PB9; //Pin for coil 1
+        pinCoil2 = PB8; //Pin for coil 2
+        pinCoil3 = PB3; //Pin for coil 3
+        pinCoil4 = PA15; //Pin for coil 4
+        pinTPS = A2;//TPS input pin
+        pinMAP = A3; //MAP sensor pin
+        pinIAT = A0; //IAT sensor pin
+        pinCLT = A1; //CLS sensor pin
+        pinO2 = A8; //O2 Sensor pin
+        pinBat = A4; //Battery reference voltage pin
+        pinBaro = pinMAP;
+        pinTachOut = PB1; //Tacho output pin  (Goes to ULN2803)
+        pinIdle1 = PB2; //Single wire idle control
+        pinIdle2 = PB10; //2 wire idle control
+        pinBoost = PA6; //Boost control
+        pinVVT_1 = NC; //Default VVT output
+        pinVVT_2 = NC; //Default VVT2 output
+        pinStepperDir = PB10; //Direction pin  for DRV8825 driver
+        pinStepperStep = PB2; //Step pin for DRV8825 driver
+        pinFuelPump = PA8; //Fuel pump output
+        pinFan = PA5; //Pin for the fan output (Goes to ULN2803)
+
+        //external interrupt enabled pins
+        pinFlex = PC14; // Flex sensor (Must be external interrupt enabled)
+        pinTrigger = PC13; //The CAS pin also led pin so bad idea
+        pinTrigger2 = PC15; //The Cam Sensor pin
+
      #elif defined(CORE_STM32)
         //blue pill wiki.stm32duino.com/index.php?title=Blue_Pill
         //Maple mini wiki.stm32duino.com/index.php?title=Maple_Mini

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -11,6 +11,8 @@
 void doUpdates()
 {
   #define CURRENT_DATA_VERSION    17
+  //Only the latest updat for small flash devices must be retained
+   #ifndef SMALL_FLASH_MODE
 
   //May 2017 firmware introduced a -40 offset on the ignition table. Update that table to +40
   if(EEPROM.read(EEPROM_DATA_VERSION) == 2)
@@ -441,6 +443,8 @@ void doUpdates()
     EEPROM.write(EEPROM_DATA_VERSION, 16);
   }
 
+  //Move this #endif to only do latest updates to safe ROM space on small devices.
+  #endif
   if(EEPROM.read(EEPROM_DATA_VERSION) == 16)
   {
     //Fix for wrong placed page 13


### PR DESCRIPTION
- Added STM32F411 blackpill to platformio.ini
- Added STM32F411 blackpill to internal Flash EEPROM emulation. 
- Fixed EEPROM on internal flash emulation on STM32F401
- Revived the SMALL_FLASH_MODE for STM32F401 only when using internal flash EEPROM emulation (to make space)
- Added pinout for STM32F401/411 (@VitorBoss please check and change according to your board)