### PR TITLE
Add doxygen documentation

### DIFF
--- a/speeduino/Doxyfile
+++ b/speeduino/Doxyfile
@@ -794,7 +794,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = .
+##INPUT                  = .
+# MUST be enabled to later pick up README.md from ".."
+INPUT                  = . ../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -987,7 +989,8 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+#USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -3,6 +3,9 @@ Speeduino - Simple engine management for the Arduino Mega 2560 platform
 Copyright (C) Josh Stewart
 A full copy of the license may be found in the projects root directory
 */
+/** @file
+ * Process Incoming and outgoing serial communications.
+ */
 #include "globals.h"
 #include "comms.h"
 #include "cancomms.h"
@@ -24,10 +27,10 @@ bool isMap = true; /**< Whether or not the currentPage contains only a 3D map th
 unsigned long requestCount = 0; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
 byte currentCommand; /**< The serial command that is currently being processed. This is only useful when cmdPending=True */
 bool cmdPending = false; /**< Whether or not a serial request has only been partially received. This occurs when a command character has been received in the serial buffer, but not all of its arguments have yet been received. If true, the active command will be stored in the currentCommand variable */
-bool chunkPending = false; /**< Whether or not the current chucnk write is complete or not */
+bool chunkPending = false; /**< Whether or not the current chunk write is complete or not */
 uint16_t chunkComplete = 0; /**< The number of bytes in a chunk write that have been written so far */
 uint16_t chunkSize = 0; /**< The complete size of the requested chunk write */
-int valueOffset; /**< THe memory offset within a given page for a value to be read from or written to. Note that we cannot use 'offset' as a variable name, it is a reserved word for several teensy libraries */
+int valueOffset; /**< The memory offset within a given page for a value to be read from or written to. Note that we cannot use 'offset' as a variable name, it is a reserved word for several teensy libraries */
 byte tsCanId = 0;     // current tscanid requested
 byte inProgressOffset;
 byte inProgressLength;
@@ -36,11 +39,12 @@ bool serialInProgress = false;
 bool toothLogSendInProgress = false;
 bool compositeLogSendInProgress = false;
 
-/*
-  Processes the data on the serial buffer.
-  Can be either a new command or a continuation of one that is already in progress:
-    * cmdPending = If a command has started but is wairing on further data to complete
-    * chunkPending = Specifically for the new receive value method where TS will send a known number of contiguous bytes to be written to a table
+/** Processes the incoming data on the serial buffer based on the command sent.
+Can be either data for a new command or a continuation of data for command that is already in progress:
+- cmdPending = If a command has started but is wairing on further data to complete
+- chunkPending = Specifically for the new receive value method where TS will send a known number of contiguous bytes to be written to a table
+
+Comands are single byte (letter symbol) commands.
 */
 void command()
 {
@@ -753,7 +757,14 @@ void command()
       break;
   }
 }
-
+/** Send a numbered byte-field (partial field in case of mul;ti-byte fields) from "current status" structure.
+ * Notes on fields:
+ * - Numbered field will be fields from @ref currentStatus, but not at all in the internal order of strct (e.g. field RPM value, number 14 will be
+ *   2nd field in struct)
+ * - The fields stored in multi-byte types will be accessed lowbyte and highbyte separately (e.g. PW1 will be broken into numbered byte-fields 75,76)
+ * @param byteNum - byte-Field number
+ * @return Field value in 1 byte size struct fields or 1 byte partial value (chunk) on multibyte fields.
+ */
 byte getStatusEntry(uint16_t byteNum)
 {
   byte statusValue = 0;
@@ -911,9 +922,15 @@ byte getStatusEntry(uint16_t byteNum)
   //Every 2-byte integer added here should have it's lowByte index added to fsIntIndex array on globals.ino@L116
 }
 
-/*
-This function returns the current values of a fixed group of variables
-*/
+/** Send a status record back to tuning/logging SW.
+ * This will "live" information from @ref currentStatus struct.
+ * @param offset - Start field number
+ * @param packetLength - Length of actual message (after possible ack/confirm headers)
+ * @param cmd - ??? - Will be used as some kind of ack on CANSerial
+ * @param portNum - Port number (0=Serial, 3=CANSerial)
+ * E.g. tuning sw command 'A' (Send all values) will send data from field number 0, LOG_ENTRY_SIZE fields.
+ * @return the current values of a fixed group of variables
+ */
 //void sendValues(int packetlength, byte portNum)
 void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
 {  
@@ -1144,11 +1161,12 @@ namespace {
   }
 }
 
-/**
- * @brief Packs the data within the current page (As set with the 'P' command) into a buffer and sends it.
+/** Pack the data within the current page (As set with the 'P' command) into a buffer and send it.
  * 
- * Note that some translation of the data is required to lay it out in the way Megasqurit / TunerStudio expect it
- * Data is sent in binary format, as defined by in each page in the ini
+ * Creates a page iterator by @ref page_begin() (See: pages.cpp). Sends page given in @ref currentPage.
+ * 
+ * Note that some translation of the data is required to lay it out in the way Megasqurit / TunerStudio expect it.
+ * Data is sent in binary format, as defined by in each page in the speeduino.ini.
  */
 void sendPage()
 {
@@ -1163,7 +1181,7 @@ void sendPage()
 
 namespace {
 
-  // Prints each element in the range [first,last)
+  /// Prints each element in the memory byte range (*first, *last).
   void serial_println_range(const byte *first, const byte *last)
   {
     while (first!=last)
@@ -1252,8 +1270,8 @@ namespace {
   }
 }
 
-/**
- * @brief Similar to sendPage(), however data is sent in human readable format
+/** Send page as ASCII for debugging purposes.
+ * Similar to sendPage(), however data is sent in human readable format. Sends page given in @ref currentPage.
  * 
  * This is used for testing only (Not used by TunerStudio) in order to see current map and config data without the need for TunerStudio. 
  */
@@ -1289,7 +1307,7 @@ void sendPageASCII()
 
     case ignSetPage:
       Serial.println(F("\nPg 4 Cfg"));
-      Serial.println(configPage4.triggerAngle);// configPsge2.triggerAngle is an int so just display it without complication
+      Serial.println(configPage4.triggerAngle);// configPage4.triggerAngle is an int so just display it without complication
       // Following loop displays byte values after that first int up to but not including the first array in config page 2
       serial_println_range((byte*)&configPage4.FixAng, configPage4.taeBins);
       serial_print_space_delimited_array(configPage4.taeBins);
@@ -1362,10 +1380,10 @@ void sendPageASCII()
 }
 
 
-/**
- * @brief Processes an incoming stream of calibration data from TunerStudio. Result is store in EEPROM and memory
+/** Processes an incoming stream of calibration data (for CLT, IAT or O2) from TunerStudio.
+ * Result is store in EEPROM and memory.
  * 
- * @param tableID Which calibration table to process. 0 = Coolant Sensor. 1 = IAT Sensor. 2 = O2 Sensor.
+ * @param tableID - calibration table to process. 0 = Coolant Sensor. 1 = IAT Sensor. 2 = O2 Sensor.
  */
 void receiveCalibration(byte tableID)
 {
@@ -1452,8 +1470,7 @@ void receiveCalibration(byte tableID)
   writeCalibration();
 }
 
-/*
-Send 256 tooth log entries
+/** Send 256 tooth log entries to serial.
  * if useChar is true, the values are sent as chars to be printed out by a terminal emulator
  * if useChar is false, the values are sent as a 2 byte integer which is readable by TunerStudios tooth logger
 */

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -4,12 +4,22 @@ Copyright (C) Josh Stewart
 A full copy of the license may be found in the projects root directory
 */
 
-/*
+/** @file
+Corrections to injection pulsewidth.
 The corrections functions in this file affect the fuel pulsewidth (Either increasing or decreasing)
 based on factors other than the VE lookup.
 
-These factors include temperature (Warmup Enrichment and After Start Enrichment), Acceleration/Decelleration,
-Flood clear mode etc.
+These factors include:
+- Temperature (Warmup Enrichment and After Start Enrichment)
+- Acceleration/Decelleration
+- Flood clear mode
+- etc.
+
+Most correction functions return value 100 (like 100% == 1) for no need for correction.
+
+There are 2 top level functions that call more detailed corrections for Fuel and Ignition respectively:
+- @ref correctionsFuel() - All fuel related corrections
+- @ref correctionsIgn() - All ignition related corrections
 */
 //************************************************************************************************************
 
@@ -22,7 +32,11 @@ Flood clear mode etc.
 #include "src/PID_v1/PID_v1.h"
 
 long PID_O2, PID_output, PID_AFRTarget;
-PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE); //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
+/** Instance of the PID object in case that algorithm is used (Always instantiated).
+* Needs to be global as it maintains state outside of each function call.
+* Comes from Arduino (?) PID library.
+*/
+PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE);
 
 int MAP_rateOfChange;
 int TPS_rateOfChange;
@@ -37,6 +51,8 @@ int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be
 uint16_t aseTaperStart;
 uint16_t dfcoStart;
 
+/** Initialize instances and vars related to corrections (at ECU boot-up).
+ */
 void initialiseCorrections()
 {
   egoPID.SetMode(AUTOMATIC); //Turn O2 PID on
@@ -47,8 +63,8 @@ void initialiseCorrections()
   currentStatus.battery10 = 125; //Set battery voltage to sensible value for dwell correction for "flying start" (else ignition gets suprious pulses after boot)  
 }
 
-/*
-correctionsTotal() calls all the other corrections functions and combines their results.
+/** Dispatch calculations for all fuel related corrections.
+Calls all the other corrections functions and combines their results.
 This is the only function that should be called from anywhere outside the file
 */
 uint16_t correctionsFuel()
@@ -163,8 +179,7 @@ static inline byte correctionsFuel_new()
 
 }
 
-/*
-Warm Up Enrichment (WUE)
+/** Warm Up Enrichment (WUE) corrections.
 Uses a 2D enrichment table (WUETable) where the X axis is engine temp and the Y axis is the amount of extra fuel to add
 */
 byte correctionWUE()
@@ -187,8 +202,7 @@ byte correctionWUE()
   return WUEValue;
 }
 
-/*
-Cranking Enrichment
+/** Cranking Enrichment corrections.
 Additional fuel % to be added when the engine is cranking
 */
 uint16_t correctionCranking()
@@ -214,11 +228,9 @@ uint16_t correctionCranking()
   return crankingValue;
 }
 
-/**
- * @brief Afer Start Enrichment calculation
- * 
+/** Afer Start Enrichment calculation.
  * This is a short period (Usually <20 seconds) immediately after the engine first fires (But not when cranking)
- * where an additional amount of fuel is added (Over and above the WUE amount)
+ * where an additional amount of fuel is added (Over and above the WUE amount).
  * 
  * @return uint8_t The After Start Enrichment modifier as a %. 100% = No modification. 
  */
@@ -259,16 +271,16 @@ byte correctionASE()
   return currentStatus.ASEValue;
 }
 
-/**
- * @brief Acceleration enrichment correction calculation
+/** Acceleration enrichment correction calculation.
  * 
  * Calculates the % change of the throttle over time (%/second) and performs a lookup based on this
  * Coolant-based modifier is applied on the top of this.
  * When the enrichment is turned on, it runs at that amount for a fixed period of time (taeTime)
  * 
- * @return uint16_t The Acceleration enrichment modifier as a %. 100% = No modification. 
+ * @return uint16_t The Acceleration enrichment modifier as a %. 100% = No modification.
+ * 
  * As the maximum enrichment amount is +255% and maximum cold adjustment for this is 255%, the overall return value
- * from this function can be 100+(255*255/100)=750. Hence this function returns a uint16_t rather than byte
+ * from this function can be 100+(255*255/100)=750. Hence this function returns a uint16_t rather than byte.
  */
 uint16_t correctionAccel()
 {
@@ -447,9 +459,8 @@ uint16_t correctionAccel()
   return accelValue;
 }
 
-/*
-Simple check to see whether we are cranking with the TPS above the flood clear threshold
-This function always returns either 100 or 0
+/** Simple check to see whether we are cranking with the TPS above the flood clear threshold.
+@return 100 (not cranking and thus no need for flood-clear) or 0 (Engine cranking and TPS above @ref config4.floodClear limit).
 */
 byte correctionFloodClear()
 {
@@ -466,9 +477,8 @@ byte correctionFloodClear()
   return floodValue;
 }
 
