### PR TITLE
BUG FIX: EEPROM emulation for STM32F401 and STM32F411

### DIFF
--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -100,37 +100,16 @@ extern "C" char* sbrk(int incr);
       extern FramClass EEPROM; //Blue/Black Pills
     #endif
 
-#elif defined(STM32F7xx)
+#else //default case, internal flash as EEPROM
   #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
   #include EEPROM_LIB_H
-  #if defined(DUAL_BANK)
-    extern EEPROM_Emulation_Config EmulatedEEPROMMconfig;
-  #else
-    extern EEPROM_Emulation_Config EmulatedEEPROMMconfig;
+    extern InternalSTM32F4_EEPROM_Class EEPROM;
+  #if defined(STM32F401xC)
+    #define SMALL_FLASH_MODE
   #endif
-    extern InternalSTM32F7_EEPROM_Class EEPROM;
-
-#elif defined(STM32F411xE)
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  #include EEPROM_LIB_H
-    extern EEPROM_Emulation_Config EmulatedEEPROMMconfig;
-    extern InternalSTM32F4_EEPROM_Class EEPROM;
-
-#elif defined(STM32F401xC)
-  //when using with internal falsh not enough rom is available so small flash mode is enabled
-  //be carefull that the only 50% of flash is can be used, the other 50% is used for eeprom emulation
-  #define SMALL_FLASH_MODE
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  #include EEPROM_LIB_H
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 4095UL, 0x08020000UL};
-    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-
-#else //default case, internal flash as EEPROM for STM32F407
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  #include EEPROM_LIB_H
-    extern EEPROM_Emulation_Config EmulatedEEPROMMconfig;
-    extern InternalSTM32F4_EEPROM_Class EEPROM;
 #endif
+
+
 
 #define RTC_LIB_H "STM32RTC.h"
 

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -37,6 +37,9 @@ STM32_CAN Can0 (_CAN1,DEF);
   #endif
     InternalSTM32F7_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 #elif defined(STM32F401xC)
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 4095UL, 0x08020000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+#elif defined(STM32F411xE)
     EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 131072UL, 4095UL, 0x08040000UL};
     InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
 #else //default case, internal flash as EEPROM for STM32F4


### PR DESCRIPTION
Fixed a bug in eeprom emulation for STM32F401 and STM32F411 
General cleanup eeprom emulation STM32 onboard flash