### PR TITLE
Boost by Gear

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -972,10 +972,10 @@ page = 9
       iacStepperInv       = bits,   U08,   153, [0:0], "No",        "Yes"
       iacCoolTime         = bits,   U08,   153, [1:3], "0", "1", "2", "3", "4", "5", "6","INVALID"
 
-      boostByGearEnabled  = bits,   U08,   153, [4:4],      "Off", "On"
+      boostByGearEnabled  = bits,   U08,   153, [4:5],      "Off", "On", "INVALID", "INVALID"
 
-      blankfield          = bits,   U08,   153, [5:5], "",""
-      unused10_153        = bits,   U08,   153, [6:7], ""
+      blankfield          = bits,   U08,   153, [6:6], "",""
+      unused10_153        = bits,   U08,   153, [7:7], ""
       
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -80,6 +80,7 @@
     #define fullStatus_def  = $fullStatus_def_1, $fullStatus_def_2, $fullStatus_def_3, $fullStatus_def_4
 
     boostTableLabels    = bits,    U08,   [0:1], "Duty Cycle %", "kPa"
+    boostByGearLabels   = bits,    U08,   [0:1], "", "%", "kPa", ""
     prgm_out_selection  = bits,    U08,   [0:2], "1", "2", "3", "4", "5", "6", "7", "8"
 
     fuelLoadMax     = scalar, U08, "", 1, 0, 0, 511, 0
@@ -972,19 +973,19 @@ page = 9
       iacStepperInv       = bits,   U08,   153, [0:0], "No",        "Yes"
       iacCoolTime         = bits,   U08,   153, [1:3], "0", "1", "2", "3", "4", "5", "6","INVALID"
 
-      boostByGearEnabled  = bits,   U08,   153, [4:5],      "Off", "On", "INVALID", "INVALID"
+      boostByGearEnabled  = bits,   U08,   153, [4:5],      "Off", "Multiplied %", "Constant limit", "INVALID"
 
       blankfield          = bits,   U08,   153, [6:6], "",""
       unused10_153        = bits,   U08,   153, [7:7], ""
       
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
 
-      boostByGear1               = scalar, U08,     155,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
-      boostByGear2               = scalar, U08,     156,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
-      boostByGear3               = scalar, U08,     157,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
-      boostByGear4               = scalar, U08,     158,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
-      boostByGear5               = scalar, U08,     159,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
-      boostByGear6               = scalar, U08,     160,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear1               = scalar, U08,     155, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+      boostByGear2               = scalar, U08,     156, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+      boostByGear3               = scalar, U08,     157, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+      boostByGear4               = scalar, U08,     158, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+      boostByGear5               = scalar, U08,     159, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+      boostByGear6               = scalar, U08,     160, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
 
       unused10_160        = array, U08,    161, [31],       "",       1, 0, 0, 255, 0
     
@@ -2559,7 +2560,6 @@ menuDialog = main
     
     dialog = boostByGear, "Boost by Gear"
         field = "Enable Boost by Gear",      boostByGearEnabled
-        field = "#Please note that Boost by Gear OVERRIDES the boost target table"
         field = "Gear 1 ",                   boostByGear1,          { boostByGearEnabled }
         field = "Gear 2 ",                   boostByGear2,          { boostByGearEnabled }
         field = "Gear 3 ",                   boostByGear3,          { boostByGearEnabled }

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -971,13 +971,22 @@ page = 9
 
       iacStepperInv       = bits,   U08,   153, [0:0], "No",        "Yes"
       iacCoolTime         = bits,   U08,   153, [1:3], "0", "1", "2", "3", "4", "5", "6","INVALID"
-      blankfield          = bits,   U08,   153, [4:4], "",""
 
-      unused10_153        = bits,   U08,   153, [5:7], ""
+      boostByGearEnabled  = bits,   U08,   153, [4:4],      "Off", "On"
+
+      blankfield          = bits,   U08,   153, [5:5], "",""
+      unused10_153        = bits,   U08,   153, [6:7], ""
       
       iacMaxSteps = scalar, U08,     154,             "Steps",     3,    0,  0,  {iacStepHome-3},    0
 