-/*
-Battery Voltage correction
-Uses a 2D enrichment table (WUETable) where the X axis is engine temp and the Y axis is the amount of extra fuel to add
+/** Battery Voltage correction.
+Uses a 2D enrichment table (WUETable) where the X axis is engine temp and the Y axis is the amount of extra fuel to add.
 */
 byte correctionBatVoltage()
 {
@@ -477,9 +487,8 @@ byte correctionBatVoltage()
   return batValue;
 }
 
-/*
-Simple temperature based corrections lookup based on the inlet air temperature.
-This corrects for changes in air density from movement of the temperature
+/** Simple temperature based corrections lookup based on the inlet air temperature (IAT).
+This corrects for changes in air density from movement of the temperature.
 */
 byte correctionIATDensity()
 {
@@ -489,8 +498,7 @@ byte correctionIATDensity()
   return IATValue;
 }
 
-/**
- * @brief 
+/** Correction for current baromtetric / ambient pressure.
  * @returns A percentage value indicating the amount the fueling should be changed based on the barometric reading. 100 = No change. 110 = 10% increase. 90 = 10% decrease
  */
 byte correctionBaro()
@@ -501,8 +509,7 @@ byte correctionBaro()
   return baroValue;
 }
 
-/*
-Launch control has a setting to increase the fuel load to assist in bringing up boost
+/** Launch control has a setting to increase the fuel load to assist in bringing up boost.
 This simple check applies the extra fuel if we're currently launching
 */
 byte correctionLaunch()
@@ -539,8 +546,7 @@ bool correctionDFCO()
   return DFCOValue;
 }
 
-/*
- * Flex fuel adjustment to vary fuel based on ethanol content
+/** Flex fuel adjustment to vary fuel based on ethanol content.
  * The amount of extra fuel required is a linear relationship based on the % of ethanol.
 */
 byte correctionFlex()
@@ -568,15 +574,15 @@ byte correctionFuelTemp()
   return fuelTempValue;
 }
 
-/*
-Lookup the AFR target table and perform either a simple or PID adjustment based on this
+/** Lookup the AFR target table and perform either a simple or PID adjustment based on this.
 
 Simple (Best suited to narrowband sensors):
 If the O2 sensor reports that the mixture is lean/rich compared to the desired AFR target, it will make a 1% adjustment
-It then waits <egoDelta> number of ignition events and compares O2 against the target table again. If it is still lean/rich then the adjustment is increased to 2%
+It then waits <egoDelta> number of ignition events and compares O2 against the target table again. If it is still lean/rich then the adjustment is increased to 2%.
+
 This continues until either:
-  a) the O2 reading flips from lean to rich, at which point the adjustment cycle starts again at 1% or
-  b) the adjustment amount increases to <egoLimit> at which point it stays at this level until the O2 state (rich/lean) changes
+- the O2 reading flips from lean to rich, at which point the adjustment cycle starts again at 1% or
+- the adjustment amount increases to <egoLimit> at which point it stays at this level until the O2 state (rich/lean) changes
 
 PID (Best suited to wideband sensors):
 
@@ -656,7 +662,10 @@ byte correctionAFRClosedLoop()
 }
 
 //******************************** IGNITION ADVANCE CORRECTIONS ********************************
-
+/** Dispatch calculations for all ignition related corrections.
+ * @param base_advance - Base ignition advance (deg. ?)
+ * @return Advance considering all (~12) individual corrections
+ */
 int8_t correctionsIgn(int8_t base_advance)
 {
   int8_t advance;
@@ -677,14 +686,18 @@ int8_t correctionsIgn(int8_t base_advance)
 
   return advance;
 }
-
+/** Correct ignition timing to configured fixed value.
+ * Must be called near end to override all other corrections.
+ */
 int8_t correctionFixedTiming(int8_t advance)
 {
   int8_t ignFixValue = advance;
   if (configPage2.fixAngEnable == 1) { ignFixValue = configPage4.FixAng; } //Check whether the user has set a fixed timing angle
   return ignFixValue;
 }
-
+/** Correct ignition timing to configured fixed value to use during craning.
+ * Must be called near end to override all other corrections.
+ */
 int8_t correctionCrankingFixedTiming(int8_t advance)
 {
   byte ignCrankFixValue = advance;
@@ -715,7 +728,8 @@ int8_t correctionWMITiming(int8_t advance)
   }
   return advance;
 }
-
+/** Ignition correction for inlet air temperature (IAT).
+ */
 int8_t correctionIATretard(int8_t advance)
 {
   byte ignIATValue = advance;
@@ -727,7 +741,8 @@ int8_t correctionIATretard(int8_t advance)
 
   return ignIATValue;
 }
-
+/** Ignition correction for coolant temperature (CLT).
+ */
 int8_t correctionCLTadvance(int8_t advance)
 {
   int8_t ignCLTValue = advance;
@@ -737,7 +752,8 @@ int8_t correctionCLTadvance(int8_t advance)
   
   return ignCLTValue;
 }
-
+/** Ignition Idle advance correction.
+ */
 int8_t correctionIdleAdvance(int8_t advance)
 {
 
@@ -765,7 +781,8 @@ int8_t correctionIdleAdvance(int8_t advance)
   }
   return ignIdleValue;
 }
-
+/** Ignition soft revlimit correction.
+ */
 int8_t correctionSoftRevLimit(int8_t advance)
 {
   byte ignSoftRevValue = advance;
@@ -780,7 +797,8 @@ int8_t correctionSoftRevLimit(int8_t advance)
 
   return ignSoftRevValue;
 }
-
+/** Ignition Nitrous oxide correction.
+ */
 int8_t correctionNitrous(int8_t advance)
 {
   byte ignNitrous = advance;
@@ -800,7 +818,8 @@ int8_t correctionNitrous(int8_t advance)
 
   return ignNitrous;
 }
-
+/** Ignition soft launch correction.
+ */
 int8_t correctionSoftLaunch(int8_t advance)
 {
   byte ignSoftLaunchValue = advance;
@@ -819,7 +838,8 @@ int8_t correctionSoftLaunch(int8_t advance)
 
   return ignSoftLaunchValue;
 }
-
+/** Ignition correction for soft flat shift.
+ */
 int8_t correctionSoftFlatShift(int8_t advance)
 {
   byte ignSoftFlatValue = advance;
@@ -833,7 +853,8 @@ int8_t correctionSoftFlatShift(int8_t advance)
 
   return ignSoftFlatValue;
 }
-
+/** Ignition knock (retard) correction.
+ */
 int8_t correctionKnock(int8_t advance)
 {
   byte knockRetard = 0;
@@ -869,7 +890,8 @@ int8_t correctionKnock(int8_t advance)
   return advance - knockRetard;
 }
 
-//******************************** DWELL CORRECTIONS ********************************
+/** Ignition Dwell Correction.
+ */
 uint16_t correctionsDwell(uint16_t dwell)
 {
   uint16_t tempDwell = dwell;

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1,3 +1,27 @@
+/** @file
+ * Global defines, macros, struct definitions (@ref statuses, @ref config2, @ref config4, config*), extern-definitions (for globally accessible vars).
+ * 
+ * ### Note on configuration struct layouts
+ * 
+ * Once the struct members have been assigned to certain "role" (in certain SW version), they should not be "moved around"
+ * as the structs are stored onto EEPROM as-is and the offset and size of member needs to remain constant. Also removing existing struct members
+ * would disturb layouts. Because of this a certain amount unused old members will be left into the structs. For the storage related reasons also the
+ * bit fields are defined in byte-size (or multiple of ...) chunks.
+ * 
+ * ### Config Structs and 2D, 3D Tables
+ * 
+ * The config* structures contain information coming from tuning SW (e.g. TS) for 2D and 3D tables, where looked up value is not a result of direct
+ * array lookup, but from interpolation algorithm. Because of standard, reusable interpolation routines associated with structs table2D and table3D,
+ * the values from config are copied from config* structs to table2D (table3D destined configurations are not stored in config* structures).
+ * 
+ * ### Board choice
+ * There's a C-preprocessor based "#if defined" logic present in this header file based on the Arduino IDE compiler set CPU
+ * (+board?) type, e.g. `__AVR_ATmega2560__`. This respectively drives (withi it's "#if defined ..." block):
+ * - The setting of various BOARD_* C-preprocessor variables (e.g. BOARD_MAX_ADC_PINS)
+ * - Setting of BOARD_H (Board header) file (e.g. "board_avr2560.h"), which is later used to include the header file
+ *   - Seems Arduino ide implicitly compiles and links respective .ino file (by it's internal build/compilation rules) (?)
+ * - Setting of CPU (?) CORE_* variables (e.g. CORE_AVR), that is used across codebase to distinguish CPU.
+ */
 #ifndef GLOBALS_H
 #define GLOBALS_H
 #include <Arduino.h>
@@ -338,7 +362,8 @@
 #define GOING_LOW         0
 #define GOING_HIGH        1
 
-#define MAX_RPM 18000 //This is the maximum rpm that the ECU will attempt to run at. It is NOT related to the rev limiter, but is instead dictates how fast certain operations will be allowed to run. Lower number gives better performance
+#define MAX_RPM 18000 /**< The maximum rpm that the ECU will attempt to run at. It is NOT related to the rev limiter,
+but is instead dictates how fast certain operations will be allowed to run. Lower number gives better performance */
 
 #define BATTV_COR_MODE_WHOLE 0
 #define BATTV_COR_MODE_OPENTIME 1
@@ -366,13 +391,14 @@
 #define ENGINE_PROTECT_BIT_OIL  2
 #define ENGINE_PROTECT_BIT_AFR  3
 
-//Table sizes
-#define CALIBRATION_TABLE_SIZE 512
-#define CALIBRATION_TEMPERATURE_OFFSET 40 // All temperature measurements are stored offset by 40 degrees. This is so we can use an unsigned byte (0-255) to represent temperature ranges from -40 to 215
-#define OFFSET_FUELTRIM 127 //The fuel trim tables are offset by 128 to allow for -128 to +128 values
-#define OFFSET_IGNITION 40 //Ignition values from the main spark table are offset 40 degrees downards to allow for negative spark timing
 
-#define SERIAL_BUFFER_THRESHOLD 32 // When the serial buffer is filled to greater than this threshold value, the serial processing operations will be performed more urgently in order to avoid it overflowing. Serial buffer is 64 bytes long, so the threshold is set at half this as a reasonable figure
+#define CALIBRATION_TABLE_SIZE 512 ///< Calibration table size for CLT, IAT, O2
+#define CALIBRATION_TEMPERATURE_OFFSET 40 /**< All temperature measurements are stored offset by 40 degrees.
+This is so we can use an unsigned byte (0-255) to represent temperature ranges from -40 to 215 */
+#define OFFSET_FUELTRIM 127 ///< The fuel trim tables are offset by 128 to allow for -128 to +128 values
+#define OFFSET_IGNITION 40 ///< Ignition values from the main spark table are offset 40 degrees downards to allow for negative spark timing
+
+#define SERIAL_BUFFER_THRESHOLD 32 ///< When the serial buffer is filled to greater than this threshold value, the serial processing operations will be performed more urgently in order to avoid it overflowing. Serial buffer is 64 bytes long, so the threshold is set at half this as a reasonable figure
 
 #ifndef CORE_TEENSY41
   #define FUEL_PUMP_ON() *pump_pin_port |= (pump_pin_mask)
@@ -385,7 +411,7 @@
 
 extern const char TSfirmwareVersion[] PROGMEM;
 
-extern const byte data_structure_version; //This identifies the data structure when reading / writing.
+extern const byte data_structure_version; //This identifies the data structure when reading / writing. Now in use: CURRENT_DATA_VERSION (migration on-the fly) ?
 
 extern struct table3D fuelTable; //16x16 fuel map
 extern struct table3D fuelTable2; //16x16 fuel map
@@ -528,7 +554,7 @@ extern volatile byte toothHistorySerialIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-//The below shouldn't be needed and probably should be cleaned up, but the Atmel SAM boards use a specific type for the trigger edge values rather than a simple byte/int
+//The below shouldn't be needed and probably should be cleaned up, but the Atmel SAM (ARM) boards use a specific type for the trigger edge values rather than a simple byte/int
 #if defined(CORE_SAMD21)
   extern PinStatus primaryTriggerEdge;
   extern PinStatus secondaryTriggerEdge;
@@ -540,16 +566,16 @@ extern volatile uint16_t ignitionCount; /**< The count of ignition events that h
 #endif
 extern int CRANK_ANGLE_MAX;
 extern int CRANK_ANGLE_MAX_IGN;
-extern int CRANK_ANGLE_MAX_INJ; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
-extern volatile uint32_t runSecsX10; /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
-extern volatile uint32_t seclx10; /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */
-extern volatile byte HWTest_INJ; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
+extern int CRANK_ANGLE_MAX_INJ;       ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
+extern volatile uint32_t runSecsX10;  /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
+extern volatile uint32_t seclx10;     /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */
+extern volatile byte HWTest_INJ;      /**< Each bit in this variable represents one of the injector channels and it's HW test status */
 extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
-extern volatile byte HWTest_IGN; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
+extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
 
-//This needs to be here because using the config page directly can prevent burning the setting
-extern byte resetControl;
+
+extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
 
 extern volatile byte TIMER_mask;
 extern volatile byte LOOP_TIMER;
@@ -561,74 +587,78 @@ extern volatile byte LOOP_TIMER;
 #define pinIsOutput(pin)    ( ((pin) == pinFuelPump) || ((pin) == pinFan) || ((pin) == pinVVT_1) || ((pin) == pinVVT_2) || ((pin) == pinBoost) || ((pin) == pinIdle1) || ((pin) == pinIdle2) || ((pin) == pinTachOut) )
 #define pinIsUsed(pin)      ( pinIsInjector((pin)) || pinIsIgnition((pin)) || pinIsSensor((pin)) || pinIsOutput((pin)) || pinIsReserved((pin)) )
 
-//The status struct contains the current values for all 'live' variables
-//In current version this is 64 bytes
+/** The status struct with current values for all 'live' variables.
+* In current version this is 64 bytes. Instantiated as global currentStatus.
+* int *ADC (Analog-to-digital value / count) values contain the "raw" value from AD conversion, which get converted to
+* unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
+*/
 struct statuses {
-  volatile bool hasSync;
-  uint16_t RPM;
-  byte RPMdiv100;
-  long longRPM;
+  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino).
+    This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
+  uint16_t RPM;   ///< RPM - Current Revs per minute
+  byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)
+  long longRPM;   ///< RPM as long int (gets assigned to / maintained in statuses.RPM as well)
   int mapADC;
   int baroADC;
