### PR TITLE
Fix boost cut

### DIFF
--- a/speeduino/engineProtection.ino
+++ b/speeduino/engineProtection.ino
@@ -33,6 +33,7 @@ byte checkRevLimit()
 byte checkBoostLimit()
 {
   byte boostLimitActive = 0;
+  BIT_CLEAR(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_MAP);
   //Boost cutoff is very similar to launchControl, but with a check against MAP rather than a switch
   if( (configPage6.boostCutEnabled > 0) && (currentStatus.MAP > (configPage6.boostLimit * 2)) ) //The boost limit is divided by 2 to allow a limit up to 511kPa
   {

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -301,7 +301,7 @@ static inline void readMAP()
 
     case 3:
       //Average of an ignition event
-      if ( (currentStatus.RPM > 0) && (currentStatus.hasSync == true) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running, fall back to instantaneous reads
+      if ( (currentStatus.RPM > 0) && (currentStatus.hasSync == true) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
       {
         if( (MAPcurRev == ignitionCount) ) //Watch for a change in the ignition counter to determine whether we're still on the same event
         {


### PR DESCRIPTION
Reset boost cut bit if not enabled and fix map reading.
When in Map reading = event average and boost cut engaged (cut ignition) the map reading got stuck because there was no ignition event. With this pull request, it defaults to instantaneous reading if engine protection is engaged.