-      unused10_154        = array, U08,    155, [37],       "",       1, 0, 0, 255, 0
+      boostByGear1               = scalar, U08,     155,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear2               = scalar, U08,     156,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear3               = scalar, U08,     157,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear4               = scalar, U08,     158,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear5               = scalar, U08,     159,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+      boostByGear6               = scalar, U08,     160,             "kPa",      2.0,   0.0,  0.0,  511.0,      0
+
+      unused10_160        = array, U08,    161, [31],       "",       1, 0, 0, 255, 0
     
 page = 10
 #if CELSIUS
@@ -1432,6 +1441,7 @@ page = 14
     defaultValue = vvtCL0DutyAng, 0
     defaultValue = vvt2CL0DutyAng, 0
     defaultValue = ANGLEFILTER_VVT, 0
+    defaultValue = boostByGearEnabled, 0
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -2546,6 +2556,16 @@ menuDialog = main
     dialog = boostCut, "Boost Cut"
         field = "Enable Boost limit",       boostCutEnabled
         field = "Boost Limit",              boostLimit,     { boostCutEnabled }
+    
+    dialog = boostByGear, "Boost by Gear"
+        field = "Enable Boost by Gear",      boostByGearEnabled
+        field = "#Please note that Boost by Gear OVERRIDES the boost target table"
+        field = "Gear 1 ",                   boostByGear1,          { boostByGearEnabled }
+        field = "Gear 2 ",                   boostByGear2,          { boostByGearEnabled }
+        field = "Gear 3 ",                   boostByGear3,          { boostByGearEnabled }
+        field = "Gear 4 ",                   boostByGear4,          { boostByGearEnabled }
+        field = "Gear 5 ",                   boostByGear5,          { boostByGearEnabled }
+        field = "Gear 6 ",                   boostByGear6,          { boostByGearEnabled }
 
     dialog = boostLoad, ""
         field = "Mode",                     boostType
@@ -2771,6 +2791,7 @@ menuDialog = main
         field = "Valve minimum duty cycle", boostMinDuty,  { boostEnabled && boostType == 1 }
         field = "Valve maximum duty cycle", boostMaxDuty,  { boostEnabled && boostType == 1 }
         panel = boostCut
