### PR TITLE
Optimizations and refactoring of ignition schedules

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ board = black_f407ve
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
-upload_protocol = dfu
+upload_protocol = stlink
 debug_tool = stlink
 monitor_speed = 115200
 
@@ -145,9 +145,9 @@ monitor_speed = 115200
 
 [platformio]
 src_dir=speeduino
-default_envs = megaatmega2560
+;default_envs = megaatmega2560
 ;The following lines are for testing / experimentation only. Comment the line above to try them out
-;default_envs = black_F407VE
+default_envs = black_F407VE
 ;default_envs = teensy35
 ;default_envs = teensy40
 ;env_default = LaunchPad_tm4c1294ncpdt

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -143,6 +143,7 @@ STM32RTC& rtc = STM32RTC::getInstance();
     Timer3.setMode(2, TIMER_OUTPUT_COMPARE);
     Timer3.setMode(3, TIMER_OUTPUT_COMPARE);
     Timer3.setMode(4, TIMER_OUTPUT_COMPARE);
+  
     Timer1.setMode(1, TIMER_OUTPUT_COMPARE);
 
     //Attach interrupt functions

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -490,7 +490,7 @@ extern bool channel6InjEnabled;
 extern bool channel7InjEnabled;
 extern bool channel8InjEnabled;
 
-extern int ignition1EndAngle;
+extern int16_t ignition1EndAngle;
 extern int ignition2EndAngle;
 extern int ignition3EndAngle;
 extern int ignition4EndAngle;
@@ -539,7 +539,7 @@ extern volatile uint16_t ignitionCount; /**< The count of ignition events that h
   extern byte tertiaryTriggerEdge;
 #endif
 extern int CRANK_ANGLE_MAX;
-extern int CRANK_ANGLE_MAX_IGN;
+extern int16_t CRANK_ANGLE_MAX_IGN;
 extern int CRANK_ANGLE_MAX_INJ; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 extern volatile uint32_t runSecsX10; /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
 extern volatile uint32_t seclx10; /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -490,7 +490,7 @@ extern bool channel6InjEnabled;
 extern bool channel7InjEnabled;
 extern bool channel8InjEnabled;
 
-extern int16_t ignition1EndAngle;
+extern int ignition1EndAngle;
 extern int ignition2EndAngle;
 extern int ignition3EndAngle;
 extern int ignition4EndAngle;
@@ -591,7 +591,7 @@ struct statuses {
   int batADC;
   int O2ADC;
   int O2_2ADC;
-  int dwell;
+  uint16_t dwell; //commanded dwell time [uS], can not really be negative so use uint16_t
   byte dwellCorrection; /**< The amount of correction being applied to the dwell time. */
   byte battery10; /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
   int8_t advance; /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -107,7 +107,7 @@ bool channel6InjEnabled = false;
 bool channel7InjEnabled = false;
 bool channel8InjEnabled = false;
 
-int ignition1EndAngle = 0;
+int16_t ignition1EndAngle = 0;
 int ignition2EndAngle = 0;
 int ignition3EndAngle = 0;
 int ignition4EndAngle = 0;
