### PR TITLE
[WIP] Coolant Based VVT Control

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2860,6 +2860,7 @@ menuDialog = main
 
     dialog = vvtSettings, "VVT Control"
         field = "VVT Control Enabled",    vvtEnabled
+        field = "VVT Minimum CLT",  aeColdTaperMax
         field = "VVT Mode",               vvtMode,          { vvtEnabled }
         field = "#Please note that closed loop is currently experimental for Miata and missing tooth patterns ONLY"
         field = "Load source",            vvtLoadSource,    { vvtEnabled }

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -299,7 +299,7 @@ void boostControl()
 
 void vvtControl()
 {
-  if( (configPage6.vvtEnabled == 1) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) )
+  if( (configPage6.vvtEnabled == 1) && (currentStatus.coolant >= configPage2.aeColdTaperMax) && (BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) )
   {
     //currentStatus.vvt1Duty = 0;
     //Calculate the current cam angle


### PR DESCRIPTION
VVT will only run when coolant is greater than set value. The VVT minimum coolant condition shares the same value with Accel enrichment cold taper max value. Didn't want to take up any more free memory. I made this PR to help @ThresherBuilt VVT Miata.

Later version could include tapering the PID values between two coolant temps.