+        panel = boostByGear                 { boostEnabled && boostType == 1 && vssMode > 1 }
         field = "Closed Loop settings"
         field = "Control mode",             boostMode,          { boostEnabled && boostType == 1 }
         slider = "Sensitivity",             boostSens,     horizontal, { boostEnabled && boostType == 1 }

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -172,7 +172,36 @@ void boostControl()
     }
     else if (configPage4.boostType == CLOSED_LOOP_BOOST)
     {
-      if( (boostCounter & 7) == 1) { currentStatus.boostTarget = get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM) * 2; } //Boost target table is in kpa and divided by 2
+      if( (boostCounter & 7) == 1) 
+      { 
+        if( (configPage9.boostByGearEnabled > 0) && (configPage2.vssMode > 1) ) 
+        {
+          switch (currentStatus.gear)
+          {
+            case 1:
+              currentStatus.boostTarget = (configPage9.boostByGear1 * 2);
+              break;
+            case 2:
+              currentStatus.boostTarget = (configPage9.boostByGear2 * 2);
+              break;
+            case 3:
+              currentStatus.boostTarget = (configPage9.boostByGear3 * 2);
+              break;
+            case 4:
+              currentStatus.boostTarget = (configPage9.boostByGear4 * 2);
+              break;
+            case 5:
+              currentStatus.boostTarget = (configPage9.boostByGear5 * 2);
+              break;
+            case 6:
+              currentStatus.boostTarget = (configPage9.boostByGear6 * 2);
+              break;
+            default:
+              break;
+          }
+        }
+        else{ currentStatus.boostTarget = get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM) * 2; } //Boost target table is in kpa and divided by 2
+      } 
       if(currentStatus.MAP >= 100 ) //Only engage boost control above 100kpa. 
       {
         //If flex fuel is enabled, there can be an adder to the boost target based on ethanol content

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -174,7 +174,46 @@ void boostControl()
     {
       if( (boostCounter & 7) == 1) 
       { 
-        if( (configPage9.boostByGearEnabled == 1) && (configPage2.vssMode > 1) ) 
+        if( (configPage9.boostByGearEnabled == 1) && (configPage2.vssMode > 1) )
+        {
+          uint16_t combinedBoost = 0;
+          switch (currentStatus.gear)
+          {
+            case 1:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear1 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            case 2:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear2 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            case 3:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear3 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            case 4:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear4 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            case 5:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear5 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            case 6:
+              combinedBoost = ( ((uint16_t)configPage9.boostByGear6 * (uint16_t)get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM)) / 100 ) << 2;
+              if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+              else{ currentStatus.boostTarget = 511; }
+              break;
+            default:
+              break;
+          }
+        }
+        else if( (configPage9.boostByGearEnabled == 2) && (configPage2.vssMode > 1) ) 
         {
           switch (currentStatus.gear)
           {

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -174,33 +174,33 @@ void boostControl()
     {
       if( (boostCounter & 7) == 1) 
       { 
-        if( (configPage9.boostByGearEnabled > 0) && (configPage2.vssMode > 1) ) 
+        if( (configPage9.boostByGearEnabled == 1) && (configPage2.vssMode > 1) ) 
         {
           switch (currentStatus.gear)
           {
             case 1:
-              currentStatus.boostTarget = (configPage9.boostByGear1 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear1 << 1);
               break;
             case 2:
-              currentStatus.boostTarget = (configPage9.boostByGear2 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear2 << 1);
               break;
             case 3:
-              currentStatus.boostTarget = (configPage9.boostByGear3 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear3 << 1);
               break;
             case 4:
-              currentStatus.boostTarget = (configPage9.boostByGear4 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear4 << 1);
               break;
             case 5:
-              currentStatus.boostTarget = (configPage9.boostByGear5 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear5 << 1);
               break;
             case 6:
-              currentStatus.boostTarget = (configPage9.boostByGear6 * 2);
+              currentStatus.boostTarget = (configPage9.boostByGear6 << 1);
               break;
             default:
               break;
           }
         }
-        else{ currentStatus.boostTarget = get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM) * 2; } //Boost target table is in kpa and divided by 2
+        else{ currentStatus.boostTarget = get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM) << 1; } //Boost target table is in kpa and divided by 2
       } 
       if(currentStatus.MAP >= 100 ) //Only engage boost control above 100kpa. 
       {

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1077,15 +1077,18 @@ struct config9 {
 
   byte iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
   byte iacCoolTime : 3; // how long to wait for the stepper to cool between steps
+  
+  byte boostByGearEnabled : 1;
 
   byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
 
-  byte unused10_155;
-  byte unused10_156;
-  byte unused10_157;
-  byte unused10_158;
-  byte unused10_159;
-  byte unused10_160;
+  byte boostByGear1;
+  byte boostByGear2;
+  byte boostByGear3;
+  byte boostByGear4;
+  byte boostByGear5;
+  byte boostByGear6;
+
   byte unused10_161;
   byte unused10_162;
   byte unused10_163;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1077,8 +1077,8 @@ struct config9 {
 
   byte iacStepperInv : 1;  //stepper direction of travel to allow reversing. 0=normal, 1=inverted.
   byte iacCoolTime : 3; // how long to wait for the stepper to cool between steps
-  
-  byte boostByGearEnabled : 1;
+
+  byte boostByGearEnabled : 2;
 
   byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.
 

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -487,6 +487,8 @@ void doUpdates()
     configPage10.vvtCLMaxAng = 200;
     configPage4.ANGLEFILTER_VVT = 0;
 
+    configPage9.boostByGearEnabled = 0;
+
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 18);
   }


### PR DESCRIPTION
This pull request adds the functionality of boost by gear.

Currently there are 2 different modes:
    1. Multiplied %
        In this mode the values specified per gear are used as a percentage value to the boost target table.
    2. Constant limit
        This mode sets a constant boost target per gear in kPa and neglects the boost target table.

This feature relies on the VSS input to determine the current gear.
Boost control has to be in closed loop.

This might not be very usefull for everyday driving, but it might come in handy at the dragstrip.