### PR TITLE
Fix CORE4 Spare In 1

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1904,7 +1904,7 @@ void setPinMapping(byte boardID)
       pinIAT = A11; //IAT sensor pin
       pinCLT = A4; //CLS sensor pin
       pinO2 = A12; //O2 Sensor pin
-      pinO2_2 = A13; //O2 sensor pin (second sensor)
+      pinO2_2 = A5; //O2 sensor pin (second sensor)
       pinBat = A1; //Battery reference voltage pin
       pinSpareTemp1 = A14; //spare Analog input 1
       pinLaunch = 24; //Can be overwritten below


### PR DESCRIPTION
Pin A13 is "Sparein1", allocating it to the second O2 sensor prevents it from working, an unused pin (A5) has now been allocated to O2_2