### PR TITLE
Consistent MAP readings for all platforms

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -211,6 +211,7 @@
 #define BIT_TIMER_10HZ            2
 #define BIT_TIMER_15HZ            3
 #define BIT_TIMER_30HZ            4
+#define BIT_TIMER_1KHZ            7
 
 #define BIT_STATUS3_RESET_PREVENT 0 //Indicates whether reset prevention is enabled
 #define BIT_STATUS3_NITROUS       1

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -242,16 +242,10 @@ void loop(void)
 
     //***Perform sensor reads***
     //-----------------------------------------------------------------------------------------------------
-#if defined(CORE_AVR) //AVR loop speed wont saturate MAP sampling time
-    readMAP();
-#endif
-    if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_1KHZ)) //Every 1ms
+    if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_1KHZ)) //Every 1ms. NOTE: This is NOT guaranteed to run at 1kHz on AVR systems. It will run at 1kHz if possible or as fast as loops/s allows if not. 
     {
       BIT_CLEAR(TIMER_mask, BIT_TIMER_1KHZ);
-
-#if !defined(CORE_AVR)
-      readMAP(); //On AVR this is performed about 600 to 1200x/S
-#endif
+      readMAP();
     }
     
     if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_15HZ)) //Every 32 loops

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -242,7 +242,17 @@ void loop(void)
 
     //***Perform sensor reads***
     //-----------------------------------------------------------------------------------------------------
-    readMAP();  
+#if defined(CORE_AVR) //AVR loop speed wont saturate MAP sampling time
+    readMAP();
+#endif
+    if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_1KHZ)) //Every 1ms
+    {
+      BIT_CLEAR(TIMER_mask, BIT_TIMER_1KHZ);
+
+#if !defined(CORE_AVR)
+      readMAP(); //On AVR this is performed about 600 to 1200x/S
+#endif
+    }
     
     if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_15HZ)) //Every 32 loops
     {

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -45,6 +45,7 @@ ISR(TIMER2_OVF_vect, ISR_NOBLOCK) //cppcheck-suppress misra-c2012-8.2
 void oneMSInterval(void) //Most ARM chips can simply call a function
 #endif
 {
+  BIT_SET(TIMER_mask, BIT_TIMER_1KHZ);
   ms_counter++;
 
   //Increment Loop Counters


### PR DESCRIPTION
On very high loops/second devices the MAP sampling are less than a millisecond, this keep MAPdot always at 0.