### PR TITLE
Fix for disable maximum output time

### DIFF
--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -210,7 +210,7 @@ void checkProgrammableIO()
       {
         if(firstCheck)
         {
-          if (ioOutDelay[y] >= configPage13.outputTimeLimit[y]) { firstCheck = false; } //Time has counted, disable the output
+          if ((configPage13.outputTimeLimit[y] != 0) && (ioOutDelay[y] >= configPage13.outputTimeLimit[y])) { firstCheck = false; } //Time has counted, disable the output
         }
         else
         {


### PR DESCRIPTION
Recently added function was missing a disable condition for the maximum time, making the option unusable if the output is desired to last "forever".