### PR TITLE
Non linear TPS

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -198,7 +198,7 @@
 
     endianness          = little
     nPages              = 14
-    pageSize            = 128,   288,     288,    128,     288,    128,    240,     384,    192,    192,    288,    192,    128,    288
+    pageSize            = 128,   288,     288,    128,     288,    134,    240,     384,    192,    192,    288,    192,    128,    288
 
     ; New commands
     pageIdentifier      = "\$tsCanId\x01", "\$tsCanId\x02", "\$tsCanId\x03", "\$tsCanId\x04", "\$tsCanId\x05", "\$tsCanId\x06", "\$tsCanId\x07", "\$tsCanId\x08", "\$tsCanId\x09", "\$tsCanId\x0A", "\$tsCanId\x0B", "\$tsCanId\x0C", "\$tsCanId\x0D", "\$tsCanId\x0E"
@@ -417,7 +417,8 @@ page = 1
       rtc_trim        = scalar,  S08,    123,               "ppm",      1, 0, -127, +127, 0
       idleAdvVss      = scalar, U08,      124,        "km/h",       1,       0.0,   0.0,     255,      0 
       mapSwitchPoint  = scalar, U08,      125,        "RPM",      100,       0.0,   0.0,     16320,    0
-      unused2-95      = array,  U08,      126, [2],   "%",        1.0,       0.0,   0.0,     255,      0
+	  tpsCurveEnbl    = bits,   U08,      126, [0:0], "2Point", "Curve"
+      unused2-95      = array,  U08,      127, [1],   "%",        1.0,       0.0,   0.0,     255,      0
 
 ;Page 2 is the fuel map and axis bins only
 page = 2
@@ -701,6 +702,8 @@ page = 6
   #else
       fanPWMBins = array, U08,      124, [4],        "F",        1.8,    -22.23,    -40,    215,      0
   #endif
+      tpsCurveADC = array, U08,      128, [3],    "ADC",      1.0,        0.0,    0.0,    255,      0
+	  tpsCurveTPS = array, U08,      131, [3],    "TPS",      1.0,        0.0,    0.0,    100,      0
 
 ;--------------------------------------------------
 ;Boost and vvt maps (Page 7)
@@ -1614,6 +1617,7 @@ menuDialog = main
       subMenu = engine_constants,   "Engine Constants"
       subMenu = injChars,           "Injector Characteristics"
       subMenu = triggerSettings,    "Trigger Setup"
+	  subMenu = tpsCurve,           "TPS Setup"
       ;subMenu = OLED,               "OLED Setup"
       subMenu = airdensity_curve,   "IAT Density"
       subMenu = baroFuel_curve,     "Barometric Correction"
@@ -2382,6 +2386,15 @@ menuDialog = main
       field = "Injector Duty Limit",        dutyLim
       panel = injOpenTimeDialog
       panel = injAngleDialog
+	  
+	dialog = tpsCurveDialog, "TPS Non Linear Curve"
+      panel = tps_Curve_Table
+	  
+	dialog = tpsCurve, "TPS Setup"
+	  field = "TPS Calibration Mode"  tpsCurveEnbl
+	  field = "2 Point TPS Min" tpsMin
+	  field = "2 Point TPS Max" tpsMax
+	  panel = tpsCurveDialog
 
     dialog = egoControl, ""
       topicHelp = "https://wiki.speeduino.com/en/configuration/O2"
@@ -4226,6 +4239,14 @@ cmdVSSratio6 =      "E\x99\x06"
           yBins           = wmiAdvAdj
           size            = 400, 200
 
+; TPS Calibration Curve
+        curve = tps_Curve_Table, "TPS Non Linear Curve"
+            columnLabel = "ADC", "TPS"
+            xAxis = 0, 255, 3
+            yAxis = 0, 100, 3
+            xBins = tpsCurveADC, tpsADC
+            yBins = tpsCurveTPS
+			gauge = tpsADCGauge
 
 [TableEditor]
    ;       table_id,    map3d_id,    "title",      page

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -458,6 +458,7 @@ extern struct table2D knockWindowStartTable;
 extern struct table2D knockWindowDurationTable;
 extern struct table2D oilPressureProtectTable;
 extern struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
+extern struct table2D tpsCurveTable; // For non linear TPS curves (2D)
 
 //These are for the direct port manipulation of the injectors, coils and aux outputs
 extern volatile PORT_TYPE *inj1_pin_port;