@@ -146,7 +146,7 @@ volatile uint16_t ignitionCount; /**< The count of ignition events that have tak
   byte tertiaryTriggerEdge;
 #endif
 int CRANK_ANGLE_MAX = 720;
-int CRANK_ANGLE_MAX_IGN = 360;
+int16_t CRANK_ANGLE_MAX_IGN = 360;
 int CRANK_ANGLE_MAX_INJ = 360; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -107,7 +107,7 @@ bool channel6InjEnabled = false;
 bool channel7InjEnabled = false;
 bool channel8InjEnabled = false;
 
-int16_t ignition1EndAngle = 0;
+int ignition1EndAngle = 0;
 int ignition2EndAngle = 0;
 int ignition3EndAngle = 0;
 int ignition4EndAngle = 0;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -413,7 +413,7 @@ void initialiseAll()
     //Calculate the number of degrees between cylinders
     //Swet some default values. These will be updated below if required. 
     CRANK_ANGLE_MAX = 720;
-    CRANK_ANGLE_MAX_IGN = 360;
+    CRANK_ANGLE_MAX_IGN = 360; //variable actually, depending ignition mode
     CRANK_ANGLE_MAX_INJ = 360;
     channel1InjEnabled = true;
     channel2InjEnabled = false;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1163,7 +1163,7 @@ void initialiseAll()
         break;
     }
 
-    initialiseSchedulers(); //reapply all nessesary changes to the Schedulers also.
+    initialiseSchedulers(); //reapply all nessesary changes to the Schedulers also(coil charge functions and channelIgnDegrees).
 
     //Begin priming the fuel pump. This is turned off in the low resolution, 1s interrupt in timers.ino
     //First check that the priming time is not 0

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1163,6 +1163,8 @@ void initialiseAll()
         break;
     }
 
+    initialiseSchedulers(); //reapply all nessesary changes to the Schedulers also.
+
     //Begin priming the fuel pump. This is turned off in the low resolution, 1s interrupt in timers.ino
     //First check that the priming time is not 0
     if(configPage2.fpPrime > 0)

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -81,7 +81,7 @@ void setFuelSchedule6(unsigned long timeout, unsigned long duration);
 void setFuelSchedule7(unsigned long timeout, unsigned long duration);
 void setFuelSchedule8(unsigned long timeout, unsigned long duration);
 
-void setIgnitionSchedule(struct Schedule *ignitionSchedule , unsigned long timeout, unsigned long duration);
+void setIgnitionSchedule(struct Schedule *ignitionSchedule , int16_t crankAngle,int channelIgnDegrees,int ignitionEndAngle, unsigned long duration);
 void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -80,6 +80,8 @@ void setFuelSchedule5(unsigned long timeout, unsigned long duration);
 void setFuelSchedule6(unsigned long timeout, unsigned long duration);
 void setFuelSchedule7(unsigned long timeout, unsigned long duration);
 void setFuelSchedule8(unsigned long timeout, unsigned long duration);
+
+void setIgnitionSchedule(struct Schedule *ignitionSchedule , unsigned long timeout, unsigned long duration);
 void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
@@ -88,6 +90,35 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
 void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
+
+void ign1TimerEnable();
+void ign2TimerEnable();
+void ign3TimerEnable();
+void ign4TimerEnable();
+void ign5TimerEnable();
+void ign6TimerEnable();
+void ign7TimerEnable();
+void ign8TimerEnable();
+
+//those small functions are needed to use ignition counter definitions on different platvorms
+uint32_t getIgn1Counter();
+uint32_t getIgn2Counter();
+uint32_t getIgn3Counter();
+uint32_t getIgn4Counter();
+uint32_t getIgn5Counter();
+uint32_t getIgn6Counter();
+uint32_t getIgn7Counter();
+uint32_t getIgn8Counter();
+
+//those small functions are needed to use ignition counter compare definitions on different platvorms
+void setIgnition1Compare(uint32_t value);
+void setIgnition2Compare(uint32_t value);
+void setIgnition3Compare(uint32_t value);
+void setIgnition4Compare(uint32_t value);
+void setIgnition5Compare(uint32_t value);
+void setIgnition6Compare(uint32_t value);
+void setIgnition7Compare(uint32_t value);
+void setIgnition8Compare(uint32_t value);
 
 inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((always_inline));
 
@@ -142,15 +173,19 @@ struct Schedule {
   volatile ScheduleStatus Status;
   volatile byte schedulesSet; //A counter of how many times the schedule has been set
   void (*StartCallback)(); //Start Callback function for schedule
-  void (*EndCallback)(); //Start Callback function for schedule
+  void (*EndCallback)(); //End Callback function for schedule
   volatile unsigned long startTime; /**< The system time (in uS) that the schedule started, used by the overdwell protection in timers.ino */
   volatile COMPARE_TYPE startCompare; //The counter value of the timer when this will start
-  volatile COMPARE_TYPE endCompare;
+  volatile COMPARE_TYPE endCompare; //The counter value when pulse will stop
 
   unsigned int nextStartCompare;
   unsigned int nextEndCompare;
   volatile bool hasNextSchedule = false;
   volatile bool endScheduleSetByDecoder = false;
+
+  uint32_t (*getIgnCounter)(); //Function for getting counter value
+  void (*setIgnitionCompare)(uint32_t); //Function for setting counter compare value
+  void (*ignTimerEnable)(); //Function to enable timer for specific channel
 };
 
 //Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables. They are removed in this struct to save RAM

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -987,195 +987,60 @@ void loop()
         while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
