### PR TITLE
Bugfix on Programmable outputs: 1) Delayed activation not shown in TS 2) Inverse logic not shown in TS

### DIFF
--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -108,20 +108,23 @@ void setResetControlPinState()
 //*********************************************************************************************************************************************************************************
 void initialiseProgrammableIO()
 {
-  for (uint8_t y = 0; y < sizeof(configPage13.outputPin); y++)  {
-    if ( (configPage13.outputPin[y] > 0) && 
-         (configPage13.outputPin[y] < BOARD_MAX_DIGITAL_PINS) ) {   // Note: no need for former check on '(configPage13.outputPin[y] <= 128)' in checkProgrammableIO()
-      if ( !pinIsUsed(configPage13.outputPin[y]) )  {                                                             
+  for (uint8_t y = 0; y < sizeof(configPage13.outputPin); y++) 
+    {
+    if ( (configPage13.outputPin[y] > 0) && (configPage13.outputPin[y] < BOARD_MAX_DIGITAL_PINS) )    // Note: no need for former check on '(configPage13.outputPin[y] <= 128)' in checkProgrammableIO()
+    {
+      if ( !pinIsUsed(configPage13.outputPin[y]) ) 
+      {                                                             
         pinMode(configPage13.outputPin[y], OUTPUT);
+        ioDelay[y] = 0;                                                                               // Initialize delay counter
         BIT_SET(pinIsValid, y);
-        procesOutputValueConditionally(y, false );                  // Assume conditions are not met at powering up. 
-        if (configPage13.outputDelay[y] >= 255){                    // Note: In 202103 there was a check on outputDelay[y] being smaller than 255. Just making it smaller than 254 is more robust
-          configPage13.outputDelay[y] = 254; 
-          } 
+        procesOutputValueConditionally(y, false );                                                    // Assume conditions are not met at powering up. 
+        if (configPage13.outputDelay[y] >= 255) { configPage13.outputDelay[y] = 254; }                // Note: In 202103 the rule would never fire if outputDelay[y]>=255. 
+                                                                                                      // It's in that case better to just set it to 254 and continue processing
       }
     }
   }
 }
+
 
 /*
  * This procedure is called every 0.1 sec. It checks the conditions for each active Programmable Output Rule.
@@ -132,70 +135,90 @@ void initialiseProgrammableIO()
  */
 void checkProgrammableIO()
 {
-  bool isEveryConditionFulfilled;
-
-  for (uint8_t y = 0; y < sizeof(configPage13.outputPin); y++)  {
-    if ( BIT_CHECK(pinIsValid, y) ) {                                                                    // is Rule enabled (is enabled when outputPin==1)?
-      bool isFirstConditionFulfilled = compare (ProgrammableIOGetData(configPage13.firstDataIn[y]),      // changing data
-                                                configPage13.firstTarget[y],                             // target data
-                                                configPage13.operation[y].firstCompType);                // comparator
-      if (configPage13.operation[y].bitwise == BITWISE_DISABLED)   {                                     // are we dealing with one or two enabled conditions?
+ bool isFirstConditionFulfilled;
+ bool isSecondConditionFulfilled;
+ bool isEveryConditionFulfilled;
+ 
+  for (uint8_t y = 0; y < sizeof(configPage13.outputPin); y++)  
+  {
+    if ( BIT_CHECK(pinIsValid, y) )                                                              // is Rule enabled (is enabled when outputPin==1)?
+    {                                                                 
+      isFirstConditionFulfilled = compare (ProgrammableIOGetData(configPage13.firstDataIn[y]),   // changing data
+                                           configPage13.firstTarget[y],                          // target data
+                                           configPage13.operation[y].firstCompType);             // comparator
+      if (configPage13.operation[y].bitwise == BITWISE_DISABLED)                                 // are we dealing with one or two enabled conditions?
+      {                                     
         isEveryConditionFulfilled = isFirstConditionFulfilled;
-      } else {
-        bool isSecondConditionFulfilled = compare (ProgrammableIOGetData(configPage13.secondDataIn[y]),  // changing data
-                                                   configPage13.secondTarget[y],                         // target data
-                                                   configPage13.operation[y].secondCompType);            // comparator
-        isEveryConditionFulfilled = combineConditions ( isFirstConditionFulfilled,                       // result first condition
-                                                        isSecondConditionFulfilled,                      // result second condition
-                                                        configPage13.operation[y].bitwise);              // AND, OR or XOR the conditions, depending on the user wishes
+      } 
+      else 
+      {
+        isSecondConditionFulfilled = compare (ProgrammableIOGetData(configPage13.secondDataIn[y]), // changing data
+                                              configPage13.secondTarget[y],                        // target data
+                                              configPage13.operation[y].secondCompType);           // comparator
+        isEveryConditionFulfilled = combineConditions ( isFirstConditionFulfilled,                 // result first condition
+                                                        isSecondConditionFulfilled,                // result second condition
+                                                        configPage13.operation[y].bitwise);        // AND, OR or XOR the conditions, depending on the user wishes
       }
-      if ( (isEveryConditionFulfilled ) && (configPage13.outputDelay[y] > 0)) {                          // does this rule qualitfy for delayed response when conditons are met?
-        if ( (ioDelay[y] >= configPage13.outputDelay[y]) ) {                                             // qualified! and did we already wait long enough?
-          procesOutputValueConditionally(y, true);                                                       // waited long enough!! update io-port en status variables
-        } else {
-          ioDelay[y]++;                                                                                  // update counter. maybe next iteration.....
-        }
-      } else {
-          if (isEveryConditionFulfilled) {
-            procesOutputValueConditionally(y, true);
-          } else { 
-            procesOutputValueConditionally(y, false);
-            ioDelay[y] = 0;
-          }
+	  
+      if ( (isEveryConditionFulfilled) && (ioDelay[y] >= configPage13.outputDelay[y]) )    // Are the rule-conditions met AND did we wait long enough? 
+      {                                                                                                         
+          procesOutputValueConditionally(y, true);                                         // Yes! Update io-port en status variable
       }
+      else 
+      { 
+ 	      if ( isEveryConditionFulfilled )                                                     // But are the rule-conditions met?
+	      {  
+		      ioDelay[y]++;                                                                      // Yes! Count up. Maybe next iteration better
+		    }
+	        else
+		    {
+          procesOutputValueConditionally(y, false);                                          // No! Reset ioport, status value and start all over. 
+          ioDelay[y] = 0;
+		    }
+      }
+      
     }
-    else {                                                                                             
+    else 
+    {                                                                                       // Disabled rule                                                                                           
       BIT_CLEAR(currentStatus.outputsStatus, y);
     }
   }
 }
 
-bool compare(int16_t data1, int16_t data2, byte comp) {
-  if ( (comp == COMPARATOR_EQUAL)          && (data1 == data2) ) { return true; }
-  if ( (comp == COMPARATOR_NOT_EQUAL)      && (data1 != data2) ) { return true; }
-  if ( (comp == COMPARATOR_GREATER)        && (data1 >  data2) ) { return true; }
-  if ( (comp == COMPARATOR_GREATER_EQUAL)  && (data1 >= data2) ) { return true; }
-  if ( (comp == COMPARATOR_LESS)           && (data1 < data2)  ) { return true; }
-  if ( (comp == COMPARATOR_LESS_EQUAL)     && (data1 <= data2) ) { return true; }
-  return false;   // shouldn't happen
+
+bool compare(int16_t data1, int16_t data2, byte comp) 
+{
+  return (  ( (comp == COMPARATOR_EQUAL)          && (data1 == data2) ) 
+         || ( (comp == COMPARATOR_NOT_EQUAL)      && (data1 != data2) ) 
+         || ( (comp == COMPARATOR_GREATER)        && (data1 >  data2) ) 
+         || ( (comp == COMPARATOR_GREATER_EQUAL)  && (data1 >= data2) )
+         || ( (comp == COMPARATOR_LESS)           && (data1 < data2)  ) 
+         || ( (comp == COMPARATOR_LESS_EQUAL)     && (data1 <= data2) ) );
 }
 
-bool combineConditions(bool bool1, bool bool2, byte operation) {
-  if (operation == BITWISE_AND) { return (bool1 & bool2); }
-  if (operation == BITWISE_OR)  { return (bool1 | bool2); }
-  if (operation == BITWISE_XOR) { return (bool1 ^ bool2); }
-  return false;  // shouldn't happen
+bool combineConditions(bool bool1, bool bool2, byte operation) 
+{
+  return (  ( (operation == BITWISE_AND) && (bool1 & bool2) )
+         || ( (operation == BITWISE_OR)  && (bool1 | bool2) )
+         || ( (operation == BITWISE_XOR) && (bool1 ^ bool2) ) );
 }
 
-void procesOutputValueConditionally(uint8_t y, bool isFulfilled) {
+
+void procesOutputValueConditionally(uint8_t y, bool isFulfilled) 
+{
   uint8_t valueToSet = (configPage13.outputInverted & (1U << y)) ^ isFulfilled;
   digitalWrite(configPage13.outputPin[y], valueToSet);
-  if ( valueToSet == 0  )  {
+  if ( valueToSet == 0  )  
+  {
     BIT_CLEAR(currentStatus.outputsStatus, y);
-  }  else  {
+  }  
+  else  
+  {
     BIT_SET(currentStatus.outputsStatus, y);
   }
 }
+
+
 int16_t ProgrammableIOGetData(uint16_t index)
 {
   int16_t result;


### PR DESCRIPTION
There are some issues with the passing of Programmable Output values to TunerStudio. 

1) 
When the conditions for a programmable Output Rule are fulfilled AND a delay is set for this rule, the actual output pin gets its new value after the delay has passed. That is expected behavior. 
But the corresponding value in TS gets its new value already on the moment the conditions get fulfilled (regardless of the delay). So that is too early.  

2)
When an output rule uses inverted logic, it is reflected in the value presented on the output pin. This is expected behavior.
But the corresponding values in TS always are the values without inverted logic. So the value in TS does not reflect the right values in case of inverted logic. 


And I took the liberty to clean up the code of ‘checkProgrammableIO()’ in ‘utilities.ino’. If that is too much or unwanted, I can make a PR with only the essentials of this bugfix. 
