### PR TITLE
injector open time resolution increase

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -281,7 +281,7 @@ page = 1
       hardCutType   = bits,   U08,      26, [3:3], "Full",      "Rolling"
       ignAlgorithm  = bits,   U08,      26, [4:6], $loadSourceNames
       indInjAng     = bits,   U08,      26, [7:7], "Disabled", "Enabled"
-      injOpen       = scalar, U08,      27,        "ms",        0.1,       0.0,   0.1,    25.5,      1
+      injOpen       = scalar, U08,      27,        "ms",       0.01,       0.0,   0.1,   2.55,       2
       injAng        = array,  U16,      28, [4],   "deg",       1.0,       0.0,   0.0,    720,       0
 
       ; Config1

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -103,7 +103,7 @@ uint16_t correctionsFuel()
   currentStatus.batCorrection = correctionBatVoltage();
   if (configPage2.battVCorMode == BATTV_COR_MODE_OPENTIME)
   {
-    inj_opentime_uS = configPage2.injOpen * currentStatus.batCorrection; // Apply voltage correction to injector open time.
+    inj_opentime_uS = (configPage2.injOpen * currentStatus.batCorrection) / 10; // Apply voltage correction to injector open time.
   }
   if (configPage2.battVCorMode == BATTV_COR_MODE_WHOLE)
   {

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -365,7 +365,7 @@ void initialiseAll()
 
     //Once the configs have been loaded, a number of one time calculations can be completed
     req_fuel_uS = configPage2.reqFuel * 100; //Convert to uS and an int. This is the only variable to be used in calculations
-    inj_opentime_uS = configPage2.injOpen * 100; //Injector open time. Comes through as ms*10 (Eg 15.5ms = 155).
+    inj_opentime_uS = configPage2.injOpen * 10; //Injector open time. Comes through as ms*10 (Eg 15.5ms = 155).
 
     if(configPage10.stagingEnabled == true)
     {

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -491,6 +491,8 @@ void doUpdates()
     configPage10.vvtCLMaxAng = 200;
     configPage4.ANGLEFILTER_VVT = 0;
 
+    configPage2.injOpen *= 10; //injector open time resolution increased from 10 to 1us
+
     writeAllConfig();
     EEPROM.write(EEPROM_DATA_VERSION, 18);
   }


### PR DESCRIPTION
Big injector have a really small open time, current setting limitation could be very difficult to get a stable fuel mixture without a lot of math.

This simplifies the use of injectors datasheets.

I made a poll on Facebook to know if there was anyone using 2,55ms or more, so far nobody uses more than 2ms open time.  https://www.facebook.com/groups/191918764521976/permalink/1454448364935670