### PR TITLE
STM32F407 Black build fix

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -48,7 +48,7 @@
 
 #elif defined(STM32_MCU_SERIES) || defined(ARDUINO_ARCH_STM32) || defined(STM32)
   #define CORE_STM32
-  #define BOARD_MAX_ADC_PINS  15 //Number of analog pins. THIS NEEDS CONFIRMING FOR STM32!
+  #define BOARD_MAX_ADC_PINS  NUM_ANALOG_INPUTS-1 //Number of analog pins from core.
   #if defined(STM32F407xx) //F407 can do 8x8 STM32F401/STM32F411 not
    #define INJ_CHANNELS 8
    #define IGN_CHANNELS 8

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -44,8 +44,12 @@ byte pinTranslateAnalog(byte rawPin)
     case 11: outputPin = A11; break;
     case 12: outputPin = A12; break;
     case 13: outputPin = A13; break;
-    case 14: outputPin = A14; break;
-    case 15: outputPin = A15; break;
+  #if BOARD_MAX_ADC_PINS >= 14
+      case 14: outputPin = A14; break;
+    #endif
+    #if BOARD_MAX_ADC_PINS >= 15
+      case 15: outputPin = A15; break;
+    #endif
     #if BOARD_MAX_ADC_PINS >= 16
       case 16: outputPin = A16; break;
     #endif


### PR DESCRIPTION
Recent analog input count changes fail the STM32F407 Black build. Here's fix for that.