@@ -874,8 +875,10 @@ struct config2 {
   int8_t rtc_trim;
   byte idleAdvVss;
   byte mapSwitchPoint;
+  
+  byte tpsCurveEnbl : 1; ///<TPS Enables 3 point curve vs max min.
 
-  byte unused2_95[2];
+  byte unused2_95[1];
 
 #if defined(CORE_AVR)
   };
@@ -1078,6 +1081,8 @@ struct config6 {
   byte fanHyster;         // Fan hysteresis
   byte fanFreq;           // Fan PWM frequency
   byte fanPWMBins[4];     //Temperature Bins for the PWM fan control
+  byte tpsCurveADC[3];    //X axis ADC values for TPS curve
+  byte tpsCurveTPS[3];    //Y axis TPS values for TPS curve
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -51,6 +51,7 @@ struct table2D knockWindowStartTable;
 struct table2D knockWindowDurationTable;
 struct table2D oilPressureProtectTable;
 struct table2D wmiAdvTable; ///< 6 bin wmi correction table for timing advance (2D)
+struct table2D tpsCurveTable; /// For non linear TPS curves (2D)
 
 /// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -245,6 +245,12 @@ void initialiseAll()
     o2CalibrationTable.xSize = 32;
     o2CalibrationTable.values = o2Calibration_values;
     o2CalibrationTable.axisX = o2Calibration_bins;
+	
+	tpsCurveTable.valueSize = SIZE_BYTE;
+    tpsCurveTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+    tpsCurveTable.xSize = 3;
+    tpsCurveTable.values = configPage6.tpsCurveTPS;
+    tpsCurveTable.axisX = configPage6.tpsCurveADC;
 
     //Setup the calibration tables
     loadCalibration();

--- a/speeduino/pages.cpp
+++ b/speeduino/pages.cpp
@@ -24,7 +24,7 @@
 //  2. Offset to intra-entity byte
 
 // Page sizes as defined in the .ini file
-constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 128, 288, 288, 128, 288, 128, 240, 384, 192, 192, 288, 192, 128, 288 };
+constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 128, 288, 288, 128, 288, 134, 240, 384, 192, 192, 288, 192, 128, 288 };
 
 // What section of a 3D table the offset mapped to
 enum table3D_section_t { 

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -408,12 +408,8 @@ void readTPS(bool useFilter)
   byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 
 
-  /* HRW TPS CURVE IN HERE */
-  if (configPage2.tpsCurveEnbl == true)
-  {
-	  //perform table lookup
-	currentStatus.TPS = table2D_getValue(&tpsCurveTable, tempADC);
-  }
+  if (configPage2.tpsCurveEnbl == true){ currentStatus.TPS = table2D_getValue(&tpsCurveTable, tempADC); } // Enable a curve fit of TPS for non-linear sensors
+
   else if(configPage2.tpsMax > configPage2.tpsMin)
   {
     //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -407,7 +407,14 @@ void readTPS(bool useFilter)
   //currentStatus.tpsADC = ADC_FILTER(tempTPS, 128, currentStatus.tpsADC);
   byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 
-  if(configPage2.tpsMax > configPage2.tpsMin)
+
+  /* HRW TPS CURVE IN HERE */
+  if (configPage2.tpsCurveEnbl == true)
+  {
+	  //perform table lookup
+	currentStatus.TPS = table2D_getValue(&tpsCurveTable, tempADC);
+  }
+  else if(configPage2.tpsMax > configPage2.tpsMin)
   {
     //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).
     if (currentStatus.tpsADC < configPage2.tpsMin) { tempADC = configPage2.tpsMin; }


### PR DESCRIPTION
My application is a 2004 Moto Guzzi 1100cc V-Twin. The factory bike uses a non-linear TPS as its primary load input. This TPS has 2 slopes to provide more resolution at lower throttle positions which are critical in ITB applications.

I added a simple 3 point table to map the non-linear voltage to a linear 0-100% TPS value so I could maintain the benifts of the enhanced resolution and more easily translate the factory tune. Also things like TPS-dot will work correctly.

I realise this sensor type is rare but I made this change for myself. Others adapting some motorbikes may use the same style of TPS. The old linear method is retained for backwards compatabilty but is essentialy redundant since using 2 points in this table achieves the same outcome. I only needed 3 points to map the curve, could easily be expanded if others need that functionality.

![TPS Non linear](https://user-images.githubusercontent.com/87687708/127492321-76df9351-413a-4e48-85f9-2e5ebe60e115.jpg)

![TPS Non linear_graph](https://user-images.githubusercontent.com/87687708/127492341-4cf08b52-c480-4b75-8d87-2c5f863ff70d.jpg)

