### PR TITLE
Fixes #646, log the load fields for TS to use

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -4918,6 +4918,9 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = advance1,         "Advance 1",      int,     "%d"
    entry = advance2,         "Advance 2",      int,     "%d"
    entry = emap,             "EMAP",           int,     "%d", { useEMAP }
+   entry = fuelLoad,         "FuelLoad",       float,   "%.1f"
+   entry = ignLoad,          "IgnitionLoad"    float,   "%.1f"
+
 
 [LoggerDefinition]
     ; valid logger types: composite, tooth, trigger, csv


### PR DESCRIPTION
Add in fuelLoad and ignLoad so that TS knows the correct load value when processing log files from engines not using MAP as load measure.