### PR TITLE
VNT turbo options

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -405,7 +405,13 @@ page = 1
 
       rtc_trim        = scalar,  S08,    123,               "ppm",      1, 0, -127, +127, 0
       idleAdvVss    = scalar, U08,      124,        "km/h",        1        0.0,    0.0,    255,       0 
-      unused2-95    = array,  U08,      125, [3],   "%",        1.0,       0.0,   0.0,     255,      0
+
+      ;VNT Boost control settings
+      vntBoostInv = bits, U08,   125, [0:0],       "Off", "On"
+      vntVaneSweepEnabled = bits, U08,   125, [1:1],       "Off", "On"
+      unused_vnt_bits = bits, U08, 125, [2:7]
+      vntVaneSweepMinDuty  = scalar, U08,      126,        "%",         1.0,       0.0,   0.0,     100.0,    0 ; Minimum duty cycles for vnt boost control sweep
+      vntVaneSweepMaxDuty  = scalar, U08,      127,        "%",         1.0,       0.0,   0.0,     100.0,    0 ; Maximum duty cycles for vnt boost control sweep
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -1432,6 +1438,10 @@ page = 14
     defaultValue = vvtCL0DutyAng, 0
     defaultValue = vvt2CL0DutyAng, 0
     defaultValue = ANGLEFILTER_VVT, 0
+    defaultValue = vntBoostInv, "off" ;Enabled for use with VNT/VGT actuators
+    defaultValue = vntVaneSweepEnabled, "Off"
+    defaultValue = vntVaneSweepMinDuty, 5 ;Most VNT actuators do not work outside 5-95% duty cycle
+    defaultValue = vntVaneSweepMaxDuty, 95
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -2039,6 +2049,8 @@ menuDialog = main
   ADCFILTER_MAP   = "This setting is only available when using the Instantaneious MAP sampling method. Recommended value: 20"
   ADCFILTER_BARO  = "This setting is only available when using an external Baro sensor. Recommended value: 64"
 
+  vntBoostInv = "This will invert the boost PWM signal. WARNING: This should only be used for OEM VNT actuators, and not for wastegate systems"
+  vntVaneSweepEnabled = "This is only for electronically actuated VNT turbos. It will sweep the actuator between the duty cycles pre-cranking to help prevent the vanes from sticking."
   boostIntv       = "The closed loop control interval will run every this many ms. Generally values between 50% and 100% of the valve frequency work best"
   vvtMode         = "Selects method of VVT control.\nOn/Off = No PWM control and output is only on or off.\nOpen Loop = PWM control where duty is taken directly from VVT table.\nClosed Loop = PWM control where VVT table is Cam angle target map and output duty is PID controlled."
   vvt2Enabled     = "Secondary VVT output. Uses same frequency and control algorithm as primary VVT output."
@@ -2761,6 +2773,12 @@ menuDialog = main
         panel = fuelPressureDialog
         panel = oilPressureDialog
 
+    dialog = vntSettings, "VNT Turbo Settings"
+        field = "Invert Boost Signal",      vntBoostInv,                { boostEnabled }
+        field = "Vane Sweep",               vntVaneSweepEnabled,        { boostEnabled }
+        field = "Minimum duty cycle",       vntVaneSweepMinDuty,        { vntVaneSweepEnabled && boostEnabled }
+        field = "Maximum duty cycle",       vntVaneSweepMaxDuty,        { vntVaneSweepEnabled && boostEnabled }
+
     dialog = boostSettings, "Boost Control"
         topicHelp = "https://wiki.speeduino.com/en/configuration/Boost_Control"
         field = "Boost Control Enabled",    boostEnabled
@@ -2778,6 +2796,7 @@ menuDialog = main
         field = "P",                        boostKP,       { boostEnabled && boostMode && boostType == 1 }
         field = "I",                        boostKI,       { boostEnabled && boostMode && boostType == 1 }
         field = "D",                        boostKD,       { boostEnabled && boostMode && boostType == 1 }
+        panel = vntSettings
 
     dialog = vvt2, "Second VVT output"
         field = "VVT2 Control Enabled",    vvt2Enabled

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -17,8 +17,10 @@ void wmiControl();
 #define SIMPLE_BOOST_I  1
 #define SIMPLE_BOOST_D  1
 
-#define BOOST_PIN_LOW()  *boost_pin_port &= ~(boost_pin_mask)
-#define BOOST_PIN_HIGH() *boost_pin_port |= (boost_pin_mask)
+#define BOOST_PIN_PORT_LOW() *boost_pin_port &= ~(boost_pin_mask)
+#define BOOST_PIN_PORT_HIGH() *boost_pin_port |= (boost_pin_mask)
+#define BOOST_PIN_LOW()    ((configPage2.vntBoostInv) ? BOOST_PIN_PORT_HIGH() : BOOST_PIN_PORT_LOW())
+#define BOOST_PIN_HIGH()   ((configPage2.vntBoostInv) ? BOOST_PIN_PORT_LOW() : BOOST_PIN_PORT_HIGH())
 #define VVT1_PIN_LOW()    *vvt1_pin_port &= ~(vvt1_pin_mask)
 #define VVT1_PIN_HIGH()   *vvt1_pin_port |= (vvt1_pin_mask)
 #define VVT2_PIN_LOW()    *vvt2_pin_port &= ~(vvt2_pin_mask)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -873,7 +873,11 @@ struct config2 {
   int8_t rtc_trim;
   byte idleAdvVss;
 
-  byte unused2_95[3];
+  byte vntBoostInv : 1;
+  byte vntVaneSweepEnabled : 1;
+  byte unused_vnt_bits : 6;
+  byte vntVaneSweepMinDuty;
+  byte vntVaneSweepMaxDuty;
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
This gives the option to invert the Boost Signal in the boost control settings.
Also reserves the necessary bytes in the TS config to implement VNT Sweep once Tacho Sweep is coded.

Adresses: 
#200 
#262

I'd be happy to add documentation to the wiki if needed.

Thanks