### PR TITLE
Enhanced cranking

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1056,7 +1056,13 @@ page = 9
       coolantProtTemp   = array,  U08,      173, [6],    "F",    1.8, -22.23,    -40,    419,      0
       #endif
 
-      unused179_184               = array,  U08,     179, [6],       "",       1, 0, 0, 255, 0
+      unused179_181               = array,  U08,     179, [3],       "",       1, 0, 0, 255, 0
+
+      crankIgnOutRpt             = bits,   U08,     182, [0:0], "No",        "Yes"
+      priminScaleEnbl            = bits,   U08,     182, [1:1], "No",        "Yes"
+      unused_182                 = bits,   U08,     182, [2:7],  ""
+      primingScaleValue          = scalar, U08,     183,         "%",        2,        0.0,    0.0,    500,       0
+      ignRptScale                = scalar, U08,     184,         "%",        1,        0.0,    0.0,    255,       0
 
       ; AFR engine protection
       afrProtectEnabled         = bits, U08, 185, [0:1], "Off", "Fixed mode", "Table mode", "INVALID"
@@ -2100,7 +2106,9 @@ menuDialog = main
   lnchPullRes       = "Whether the internal pullup resistor is enabled or left floating. For a ground switching input (Most clutch switches), select Pullup. For a 0v-5v input, select Floating"
   ignBypassPin      = "The ARDUINO pin that the ignition bypass is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
   ignBypassEnable   = "If turned on, a ground signal will be output during cranking on the specified pin. This is used to bypass the Speeduino ignition control during cranking."
-  ignCranklock      = "On certain low resolution ignition patterns, the cranking timing can be locked to occur when a pulse is received."
+  ignCranklock      = "On certain low resolution ignition patterns, the cranking timing can be locked to occur when a pulse is recieved."
+  crankIgnOutRpt    = "This will do another pulse after spark duration to the scheduled event during cranking. Make sure your spark duration isn't 0! This helps ethanol engines cold start."
+  ignRptScale       = "Percentage of ignition dwell Value used on pulse repetition."
 
   multiplyMAP       = "If enabled, the MAP reading is included directly into the pulsewidth calculation by multiplying the VE lookup value by the MAP:Baro ratio. This results in a flatter VE table that can be easier to tune in some instances. VE table must be retuned when this value is changed."
   legacyMAP         = "Use the legacy method of reading the MAP sensor that was used prior to the 201905 firmware. This should ONLY be enabled if you are upgrading from a firmware earlier than this"
@@ -2842,6 +2850,7 @@ menuDialog = main
 
     dialog = crankingIgnOptions, "Cranking Timing", yAxis
         field = "Cranking advance Angle",       CrankAng,       { ignCranklock == 0 }
+        field = "Repeat ignition pulse", crankIgnOutRpt
         field = "Cranking bypass", ignBypassEnable
         field = "Bypass output pin", ignBypassPin               { ignBypassEnable }
         field = "Fix cranking timing with trigger", ignCranklock,   { TrigPattern == 1 || TrigPattern == 4 || TrigPattern == 10 || TrigPattern == 9 }
@@ -2850,10 +2859,12 @@ menuDialog = main
         field = "Cranking RPM (Max)", crankRPM
         field = "Flood Clear level", tpsflood
         field = "Fuel pump prime duration", fpPrime
-        field = "Injectors priming delay", primingDelay
-    field = "Cranking enrichment taper time", crankingEnrichTaper
+        field = "Cranking enrichment taper time", crankingEnrichTaper
 
     dialog = primePW, "Priming Pulsewidth"
+        field = "Enable priming scale adder", priminScaleEnbl
+        field = "Priming add", primingScaleValue,        { priminScaleEnbl }
+        field = "Injectors priming delay", primingDelay
         panel = priming_pw_curve
 
     dialog = crankPW, "Cranking Settings", yAxis
@@ -2926,7 +2937,7 @@ menuDialog = main
         field = "  Use dwell map",            useDwellMap
         field = "  Running dwell",            dwellrun, { useDwellMap == 0 }
         field = "  Spark duration",           sparkDur
