### PR TITLE
Fix CAN library for 2.0.0 STM32 core support 

### DIFF
--- a/speeduino/src/STM32_CAN/STM32_CAN.h
+++ b/speeduino/src/STM32_CAN/STM32_CAN.h
@@ -9,7 +9,7 @@ https://github.com/nopnop2002/Arduino-STM32-CAN
 #ifndef STM32_CAN_H
 #define STM32_CAN_H
 
-#if defined(STM32F407xx) || defined(STM32F103xB) || defined(STM32F405xx)
+#if defined(STM32F407xx) || defined(STM32F1xx) || defined(STM32F405xx)
 #include <Arduino.h>
 
 #define STM32_CAN_TIR_TXRQ              (1U << 0U)  // Bit 0: Transmit Mailbox Request
@@ -48,7 +48,7 @@ typedef const struct
   uint8_t BRP;
 } CAN_bit_timing_config_t;
 
-typedef enum CAN_PINS {DEF, ALT, ALT2,} CAN_PINS;
+typedef enum CAN_PINS {DEF, ALT, ALT_2,} CAN_PINS;
 
 //STM32 has only 3 TX mailboxes
 typedef enum CAN_MAILBOX {


### PR DESCRIPTION
With introduction of 2.0.0 STM32 core version, there was ENUM conflict in the CAN-bus library. Which is now fixed in this PR. There is also few fixes for STM32F1 to make the library more generic and also some code duplication has been removed.