### PR TITLE
EMAP gauge addition

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2700,7 +2700,7 @@ menuDialog = main
 
         field = "#EMAP Sensor"
         field = "Use EMAP sensor", useEMAP
-        field = "Analog pin to use for ext. Baro sensor", EMAPPin,  { useEMAP }
+        field = "Analog pin to use", EMAPPin,  { useEMAP }
 
         settingSelector = "Common Pressure Sensors",  { useEMAP }
             settingOption = "MPX4115",  EMAPMin=10,   EMAPMax=118 ; https://www.nxp.com/docs/en/data-sheet/MPX4115.pdf
@@ -4511,6 +4511,7 @@ cmdVSSratio6 =      "E\x99\x06"
     mapGauge_psi      = map_psi,       "Engine MAP (PSI)",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
     mapGauge_bar      = map_bar,       "Engine MAP (BAR)",        "Bar",          -1,     3,      -1,     -1,    5,  5,  2, 2
     mapGauge_vacBoost = map_vacboost,  "Engine MAP (in-Hg/PSI)",  "in-Hg/PSI",    -30,    30,     -30,    -30, 30, 30, 1, 1
+    emapGauge         = emap,          "Exhaust MAP",             "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
     baroGauge         = baro,          "Baro Pressure",           "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
     batteryVoltage    = batteryVoltage,"Battery Voltage",         "volts",        0,    25,      8,     9,   15,   16, 2, 2
     vssGauge          = vss,           "Vehicle Speed (kph)",     "km/h",         0,    250,     5,    10,   180,   200, 0, 0
@@ -4634,7 +4635,7 @@ cmdVSSratio6 =      "E\x99\x06"
    ; you change it.
 
    ochGetCommand    = "r\$tsCanId\x30%2o%2c"
-   ochBlockSize     =  119
+   ochBlockSize     =  121
 
    secl             = scalar, U08,  0, "sec",    1.000, 0.000
    status1          = scalar, U08,  1, "bits",   1.000, 0.000
@@ -4774,6 +4775,7 @@ cmdVSSratio6 =      "E\x99\x06"
    advance1         = scalar,   S08,    116, "deg",      1.000, 0.000
    advance2         = scalar,   S08,    117, "deg",      1.000, 0.000
    sd_status        = scalar,   U08,    118, "",         1.0,   0.0
+   emap             = scalar,   U16,    119, "kpa",    1.000, 0.000
    ;sd_filenum       = scalar,   U16,    117, "", 1, 0
    ;sd_error         = scalar,   U08,    119, "", 1, 0
    ;sd_phase         = scalar,   U08,    120, "", 1, 0
@@ -4949,6 +4951,7 @@ cmdVSSratio6 =      "E\x99\x06"
 
    entry = advance1,         "Advance 1",      int,     "%d"
    entry = advance2,         "Advance 2",      int,     "%d"
+   entry = emap,             "EMAP",           int,     "%d", { useEMAP }
 
 [LoggerDefinition]
     ; valid logger types: composite, tooth, trigger, csv

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -903,6 +903,8 @@ byte getStatusEntry(uint16_t byteNum)
     case 116: statusValue = currentStatus.advance1; break; //advance 1 (%)
     case 117: statusValue = currentStatus.advance2; break; //advance 2 (%)
     case 118: statusValue = currentStatus.TS_SD_Status; break; //SD card status
+    case 119: statusValue = lowByte(currentStatus.EMAP); break; //2 bytes for EMAP
+    case 120: statusValue = highByte(currentStatus.EMAP); break;
   }
 
   return statusValue;

--- a/speeduino/logger.h
+++ b/speeduino/logger.h
@@ -10,8 +10,8 @@
 #define LOGGER_H
 
 #ifndef UNIT_TEST // Scope guard for unit testing
-  #define LOG_ENTRY_SIZE      119 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
-  #define SD_LOG_ENTRY_SIZE   119 /**< The size of the live data packet used by the SD car.*/
+  #define LOG_ENTRY_SIZE      121 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
+  #define SD_LOG_ENTRY_SIZE   121 /**< The size of the live data packet used by the SD car.*/
 #else
   #define LOG_ENTRY_SIZE      1 /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
   #define SD_LOG_ENTRY_SIZE   1 /**< The size of the live data packet used by the SD car.*/

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -174,6 +174,22 @@ static inline void instanteneousMAPReading()
 
   currentStatus.MAP = fastMap10Bit(currentStatus.mapADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
   if(currentStatus.MAP < 0) { currentStatus.MAP = 0; } //Sanity check
+  
+  //Repeat for EMAP if it's enabled
+  if(configPage6.useEMAP == true)
+  {
+    tempReading = analogRead(pinEMAP);
+    tempReading = analogRead(pinEMAP);
+
+    //Error check
+    if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
+      {
+        currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
+      }
+    else { mapErrorCount += 1; }
+    currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.EMAPMin, configPage2.EMAPMax);
+    if(currentStatus.EMAP < 0) { currentStatus.EMAP = 0; } //Sanity check
+  }
 
 }
 


### PR DESCRIPTION
Speeduino FW already has possibility to use EMAP sensor for IMAP/EMAP load calculation but no way of monitorin/checking what the actual EMAP reading is. This PR adds the EMAP gauge and few other missing bits. The EMAP gauge is also useful for monitoring turbo exhaust back pressure even when IMAP/EMAP load calculation is not in use, because that tells how choked up the turbo is in the setup. It's at least what I use the EMAP gauge for.