### PR TITLE
VeAnalyzeLive for second fuel table

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5040,8 +5040,10 @@ cmdVSSratio6 =      "E\x99\x06"
            ;    tableName,  lambdaTargetTableName, lambdaChannel, egoCorrectionChannel, activeCondition
 #if LAMBDA
      veAnalyzeMap = veTable1Tbl, afrTable1Tbl, lambda, egoCorrection
+     veAnalyzeMap = fuelTable2Tbl, afrTable1Tbl, lambda, egoCorrection
 #else
      veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+     veAnalyzeMap = fuelTable2Tbl, afrTable1Tbl, afr, egoCorrection
 #endif
      lambdaTargetTables = afrTable1Tbl, afrTSCustom
          filter = std_xAxisMin ; Auto build with appropriate axis channels


### PR DESCRIPTION
This pull request adds the functionality to use VeAnalyzeLive for the second fuel table, although having the same AFR target map as the generic VE table. 