-        ;field = "  Dwell scale for repeated spark",           ignRptScale,  { crankIgnOutRpt }
+        field = "  Dwell scale for repeated spark",           ignRptScale,  { crankIgnOutRpt }
         field = ""
         field = "#Note"
         field = "The above times are for 12V. Voltage correction"

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -290,49 +290,49 @@ static inline void checkPerToothTiming(int16_t crankAngle, uint16_t currentTooth
     if ( (currentTooth == ignition1EndTooth) )
     {
       if( (ignitionSchedule1.Status == RUNNING) ) { SET_COMPARE(IGN1_COMPARE, IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule1.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
     else if ( (currentTooth == ignition2EndTooth) )
     {
       if( (ignitionSchedule2.Status == RUNNING) ) { SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule2.endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule2.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule2.endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
     else if ( (currentTooth == ignition3EndTooth) )
     {
       if( (ignitionSchedule3.Status == RUNNING) ) { SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule3.endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule3.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule3.endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
     else if ( (currentTooth == ignition4EndTooth) )
     {
       if( (ignitionSchedule4.Status == RUNNING) ) { SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
 #if IGN_CHANNELS >= 5
     else if ( (currentTooth == ignition5EndTooth) )
     {
       if( (ignitionSchedule5.Status == RUNNING) ) { SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule5.endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); ignitionSchedule5.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule5.endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
 #endif
 #if IGN_CHANNELS >= 6
     else if ( (currentTooth == ignition6EndTooth) )
     {
       if( (ignitionSchedule6.Status == RUNNING) ) { SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule6.endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); ignitionSchedule6.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule6.endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
 #endif
 #if IGN_CHANNELS >= 7
     else if ( (currentTooth == ignition7EndTooth) )
     {
       if( (ignitionSchedule7.Status == RUNNING) ) { SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule7.endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); ignitionSchedule7.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule7.endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
 #endif
 #if IGN_CHANNELS >= 8
     else if ( (currentTooth == ignition8EndTooth) )
     {
       if( (ignitionSchedule8.Status == RUNNING) ) { SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule8.endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); ignitionSchedule8.endScheduleSetByDecoder = true; }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule8.endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); BIT_SET(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_DECODER); }
     }
 #endif
   }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -614,7 +614,7 @@ extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents 
 extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
 extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-
+extern COMPARE_TYPE ignRptDur;
 
 extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1180,9 +1180,11 @@ struct config9 {
   byte unused10_179;
   byte unused10_180;
   byte unused10_181;
-  byte unused10_182;
-  byte unused10_183;
-  byte unused10_184;
+  byte crankIgnOutRpt : 1;  ///< Add another ignition pulse
+  byte priminScaleEnbl : 1; ///< Enable scale priming pulse
+  byte unused10_182 : 5;
+  byte primingScaleValue;
+  byte ignRptScale;
   byte afrProtectEnabled : 2; /* < AFR protection enabled status. 0 = disabled, 1 = fixed mode, 2 = table mode */
   byte afrProtectMinMAP; /* < Minimum MAP. Stored value is divided by 2. Increments of 2 kPa, maximum 511 (?) kPa */
   byte afrProtectMinRPM; /* < Minimum RPM. Stored value is divded by 100. Increments of 100 RPM, maximum 25500 RPM */

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -614,7 +614,7 @@ extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents 
 extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
 extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-extern COMPARE_TYPE ignRptDur;
+extern volatile COMPARE_TYPE ignRptDur;
 
 extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -614,7 +614,6 @@ extern volatile byte HWTest_INJ_50pc; /**< Each bit in this variable represents 
 extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_50pc; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
 extern byte maxIgnOutputs; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-extern volatile COMPARE_TYPE ignRptDur;
 
 extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
 

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -153,6 +153,7 @@ volatile byte HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one
 volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 volatile byte HWTest_IGN_50pc = 0; 
 byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
+COMPARE_TYPE ignRptDur = 0;
 
 
 //This needs to be here because using the config page directly can prevent burning the setting

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -153,8 +153,6 @@ volatile byte HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one
 volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 volatile byte HWTest_IGN_50pc = 0; 
 byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-volatile COMPARE_TYPE ignRptDur = 0;
-
 
 //This needs to be here because using the config page directly can prevent burning the setting
 byte resetControl = RESET_CONTROL_DISABLED;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -153,7 +153,7 @@ volatile byte HWTest_INJ_50pc = 0; /**< Each bit in this variable represents one
 volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 volatile byte HWTest_IGN_50pc = 0; 
 byte maxIgnOutputs = 1; /**< Used for rolling rev limiter to indicate how many total ignition channels should currently be firing */
-COMPARE_TYPE ignRptDur = 0;
+volatile COMPARE_TYPE ignRptDur = 0;
 
 
 //This needs to be here because using the config page directly can prevent burning the setting

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -462,7 +462,7 @@ void initialiseAll(void)
     ignitionSchedule6.scheduleFlags = 0;
     ignitionSchedule7.scheduleFlags = 0;
     ignitionSchedule8.scheduleFlags = 0;
-    ignRptDur = uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100));
+    ignRptDur = uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
 
     if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX_INJ = 720 / currentStatus.nSquirts; }
     else { CRANK_ANGLE_MAX_INJ = 360 / currentStatus.nSquirts; }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -462,7 +462,15 @@ void initialiseAll(void)
     ignitionSchedule6.scheduleFlags = 0;
     ignitionSchedule7.scheduleFlags = 0;
     ignitionSchedule8.scheduleFlags = 0;
-    ignRptDur = uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    ignitionSchedule1.ignRptCnt = 0;
+    ignitionSchedule2.ignRptCnt = 0;
+    ignitionSchedule3.ignRptCnt = 0;
+    ignitionSchedule4.ignRptCnt = 0;
+    ignitionSchedule5.ignRptCnt = 0;
+    ignitionSchedule6.ignRptCnt = 0;
+    ignitionSchedule7.ignRptCnt = 0;
+    ignitionSchedule8.ignRptCnt = 0;
+    
 
     if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX_INJ = 720 / currentStatus.nSquirts; }
     else { CRANK_ANGLE_MAX_INJ = 360 / currentStatus.nSquirts; }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -454,6 +454,16 @@ void initialiseAll(void)
     ignition7EndAngle = 0;
     ignition8EndAngle = 0;
 
+    ignitionSchedule1.scheduleFlags = 0;
+    ignitionSchedule2.scheduleFlags = 0;
+    ignitionSchedule3.scheduleFlags = 0;
+    ignitionSchedule4.scheduleFlags = 0;
+    ignitionSchedule5.scheduleFlags = 0;
+    ignitionSchedule6.scheduleFlags = 0;
+    ignitionSchedule7.scheduleFlags = 0;
+    ignitionSchedule8.scheduleFlags = 0;
+    ignRptDur = uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100));
+
     if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX_INJ = 720 / currentStatus.nSquirts; }
     else { CRANK_ANGLE_MAX_INJ = 360 / currentStatus.nSquirts; }
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -175,6 +175,7 @@ struct Schedule {
   COMPARE_TYPE nextEndCompare;        ///< Planned end of next schedule (when current schedule is RUNNING)
   volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
   volatile bool endScheduleSetByDecoder = false;
+  volatile bool outputHadRepeated = false;
 };
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -159,6 +159,10 @@ inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((alw
  */
 enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The statuses that a schedule can have
 
+//Define bit positions within engine variable
+#define BIT_SCHEDULE_NEXT       0   // Enable flag for planned next schedule (when current schedule is RUNNING)
+#define BIT_SCHEDULE_DECODER    1   // Decoder had set the scheduler timer
+#define BIT_SCHEDULE_REPEATED   2   // Ignition had alread repeated
 /** Ignition schedule.
  */
 struct Schedule {
@@ -173,9 +177,11 @@ struct Schedule {
 
   COMPARE_TYPE nextStartCompare;      ///< Planned start of next schedule (when current schedule is RUNNING)
   COMPARE_TYPE nextEndCompare;        ///< Planned end of next schedule (when current schedule is RUNNING)
-  volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
-  volatile bool endScheduleSetByDecoder = false;
-  volatile bool outputHadRepeated = false;
+  volatile byte scheduleFlags;        ///< All flags used in the scheduler
+
+//  volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
+//  volatile bool endScheduleSetByDecoder = false;
+//  volatile bool outputHadRepeated = false;
 };
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -178,8 +178,8 @@ struct Schedule {
   COMPARE_TYPE nextStartCompare;      ///< Planned start of next schedule (when current schedule is RUNNING)
   COMPARE_TYPE nextEndCompare;        ///< Planned end of next schedule (when current schedule is RUNNING)
 
-  volatile byte scheduleFlags;        ///< All flags used in the scheduler
-  volatile byte ignRptCnt;            ///< Number of ignition events occurred
+  volatile uint8_t scheduleFlags : 5; ///< All flags used in the scheduler
+  volatile uint8_t ignRptCnt : 3;     ///< Number of ignition events occurred
 };
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -177,11 +177,13 @@ struct Schedule {
 
   COMPARE_TYPE nextStartCompare;      ///< Planned start of next schedule (when current schedule is RUNNING)
   COMPARE_TYPE nextEndCompare;        ///< Planned end of next schedule (when current schedule is RUNNING)
+  COMPARE_TYPE repeatStartCompare;
+  COMPARE_TYPE repeatEndCompare;
   volatile byte scheduleFlags;        ///< All flags used in the scheduler
-
-//  volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
-//  volatile bool endScheduleSetByDecoder = false;
-//  volatile bool outputHadRepeated = false;
+  volatile byte ignRptCnt;
+  // volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
+  // volatile bool endScheduleSetByDecoder = false;
+  // volatile bool outputHadRepeated = false;
 };
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -177,13 +177,9 @@ struct Schedule {
 
   COMPARE_TYPE nextStartCompare;      ///< Planned start of next schedule (when current schedule is RUNNING)
   COMPARE_TYPE nextEndCompare;        ///< Planned end of next schedule (when current schedule is RUNNING)
-  COMPARE_TYPE repeatStartCompare;
-  COMPARE_TYPE repeatEndCompare;
+
   volatile byte scheduleFlags;        ///< All flags used in the scheduler
-  volatile byte ignRptCnt;
-  // volatile bool hasNextSchedule = false; ///< Enable flag for planned next schedule (when current schedule is RUNNING)
-  // volatile bool endScheduleSetByDecoder = false;
-  // volatile bool outputHadRepeated = false;
+  volatile byte ignRptCnt;            ///< Number of ignition events occurred
 };
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -185,7 +185,7 @@ void setFuelSchedule(struct Schedule *targetSchedule, unsigned long timeout, uns
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     //targetSchedule->nextStartCompare = *targetSchedule->counter + uS_TO_TIMER_COMPARE(timeout);
     targetSchedule->nextEndCompare = targetSchedule->nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-    targetSchedule->hasNextSchedule = true;
+    BIT_SET(targetSchedule->scheduleFlags, BIT_SCHEDULE_NEXT);
   }
 }
 
@@ -513,7 +513,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.startCompare);
     ignitionSchedule1.Status = PENDING; //Turn this schedule on
     ignitionSchedule1.schedulesSet++;
@@ -528,7 +528,8 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule1.hasNextSchedule = true;
+      //ignitionSchedule1.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
 
   }
@@ -562,7 +563,7 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.startCompare);
     ignitionSchedule2.Status = PENDING; //Turn this schedule on
     ignitionSchedule2.schedulesSet++;
@@ -577,7 +578,8 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule2.nextEndCompare = ignitionSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule2.hasNextSchedule = true;
+      //ignitionSchedule2.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -597,7 +599,7 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.startCompare);
     ignitionSchedule3.Status = PENDING; //Turn this schedule on
     ignitionSchedule3.schedulesSet++;
@@ -612,7 +614,8 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule3.hasNextSchedule = true;
+      //ignitionSchedule3.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -632,7 +635,7 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.startCompare);
     ignitionSchedule4.Status = PENDING; //Turn this schedule on
     ignitionSchedule4.schedulesSet++;
@@ -647,7 +650,8 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule4.hasNextSchedule = true;
+      //ignitionSchedule4.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -667,7 +671,7 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.startCompare);
     ignitionSchedule5.Status = PENDING; //Turn this schedule on
     ignitionSchedule5.schedulesSet++;
@@ -682,7 +686,8 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule5.nextEndCompare = ignitionSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule5.hasNextSchedule = true;
+      //ignitionSchedule5.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -702,7 +707,7 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.startCompare);
     ignitionSchedule6.Status = PENDING; //Turn this schedule on
     ignitionSchedule6.schedulesSet++;
@@ -717,7 +722,8 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule6.hasNextSchedule = true;
+      //ignitionSchedule6.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -737,7 +743,7 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.startCompare);
     ignitionSchedule7.Status = PENDING; //Turn this schedule on
     ignitionSchedule7.schedulesSet++;
@@ -752,7 +758,8 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule7.hasNextSchedule = true;
+      //ignitionSchedule7.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -772,7 +779,7 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
 
     noInterrupts();
     ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    if(!BIT_CHECK(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_DECODER)) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
     SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.startCompare);
     ignitionSchedule8.Status = PENDING; //Turn this schedule on
     ignitionSchedule8.schedulesSet++;
@@ -787,7 +794,8 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule8.hasNextSchedule = true;
+      //ignitionSchedule8.hasNextSchedule = true;
+      BIT_SET(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
 }
@@ -1129,7 +1137,7 @@ static inline void ignitionSchedule1Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule1.StartCallback();
       ignitionSchedule1.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule1.startTime = micros();
-      if(ignitionSchedule1.endScheduleSetByDecoder == true) { SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.endCompare); }
+      if(BIT_CHECK(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.endCompare); }
       else { SET_COMPARE(IGN1_COMPARE, IGN1_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule1.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule1.Status == RUNNING)
@@ -1137,35 +1145,43 @@ static inline void ignitionSchedule1Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule1.EndCallback();
       ignitionSchedule1.Status = OFF; //Turn off the schedule
       ignitionSchedule1.schedulesSet = 0;
-      ignitionSchedule1.endScheduleSetByDecoder = false;
+      //ignitionSchedule1.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule1.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN1_COMPARE, IGN1_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule1.endCompare = (uint16_t)(IGN1_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule1.endScheduleSetByDecoder = true;
-        ignitionSchedule1.outputHadRepeated = true;
+        SET_COMPARE(IGN1_COMPARE, IGN1_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule1.endCompare = (uint16_t)(IGN1_COMPARE + ignRptDur);
         ignitionSchedule1.Status = PENDING;
         ignitionSchedule1.schedulesSet = 1;
-        ignitionSchedule1.hasNextSchedule = false;
+        //ignitionSchedule1.endScheduleSetByDecoder = true;
+        //ignitionSchedule1.outputHadRepeated = true;
+        //ignitionSchedule1.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule1.hasNextSchedule == true)
+      //else if(ignitionSchedule1.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.nextStartCompare);
         ignitionSchedule1.Status = PENDING;
         ignitionSchedule1.schedulesSet = 1;
-        ignitionSchedule1.hasNextSchedule = false;
-        ignitionSchedule1.outputHadRepeated = false;
+        //ignitionSchedule1.hasNextSchedule = false;
+        //ignitionSchedule1.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN1_TIMER_DISABLE(); ignitionSchedule1.outputHadRepeated = false; }
+      else{ IGN1_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule1.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN1_TIMER_DISABLE();
-      ignitionSchedule1.outputHadRepeated = false;
+      //ignitionSchedule1.outputHadRepeated = false;
+      ignitionSchedule1.scheduleFlags = 0;
     }
   }
 #endif
@@ -1182,43 +1198,51 @@ static inline void ignitionSchedule2Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule2.StartCallback();
       ignitionSchedule2.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule2.startTime = micros();
-      if(ignitionSchedule2.endScheduleSetByDecoder == true) { SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.endCompare); }
+      else { SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule2.Status == RUNNING)
     {
-      ignitionSchedule2.Status = OFF; //Turn off the schedule
       ignitionSchedule2.EndCallback();
+      ignitionSchedule2.Status = OFF; //Turn off the schedule
       ignitionSchedule2.schedulesSet = 0;
-      ignitionSchedule2.endScheduleSetByDecoder = false;
+      //ignitionSchedule2.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
-      
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule2.outputHadRepeated)
+
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule2.endCompare = (uint16_t)(IGN2_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule2.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule2.endScheduleSetByDecoder = true;
-        ignitionSchedule2.outputHadRepeated = true;
+        SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule2.endCompare = (uint16_t)(IGN2_COMPARE + ignRptDur);
         ignitionSchedule2.Status = PENDING;
         ignitionSchedule2.schedulesSet = 1;
-        ignitionSchedule2.hasNextSchedule = false;
-        ignitionSchedule2.outputHadRepeated = false;
+        //ignitionSchedule2.endScheduleSetByDecoder = true;
+        //ignitionSchedule2.outputHadRepeated = true;
+        //ignitionSchedule2.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule2.hasNextSchedule == true)
+      //else if(ignitionSchedule2.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.nextStartCompare);
         ignitionSchedule2.Status = PENDING;
         ignitionSchedule2.schedulesSet = 1;
-        ignitionSchedule2.hasNextSchedule = false;
+        //ignitionSchedule2.hasNextSchedule = false;
+        //ignitionSchedule2.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN2_TIMER_DISABLE(); ignitionSchedule2.outputHadRepeated = false; }
+      else{ IGN2_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule2.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN2_TIMER_DISABLE();
-      ignitionSchedule2.outputHadRepeated = false;
+      //ignitionSchedule2.outputHadRepeated = false;
+      ignitionSchedule2.scheduleFlags = 0;
     }
   }
 #endif
