### PR TITLE
AE graph unit for O2 sensor

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2290,7 +2290,11 @@ menuDialog = main
 
     dialog = accelEnrichments_north_south, ""
       liveGraph = pump_ae_Graph, "AE Graph"
+#if LAMBDA
+            graphLine = lambda
+#else
             graphLine = afr
+#endif
             graphLine = TPSdot, "%", -2000, 2000, auto, auto
             graphLine = MAPdot, "%", -2000, 2000, auto, auto
 


### PR DESCRIPTION
I know the add new features windows has closed, but hope that simple 3 lines code get pulled in, this add the selected O2 unit to the acceleration enrichment graph, currently shows AFR even with lambda scale selected.