-  long MAP; //Has to be a long for PID calcs (Boost control)
-  int16_t EMAP;
+  long MAP;     ///< Manifold absolute pressure. Has to be a long for PID calcs (Boost control)
+  int16_t EMAP; ///< EMAP ... (See @ref config6.useEMAP for EMAP enablement)
   int16_t EMAPADC;
-  byte baro; //Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
-  byte TPS; /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
-  byte tpsADC; /**< 0-255 byte representation of the TPS. Downsampled from the original 10-bit reading, but before any calibration is applied */
+  byte baro;   ///< Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
+  byte TPS;    /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
+  byte tpsADC; /**< byte (valued: 0-255) representation of the TPS. Downsampled from the original 10-bit (0-1023) reading, but before any calibration is applied */
   byte tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
   byte mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
-  volatile int rpmDOT;
-  byte VE; /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both */
-  byte VE1; /**< The VE value from fuel table 1 */
-  byte VE2; /**< The VE value from fuel table 2, if in use (and required conditions are met) */
-  byte O2;
-  byte O2_2;
-  int coolant;
+  volatile int rpmDOT; /**< RPM delta over time (RPM increase / s ?) */
+  byte VE;     /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both. */
+  byte VE1;    /**< The VE value from fuel table 1 */
+  byte VE2;    /**< The VE value from fuel table 2, if in use (and required conditions are met) */
+  byte O2;     /**< Primary O2 sensor reading */
+  byte O2_2;   /**< Secondary O2 sensor reading */
+  int coolant; /**< Coolant temperature reading */
   int cltADC;
-  int IAT;
+  int IAT;     /**< Inlet air temperature reading */
   int iatADC;
   int batADC;
   int O2ADC;
   int O2_2ADC;
-  int dwell;
-  byte dwellCorrection; /**< The amount of correction being applied to the dwell time. */
-  byte battery10; /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
-  int8_t advance; /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
-  int8_t advance1; /**< The advance value from ignition table 1 */
-  int8_t advance2; /**< The advance value from ignition table 2 */
+  int dwell;          ///< dwell (coil primary winding/circuit on) time (in ms * 10 ? See @ref correctionsDwell)
+  byte dwellCorrection; /**< The amount of correction being applied to the dwell time (in unit ...). */
+  byte battery10;     /**< The current BRV in volts (multiplied by 10. Eg 12.5V = 125) */
+  int8_t advance;     /**< The current advance value being used in the spark calculation. Can be the same as advance1 or advance2, or a calculated value of both */
+  int8_t advance1;    /**< The advance value from ignition table 1 */
+  int8_t advance2;    /**< The advance value from ignition table 2 */
   uint16_t corrections; /**< The total current corrections % amount */
-  uint16_t AEamount; /**< The amount of accleration enrichment currently being applied. 100=No change. Varies above 255 */
+  uint16_t AEamount;    /**< The amount of accleration enrichment currently being applied. 100=No change. Varies above 255 */
   byte egoCorrection; /**< The amount of closed loop AFR enrichment currently being applied */
   byte wueCorrection; /**< The amount of warmup enrichment currently being applied */
   byte batCorrection; /**< The amount of battery voltage enrichment currently being applied */
   byte iatCorrection; /**< The amount of inlet air temperature adjustment currently being applied */
   byte baroCorrection; /**< The amount of correction being applied for the current baro reading */
-  byte launchCorrection; /**< The amount of correction being applied if launch control is active */
-  byte flexCorrection; /**< Amount of correction being applied to compensate for ethanol content */
+  byte launchCorrection;   /**< The amount of correction being applied if launch control is active */
+  byte flexCorrection;     /**< Amount of correction being applied to compensate for ethanol content */
   byte fuelTempCorrection; /**< Amount of correction being applied to compensate for fuel temperature */
-  int8_t flexIgnCorrection; /**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
-  byte afrTarget;
-  byte idleDuty; /**< The current idle duty cycle amount if PWM idle is selected and active */
+  int8_t flexIgnCorrection;/**< Amount of additional advance being applied based on flex. Note the type as this allows for negative values */
+  byte afrTarget;    /**< Current AFR Target looked up from AFR target table (x10 ? See @ref afrTable)*/
+  byte idleDuty;     /**< The current idle duty cycle amount if PWM idle is selected and active */
   byte CLIdleTarget; /**< The target idle RPM (when closed loop idle control is active) */
   bool idleUpActive; /**< Whether the externally controlled idle up is currently active */
-  bool CTPSActive; /**< Whether the externally controlled closed throttle position sensor is currently active */
-  bool fanOn; /**< Whether or not the fan is turned on */
+  bool CTPSActive;   /**< Whether the externally controlled closed throttle position sensor is currently active */
+  bool fanOn;        /**< Whether or not the fan is turned on */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   volatile int8_t fuelTemp;
-  unsigned long AEEndTime; /**< The target end time used whenever AE is turned on */
-  volatile byte status1;
-  volatile byte spark;
-  volatile byte spark2;
-  uint8_t engine;
-  unsigned int PW1; //In uS
-  unsigned int PW2; //In uS
-  unsigned int PW3; //In uS
-  unsigned int PW4; //In uS
-  unsigned int PW5; //In uS
-  unsigned int PW6; //In uS
-  unsigned int PW7; //In uS
-  unsigned int PW8; //In uS
+  unsigned long AEEndTime; /**< The target end time used whenever AE (acceleration enrichment) is turned on */
+  volatile byte status1; ///< Status bits (See BIT_STATUS1_* defines on top of this file)
+  volatile byte spark;   ///< Spark status/control indicator bits (launch control, boost cut, spark errors, See BIT_SPARK_* defines)
+  volatile byte spark2;  ///< Spark 2 ... (See also @ref config10 spark2* members and BIT_SPARK2_* defines)
+  uint8_t engine; ///< Engine status bits (See BIT_ENGINE_* defines on top of this file)
+  unsigned int PW1; ///< In uS
+  unsigned int PW2; ///< In uS
+  unsigned int PW3; ///< In uS
+  unsigned int PW4; ///< In uS
+  unsigned int PW5; ///< In uS
+  unsigned int PW6; ///< In uS
+  unsigned int PW7; ///< In uS
+  unsigned int PW8; ///< In uS
   volatile byte runSecs; /**< Counter of seconds since cranking commenced (Maxes out at 255 to prevent overflow) */
   volatile byte secl; /**< Counter incrementing once per second. Will overflow after 255 and begin again. This is used by TunerStudio to maintain comms sync */
   volatile uint32_t loopsPerSecond; /**< A performance indicator showing the number of main loops that are being executed each second */ 