@@ -1235,43 +1259,51 @@ static inline void ignitionSchedule3Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule3.StartCallback();
       ignitionSchedule3.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule3.startTime = micros();
-      if(ignitionSchedule3.endScheduleSetByDecoder == true) { SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.endCompare ); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.endCompare); }
+      else { SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule3.Status == RUNNING)
     {
-      ignitionSchedule3.Status = OFF; //Turn off the schedule
       ignitionSchedule3.EndCallback();
+      ignitionSchedule3.Status = OFF; //Turn off the schedule
       ignitionSchedule3.schedulesSet = 0;
-      ignitionSchedule3.endScheduleSetByDecoder = false;
-      ignitionCount += 1; //Increment the igintion counter
+      //ignitionSchedule3.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER);
+      ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule3.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule3.endCompare = (uint16_t)(IGN3_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule3.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule3.endScheduleSetByDecoder = true;
-        ignitionSchedule3.outputHadRepeated = true;
+        SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule3.endCompare = (uint16_t)(IGN3_COMPARE + ignRptDur);
         ignitionSchedule3.Status = PENDING;
         ignitionSchedule3.schedulesSet = 1;
-        ignitionSchedule3.hasNextSchedule = false;
+        //ignitionSchedule3.endScheduleSetByDecoder = true;
+        //ignitionSchedule3.outputHadRepeated = true;
+        //ignitionSchedule3.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule3.hasNextSchedule == true)
+      //If there is a next schedule queued up, activate it
+      //else if(ignitionSchedule3.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.nextStartCompare);
         ignitionSchedule3.Status = PENDING;
         ignitionSchedule3.schedulesSet = 1;
-        ignitionSchedule3.hasNextSchedule = false;
-        ignitionSchedule3.outputHadRepeated = false;
+        //ignitionSchedule3.hasNextSchedule = false;
+        //ignitionSchedule3.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else { IGN3_TIMER_DISABLE(); ignitionSchedule3.outputHadRepeated = false; }
+      else{ IGN3_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule3.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN3_TIMER_DISABLE();
-      ignitionSchedule3.outputHadRepeated = false;
+      //ignitionSchedule3.outputHadRepeated = false;
+      ignitionSchedule3.scheduleFlags = 0;
     }
   }
 #endif
@@ -1288,43 +1320,51 @@ static inline void ignitionSchedule4Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule4.StartCallback();
       ignitionSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule4.startTime = micros();
-      if(ignitionSchedule4.endScheduleSetByDecoder == true) { SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.endCompare); }
+      else { SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule4.Status == RUNNING)
     {
-      ignitionSchedule4.Status = OFF; //Turn off the schedule
       ignitionSchedule4.EndCallback();
+      ignitionSchedule4.Status = OFF; //Turn off the schedule
       ignitionSchedule4.schedulesSet = 0;
-      ignitionSchedule4.endScheduleSetByDecoder = false;
-      ignitionCount += 1; //Increment the igintion counter
+      //ignitionSchedule4.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER);
+      ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule4.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule4.endCompare = (uint16_t)(IGN4_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule4.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule4.endScheduleSetByDecoder = true;
-        ignitionSchedule4.outputHadRepeated = true;
+        SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule4.endCompare = (uint16_t)(IGN4_COMPARE + ignRptDur);
         ignitionSchedule4.Status = PENDING;
         ignitionSchedule4.schedulesSet = 1;
-        ignitionSchedule4.hasNextSchedule = false;
+        //ignitionSchedule4.endScheduleSetByDecoder = true;
+        //ignitionSchedule4.outputHadRepeated = true;
+        //ignitionSchedule4.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule4.hasNextSchedule == true)
+      //else if(ignitionSchedule4.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.nextStartCompare);
         ignitionSchedule4.Status = PENDING;
         ignitionSchedule4.schedulesSet = 1;
-        ignitionSchedule4.hasNextSchedule = false;
-        ignitionSchedule4.outputHadRepeated = false;
+        //ignitionSchedule4.hasNextSchedule = false;
+        //ignitionSchedule4.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else { IGN4_TIMER_DISABLE(); ignitionSchedule4.outputHadRepeated = false; }
+      else{ IGN4_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule4.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN4_TIMER_DISABLE();
-      ignitionSchedule4.outputHadRepeated = false;
+      //ignitionSchedule4.outputHadRepeated = false;
+      ignitionSchedule4.scheduleFlags = 0;
     }
   }
 #endif
@@ -1341,42 +1381,51 @@ static inline void ignitionSchedule5Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule5.StartCallback();
       ignitionSchedule5.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule5.startTime = micros();
-      if(ignitionSchedule5.endScheduleSetByDecoder == true) { SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.endCompare); }
+      else { SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule5.Status == RUNNING)
     {
-      ignitionSchedule5.Status = OFF; //Turn off the schedule
       ignitionSchedule5.EndCallback();
+      ignitionSchedule5.Status = OFF; //Turn off the schedule
       ignitionSchedule5.schedulesSet = 0;
-      ignitionSchedule5.endScheduleSetByDecoder = false;
+      //ignitionSchedule5.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule5.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule5.endCompare = (uint16_t)(IGN5_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule5.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule5.endScheduleSetByDecoder = true;
-        ignitionSchedule5.outputHadRepeated = true;
+        SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule5.endCompare = (uint16_t)(IGN5_COMPARE + ignRptDur);
         ignitionSchedule5.Status = PENDING;
         ignitionSchedule5.schedulesSet = 1;
-        ignitionSchedule5.hasNextSchedule = false;
+        //ignitionSchedule5.endScheduleSetByDecoder = true;
+        //ignitionSchedule5.outputHadRepeated = true;
+        //ignitionSchedule5.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule5.hasNextSchedule == true)
+      //else if(ignitionSchedule5.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.nextStartCompare);
         ignitionSchedule5.Status = PENDING;
         ignitionSchedule5.schedulesSet = 1;
-        ignitionSchedule5.hasNextSchedule = false;
-        ignitionSchedule5.outputHadRepeated = false;
+        //ignitionSchedule5.hasNextSchedule = false;
+        //ignitionSchedule5.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN5_TIMER_DISABLE(); }
+      else{ IGN5_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule5.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN5_TIMER_DISABLE();
+      //ignitionSchedule5.outputHadRepeated = false;
+      ignitionSchedule5.scheduleFlags = 0;
     }
   }
 #endif
