### PR TITLE
fix: install STM32RTC from Github

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ platform = ststm32
 framework = arduino
 ;board = genericSTM32F407VET6
 board = black_f407ve
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
@@ -71,7 +71,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f401cc
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
 upload_protocol = dfu
@@ -83,7 +83,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
 board_build.core = stm32
 build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS
 upload_protocol = dfu
@@ -95,7 +95,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
 board_build.core = stm32
 build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
@@ -107,7 +107,7 @@ platform = ststm32
 framework = arduino
 ; framework-arduinoststm32
 board = bluepill_f103c8_128k
-lib_deps = EEPROM, stm32duino/STM32duino RTC
+lib_deps = EEPROM, https://github.com/stm32duino/STM32RTC#1.1.0
 ;build_flags = -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map
 build_flags = -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
 


### PR DESCRIPTION
This fixes the build on the latest `ststm32` platform. With release of the platform [2.0.0](https://github.com/stm32duino/Arduino_Core_STM32/releases/tag/2.0.0) it moved some RTC files from the core to the `STM32RTC` library. 

Platform side:
https://github.com/stm32duino/Arduino_Core_STM32/pull/1110

Library side:
https://github.com/stm32duino/STM32RTC/commit/bf74a2c0c62aab65380e699c4d51c6414f67345a

But the library is wrongly tagged in the PlatformIO library manager, the latest release is 1.1.0 of May 2020. Since that release is missing the moved core files it breaks the build.
I opened an issue to fix it but the maintainer isn't that keen to look into it:
https://github.com/stm32duino/STM32RTC/issues/49

I will followup on the issue on the PIO side but for now this will fix the build.