### PR TITLE
Sincronize tacho events with coil events

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -733,7 +733,7 @@ struct config2 {
   byte crankingPct;     ///< Cranking enrichment (See @ref config10, updates.ino)
   byte pinMapping;      ///< The board / ping mapping number / id to be used (See: @ref setPinMapping in init.ino)
   byte tachoPin : 6;    ///< Custom pin setting for tacho output (if != 0, override copied to pinTachOut, which defaults to board assigned tach pin)
-  byte tachoDiv : 2;    ///< Whether to change the tacho speed ("half speed tacho" ?)
+  byte tachoDiv : 2;    ///< Whether to change the tacho speed (1 = "half speed tacho")
   byte tachoDuration;   //The duration of the tacho pulse in mS
   byte maeThresh;       /**< The MAPdot threshold that must be exceeded before AE is engaged */
   byte taeThresh;       /**< The TPSdot threshold that must be exceeded before AE is engaged */

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -105,6 +105,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
 void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
 void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)());
+void setTachoLow(void);
 
 inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((always_inline));
 

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -23,7 +23,7 @@ volatile bool tachoAlt = false;
 #define TACHO_PULSE_HIGH() *tach_pin_port |= (tach_pin_mask)
 #define TACHO_PULSE_LOW() *tach_pin_port &= ~(tach_pin_mask)
 enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tacho output pulse can have
-volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
+volatile uint8_t tachoTime; //The time (in ms) that the tacho pulse needs
 volatile TachoOutputStatus tachoOutputFlag;
 
 volatile byte loop33ms;

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -69,32 +69,15 @@ void oneMSInterval() //Most ARM chips can simply call a function
   if(ignitionSchedule8.Status == RUNNING) { if( (ignitionSchedule8.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign8EndFunction(); ignitionSchedule8.Status = OFF; } }
 
   //Tacho output check
-  //Tacho is flagged as being ready for a pulse by the ignition outputs. 
-  if(tachoOutputFlag == READY)
-  {
-    //Check for half speed tacho
-    if( (configPage2.tachoDiv == 0) || (tachoAlt == true) ) 
-    { 
-      TACHO_PULSE_LOW();
-      //ms_counter is cast down to a byte as the tacho duration can only be in the range of 1-6, so no extra resolution above that is required
-      tachoEndTime = (uint8_t)ms_counter + configPage2.tachoDuration;
-      tachoOutputFlag = ACTIVE;
-    }
-    else
-    {
-      //Don't run on this pulse (Half speed tacho)
-      tachoOutputFlag = DEACTIVE;
-    }
-    tachoAlt = !tachoAlt; //Flip the alternating value incase half speed tacho is in use. 
-  }
-  else if(tachoOutputFlag == ACTIVE)
+  if(tachoOutputFlag == ACTIVE)
   {
     //If the tacho output is already active, check whether it's reached it's end time
-    if((uint8_t)ms_counter == tachoEndTime)
+    if( tachoTime >= configPage2.tachoDuration )
     {
       TACHO_PULSE_HIGH();
       tachoOutputFlag = DEACTIVE;
     }
+    tachoTime++; //Need to add after check because sometimes the tacho is set 0.1ms before this interrupt
   }
   // Tacho sweep
   


### PR DESCRIPTION
Current mode is asynchronous making electronic reading of tacho be totally unusable.

This change make the tacho pulse at beginning of coil charge because pulsing at end is buggy.

The tacho time setting is a minimum duration pulse at low level, sometimes it is bigger because the nature os asynchronous operation.

Sincronize tacho events with coil events