@@ -1393,43 +1442,51 @@ static inline void ignitionSchedule6Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule6.StartCallback();
       ignitionSchedule6.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule6.startTime = micros();
-      if(ignitionSchedule6.endScheduleSetByDecoder == true) { SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.endCompare); }
+      else { SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule6.Status == RUNNING)
     {
-      ignitionSchedule6.Status = OFF; //Turn off the schedule
       ignitionSchedule6.EndCallback();
+      ignitionSchedule6.Status = OFF; //Turn off the schedule
       ignitionSchedule6.schedulesSet = 0;
-      ignitionSchedule6.endScheduleSetByDecoder = false;
+      //ignitionSchedule6.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule6.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule6.endCompare = (uint16_t)(IGN6_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule6.endScheduleSetByDecoder = true;
-        ignitionSchedule6.outputHadRepeated = true;
+        SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule6.endCompare = (uint16_t)(IGN6_COMPARE + ignRptDur);
         ignitionSchedule6.Status = PENDING;
         ignitionSchedule6.schedulesSet = 1;
-        ignitionSchedule6.hasNextSchedule = false;
+        //ignitionSchedule6.endScheduleSetByDecoder = true;
+        //ignitionSchedule6.outputHadRepeated = true;
+        //ignitionSchedule6.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule6.hasNextSchedule == true)
+      //else if(ignitionSchedule6.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.nextStartCompare);
         ignitionSchedule6.Status = PENDING;
         ignitionSchedule6.schedulesSet = 1;
-        ignitionSchedule6.hasNextSchedule = false;
-        ignitionSchedule6.outputHadRepeated = false;
+        //ignitionSchedule6.hasNextSchedule = false;
+        //ignitionSchedule6.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN6_TIMER_DISABLE(); ignitionSchedule6.outputHadRepeated = false; }
+      else{ IGN6_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule6.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN6_TIMER_DISABLE();
-      ignitionSchedule6.outputHadRepeated = false;
+      //ignitionSchedule6.outputHadRepeated = false;
+      ignitionSchedule6.scheduleFlags = 0;
     }
   }
 #endif
