### PR TITLE
Fix for OL+CL PWM idle control

### DIFF
--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -90,7 +90,7 @@ void initialiseIdle()
       iacPWMTable.axisSize = SIZE_BYTE;
       iacPWMTable.values = configPage6.iacOLPWMVal;
       iacPWMTable.axisX = configPage6.iacBins;
-      break;
+      //missing break; is deliberately, init of both OL and CL must be done here.
 
     case IAC_ALGORITHM_PWM_CL:
       //Case 3 is PWM closed loop


### PR DESCRIPTION
Option 1 to fix open+closed loop PWM idle control, please choose this PR or the PR that comes after this one, both will not be the best option :-D. 