### PR TITLE
Enable use of disabled functions pins

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -611,6 +611,7 @@ extern volatile byte HWTest_INJ;      /**< Each bit in this variable represents 
 extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
 extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
+extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
 
 
 extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
@@ -623,7 +624,7 @@ extern volatile byte LOOP_TIMER;
 #define pinIsIgnition(pin)  ( ((pin) == pinCoil1) || ((pin) == pinCoil2) || ((pin) == pinCoil3) || ((pin) == pinCoil4) || ((pin) == pinCoil5) || ((pin) == pinCoil6) || ((pin) == pinCoil7) || ((pin) == pinCoil8) )
 #define pinIsOutput(pin)    ( pinIsInjector((pin)) || pinIsIgnition((pin)) || ((pin) == pinFuelPump) || ((pin) == pinFan) || ((pin) == pinVVT_1) || ((pin) == pinVVT_2) || ( ((pin) == pinBoost) && configPage6.boostEnabled) || ((pin) == pinIdle1) || ((pin) == pinIdle2) || ((pin) == pinTachOut) || ((pin) == pinStepperEnable) || ((pin) == pinStepperStep) )
 #define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinO2) || ((pin) == pinBat) )
-#define pinIsUsed(pin)      ( pinIsSensor((pin)) || pinIsOutput((pin)) || pinIsReserved((pin)) )
+//#define pinIsUsed(pin)      ( pinIsSensor((pin)) || pinIsOutput((pin)) || pinIsReserved((pin)) )
 
 /** The status struct with current values for all 'live' variables.
 * In current version this is 64 bytes. Instantiated as global currentStatus.
@@ -1562,5 +1563,7 @@ extern uint8_t  o2Calibration_values[32]; // Note 8-bit values
 extern struct table2D cltCalibrationTable; /**< A 32 bin array containing the coolant temperature sensor calibration values */
 extern struct table2D iatCalibrationTable; /**< A 32 bin array containing the inlet air temperature sensor calibration values */
 extern struct table2D o2CalibrationTable; /**< A 32 bin array containing the O2 sensor calibration values */
+
+bool pinIsUsed(byte pin);
 
 #endif // GLOBALS_H

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -622,8 +622,8 @@ extern volatile byte LOOP_TIMER;
 //These functions all do checks on a pin to determine if it is already in use by another (higher importance) function
 #define pinIsInjector(pin)  ( ((pin) == pinInjector1) || ((pin) == pinInjector2) || ((pin) == pinInjector3) || ((pin) == pinInjector4) || ((pin) == pinInjector5) || ((pin) == pinInjector6) || ((pin) == pinInjector7) || ((pin) == pinInjector8) )
 #define pinIsIgnition(pin)  ( ((pin) == pinCoil1) || ((pin) == pinCoil2) || ((pin) == pinCoil3) || ((pin) == pinCoil4) || ((pin) == pinCoil5) || ((pin) == pinCoil6) || ((pin) == pinCoil7) || ((pin) == pinCoil8) )
-#define pinIsOutput(pin)    ( pinIsInjector((pin)) || pinIsIgnition((pin)) || ((pin) == pinFuelPump) || ((pin) == pinFan) || ((pin) == pinVVT_1) || ((pin) == pinVVT_2) || ( ((pin) == pinBoost) && configPage6.boostEnabled) || ((pin) == pinIdle1) || ((pin) == pinIdle2) || ((pin) == pinTachOut) || ((pin) == pinStepperEnable) || ((pin) == pinStepperStep) )
-#define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinO2) || ((pin) == pinBat) )
+//#define pinIsOutput(pin)    ( pinIsInjector((pin)) || pinIsIgnition((pin)) || ((pin) == pinFuelPump) || ((pin) == pinFan) || ((pin) == pinVVT_1) || ((pin) == pinVVT_2) || ( ((pin) == pinBoost) && configPage6.boostEnabled) || ((pin) == pinIdle1) || ((pin) == pinIdle2) || ((pin) == pinTachOut) || ((pin) == pinStepperEnable) || ((pin) == pinStepperStep) )
+#define pinIsSensor(pin)    ( ((pin) == pinCLT) || ((pin) == pinIAT) || ((pin) == pinMAP) || ((pin) == pinTPS) || ((pin) == pinO2) || ((pin) == pinBat) || (((pin) == pinFlex) && (configPage2.flexEnabled != 0)) )
 //#define pinIsUsed(pin)      ( pinIsSensor((pin)) || pinIsOutput((pin)) || pinIsReserved((pin)) )
 
 /** The status struct with current values for all 'live' variables.
@@ -1564,6 +1564,7 @@ extern struct table2D cltCalibrationTable; /**< A 32 bin array containing the co
 extern struct table2D iatCalibrationTable; /**< A 32 bin array containing the inlet air temperature sensor calibration values */
 extern struct table2D o2CalibrationTable; /**< A 32 bin array containing the O2 sensor calibration values */
 