@@ -1446,43 +1503,51 @@ static inline void ignitionSchedule7Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule7.StartCallback();
       ignitionSchedule7.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule7.startTime = micros();
-      if(ignitionSchedule7.endScheduleSetByDecoder == true) { SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.endCompare); }
+      else { SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule7.Status == RUNNING)
     {
-      ignitionSchedule7.Status = OFF; //Turn off the schedule
       ignitionSchedule7.EndCallback();
+      ignitionSchedule7.Status = OFF; //Turn off the schedule
       ignitionSchedule7.schedulesSet = 0;
-      ignitionSchedule7.endScheduleSetByDecoder = false;
+      //ignitionSchedule7.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule7.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule7.endCompare = (uint16_t)(IGN7_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule7.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule7.endScheduleSetByDecoder = true;
-        ignitionSchedule7.outputHadRepeated = true;
+        SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule7.endCompare = (uint16_t)(IGN7_COMPARE + ignRptDur);
         ignitionSchedule7.Status = PENDING;
         ignitionSchedule7.schedulesSet = 1;
-        ignitionSchedule7.hasNextSchedule = false;
+        //ignitionSchedule7.endScheduleSetByDecoder = true;
+        //ignitionSchedule7.outputHadRepeated = true;
+        //ignitionSchedule7.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule7.hasNextSchedule == true)
+      //else if(ignitionSchedule7.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.nextStartCompare);
         ignitionSchedule7.Status = PENDING;
         ignitionSchedule7.schedulesSet = 1;
-        ignitionSchedule7.hasNextSchedule = false;
-        ignitionSchedule7.outputHadRepeated = false;
+        //ignitionSchedule7.hasNextSchedule = false;
+        //ignitionSchedule7.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN7_TIMER_DISABLE(); ignitionSchedule7.outputHadRepeated = false; }
+      else{ IGN7_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule7.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN7_TIMER_DISABLE();
-      ignitionSchedule7.outputHadRepeated = false;
+      //ignitionSchedule7.outputHadRepeated = false;
+      ignitionSchedule7.scheduleFlags = 0;
     }
   }
 #endif