@@ -639,17 +669,17 @@ struct statuses {
   bool flatShiftingHard;
   volatile uint32_t startRevolutions; /**< A counter for how many revolutions have been completed since sync was achieved. */
   uint16_t boostTarget;
-  byte testOutputs;
-  bool testActive;
-  uint16_t boostDuty; //Percentage value * 100 to give 2 points of precision
-  byte idleLoad; /**< Either the current steps or current duty cycle for the idle control. */
-  uint16_t canin[16];   //16bit raw value of selected canin data for channel 0-15
+  byte testOutputs;   ///< Test Output bits (only first bit used/tested ?)
+  bool testActive;    // Not in use ? Replaced by testOutputs ?
+  uint16_t boostDuty; ///< Boost Duty percentage value * 100 to give 2 points of precision
+  byte idleLoad;      ///< Either the current steps or current duty cycle for the idle control
+  uint16_t canin[16]; ///< 16bit raw value of selected canin data for channels 0-15
   uint8_t current_caninchannel = 0; /**< Current CAN channel, defaults to 0 */
   uint16_t crankRPM = 400; /**< The actual cranking RPM limit. This is derived from the value in the config page, but saves us multiplying it everytime it's used (Config page value is stored divided by 10) */
-  volatile byte status3;
+  volatile byte status3; ///< Status bits (See BIT_STATUS3_* defines on top of this file)
   int16_t flexBoostCorrection; /**< Amount of boost added based on flex */
   byte nitrous_status;
-  byte nSquirts;
+  byte nSquirts;  ///< Number of injector squirts per cycle (per injector)
   byte nChannels; /**< Number of fuel and ignition channels.  */
   int16_t fuelLoad;
   int16_t fuelLoad2;
@@ -666,14 +696,14 @@ struct statuses {
   long vvt1Duty; //Has to be a long for PID calcs (CL VVT control)
   uint16_t injAngle;
   byte ASEValue;
-  uint16_t vss; /**< Current speed reading. Natively stored in kph and converted to mph in TS if required */
+  uint16_t vss;      /**< Current speed reading. Natively stored in kph and converted to mph in TS if required */
   bool idleUpOutputActive; /**< Whether the idle up output is currently active */
-  byte gear; /**< Current gear (Calculated from vss) */
+  byte gear;         /**< Current gear (Calculated from vss) */
   byte fuelPressure; /**< Fuel pressure in PSI */
-  byte oilPressure; /**< Oil pressure in PSI */
+  byte oilPressure;  /**< Oil pressure in PSI */
   byte engineProtectStatus;
   byte wmiPW;
-  volatile byte status4;
+  volatile byte status4; ///< Status bits (See BIT_STATUS4_* defines on top of this file)
   int16_t vvt2Angle; //Has to be a long for PID calcs (CL VVT control)
   byte vvt2TargetAngle;
   long vvt2Duty; //Has to be a long for PID calcs (CL VVT control)
@@ -681,31 +711,32 @@ struct statuses {
   byte TS_SD_Status; //TunerStudios SD card status
 };
 
-/**
- * @brief This mostly covers off variables that are required for fuel
- * 
- * See the ini file for further reference
+/** Page 2 of the config - mostly variables that are required for fuel.
+ * These are "non-live" EFI setting, engine and "system" variables that remain fixed once sent
+ * (and stored to e.g. EEPROM) from configuration/tuning SW (from outside by USBserial/bluetooth).
+ * Contains a lots of *Min, *Max (named) variables to constrain values to sane ranges.
+ * See the ini file for further reference.
  * 
  */
 struct config2 {
 
   byte aseTaperTime;
   byte aeColdPct;  //AE cold clt modifier %
-  byte aeColdTaperMin; //AE cold modifier, taper start temp (full modifier), was ASE in early versions
-  byte aeMode : 2; /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */
+  byte aeColdTaperMin; //AE cold modifier, taper start temp (full modifier, was ASE in early versions)
+  byte aeMode : 2;      /**< Acceleration Enrichment mode. 0 = TPS, 1 = MAP. Values 2 and 3 reserved for potential future use (ie blended TPS / MAP) */
   byte battVCorMode : 1;
   byte SoftLimitMode : 1;
   byte useTachoSweep : 1;
-  byte aeApplyMode : 1; //0 = Multiply | 1 = Add
-  byte multiplyMAP : 2; //0 = off | 1 = baro | 2 = 100
-  byte wueValues[10]; //Warm up enrichment array (10 bytes)
-  byte crankingPct; //Cranking enrichment
-  byte pinMapping; // The board / ping mapping to be used
-  byte tachoPin : 6; //Custom pin setting for tacho output
-  byte tachoDiv : 2; //Whether to change the tacho speed
-  byte tachoDuration; //The duration of the tacho pulse in mS
-  byte maeThresh; /**< The MAPdot threshold that must be exceeded before AE is engaged */
-  byte taeThresh; /**< The TPSdot threshold that must be exceeded before AE is engaged */
+  byte aeApplyMode : 1; ///< Acceleration enrichment calc mode: 0 = Multiply | 1 = Add (AE_MODE_ADDER)
+  byte multiplyMAP : 2; ///< MAP value processing: 0 = off, 1 = div by currentStatus.baro, 2 = div by 100 (to gain usable value)
+  byte wueValues[10];   ///< Warm up enrichment array (10 bytes, transferred to @ref WUETable)
+  byte crankingPct;     ///< Cranking enrichment (See @ref config10, updates.ino)
+  byte pinMapping;      ///< The board / ping mapping number / id to be used (See: @ref setPinMapping in init.ino)
+  byte tachoPin : 6;    ///< Custom pin setting for tacho output (if != 0, override copied to pinTachOut, which defaults to board assigned tach pin)
+  byte tachoDiv : 2;    ///< Whether to change the tacho speed ("half speed tacho" ?)
+  byte tachoDuration;   //The duration of the tacho pulse in mS
+  byte maeThresh;       /**< The MAPdot threshold that must be exceeded before AE is engaged */
+  byte taeThresh;       /**< The TPSdot threshold that must be exceeded before AE is engaged */
   byte aeTime;
 
   //Display config bits
@@ -722,37 +753,38 @@ struct config2 {
 
   byte reqFuel;       //24
   byte divider;
-  byte injTiming : 1;
+  byte injTiming : 1; ///< Injector timing (aka. injector staging) 0=simultaneous, 1=alternating
   byte multiplyMAP_old : 1;
-  byte includeAFR : 1;
+  byte includeAFR : 1; //< Enable AFR compensation ? (See also @ref config2.incorporateAFR)
   byte hardCutType : 1;
   byte ignAlgorithm : 3;
   byte indInjAng : 1;
-  byte injOpen; //Injector opening time (ms * 10)
+  byte injOpen;     ///< Injector opening time (ms * 10)
   uint16_t injAng[4];
 
   //config1 in ini
-  byte mapSample : 2;
-  byte strokes : 1;
-  byte injType : 1;
-  byte nCylinders : 4; //Number of cylinders
+  byte mapSample : 2;  ///< MAP sampling method (0=Instantaneous, 1=Cycle Average, 2=Cycle Minimum, 4=Ign. event average, See sensors.ino)
+  byte strokes : 1;    ///< Engine cycle type: four-stroke (0) / two-stroke (1)
+  byte injType : 1;    ///< Injector type 0=Port (INJ_TYPE_PORT), 1=Throttle Body / TBI (INJ_TYPE_TBODY)
+  byte nCylinders : 4; ///< Number of cylinders
 
   //config2 in ini
-  byte fuelAlgorithm : 3;
-  byte fixAngEnable : 1; //Whether fixed/locked timing is enabled
-  byte nInjectors : 4; //Number of injectors
+  byte fuelAlgorithm : 3;///< Fuel algorithm - 0=Manifold pressure/MAP (LOAD_SOURCE_MAP, default, proven), 1=Throttle/TPS (LOAD_SOURCE_TPS), 2=IMAP/EMAP (LOAD_SOURCE_IMAPEMAP)
+  byte fixAngEnable : 1; ///< Whether fixed/locked timing is enabled (0=diable, 1=enable, See @ref configPage4.FixAng)
+  byte nInjectors : 4;   ///< Number of injectors
 
 
   //config3 in ini
-  byte engineType : 1;
-  byte flexEnabled : 1;
-  byte legacyMAP  : 1;
-  byte baroCorr : 1;
-  byte injLayout : 2;
-  byte perToothIgn : 1;
-  byte dfcoEnabled : 1; //Whether or not DFCO is turned on
+  byte engineType : 1;  ///< Engine crank/ign phasing type: 0=even fire, 1=odd fire
+  byte flexEnabled : 1; ///< Enable Flex fuel sensing (pin / interrupt)
+  byte legacyMAP  : 1;  ///< Legacy MAP reading behavior
+  byte baroCorr : 1;    // Unused ?
+  byte injLayout : 2;   /**< Injector Layout - 0=INJ_PAIRED (#outputs == #cyls/2, timed over 1 crank rev), 1=INJ_SEMISEQUENTIAL (like paired, but #outputs == #cyls, only for 4 cyl),
+                         2=INJ_BANKED (2 outputs are used), 3=INJ_SEQUENTIAL (#ouputs == #cyls, timed over full cycle, 2 crank revs) */
+  byte perToothIgn : 1; ///< Experimental / New ign. mode ... (?) (See decoders.ino)
+  byte dfcoEnabled : 1; ///< Whether or not DFCO (deceleration fuel cut-off) is turned on
 
-  byte aeColdTaperMax;  //AE cold modifier, taper end temp (no modifier applied), was primePulse in early versions
+  byte aeColdTaperMax;  ///< AE cold modifier, taper end temp (no modifier applied, was primePulse in early versions)
   byte dutyLim;
   byte flexFreqLow; //Lowest valid frequency reading from the flex sensor
   byte flexFreqHigh; //Highest valid frequency reading from the flex sensor
@@ -762,11 +794,11 @@ struct config2 {
   byte tpsMax;
   int8_t mapMin; //Must be signed
   uint16_t mapMax;
-  byte fpPrime; //Time (In seconds) that the fuel pump should be primed for on power up
-  byte stoich;
-  uint16_t oddfire2; //The ATDC angle of channel 2 for oddfire
-  uint16_t oddfire3; //The ATDC angle of channel 3 for oddfire
-  uint16_t oddfire4; //The ATDC angle of channel 4 for oddfire
+  byte fpPrime; ///< Time (In seconds) that the fuel pump should be primed for on power up
+  byte stoich;  ///< Stoichiometric ratio (x10, so e.g. 14.7 => 147)
+  uint16_t oddfire2; ///< The ATDC angle of channel 2 for oddfire
+  uint16_t oddfire3; ///< The ATDC angle of channel 3 for oddfire
+  uint16_t oddfire4; ///< The ATDC angle of channel 4 for oddfire
 
   byte idleUpPin : 6;
   byte idleUpPolarity : 1;
@@ -786,17 +818,17 @@ struct config2 {
   int8_t EMAPMin; //Must be signed
   uint16_t EMAPMax;
 
-  byte fanWhenOff : 1;      // Only run fan when engine is running
-  byte fanWhenCranking : 1;      //**< Setting whether the fan output will stay on when the engine is cranking */ 
-  byte useDwellMap : 1;  // Setting to change between fixed dwell value and dwell map
-  byte fanUnused : 2;
-  byte rtc_mode : 2;
-  byte incorporateAFR : 1;  //Incorporate AFR
-  byte asePct[4];  //Afterstart enrichment (%)
-  byte aseCount[4]; //Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
-  byte aseBins[4]; //Afterstart enrichment temp axis
-  byte primePulse[4]; //Priming pulsewidth
-  byte primeBins[4]; //Priming temp axis
+  byte fanWhenOff : 1;      ///< Allow running fan with engine off: 0 = Only run fan when engine is running, 1 = Allow even with engine off
+  byte fanWhenCranking : 1; ///< Set whether the fan output will stay on when the engine is cranking (0=force off, 1=allow on)
+  byte useDwellMap : 1;     ///< Setting to change between fixed dwell value and dwell map (0=Fixed value from @ref configPage4.dwellRun, 1=Use @ref dwellTable)
+  byte fanUnused : 2;       // Unused ?
+  byte rtc_mode : 2;        // Unused ?
+  byte incorporateAFR : 1;  ///< Enable AFR target (stoich/afrtgt) compensation in PW calculation
+  byte asePct[4];           ///< Afterstart enrichment values (%)
+  byte aseCount[4];         ///< Afterstart enrichment cycles. This is the number of ignition cycles that the afterstart enrichment % lasts for
+  byte aseBins[4];          ///< Afterstart enrichment temperatures (x-axis) for (target) enrichment values
+  byte primePulse[4];//Priming pulsewidth values (mS, copied to @ref PrimingPulseTable)
+  byte primeBins[4]; //Priming temperatures (source,x-axis)
 
   byte CTPSPin : 6;
   byte CTPSPolarity : 1;
@@ -816,10 +848,10 @@ struct config2 {
   byte dfcoMinCLT;
 
   //VSS Stuff
-  byte vssMode : 2;
-  byte vssPin : 6;
+  byte vssMode : 2; ///< VSS (Vehicle speed sensor) mode (0=none, 1=CANbus, 2,3=Interrupt driven)
+  byte vssPin : 6; ///< VSS (Vehicle speed sensor) pin number
   
-  uint16_t vssPulsesPerKm;
+  uint16_t vssPulsesPerKm; ///< VSS (Vehicle speed sensor) pulses per Km
   byte vssSmoothing;
   uint16_t vssRatio1;
   uint16_t vssRatio2;
@@ -846,63 +878,66 @@ struct config2 {
 #if defined(CORE_AVR)
   };
 #else
-  } __attribute__((__packed__)); //The 32 bi systems require all structs to be fully packed
+  } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
-//Page 4 of the config - See the ini file for further reference
-//This mostly covers off variables that are required for ignition
+/** Page 4 of the config - variables required for ignition and rpm/crank phase /cam phase decoding.
+* See the ini file for further reference.
+*/
 struct config4 {
 
-  int16_t triggerAngle;
-  int8_t FixAng; //Negative values allowed
-  byte CrankAng;
-  byte TrigAngMul; //Multiplier for non evenly divisible tooth counts.
+  int16_t triggerAngle; ///< Angle (ATDC) when tooth No:1 on the primary wheel sends signal (-360 to +360 deg.)
+  int8_t FixAng; ///< Fixed Ignition angle value (enabled by @ref configPage2.fixAngEnable, copied to ignFixValue, Negative values allowed, See corrections.ino)
+  byte CrankAng; ///< Fixed start-up/cranking ignition angle (See: corrections.ino)
+  byte TrigAngMul; ///< Multiplier for non evenly divisible tooth counts.
 
-  byte TrigEdge : 1;
-  byte TrigSpeed : 1;
-  byte IgInv : 1;
-  byte TrigPattern : 5;
+  byte TrigEdge : 1;  ///< Primary (RPM1) Trigger Edge - 0 - RISING, 1 = FALLING (Copied from this config to primaryTriggerEdge)
+  byte TrigSpeed : 1; ///< Primary (RPM1) Trigger speed - 0 = crank speed (CRANK_SPEED), 1 = cam speed (CAM_SPEED), See decoders.ino
+  byte IgInv : 1;     ///< Ignition signal invert (?) (GOING_LOW=0 (default by init.ino) / GOING_HIGH=1 )
+  byte TrigPattern : 5; ///< Decoder configured (DECODER_MISSING_TOOTH, DECODER_BASIC_DISTRIBUTOR, DECODER_GM7X, ... See init.ino)
 
-  byte TrigEdgeSec : 1;
-  byte fuelPumpPin : 6;
+  byte TrigEdgeSec : 1; ///< Secondary (RPM2) Trigger Edge (See RPM1)
+  byte fuelPumpPin : 6; ///< Fuel pump pin (copied as override to pinFuelPump, defaults to board default, See: init.ino)
   byte useResync : 1;
 
-  byte sparkDur; //Spark duration in ms * 10
-  byte trigPatternSec : 7; //Mode for Missing tooth secondary trigger.  Either single tooth cam wheel, 4-1 or poll level
+  byte sparkDur; ///< Spark duration in ms * 10
+  byte trigPatternSec : 7; ///< Mode for Missing tooth secondary trigger - 0=single tooth cam wheel (SEC_TRIGGER_SINGLE), 1=4-1 (SEC_TRIGGER_4_1) or 2=poll level mode (SEC_TRIGGER_POLL)
   byte PollLevelPolarity : 1; //for poll level cam trigger. Sets if the cam trigger is supposed to be high or low for revolution one.
   uint8_t bootloaderCaps; //Capabilities of the bootloader over stock. e.g., 0=Stock, 1=Reset protection, etc.
 
-  byte resetControlConfig : 2; //Which method of reset control to use (0=None, 1=Prevent When Running, 2=Prevent Always, 3=Serial Command)
+  byte resetControlConfig : 2; /** Which method of reset control to use - 0=Disabled (RESET_CONTROL_DISABLED), 1=Prevent When Running (RESET_CONTROL_PREVENT_WHEN_RUNNING),
+     2=Prevent Always (RESET_CONTROL_PREVENT_ALWAYS), 3=Serial Command (RESET_CONTROL_SERIAL_COMMAND) - Copied to resetControl (See init.ino, utilities.ino) */
   byte resetControlPin : 6;
 
   byte StgCycles; //The number of initial cycles before the ignition should fire when first cranking
 
-  byte boostType : 1; //Open or closed loop boost control
+  byte boostType : 1; ///< Boost Control type: 0=Open loop (OPEN_LOOP_BOOST), 1=closed loop (CLOSED_LOOP_BOOST)
   byte useDwellLim : 1; //Whether the dwell limiter is off or on
-  byte sparkMode : 3; //Spark output mode (Eg Wasted spark, single channel or Wasted COP)
+  byte sparkMode : 3; /** Ignition/Spark output mode - 0=Wasted spark (IGN_MODE_WASTED), 1=single channel (IGN_MODE_SINGLE),
+      2=Wasted COP (IGN_MODE_WASTEDCOP), 3=Sequential (IGN_MODE_SEQUENTIAL), 4=Rotary (IGN_MODE_ROTARY) */
   byte triggerFilter : 2; //The mode of trigger filter being used (0=Off, 1=Light (Not currently used), 2=Normal, 3=Aggressive)
-  byte ignCranklock : 1; //Whether or not the ignition timing during cranking is locked to a CAS pulse. Only currently valid for Basic distributor and 4G63.
+  byte ignCranklock : 1; //Whether or not the ignition timing during cranking is locked to a CAS (crank) pulse. Only currently valid for Basic distributor and 4G63.
 
-  byte dwellCrank; //Dwell time whilst cranking
-  byte dwellRun; //Dwell time whilst running
-  byte triggerTeeth; //The full count of teeth on the trigger wheel if there were no gaps
-  byte triggerMissingTeeth; //The size of the tooth gap (ie number of missing teeth)
-  byte crankRPM; //RPM below which the engine is considered to be cranking
-  byte floodClear; //TPS value that triggers flood clear mode (No fuel whilst cranking)
-  byte SoftRevLim; //Soft rev limit (RPM/100)
-  byte SoftLimRetard; //Amount soft limit retards (degrees)
-  byte SoftLimMax; //Time the soft limit can run
-  byte HardRevLim; //Hard rev limit (RPM/100)
-  byte taeBins[4]; //TPS based acceleration enrichment bins (%/s)
-  byte taeValues[4]; //TPS based acceleration enrichment rates (% to add)
-  byte wueBins[10]; //Warmup Enrichment bins (Values are in configTable1)
+  byte dwellCrank;    ///< Dwell time whilst cranking
+  byte dwellRun;      ///< Dwell time whilst running
+  byte triggerTeeth;  ///< The full count of teeth on the trigger wheel if there were no gaps
+  byte triggerMissingTeeth; ///< The size of the tooth gap (ie number of missing teeth)
+  byte crankRPM;      ///< RPM below which the engine is considered to be cranking
+  byte floodClear;    ///< TPS (raw adc count? % ?) value that triggers flood clear mode (No fuel whilst cranking, See @ref correctionFloodClear())
+  byte SoftRevLim;    ///< Soft rev limit (RPM/100)
+  byte SoftLimRetard; ///< Amount soft limit (ignition) retard (degrees)
+  byte SoftLimMax;    ///< Time the soft limit can run (units ?)
+  byte HardRevLim;    ///< Hard rev limit (RPM/100)
+  byte taeBins[4];    ///< TPS based acceleration enrichment bins (Unit: %/s)
+  byte taeValues[4];  ///< TPS based acceleration enrichment rates (Unit: % to add), values matched to thresholds of taeBins
+  byte wueBins[10];   ///< Warmup Enrichment bins (Values are in @ref configPage2.wueValues OLD:configTable1)
   byte dwellLimit;
-  byte dwellCorrectionValues[6]; //Correction table for dwell vs battery voltage
-  byte iatRetBins[6]; // Inlet Air Temp timing retard curve bins
-  byte iatRetValues[6]; // Inlet Air Temp timing retard curve values
-  byte dfcoRPM; //RPM at which DFCO turns off/on at
-  byte dfcoHyster; //Hysteris RPM for DFCO
-  byte dfcoTPSThresh; //TPS must be below this figure for DFCO to engage
+  byte dwellCorrectionValues[6]; ///< Correction table for dwell vs battery voltage
+  byte iatRetBins[6]; ///< Inlet Air Temp timing retard curve bins (Unit: ...)
+  byte iatRetValues[6]; ///< Inlet Air Temp timing retard curve values (Unit: ...)
+  byte dfcoRPM;       ///< RPM at which DFCO turns off/on at
+  byte dfcoHyster;    //Hysteris RPM for DFCO
+  byte dfcoTPSThresh; //TPS must be below this figure for DFCO to engage (Unit: ...)
 
   byte ignBypassEnabled : 1; //Whether or not the ignition bypass is enabled
   byte ignBypassPin : 6; //Pin the ignition bypass is activated on
@@ -916,13 +951,13 @@ struct config4 {
   byte ADCFILTER_MAP; //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
   byte ADCFILTER_BARO;
   
-  byte cltAdvBins[6]; /**< Coolant Temp timing advance curve bins */
+  byte cltAdvBins[6];   /**< Coolant Temp timing advance curve bins */
   byte cltAdvValues[6]; /**< Coolant timing advance curve values. These are translated by 15 to allow for negative values */
 
-  byte maeBins[4]; /**< MAP based AE MAPdot bins */
-  byte maeRates[4]; /**< MAP based AE values */
+  byte maeBins[4];      /**< MAP based AE MAPdot bins */
+  byte maeRates[4];     /**< MAP based AE values */
 
-  int8_t batVoltCorrect; /**< Battery voltage calibration offset */
+  int8_t batVoltCorrect; /**< Battery voltage calibration offset (Given as 10x value, e.g. 2v => 20) */
 
   byte baroFuelBins[8];
   byte baroFuelValues[8];
@@ -945,50 +980,51 @@ struct config4 {
   } __attribute__((__packed__)); //The 32 bi systems require all structs to be fully packed
 #endif
 
-//Page 6 of the config - See the ini file for further reference
-//This mostly covers off variables that are required for AFR targets and closed loop
+/** Page 6 of the config - mostly variables that are required for AFR targets and closed loop.
+See the ini file for further reference.
+*/
 struct config6 {
 
-  byte egoAlgorithm : 2;
-  byte egoType : 2;
-  byte boostEnabled : 1;
-  byte vvtEnabled : 1;
+  byte egoAlgorithm : 2; ///< EGO Algorithm - Simple, PID, No correction
+  byte egoType : 2;      ///< EGO Sensor Type 0=Disabled/None, 1=Narrowband, 2=Wideband
+  byte boostEnabled : 1; ///< Boost control enabled 0 =off, 1 = on
+  byte vvtEnabled : 1;   ///< 
   byte engineProtectType : 2;
 
   byte egoKP;
   byte egoKI;
   byte egoKD;
-  byte egoTemp; //The temperature above which closed loop functions
-  byte egoCount; //The number of ignition cylces per step
-  byte vvtMode : 2; //Valid VVT modes are 'on/off', 'open loop' and 'closed loop'
-  byte vvtLoadSource : 2; //Load source for VVT (TPS or MAP)
-  byte vvtPWMdir : 1; //VVT direction (normal or reverse)
+  byte egoTemp;     ///< The temperature above which closed loop is enabled
+  byte egoCount;    ///< The number of ignition cylces per (ego AFR ?) step
+  byte vvtMode : 2; ///< Valid VVT modes are 'on/off', 'open loop' and 'closed loop'
+  byte vvtLoadSource : 2; ///< Load source for VVT (TPS or MAP)
+  byte vvtPWMdir : 1; ///< VVT direction (normal or reverse)
   byte vvtCLUseHold : 1; //Whether or not to use a hold duty cycle (Most cases are Yes)
   byte vvtCLAlterFuelTiming : 1;
   byte boostCutEnabled : 1;
-  byte egoLimit; //Maximum amount the closed loop will vary the fueling
-  byte ego_min; //AFR must be above this for closed loop to function
-  byte ego_max; //AFR must be below this for closed loop to function
-  byte ego_sdelay; //Time in seconds after engine starts that closed loop becomes available
-  byte egoRPM; //RPM must be above this for closed loop to function
-  byte egoTPSMax; //TPS must be below this for closed loop to function
+  byte egoLimit;    /// Maximum amount the closed loop EGO control will vary the fueling
+  byte ego_min;     /// AFR must be above this for closed loop to function
+  byte ego_max;     /// AFR must be below this for closed loop to function
+  byte ego_sdelay;  /// Time in seconds after engine starts that closed loop becomes available
+  byte egoRPM;      /// RPM must be above this for closed loop to function
+  byte egoTPSMax;   /// TPS must be below this for closed loop to function
   byte vvt1Pin : 6;
   byte useExtBaro : 1;
-  byte boostMode : 1; //Simple of full boost control
+  byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
   byte unused_bit : 1; //Previously was VVTasOnOff
-  byte useEMAP : 1;
+  byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage
   byte airDenBins[9];
   byte airDenRates[9];
-  byte boostFreq; //Frequency of the boost PWM valve
-  byte vvtFreq; //Frequency of the vvt PWM valve
+  byte boostFreq;   /// Frequency of the boost PWM valve
+  byte vvtFreq;     /// Frequency of the vvt PWM valve
   byte idleFreq;
-
-  byte launchPin : 6;
-  byte launchEnabled : 1;
-  byte launchHiLo : 1;
+  // Launch stuff, see beginning of speeduino.ino main loop
+  byte launchPin : 6; ///< Launch (control ?) pin
+  byte launchEnabled : 1; ///< Launch ...???... (control?) enabled
+  byte launchHiLo : 1;  // 
 
   byte lnchSoftLim;
   int8_t lnchRetard; //Allow for negative advance value (ATDC)
@@ -1000,15 +1036,15 @@ struct config6 {
   byte idleKI;
   byte idleKD;
 
-  byte boostLimit; //Is divided by 2, allowing kPa values up to 511
+  byte boostLimit; ///< Boost limit (Kpa). Stored value is actual (kPa) value divided by 2, allowing kPa values up to 511
   byte boostKP;
   byte boostKI;
   byte boostKD;
 
   byte lnchPullRes : 1;
-  byte iacPWMrun : 1; //Should the PWM idle valve run before engine is cranked over
+  byte iacPWMrun : 1; ///< Run the PWM idle valve before engine is cranked over (0 = off, 1 = on)
   byte fuelTrimEnabled : 1;
-  byte flatSEnable : 1;
+  byte flatSEnable : 1; ///< Flat shift enable
   byte baroPin : 4;
   byte flatSSoftWin;
   byte flatSRetard;
@@ -1046,8 +1082,9 @@ struct config6 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
-//Page 9 of the config mostly deals with CANBUS control
-//See ini file for further info (Config Page 10 in the ini)
+/** Page 9 of the config - mostly deals with CANBUS control.
+See ini file for further info (Config Page 10 in the ini).
+*/
 struct config9 {
   byte enable_secondarySerial:1;            //enable secondary serial
   byte intcan_available:1;                     //enable internal can module
@@ -1124,10 +1161,9 @@ struct config9 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
-/*
-Page 10 - No specific purpose. Created initially for the cranking enrich curve
-192 bytes long
-See ini file for further info (Config Page 11 in the ini)
+/** Page 10 - No specific purpose. Created initially for the cranking enrich curve.
+192 bytes long.
+See ini file for further info (Config Page 11 in the ini).
 */
 struct config10 {
   byte crankingEnrichBins[4]; //Bytes 0-4
@@ -1234,8 +1270,8 @@ struct config10 {
 
   byte crankingEnrichTaper; //Byte 134
 
-  byte fuelPressureEnable : 1;
-  byte oilPressureEnable : 1;
+  byte fuelPressureEnable : 1; ///< Enable fuel pressure sensing from an analog pin (@ref pinFuelPressure)
+  byte oilPressureEnable : 1;  ///< Enable oil pressure sensing from an analog pin (@ref pinOilPressure)
   byte oilPressureProtEnbl : 1;
   byte oilPressurePin : 5;
 
@@ -1304,33 +1340,35 @@ struct config10 {
 #else
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
-
+/** Config for programmable I/O comparison operation (between 2 vars).
+ * Operations are implemented in utilities.ino (@ref checkProgrammableIO()).
+ */
 struct cmpOperation{
-  uint8_t firstCompType : 3;
-  uint8_t secondCompType : 3;
-  uint8_t bitwise : 2;
+  uint8_t firstCompType : 3;  ///< First cmp. op (COMPARATOR_* ops, see below)
+  uint8_t secondCompType : 3; ///< Second cmp. op (0=COMPARATOR_EQUAL, 1=COMPARATOR_NOT_EQUAL,2=COMPARATOR_GREATER,3=COMPARATOR_GREATER_EQUAL,4=COMPARATOR_LESS,5=COMPARATOR_LESS_EQUAL,6=COMPARATOR_CHANGE)
+  uint8_t bitwise : 2; ///< BITWISE_AND, BITWISE_OR, BITWISE_XOR
 };
 
-/*
-Page 13 - Programmable outputs conditions.
-128 bytes long
+/**
+Page 13 - Programmable outputs logic rules.
+128 bytes long. Rules implemented in utilities.ino @ref checkProgrammableIO().
 */
 struct config13 {
-  uint8_t outputInverted;
-  uint8_t unused12_1;
-  uint8_t outputPin[8];
-  uint8_t outputDelay[8]; //0.1S
-  uint8_t firstDataIn[8];
-  uint8_t secondDataIn[8];
-  uint8_t unused_13[16];
-  int16_t firstTarget[8];
-  int16_t secondTarget[8];
+  uint8_t outputInverted; ///< Invert (on/off) value before writing to output pin (for all programmable I/O:s?).
+  uint8_t unused12_1; // Unused
+  uint8_t outputPin[8];   ///< Disable(0) or enable (set to valid pin number) Programmable Pin (output/target pin to set)
+  uint8_t outputDelay[8]; ///< Output write delay for each programmable I/O (Unit: 0.1S ?)
+  uint8_t firstDataIn[8]; ///< Set of first I/O vars to compare
+  uint8_t secondDataIn[8];///< Set of second I/O vars to compare
+  uint8_t unused_13[16]; // Unused
+  int16_t firstTarget[8]; ///< first  target value to compare with numeric comp
+  int16_t secondTarget[8];///< second target value to compare with bitwise op
   //89bytes
-  struct cmpOperation operation[8];
+  struct cmpOperation operation[8]; ///< I/O variable comparison operations (See @ref cmpOperation)
 
-  uint16_t candID[8]; //Actual CAN ID need 16bits, this is a placeholder
+  uint16_t candID[8]; ///< Actual CAN ID need 16bits, this is a placeholder
 
-  byte unused12_106_127[22];
+  byte unused12_106_127[22]; // Unused
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -1,55 +1,58 @@
+/** @file
+ * Instantiation of various (table2D, table3D) tables, volatile (interrupt modified) variables, Injector (1...8) enablement flags, etc.
+ */
 #include "globals.h"
 
 const char TSfirmwareVersion[] PROGMEM = "Speeduino";
 
-const byte data_structure_version = 2; //This identifies the data structure when reading / writing.
+const byte data_structure_version = 2; //This identifies the data structure when reading / writing. (outdated ?)
 
-struct table3D fuelTable; //16x16 fuel map
-struct table3D fuelTable2; //16x16 fuel map
-struct table3D ignitionTable; //16x16 ignition map
-struct table3D ignitionTable2; //16x16 ignition map
-struct table3D afrTable; //16x16 afr target map
-struct table3D stagingTable; //8x8 fuel staging table
-struct table3D boostTable; //8x8 boost map
-struct table3D vvtTable; //8x8 vvt map
-struct table3D vvt2Table; //8x8 vvt2 map
-struct table3D wmiTable; //8x8 wmi map
-struct table3D trim1Table; //6x6 Fuel trim 1 map
-struct table3D trim2Table; //6x6 Fuel trim 2 map
-struct table3D trim3Table; //6x6 Fuel trim 3 map
-struct table3D trim4Table; //6x6 Fuel trim 4 map
-struct table3D trim5Table; //6x6 Fuel trim 5 map
-struct table3D trim6Table; //6x6 Fuel trim 6 map
-struct table3D trim7Table; //6x6 Fuel trim 7 map
-struct table3D trim8Table; //6x6 Fuel trim 8 map
-struct table3D dwellTable; //4x4 Dwell map
-struct table2D taeTable; //4 bin TPS Acceleration Enrichment map (2D)
+struct table3D fuelTable; ///< 16x16 fuel map
+struct table3D fuelTable2; ///< 16x16 fuel map
+struct table3D ignitionTable; ///< 16x16 ignition map
+struct table3D ignitionTable2; ///< 16x16 ignition map
+struct table3D afrTable; ///< 16x16 afr target map
+struct table3D stagingTable; ///< 8x8 fuel staging table
+struct table3D boostTable; ///< 8x8 boost map
+struct table3D vvtTable; ///< 8x8 vvt map
+struct table3D vvt2Table; ///< 8x8 vvt2 map
+struct table3D wmiTable; ///< 8x8 wmi map
+struct table3D trim1Table; ///< 6x6 Fuel trim 1 map
+struct table3D trim2Table; ///< 6x6 Fuel trim 2 map
+struct table3D trim3Table; ///< 6x6 Fuel trim 3 map
+struct table3D trim4Table; ///< 6x6 Fuel trim 4 map
+struct table3D trim5Table; ///< 6x6 Fuel trim 5 map
+struct table3D trim6Table; ///< 6x6 Fuel trim 6 map
+struct table3D trim7Table; ///< 6x6 Fuel trim 7 map
+struct table3D trim8Table; ///< 6x6 Fuel trim 8 map
+struct table3D dwellTable; ///< 4x4 Dwell map
+struct table2D taeTable; ///< 4 bin TPS Acceleration Enrichment map (2D)
 struct table2D maeTable;
-struct table2D WUETable; //10 bin Warm Up Enrichment map (2D)
-struct table2D ASETable; //4 bin After Start Enrichment map (2D)
-struct table2D ASECountTable; //4 bin After Start duration map (2D)
-struct table2D PrimingPulseTable; //4 bin Priming pulsewidth map (2D)
-struct table2D crankingEnrichTable; //4 bin cranking Enrichment map (2D)
-struct table2D dwellVCorrectionTable; //6 bin dwell voltage correction (2D)
-struct table2D injectorVCorrectionTable; //6 bin injector voltage correction (2D)
-struct table2D injectorAngleTable; //4 bin injector angle curve (2D)
-struct table2D IATDensityCorrectionTable; //9 bin inlet air temperature density correction (2D)
-struct table2D baroFuelTable; //8 bin baro correction curve (2D)
-struct table2D IATRetardTable; //6 bin ignition adjustment based on inlet air temperature  (2D)
-struct table2D idleTargetTable; //10 bin idle target table for idle timing (2D)
-struct table2D idleAdvanceTable; //6 bin idle advance adjustment table based on RPM difference  (2D)
-struct table2D CLTAdvanceTable; //6 bin ignition adjustment based on coolant temperature  (2D)
-struct table2D rotarySplitTable; //8 bin ignition split curve for rotary leading/trailing  (2D)
-struct table2D flexFuelTable;  //6 bin flex fuel correction table for fuel adjustments (2D)
-struct table2D flexAdvTable;   //6 bin flex fuel correction table for timing advance (2D)
-struct table2D flexBoostTable; //6 bin flex fuel correction table for boost adjustments (2D)
-struct table2D fuelTempTable;  //6 bin flex fuel correction table for fuel adjustments (2D)
+struct table2D WUETable; ///< 10 bin Warm Up Enrichment map (2D)
+struct table2D ASETable; ///< 4 bin After Start Enrichment map (2D)
+struct table2D ASECountTable; ///< 4 bin After Start duration map (2D)
+struct table2D PrimingPulseTable; ///< 4 bin Priming pulsewidth map (2D)
+struct table2D crankingEnrichTable; ///< 4 bin cranking Enrichment map (2D)
+struct table2D dwellVCorrectionTable; ///< 6 bin dwell voltage correction (2D)
+struct table2D injectorVCorrectionTable; ///< 6 bin injector voltage correction (2D)
+struct table2D injectorAngleTable; ///< 4 bin injector angle curve (2D)
+struct table2D IATDensityCorrectionTable; ///< 9 bin inlet air temperature density correction (2D)
+struct table2D baroFuelTable; ///< 8 bin baro correction curve (2D)
+struct table2D IATRetardTable; ///< 6 bin ignition adjustment based on inlet air temperature  (2D)
+struct table2D idleTargetTable; ///< 10 bin idle target table for idle timing (2D)
+struct table2D idleAdvanceTable; ///< 6 bin idle advance adjustment table based on RPM difference  (2D)
+struct table2D CLTAdvanceTable; ///< 6 bin ignition adjustment based on coolant temperature  (2D)
+struct table2D rotarySplitTable; ///< 8 bin ignition split curve for rotary leading/trailing  (2D)
+struct table2D flexFuelTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
+struct table2D flexAdvTable;   ///< 6 bin flex fuel correction table for timing advance (2D)
+struct table2D flexBoostTable; ///< 6 bin flex fuel correction table for boost adjustments (2D)
+struct table2D fuelTempTable;  ///< 6 bin flex fuel correction table for fuel adjustments (2D)
 struct table2D knockWindowStartTable;
 struct table2D knockWindowDurationTable;
 struct table2D oilPressureProtectTable;
-struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
+struct table2D wmiAdvTable; ///< 6 bin wmi correction table for timing advance (2D)
 
-//These are for the direct port manipulation of the injectors, coils and aux outputs
+/// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;
 volatile PINMASK_TYPE inj1_pin_mask;
 volatile PORT_TYPE *inj2_pin_port;
@@ -97,7 +100,7 @@ volatile PINMASK_TYPE triggerPri_pin_mask;
 volatile PORT_TYPE *triggerSec_pin_port;
 volatile PINMASK_TYPE triggerSec_pin_mask;
 
-//These need to be here as they are used in both speeduino.ino and scheduler.ino
+/// These need to be here as they are used in both speeduino.ino and scheduler.ino
 bool channel1InjEnabled = true;
 bool channel2InjEnabled = false;
 bool channel3InjEnabled = false;
@@ -117,21 +120,22 @@ int ignition7EndAngle = 0;
 int ignition8EndAngle = 0;
 
 //These are variables used across multiple files
-const byte PROGMEM fsIntIndex[34] = {4, 14, 17, 25, 27, 32, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 75, 77, 79, 81, 85, 87, 89, 93, 97, 102, 190 }; //int indexes in fullStatus array
-bool initialisationComplete = false; //Tracks whether the setup() function has run completely
-byte fpPrimeTime = 0; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
-volatile uint16_t mainLoopCount;
+/// int (member) indexes in fullStatus array
+const byte PROGMEM fsIntIndex[34] = {4, 14, 17, 25, 27, 32, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 75, 77, 79, 81, 85, 87, 89, 93, 97, 102, 190 };
+bool initialisationComplete = false; ///< Tracks whether the setup() function has run completely (true = has run)
+byte fpPrimeTime = 0; ///< The time (in seconds, based on @ref statuses.secl) that the fuel pump started priming
+volatile uint16_t mainLoopCount; //Main loop counter (incremented at each main loop rev., used for maintaining currentStatus.loopsPerSecond)
 unsigned long revolutionTime; //The time in uS that one revolution would take at current speed (The time tooth 1 was last seen, minus the time it was seen prior to that)
 volatile unsigned long timer5_overflow_count = 0; //Increments every time counter 5 overflows. Used for the fast version of micros()
 volatile unsigned long ms_counter = 0; //A counter that increments once per ms
 uint16_t fixedCrankingOverride = 0;
 bool clutchTrigger;
 bool previousClutchTrigger;
-volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
+volatile uint32_t toothHistory[TOOTH_LOG_BUFFER]; ///< Tooth trigger history - delta time (in uS) from last tooth (Indexed by @ref toothHistoryIndex)
 volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
-volatile bool fpPrimed = false; //Tracks whether or not the fuel pump priming has been completed yet
-volatile bool injPrimed = false; //Tracks whether or not the injectors priming has been completed yet
-volatile unsigned int toothHistoryIndex = 0;
+volatile bool fpPrimed = false; ///< Tracks whether or not the fuel pump priming has been completed yet
+volatile bool injPrimed = false; ///< Tracks whether or not the injectors priming has been completed yet
+volatile unsigned int toothHistoryIndex = 0; ///< Current index to @ref toothHistory array
 volatile byte toothHistorySerialIndex = 0;
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
@@ -147,7 +151,7 @@ volatile uint16_t ignitionCount; /**< The count of ignition events that have tak
 #endif
 int CRANK_ANGLE_MAX = 720;
 int CRANK_ANGLE_MAX_IGN = 360;
-int CRANK_ANGLE_MAX_INJ = 360; //The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
+int CRANK_ANGLE_MAX_INJ = 360; ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;
 volatile byte HWTest_INJ = 0; /**< Each bit in this variable represents one of the injector channels and it's HW test status */
@@ -162,55 +166,57 @@ byte resetControl = RESET_CONTROL_DISABLED;
 volatile byte TIMER_mask;
 volatile byte LOOP_TIMER;
 
-
-byte pinInjector1; //Output pin injector 1
-byte pinInjector2; //Output pin injector 2
-byte pinInjector3; //Output pin injector 3
-byte pinInjector4; //Output pin injector 4
-byte pinInjector5; //Output pin injector 5
-byte pinInjector6; //Output pin injector 6
-byte pinInjector7; //Output pin injector 7
-byte pinInjector8; //Output pin injector 8
-byte injectorOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
-byte pinCoil1; //Pin for coil 1
-byte pinCoil2; //Pin for coil 2
-byte pinCoil3; //Pin for coil 3
-byte pinCoil4; //Pin for coil 4
-byte pinCoil5; //Pin for coil 5
-byte pinCoil6; //Pin for coil 6
-byte pinCoil7; //Pin for coil 7
-byte pinCoil8; //Pin for coil 8
-byte ignitionOutputControl = OUTPUT_CONTROL_DIRECT; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810. 0=Direct
-byte pinTrigger; //The CAS pin
-byte pinTrigger2; //The Cam Sensor pin
-byte pinTrigger3;	//the 2nd cam sensor pin
-byte pinTPS;//TPS input pin
-byte pinMAP; //MAP sensor pin
-byte pinEMAP; //EMAP sensor pin
-byte pinMAP2; //2nd MAP sensor (Currently unused)
-byte pinIAT; //IAT sensor pin
-byte pinCLT; //CLS sensor pin
-byte pinO2; //O2 Sensor pin
-byte pinO2_2; //second O2 pin
-byte pinBat; //Battery voltage pin
+/// Various pin numbering (Injectors, Ign outputs, CAS, Cam, Sensors. etc.) assignments
+byte pinInjector1; ///< Output pin injector 1
+byte pinInjector2; ///< Output pin injector 2
+byte pinInjector3; ///< Output pin injector 3
+byte pinInjector4; ///< Output pin injector 4
+byte pinInjector5; ///< Output pin injector 5
+byte pinInjector6; ///< Output pin injector 6
+byte pinInjector7; ///< Output pin injector 7
+byte pinInjector8; ///< Output pin injector 8
+byte injectorOutputControl = OUTPUT_CONTROL_DIRECT; /**< Specifies whether the injectors are controlled directly (Via an IO pin)
+    or using something like the MC33810. 0 = Direct (OUTPUT_CONTROL_DIRECT), 10 = MC33810 (OUTPUT_CONTROL_MC33810) */
+byte pinCoil1; ///< Pin for coil 1
+byte pinCoil2; ///< Pin for coil 2
+byte pinCoil3; ///< Pin for coil 3
+byte pinCoil4; ///< Pin for coil 4
+byte pinCoil5; ///< Pin for coil 5
+byte pinCoil6; ///< Pin for coil 6
+byte pinCoil7; ///< Pin for coil 7
+byte pinCoil8; ///< Pin for coil 8
+byte ignitionOutputControl = OUTPUT_CONTROL_DIRECT; /**< Specifies whether the coils are controlled directly (Via an IO pin)
+   or using something like the MC33810. 0 = Direct (OUTPUT_CONTROL_DIRECT), 10 = MC33810 (OUTPUT_CONTROL_MC33810) */
+byte pinTrigger;  ///< RPM1 (Typically CAS=crankshaft angle sensor) pin
+byte pinTrigger2; ///< RPM2 (Typically the Cam Sensor) pin
+byte pinTrigger3;	///< the 2nd cam sensor pin
+byte pinTPS;      //TPS input pin
+byte pinMAP;      //MAP sensor pin
+byte pinEMAP;     //EMAP sensor pin
+byte pinMAP2;     //2nd MAP sensor (Currently unused)
+byte pinIAT;      //IAT sensor pin
+byte pinCLT;      //CLS sensor pin
+byte pinO2;       //O2 Sensor pin
+byte pinO2_2;     //second O2 pin
+byte pinBat;      //Battery voltage pin
 byte pinDisplayReset; // OLED reset pin
-byte pinTachOut; //Tacho output
+byte pinTachOut;  //Tacho output
 byte pinFuelPump; //Fuel pump on/off
-byte pinIdle1; //Single wire idle control
-byte pinIdle2; //2 wire idle control (Not currently used)
-byte pinIdleUp; //Input for triggering Idle Up
+byte pinIdle1;    //Single wire idle control
+byte pinIdle2;    //2 wire idle control (Not currently used)
+byte pinIdleUp;   //Input for triggering Idle Up
 byte pinIdleUpOutput; //Output that follows (normal or inverted) the idle up pin
-byte pinCTPS; //Input for triggering closed throttle state
-byte pinFuel2Input; //Input for switching to the 2nd fuel table
+byte pinCTPS;     //Input for triggering closed throttle state
+byte pinFuel2Input;  //Input for switching to the 2nd fuel table
 byte pinSpark2Input; //Input for switching to the 2nd ignition table
-byte pinSpareTemp1; // Future use only
-byte pinSpareTemp2; // Future use only
-byte pinSpareOut1; //Generic output
-byte pinSpareOut2; //Generic output
-byte pinSpareOut3; //Generic output
-byte pinSpareOut4; //Generic output
-byte pinSpareOut5; //Generic output
-byte pinSpareOut6; //Generic output
+byte pinSpareTemp1;  // Future use only
+byte pinSpareTemp2;  // Future use only
+byte pinSpareOut1;  //Generic output
+byte pinSpareOut2;  //Generic output
+byte pinSpareOut3;  //Generic output
+byte pinSpareOut4;  //Generic output
+byte pinSpareOut5;  //Generic output
+byte pinSpareOut6;  //Generic output
 byte pinSpareHOut1; //spare high current output
 byte pinSpareHOut2; // spare high current output
 byte pinSpareLOut1; // spare low current output
@@ -219,30 +225,30 @@ byte pinSpareLOut3;
 byte pinSpareLOut4;
 byte pinSpareLOut5;
 byte pinBoost;
-byte pinVVT_1;		// vvt output 1
-byte pinVVT_2;		// vvt output 2
-byte pinFan;       // Cooling fan output
+byte pinVVT_1;     ///< vvt (variable valve timing) output 1
+byte pinVVT_2;     ///< vvt (variable valve timing) output 2
+byte pinFan;       ///< Cooling fan output (on/off? See: auxiliaries.ino)
 byte pinStepperDir; //Direction pin for the stepper motor driver
 byte pinStepperStep; //Step pin for the stepper motor driver
 byte pinStepperEnable; //Turning the DRV8825 driver on/off
 byte pinLaunch;
 byte pinIgnBypass; //The pin used for an ignition bypass (Optional)
 byte pinFlex; //Pin with the flex sensor attached
-byte pinVSS;
+byte pinVSS;  // VSS (Vehicle speed sensor) Pin
 byte pinBaro; //Pin that an al barometric pressure sensor is attached to (If used)
 byte pinResetControl; // Output pin used control resetting the Arduino
 byte pinFuelPressure;
 byte pinOilPressure;
 byte pinWMIEmpty; // Water tank empty sensor
 byte pinWMIIndicator; // No water indicator bulb
-byte pinWMIEnabled; // ON-OFF ouput to relay/pump/solenoid 
+byte pinWMIEnabled; // ON-OFF output to relay/pump/solenoid 
 byte pinMC33810_1_CS;
 byte pinMC33810_2_CS;
 #ifdef USE_SPI_EEPROM
   byte pinSPIFlash_CS;
 #endif
 
-struct statuses currentStatus; /**< The master global status struct. Contains all values that are updated frequently and used across modules */
+struct statuses currentStatus; /**< The master global "live" status struct. Contains all values that are updated frequently and used across modules */
 struct config2 configPage2;
 struct config4 configPage4;
 struct config6 configPage6;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1,3 +1,6 @@
+/** @file
+ * Speeduino Initialization (called at Arduino setup()).
+ */
 #include "globals.h"
 #include "init.h"
 #include "storage.h"
@@ -22,7 +25,26 @@
   #include "rtc_common.h"
 #endif
 
-
+/** Initialize Speeduino for the main loop.
+ * Top level init entrypoint for all initializations:
+ * - Intialize and set sizes of 3D tables
+ * - Load config from EEPROM, update config structures to current version of SW if needed.
+ * - Initialize board (The initBoard() is for board X implemented in board_X.ino file)
+ * - Initialize timers (See timers.ino)
+ * - Perform optional SD card and RTC battery inits
+ * - Load calibrarion tables from EEPROM
+ * - Perform pin mapping (calling @ref setPinMapping() based on @ref config2.pinMapping)
+ * - Stop any coil charging and close injectors
+ * - Intialize schedulers, Idle, Fan, auxPWM, Corrections, AD-conversions, Programmable I/O
+ * - Intialize baro (ambient pressure) by reading MAP (before engine runs)
+ * - Intialize triggers (by @ref initialiseTriggers() )
+ * - Perform cyl. count based initializations (@ref config2.nCylinders)
+ * - Perform injection and spark mode based setup
+ *   - Assign injector open/close and coil charge begin/end functions to their dedicated global vars
+ * - Perform fuel pressure priming by turning fuel pump on
+ * - Read CLT and TPS sensors to have cranking pulsewidths computed correctly
+ * - Mark Initialization completed (this flag-marking is used in code to prevent after-init changes)
+ */
 void initialiseAll()
 {   
     fpPrimed = false;
@@ -246,7 +268,8 @@ void initialiseAll()
     }
     else { setPinMapping(configPage2.pinMapping); }
 
-    //Note: This must come after the call to setPinMapping() or else pins 29 and 30 will become unusable as outputs. Workaround for: https://github.com/tonton81/FlexCAN_T4/issues/14
+    /* Note: This must come after the call to setPinMapping() or else pins 29 and 30 will become unusable as outputs.
+     * Workaround for: https://github.com/tonton81/FlexCAN_T4/issues/14 */
     #if defined(CORE_TEENSY35)
       Can0.setRX(DEF);
       Can0.setTX(DEF);
@@ -1179,7 +1202,11 @@ void initialiseAll()
     initialisationComplete = true;
     digitalWrite(LED_BUILTIN, HIGH);
 }
-
+/** Set board / microcontroller specfic pin mappings / assignments.
+ * The boardID is switch-case compared against raw boardID integers (not enum or #define:d label, and probably no need for that either)
+ * which are originated from tuning SW (e.g. TS) set values and are avilable in reference/speeduino.ini (See pinLayout, note also that
+ * numbering is not contiguous here).
+ */
 void setPinMapping(byte boardID)
 {
   //Force set defaults. Will be overwritten below if needed.
@@ -2695,7 +2722,12 @@ void setPinMapping(byte boardID)
   flex_pin_mask = digitalPinToBitMask(pinFlex);
 
 }
-
+/** Initialize the chosen trigger decoder.
+ * - Set Interrput numbers @ref triggerInterrupt, @ref triggerInterrupt2 and @ref triggerInterrupt3  by pin their numbers (based on board CORE_* define)
+ * - Call decoder specific setup function triggerSetup_*() (by @ref config4.TrigPattern, set to one of the DECODER_* defines) and do any additional initializations needed.
+ * 
+ * @todo Explain why triggerSetup_*() alone cannot do all the setup, but there's ~10+ lines worth of extra init for each of decoders.
+ */
 void initialiseTriggers()
 {
   byte triggerInterrupt = 0; // By default, use the first interrupt

--- a/speeduino/scheduledIO.ino
+++ b/speeduino/scheduledIO.ino
@@ -3,7 +3,12 @@
 #include "globals.h"
 #include "timers.h"
 #include "acc_mc33810.h"
-
+/** @file
+ * Injector and Coil (toggle/open/close) control (under various situations, eg with particular cylinder count, rotary engine type or wasted spark ign, etc.).
+ * Also accounts for presence of MC33810 injector/ignition (dwell, etc.) control circuit.
+ * Functions here are typically assigned (at initialization) to callback function variables (e.g. inj1StartFunction or inj1EndFunction) 
+ * form where they are called (by scheduler.ino).
+ */
 inline void openInjector1()   { if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { openInjector1_DIRECT(); }   else { openInjector1_MC33810(); } }
 inline void closeInjector1()  { if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { closeInjector1_DIRECT(); }  else { closeInjector1_MC33810(); } }
 inline void openInjector2()   { if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { openInjector2_DIRECT(); }   else { openInjector2_MC33810(); } }

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -3,7 +3,27 @@ Speeduino - Simple engine management for the Arduino Mega 2560 platform
 Copyright (C) Josh Stewart
 A full copy of the license may be found in the projects root directory
 */
-
+/** @file
+ * Injector and Ignition (on/off) scheduling (functions).
+ * There is usually 8 functions for cylinders 1-8 with same naming pattern.
+ * 
+ * ## Scheduling structures
+ * 
+ * Structures @ref FuelSchedule and @ref Schedule describe (from scheduler.h) describe the scheduling info for Fuel and Ignition respectively.
+ * They contain duration, current activity status, start timing, end timing, callbacks to carry out action, etc.
+ * 
+ * ## Scheduling Functions
+ * 
+ * For Injection:
+ * - setFuelSchedule*(tout,dur) - **Setup** schedule for (next) injection on the channel
+ * - inj*StartFunction() - Execute **start** of injection (Interrupt handler)
+ * - inj*EndFunction() - Execute **end** of injection (interrupt handler)
+ * 
+ * For Ignition (has more complex schedule setup):
+ * - setIgnitionSchedule*(cb_st,tout,dur,cb_end) - **Setup** schedule for (next) ignition on the channel
+ * - ign*StartFunction() - Execute **start** of ignition (Interrupt handler)
+ * - ign*EndFunction() - Execute **end** of ignition (Interrupt handler)
+ */
 #include "globals.h"
 #include "scheduler.h"
 #include "scheduledIO.h"
@@ -757,10 +777,12 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     }
   }
 }
-
+/** Perform the injector priming pulses.
+ * Set these to run at an arbitrary time in the future (100us).
+ * The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
+ */
 extern void beginInjectorPriming()
 {
-  //Perform the injector priming pulses. Set these to run at an arbitrary time in the future (100us). The prime pulse value is in ms*10, so need to multiple by 100 to get to uS
   unsigned long primingValue = table2D_getValue(&PrimingPulseTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET);
   if( (primingValue > 0) && (currentStatus.TPS < configPage4.floodClear) )
   {
@@ -791,9 +813,12 @@ extern void beginInjectorPriming()
 }
 
 /*******************************************************************************************************************************************************************************************************/
-//This function (All 8 ISR functions that are below) gets called when either the start time or the duration time are reached
-//This calls the relevant callback function (startCallback or endCallback) depending on the status of the schedule.
-//If the startCallback function is called, we put the scheduler into RUNNING state
+/** fuelSchedule*Interrupt (All 8 ISR functions below) get called (as timed interrupts) when either the start time or the duration time are reached.
+* This calls the relevant callback function (startCallback or endCallback) depending on the status (PENDING => Needs to run, RUNNING => Needs to stop) of the schedule.
+* The status of schedule is managed here based on startCallback /endCallback function called:
+* - startCallback - change scheduler into RUNNING state
+* - endCallback - change scheduler into OFF state (or PENDING if schedule.hasNextSchedule is set)
+*/
 //Timer3A (fuel schedule 1) Compare Vector
 #if (INJ_CHANNELS >= 1)
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) //AVR chips use the ISR for this

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -3,6 +3,9 @@ Speeduino - Simple engine management for the Arduino Mega 2560 platform
 Copyright (C) Josh Stewart
 A full copy of the license may be found in the projects root directory
 */
+/** @file
+ * Read sensors with appropriate timing / scheduling.
+ */
 #include "sensors.h"
 #include "crankMaths.h"
 #include "globals.h"
@@ -14,6 +17,8 @@ A full copy of the license may be found in the projects root directory
 #include "corrections.h"
 #include "pages.h"
 
+/** Init all ADC conversions by setting resolutions, etc.
+ */
 void initialiseADC()
 {
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) //AVR chips use the ISR for this
@@ -544,6 +549,7 @@ uint16_t getSpeed()
   {
     //VSS mode 1 is (Will be) CAN
   }
+  // Interrupt driven mode
   else if(configPage2.vssMode > 1)
   {
     if( vssCount == VSS_SAMPLES ) //We only change the reading if we've reached the required number of samples

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -1,8 +1,12 @@
-/*
- * This routine is used for doing any data conversions that are required during firmware changes
+/** @file
+ * EEPROM Storage updates.
+ */
+/** Store and load various configs to/from EEPROM considering the the data format versions of various SW generations.
+ * This routine is used for doing any data conversions that are required during firmware changes.
  * This prevents users getting difference reports in TS when such a data change occurs.
- * It also can be used for setting good values when there are viarables that move locations in the ini
- * When a user skips multiple firmware versions at a time, this will roll through the updates 1 at a time
+ * It also can be used for setting good values when there are viarables that move locations in the ini.
+ * When a user skips multiple firmware versions at a time, this will roll through the updates 1 at a time.
+ * The doUpdates() uses may lower level routines from Arduino EEPROM library and storage.ino to carry out EEPROM storage tasks.
  */
 #include "globals.h"
 #include "storage.h"

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -3,7 +3,10 @@
   Copyright (C) Josh Stewart
   A full copy of the license may be found in the projects root directory
 */
-
+/** @file
+ * Custom Programmable I/O.
+ * The config related to Programmable I/O is found on configPage13 (of type @ref config13).
+ */
 #include <avr/pgmspace.h>
 #include "globals.h"
 #include "utilities.h"
@@ -14,9 +17,12 @@ uint16_t ioDelay[sizeof(configPage13.outputPin)];
 uint8_t pinIsValid = 0;
 
 
-//This function performs a translation between the pin list that appears in TS and the actual pin numbers
-//For the digital IO, this will simply return the same number as the rawPin value as those are mapped directly.
-//For analog pins, it will translate them into the currect internal pin number
+/** Translate between the pin list that appears in TS and the actual pin numbers.
+For the **digital IO**, this will simply return the same number as the rawPin value as those are mapped directly.
+For **analog pins**, it will translate them into the correct internal pin number.
+* @param rawPin - High level pin number
+* @return Translated / usable pin number
+*/
 byte pinTranslate(byte rawPin)
 {
   byte outputPin = rawPin;
@@ -24,8 +30,9 @@ byte pinTranslate(byte rawPin)
 
   return outputPin;
 }
-//Translates an pin number (0 - 22) to the relevant Ax pin reference.
-//This is required as some ARM chips do not have all analog pins in order (EG pin A15 != A14 + 1)
+/** Translate a pin number (0 - 22) to the relevant Ax (analog) pin reference.
+* This is required as some ARM chips do not have all analog pins in order (EG pin A15 != A14 + 1).
+* */
 byte pinTranslateAnalog(byte rawPin)
 {
   byte outputPin = rawPin;
@@ -121,7 +128,11 @@ void initialiseProgrammableIO()
     }
   }
 }
-
+/** Check all (8) programmable I/O:s and carry out action on output pin as needed.
+ * Compare 2 (16 bit) vars in a way configured by @ref config13.cmpOperation.
+ * Use ProgrammableIOGetData() to get 2 vars to compare.
+ * Skip all programmable I/O:s where output pin is set 0 (meaning: not programmed).
+ */
 void checkProgrammableIO()
 {
   int16_t data, data2;
@@ -184,7 +195,11 @@ void checkProgrammableIO()
     else { BIT_CLEAR(currentStatus.outputsStatus, y); }
   }
 }
-
+/** Get single I/O data var (from currentStatus) for comparison.
+ * Uses member offset index @ref fsIntIndex to lookup realtime 'live' data from @ref currentStatus.
+ * @param index - Field index/number (?)
+ * @return 16 bit (int) result
+ */
 int16_t ProgrammableIOGetData(uint16_t index)
 {
   int16_t result;
@@ -194,10 +209,11 @@ int16_t ProgrammableIOGetData(uint16_t index)
     
     for(x = 0; x<sizeof(fsIntIndex); x++)
     {
+      // Stop at desired field
       if (fsIntIndex[x] == index) { break; }
     }
-    if (x >= sizeof(fsIntIndex)) { result = getStatusEntry(index); }
-    else { result = word(getStatusEntry(index+1), getStatusEntry(index)); }
+    if (x >= sizeof(fsIntIndex)) { result = getStatusEntry(index); } // 8-bit, coerce to 16 bit result
+    else { result = word(getStatusEntry(index+1), getStatusEntry(index)); } // Assemble 2 bytes to word of 16 bit result
     
 
     //Special cases for temperatures


### PR DESCRIPTION
Document statuses and config* structure members in globals.h:
- Convert existing documentation to doxygen
- Document some of the undocumented members cross-referencing code files
  where they are used (often containing good explanations in code comments) or
  deriving meaning from code (leave question mark as marker of uncertainty
  or need for clarification)
- Same activity in misc .h header files w. struct declarations.
Misc .ino files with code:
- Convert existing code documentation to doxygen
- Add documentation to undocumented functions (deriving idea from raw code and
  code embedded comments)
- Some additions to existing documentation.

End sentences with period, as it has many iportant meanings for Doxygen
e.g. auto-brief ends at first-sentence period and in (doxygen generated)
HTML ascii newline does not break lines (or sentences).
Doxyfile: Add README.md file as INPUT from upper (codebase root) directory.