+bool pinIsOutput(byte pin);
 bool pinIsUsed(byte pin);
 
 #endif // GLOBALS_H

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -159,6 +159,7 @@ volatile byte HWTest_INJ = 0; /**< Each bit in this variable represents one of t
 volatile byte HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
 volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 volatile byte HWTest_IGN_50pc = 0; 
+byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
 
 
 //This needs to be here because using the config page directly can prevent burning the setting
@@ -271,3 +272,53 @@ struct table2D iatCalibrationTable;
 uint16_t o2Calibration_bins[32];
 uint8_t o2Calibration_values[32];
 struct table2D o2CalibrationTable; 
+
+//These function do checks on a pin to determine if it is already in use by another (higher importance) active function
+bool pinIsUsed(byte pin)
+{
+  bool used = false;
+  //Injector?
+  if ((pin == pinInjector1)
+  || ((pin == pinInjector2) && (configPage2.nInjectors > 1))
+  || ((pin == pinInjector3) && (configPage2.nInjectors > 2))
+  || ((pin == pinInjector4) && (configPage2.nInjectors > 3))
+  || ((pin == pinInjector5) && (configPage2.nInjectors > 4))
+  || ((pin == pinInjector6) && (configPage2.nInjectors > 5))
+  || ((pin == pinInjector7) && (configPage2.nInjectors > 6))
+  || ((pin == pinInjector8) && (configPage2.nInjectors > 7)))
+  {
+    used = true;
+  }
+  //Ignition?
+  if ((pin == pinCoil1)
+  || ((pin == pinCoil2) && (maxIgnOutputs > 1))
+  || ((pin == pinCoil3) && (maxIgnOutputs > 2))
+  || ((pin == pinCoil4) && (maxIgnOutputs > 3))
+  || ((pin == pinCoil5) && (maxIgnOutputs > 4))
+  || ((pin == pinCoil6) && (maxIgnOutputs > 5))
+  || ((pin == pinCoil7) && (maxIgnOutputs > 6))
+  || ((pin == pinCoil8) && (maxIgnOutputs > 7)))
+  {
+    used = true;
+  }
+  //Analog input?
+  if ( pinIsSensor(pin) )
+  {
+    used = true;
+  }
+  //Functions?
+  if ((pin == pinFuelPump)
+  || ((pin == pinFan) && (configPage2.fanEnable == 1))
+  || ((pin == pinVVT_1) && (configPage6.vvtEnabled > 0))
+  || ((pin == pinVVT_2) && (configPage6.vvtEnabled > 0))
+  || ((pin == pinBoost) && (configPage6.boostEnabled == 1))
+  || ((pin == pinIdle1) && ((configPage6.iacAlgorithm > 0) && (configPage6.iacAlgorithm <= 3)))
+  || ((pin == pinIdle2) && (configPage6.iacChannels == 1)) || (pin == pinTachOut) )
+  {
+    used = true;
+  }
+  //Forbiden or hardware reserved? (Defined at board_xyz.h file)
+  if ( pinIsReserved(pin) ) { used = true; }
+
+  return used;
+}

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -38,7 +38,6 @@ extern uint16_t inj_opentime_uS; /**< The injector opening time. This is set wit
 extern bool ignitionOn; /**< The current state of the ignition system (on or off) */
 extern bool fuelOn; /**< The current state of the fuel system (on or off) */
 
-extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
 extern byte curRollingCut; /**< Rolling rev limiter, current ignition channel being cut */
 extern byte rollingCutCounter; /**< how many times (revolutions) the ignition has been cut in a row */
 extern uint32_t rollingCutLastRev; /**< Tracks whether we're on the same or a different rev for the rolling cut */

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -78,7 +78,6 @@ uint16_t inj_opentime_uS = 0;
 bool ignitionOn = false; /**< The current state of the ignition system (on or off) */
 bool fuelOn = false; /**< The current state of the fuel system (on or off) */
 
-byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
 byte curRollingCut = 0; /**< Rolling rev limiter, current ignition channel being cut */
 byte rollingCutCounter = 0; /**< how many times (revolutions) the ignition has been cut in a row */
 uint32_t rollingCutLastRev = 0; /**< Tracks whether we're on the same or a different rev for the rolling cut */


### PR DESCRIPTION
A lot of beginners struggles with unused pins/outputs been forbidden to use if the function is disabled, this replaces some macros with a function which checks if the pin function is enable, the default pin definition have priority, in case of function activation it will function normally.

That allow for easier use of unused FETs on the boards.