@@ -1499,43 +1564,51 @@ static inline void ignitionSchedule8Interrupt(void) //Most ARM chips can simply 
       ignitionSchedule8.StartCallback();
       ignitionSchedule8.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
       ignitionSchedule8.startTime = micros();
-      if(ignitionSchedule8.endScheduleSetByDecoder == true) { SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.endCompare); } //If the decoder has set the end compare value, assign it to the next compare
-      else { SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration) ); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      if(BIT_CHECK(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_DECODER)) { SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.endCompare); }
+      else { SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration) ); } //Doing this here prevents a potential overflow on restarts
     }
     else if (ignitionSchedule8.Status == RUNNING)
     {
-      ignitionSchedule8.Status = OFF; //Turn off the schedule
       ignitionSchedule8.EndCallback();
+      ignitionSchedule8.Status = OFF; //Turn off the schedule
       ignitionSchedule8.schedulesSet = 0;
-      ignitionSchedule8.endScheduleSetByDecoder = false;
+      //ignitionSchedule8.endScheduleSetByDecoder = false;
+      BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_DECODER);
       ignitionCount += 1; //Increment the ignition counter
 
-      if ((configPage9.crankIgnOutRpt) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !ignitionSchedule8.outputHadRepeated)
+      if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur*100));
-        ignitionSchedule8.endCompare = (uint16_t)(IGN8_COMPARE + uS_TO_TIMER_COMPARE(((ignitionSchedule8.duration * configPage9.ignRptScale)/100)));
-        ignitionSchedule8.endScheduleSetByDecoder = true;
-        ignitionSchedule8.outputHadRepeated = true;
+        SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE(configPage4.sparkDur * 100));
+        ignitionSchedule8.endCompare = (uint16_t)(IGN8_COMPARE + ignRptDur);
         ignitionSchedule8.Status = PENDING;
         ignitionSchedule8.schedulesSet = 1;
-        ignitionSchedule8.hasNextSchedule = false;
+        //ignitionSchedule8.endScheduleSetByDecoder = true;
+        //ignitionSchedule8.outputHadRepeated = true;
+        //ignitionSchedule8.hasNextSchedule = false;
+        BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_SET(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_DECODER);
+        BIT_SET(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
       //If there is a next schedule queued up, activate it
-      else if(ignitionSchedule8.hasNextSchedule == true)
+      //else if(ignitionSchedule8.hasNextSchedule == true)
+      else if (BIT_SET(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.nextStartCompare);
         ignitionSchedule8.Status = PENDING;
         ignitionSchedule8.schedulesSet = 1;
-        ignitionSchedule8.hasNextSchedule = false;
-        ignitionSchedule8.outputHadRepeated = false;
+        //ignitionSchedule8.hasNextSchedule = false;
+        //ignitionSchedule8.outputHadRepeated = false;
+        BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_NEXT);
+        BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN8_TIMER_DISABLE(); ignitionSchedule8.outputHadRepeated = false; }
+      else{ IGN8_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED); }
     }
     else if (ignitionSchedule8.Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN8_TIMER_DISABLE();
-      ignitionSchedule8.outputHadRepeated = false;
+      //ignitionSchedule8.outputHadRepeated = false;
+      ignitionSchedule8.scheduleFlags = 0;
     }
   }
 #endif

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -539,7 +539,7 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     {
       ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
       ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
+      BIT_SET(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
     }
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule1.ignRptCnt <= 3))
@@ -1309,7 +1309,7 @@ static inline void ignitionSchedule2Interrupt(void) //Most ARM chips can simply 
         BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_DECODER);
       }
       //If there is a next schedule queued up, activate it
-      else if (BIT_SET(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT))
+      else if (BIT_CHECK(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.nextStartCompare);
         ignitionSchedule2.Status = PENDING;
@@ -1365,7 +1365,7 @@ static inline void ignitionSchedule3Interrupt(void) //Most ARM chips can simply 
         BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_DECODER);
       }
       //If there is a next schedule queued up, activate it
-      else if (BIT_SET(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT))
+      else if (BIT_CHECK(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.nextStartCompare);
         ignitionSchedule3.Status = PENDING;
@@ -1421,7 +1421,7 @@ static inline void ignitionSchedule4Interrupt(void) //Most ARM chips can simply 
         BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_DECODER);
       }
       //If there is a next schedule queued up, activate it