-        int16_t tempEndAngle;
-        tempCrankAngle = crankAngle - channel1IgnDegrees;
-        if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-        tempEndAngle = ignition1EndAngle - channel1IgnDegrees;
-        if ( tempEndAngle < 0) { tempEndAngle += CRANK_ANGLE_MAX_IGN; }
-
-        if (tempEndAngle <= tempCrankAngle)   { tempEndAngle += CRANK_ANGLE_MAX_IGN; }//calculate into the next cycle
-        if ( (tempEndAngle > tempCrankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
+        if (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT) )
         {
-          unsigned long ignition1EndTime = 0;
-          ignition1EndTime= angleToTime((tempEndAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV);
-          setIgnitionSchedule(&ignitionSchedule1, ignition1EndTime, currentStatus.dwell + fixedCrankingOverride); //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride, 
+          setIgnitionSchedule(&ignitionSchedule1, crankAngle, channel1IgnDegrees, ignition1EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
         
 #if IGN_CHANNELS >= 2
-        if (maxIgnOutputs >= 2)
+        if (maxIgnOutputs >= 2 && !BIT_CHECK(curRollingCut, IGN2_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel2IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition2StartAngle - channel2IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition2StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule2.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition2StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition2StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition2StartTime = 0; }
-
-            if ( (ignition2StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN2_CMD_BIT)) )
-            {
-              setIgnitionSchedule2(ign2StartFunction,
-                        ignition2StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign2EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule2, crankAngle, channel2IgnDegrees, ignition2EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 3
-        if (maxIgnOutputs >= 3)
+        if (maxIgnOutputs >= 3 && !BIT_CHECK(curRollingCut, IGN3_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel3IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition3StartAngle - channel3IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition3StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule3.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition3StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition3StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition3StartTime = 0; }
-
-            if ( (ignition3StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN3_CMD_BIT)) )
-            {
-              setIgnitionSchedule3(ign3StartFunction,
-                        ignition3StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign3EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule3, crankAngle, channel3IgnDegrees, ignition3EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 4
-        if (maxIgnOutputs >= 4)
+        if (maxIgnOutputs >= 4 && !BIT_CHECK(curRollingCut, IGN4_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel4IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition4StartAngle - channel4IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition4StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule4.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition4StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition4StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition4StartTime = 0; }
-
-            if ( (ignition4StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN4_CMD_BIT)) )
-            {
-              setIgnitionSchedule4(ign4StartFunction,
-                        ignition4StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign4EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule4, crankAngle, channel4IgnDegrees, ignition4EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 5
-        if (maxIgnOutputs >= 5)
+        if (maxIgnOutputs >= 5  && !BIT_CHECK(curRollingCut, IGN5_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel5IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition5StartAngle - channel5IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition5StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule5.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition5StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition5StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition5StartTime = 0; }
-
-            if ( (ignition5StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN5_CMD_BIT)) )
-            {
-              setIgnitionSchedule5(ign5StartFunction,
-                        ignition5StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign5EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule5, crankAngle, channel5IgnDegrees, ignition5EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 6
-        if (maxIgnOutputs >= 6)
+        if (maxIgnOutputs >= 6 && !BIT_CHECK(curRollingCut, IGN6_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel6IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition6StartAngle - channel6IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition6StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule6.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition6StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition6StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition6StartTime = 0; }
-
-            if ( (ignition6StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN6_CMD_BIT)) )
-            {
-              setIgnitionSchedule6(ign6StartFunction,
-                        ignition6StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign6EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule6, crankAngle, channel6IgnDegrees, ignition6EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 7
-        if (maxIgnOutputs >= 7)
+        if (maxIgnOutputs >= 7 && !BIT_CHECK(curRollingCut, IGN7_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel7IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition7StartAngle - channel7IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition7StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule7.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition7StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition7StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition7StartTime = 0; }
-
-            if ( (ignition7StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN7_CMD_BIT)) )
-            {
-              setIgnitionSchedule7(ign7StartFunction,
-                        ignition7StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign7EndFunction
-                        );
-            }
+          setIgnitionSchedule(&ignitionSchedule7, crankAngle, channel7IgnDegrees, ignition7EndAngle, currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
 
 #if IGN_CHANNELS >= 8
-        if (maxIgnOutputs >= 8)
+        if (maxIgnOutputs >= 8  && !BIT_CHECK(curRollingCut, IGN8_CMD_BIT))
         {
-            tempCrankAngle = crankAngle - channel8IgnDegrees;
-            if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
-            tempStartAngle = ignition8StartAngle - channel8IgnDegrees;
-            if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-
-            unsigned long ignition8StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule8.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
-            if(tempStartAngle > tempCrankAngle) { ignition8StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
-            //else if (tempStartAngle < tempCrankAngle) { ignition8StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
-            else { ignition8StartTime = 0; }
-
-            if ( (ignition8StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN8_CMD_BIT)) )
-            {
-              setIgnitionSchedule8(ign8StartFunction,
-                        ignition8StartTime,
-                        currentStatus.dwell + fixedCrankingOverride,
-                        ign8EndFunction
-                        );
-            }
-        }
+          setIgnitionSchedule(&ignitionSchedule8, crankAngle, channel8IgnDegrees, ignition8EndAngle, currentStatus.dwell + fixedCrankingOverride);
+        } 
 #endif
 
       } //Ignition schedules on

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -691,7 +691,7 @@ void loop()
       //Set dwell
       //Dwell is stored as ms * 10. ie Dwell of 4.3ms would be 43 in configPage4. This number therefore needs to be multiplied by 100 to get dwell in uS
       if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) ) {
-        currentStatus.dwell =  (configPage4.dwellCrank * 100); //use cranking dwell
+        currentStatus.dwell =  ((uint16_t)configPage4.dwellCrank * 100); //use cranking dwell
       }
       else 
       {
@@ -987,22 +987,18 @@ void loop()
         while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
-        int tempEndAngle;
+        int16_t tempEndAngle;
         tempCrankAngle = crankAngle - channel1IgnDegrees;
         if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_IGN; }
         tempEndAngle = ignition1EndAngle - channel1IgnDegrees;
-        if ( tempEndAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+        if ( tempEndAngle < 0) { tempEndAngle += CRANK_ANGLE_MAX_IGN; }
 
         if (tempEndAngle <= tempCrankAngle)   { tempEndAngle += CRANK_ANGLE_MAX_IGN; }//calculate into the next cycle
         if ( (tempEndAngle > tempCrankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
         {
           unsigned long ignition1EndTime = 0;
           ignition1EndTime= angleToTime((tempEndAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV);
-          setIgnitionSchedule1(ign1StartFunction,
-                    ignition1EndTime,
-                    currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
-                    ign1EndFunction
-                    );
+          setIgnitionSchedule(&ignitionSchedule1, ignition1EndTime, currentStatus.dwell + fixedCrankingOverride); //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride, 
         }
 #endif
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -987,14 +987,13 @@ void loop()
         while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
-        if ( (ignition1StartAngle <= crankAngle) && (ignitionSchedule1.Status == RUNNING) ) { ignition1StartAngle += CRANK_ANGLE_MAX_IGN; }
-        //if ( (ignition1StartAngle > crankAngle) && (curRollingCut != 1) )
-        if ( (ignition1StartAngle > crankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
+        if ( (ignition1EndAngle <= crankAngle) && (ignitionSchedule1.Status == RUNNING) ) { ignition1EndAngle += CRANK_ANGLE_MAX_IGN; }
+        if ( (ignition1EndAngle > crankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
         {
           
           setIgnitionSchedule1(ign1StartFunction,
                     //((unsigned long)(ignition1StartAngle - crankAngle) * (unsigned long)timePerDegree),
-                    angleToTime((ignition1StartAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV),
+                    angleToTime((ignition1EndAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV)-currentStatus.dwell - fixedCrankingOverride,
                     currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
                     ign1EndFunction
                     );


### PR DESCRIPTION
Made ignition timing be calculated in the schedulers from the IgnitionEndAngle. Should be more accurate because IgnitionEndAngle is directly the angle that the spark is suppose to be fired at.

Improvements to the dwell timing: 
-Dwell time is directly applied to timers now without intermediate conversion to the dwell angle domain and back. 
-Dwell time is controlled entirely in the interrupts, so even when main loop completely locks up, it do not cause changes to the dwell time.

Also reduced code repetition and made all ignition channels to use the same function. To get them all channels accept the changes with less effort. 

Cons: Unknown effect to the per tooth ignition timing ,at the moment!