-      else if (BIT_SET(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT))
+      else if (BIT_CHECK(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT))
       {
         SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.nextStartCompare);
         ignitionSchedule4.Status = PENDING;

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -544,11 +544,10 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule1.ignRptCnt <= 3))
   {
-    if (ignitionSchedule1.ignRptCnt >=1)
-    { ignitionSchedule1.repeatStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule1.repeatStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule1.repeatEndCompare = ignitionSchedule1.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule1.ignRptCnt >=1) { ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 
@@ -603,11 +602,10 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule2.ignRptCnt <= 3))
   {
-    if (ignitionSchedule2.ignRptCnt >=1)
-    { ignitionSchedule2.repeatStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule2.repeatStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule2.repeatEndCompare = ignitionSchedule2.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule2.ignRptCnt >=1) { ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule2.nextEndCompare = ignitionSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
@@ -649,11 +647,10 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule3.ignRptCnt <= 3))
   {
-    if (ignitionSchedule3.ignRptCnt >=1)
-    { ignitionSchedule3.repeatStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule3.repeatStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule3.repeatEndCompare = ignitionSchedule3.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule3.ignRptCnt >=1) { ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
@@ -696,11 +693,10 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule4.ignRptCnt <= 3))
   {
-    if (ignitionSchedule4.ignRptCnt >=1)
-    { ignitionSchedule4.repeatStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule4.repeatStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule4.repeatEndCompare = ignitionSchedule4.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule4.ignRptCnt >=1) { ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 #if IGN_CHANNELS >= 5
@@ -743,11 +739,10 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule5.ignRptCnt <= 3))
   {
-    if (ignitionSchedule5.ignRptCnt >=1)
-    { ignitionSchedule5.repeatStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule5.repeatStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule5.repeatEndCompare = ignitionSchedule5.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule5.ignRptCnt >=1) { ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule5.nextEndCompare = ignitionSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 #endif
@@ -790,11 +785,10 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule6.ignRptCnt <= 3))
   {
-    if (ignitionSchedule6.ignRptCnt >=1)
-    { ignitionSchedule6.repeatStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule6.repeatStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule6.repeatEndCompare = ignitionSchedule6.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule6.ignRptCnt >=1) { ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 #endif
@@ -837,11 +831,10 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule7.ignRptCnt <= 3))
   {
-    if (ignitionSchedule7.ignRptCnt >=1)
-    { ignitionSchedule7.repeatStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule7.repeatStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule7.repeatEndCompare = ignitionSchedule7.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule7.ignRptCnt >=1) { ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+
+    ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 #endif
@@ -884,11 +877,10 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
   }
   if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && (ignitionSchedule8.ignRptCnt <= 3))
   {
-    if (ignitionSchedule8.ignRptCnt >=1)
-    { ignitionSchedule8.repeatStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
-    else
-    { ignitionSchedule8.repeatStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
-    ignitionSchedule8.repeatEndCompare = ignitionSchedule8.repeatStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+    if (ignitionSchedule8.ignRptCnt >=1) { ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100) + (configPage4.sparkDur * 100)); }
+    else { ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(duration + (configPage4.sparkDur * 100)); }
+    
+    ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
   }
 }
 #endif
@@ -1244,8 +1236,8 @@ static inline void ignitionSchedule1Interrupt(void) //Most ARM chips can simply 
       
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.repeatStartCompare);
-        ignitionSchedule1.endCompare = ignitionSchedule1.repeatEndCompare;
+        SET_COMPARE(IGN1_COMPARE, ignitionSchedule1.nextStartCompare);
+        ignitionSchedule1.endCompare = ignitionSchedule1.nextEndCompare;
         ignitionSchedule1.Status = PENDING;
         ignitionSchedule1.schedulesSet = 1;
         ignitionSchedule1.ignRptCnt += 1;
@@ -1262,7 +1254,12 @@ static inline void ignitionSchedule1Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN1_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule1.ignRptCnt = 0; }
+      else
+      {
+        IGN1_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule1.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule1.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule1.Status == OFF)
     {
@@ -1300,8 +1297,8 @@ static inline void ignitionSchedule2Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.repeatStartCompare);
-        ignitionSchedule2.endCompare = ignitionSchedule2.repeatEndCompare;
+        SET_COMPARE(IGN2_COMPARE, ignitionSchedule2.nextStartCompare);
+        ignitionSchedule2.endCompare = ignitionSchedule2.nextEndCompare;
         ignitionSchedule2.Status = PENDING;
         ignitionSchedule2.schedulesSet = 1;
         ignitionSchedule2.ignRptCnt += 1;
@@ -1318,7 +1315,12 @@ static inline void ignitionSchedule2Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN2_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule2.ignRptCnt = 0; }
+      else
+      {
+        IGN2_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule2.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule2.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule2.Status == OFF)
     {
@@ -1356,8 +1358,8 @@ static inline void ignitionSchedule3Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.repeatStartCompare);
-        ignitionSchedule3.endCompare = ignitionSchedule3.repeatEndCompare;
+        SET_COMPARE(IGN3_COMPARE, ignitionSchedule3.nextStartCompare);
+        ignitionSchedule3.endCompare = ignitionSchedule3.nextEndCompare;
         ignitionSchedule3.Status = PENDING;
         ignitionSchedule3.schedulesSet = 1;
         ignitionSchedule3.ignRptCnt += 1;
@@ -1374,7 +1376,12 @@ static inline void ignitionSchedule3Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else { IGN3_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule3.ignRptCnt = 0; }
+      else
+      {
+        IGN3_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule3.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule3.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule3.Status == OFF)
     {
@@ -1412,8 +1419,8 @@ static inline void ignitionSchedule4Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.repeatStartCompare);
-        ignitionSchedule4.endCompare = ignitionSchedule4.repeatEndCompare;
+        SET_COMPARE(IGN4_COMPARE, ignitionSchedule4.nextStartCompare);
+        ignitionSchedule4.endCompare = ignitionSchedule4.nextEndCompare;
         ignitionSchedule4.Status = PENDING;
         ignitionSchedule4.schedulesSet = 1;
         ignitionSchedule4.ignRptCnt += 1;
@@ -1430,7 +1437,12 @@ static inline void ignitionSchedule4Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else { IGN4_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule4.ignRptCnt = 0; }
+      else
+      {
+        IGN4_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule4.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule4.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule4.Status == OFF)
     {
@@ -1468,8 +1480,8 @@ static inline void ignitionSchedule5Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.repeatStartCompare);
-        ignitionSchedule5.endCompare = ignitionSchedule5.repeatEndCompare;
+        SET_COMPARE(IGN5_COMPARE, ignitionSchedule5.nextStartCompare);
+        ignitionSchedule5.endCompare = ignitionSchedule5.nextEndCompare;
         ignitionSchedule5.Status = PENDING;
         ignitionSchedule5.schedulesSet = 1;
         ignitionSchedule5.ignRptCnt += 1;
@@ -1486,7 +1498,12 @@ static inline void ignitionSchedule5Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN5_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule5.ignRptCnt = 0; }
+      else
+      {
+        IGN5_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule5.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule5.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule5.Status == OFF)
     {
@@ -1524,8 +1541,8 @@ static inline void ignitionSchedule6Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.repeatStartCompare);
-        ignitionSchedule6.endCompare = ignitionSchedule6.repeatEndCompare;
+        SET_COMPARE(IGN6_COMPARE, ignitionSchedule6.nextStartCompare);
+        ignitionSchedule6.endCompare = ignitionSchedule6.nextEndCompare;
         ignitionSchedule6.Status = PENDING;
         ignitionSchedule6.schedulesSet = 1;
         ignitionSchedule6.ignRptCnt += 1;
@@ -1542,7 +1559,12 @@ static inline void ignitionSchedule6Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN6_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule6.ignRptCnt = 0; }
+      else
+      {
+        IGN6_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule6.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule6.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule6.Status == OFF)
     {
@@ -1580,8 +1602,8 @@ static inline void ignitionSchedule7Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.repeatStartCompare);
-        ignitionSchedule7.endCompare = ignitionSchedule7.repeatEndCompare;
+        SET_COMPARE(IGN7_COMPARE, ignitionSchedule7.nextStartCompare);
+        ignitionSchedule7.endCompare = ignitionSchedule7.nextEndCompare;
         ignitionSchedule7.Status = PENDING;
         ignitionSchedule7.schedulesSet = 1;
         ignitionSchedule7.ignRptCnt += 1;
@@ -1598,7 +1620,12 @@ static inline void ignitionSchedule7Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN7_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule7.ignRptCnt = 0; }
+      else
+      {
+        IGN7_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule7.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule7.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule7.Status == OFF)
     {
@@ -1636,8 +1663,8 @@ static inline void ignitionSchedule8Interrupt(void) //Most ARM chips can simply 
 
       if ((configPage9.crankIgnOutRpt == 1) && BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && !BIT_CHECK(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED))
       {
-        SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.repeatStartCompare);
-        ignitionSchedule8.endCompare = ignitionSchedule8.repeatEndCompare;
+        SET_COMPARE(IGN8_COMPARE, ignitionSchedule8.nextStartCompare);
+        ignitionSchedule8.endCompare = ignitionSchedule8.nextEndCompare;
         ignitionSchedule8.Status = PENDING;
         ignitionSchedule8.schedulesSet = 1;
         ignitionSchedule8.ignRptCnt += 1;
@@ -1654,7 +1681,12 @@ static inline void ignitionSchedule8Interrupt(void) //Most ARM chips can simply 
         BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_NEXT);
         BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED);
       }
-      else{ IGN8_TIMER_DISABLE(); BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED); ignitionSchedule8.ignRptCnt = 0; }
+      else
+      {
+        IGN8_TIMER_DISABLE();
+        BIT_CLEAR(ignitionSchedule8.scheduleFlags, BIT_SCHEDULE_REPEATED);
+        ignitionSchedule8.ignRptCnt = 0;
+      }
     }
     else if (ignitionSchedule8.Status == OFF)
     {

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -439,7 +439,10 @@ void loop(void)
         if(configPage13.onboard_log_file_rate == LOGGER_RATE_1HZ) { writeSDLogEntry(); }
       #endif
 
-      ignRptDur = uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100));
+      if ( configPage9.crankIgnOutRpt == 1 )
+      {
+        ignRptDur = uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
+      }
     } //1Hz timer
 
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -439,6 +439,7 @@ void loop(void)
         if(configPage13.onboard_log_file_rate == LOGGER_RATE_1HZ) { writeSDLogEntry(); }
       #endif
 
+      ignRptDur = uS_TO_TIMER_COMPARE(((ignitionSchedule1.duration * configPage9.ignRptScale)/100));
     } //1Hz timer
 
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -438,11 +438,6 @@ void loop(void)
       #ifdef SD_LOGGING
         if(configPage13.onboard_log_file_rate == LOGGER_RATE_1HZ) { writeSDLogEntry(); }
       #endif
-
-      if ( configPage9.crankIgnOutRpt == 1 )
-      {
-        ignRptDur = uS_TO_TIMER_COMPARE(((((uint32_t)configPage4.dwellCrank * 100) * configPage9.ignRptScale) / 100));
-      }
     } //1Hz timer
 
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL)


### PR DESCRIPTION
Added possibility to scale up priming size, some pure ethanol(E100) vehicles struggle to start, doing prime pulse 2 or 3 times makes it start on first cranking, possible to add 2 to 500% of table content. An enable toggle was added.

Added possibility to add a second ignition pulse during cranking, some OEM ECU already does that for cold start, the spark duration must be grater than 0, a scale to the second pulse was added as the second discharge may or may not need the same dwell. An enable toggle was added.
![image](https://user-images.githubusercontent.com/22614869/126048438-44fe763f-5e07-4ffb-aa76-6068ea9e86b5.png)![image](https://user-images.githubusercontent.com/22614869/126048447-72b760a8-ac4a-4661-93f0-238afb767fed.png)
