### PR TITLE
[Request for comment] Abstracted timers from schedulers

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -305,50 +305,50 @@ static inline void checkPerToothTiming(int16_t crankAngle, uint16_t currentTooth
   {
     if ( (currentTooth == ignition1EndTooth) )
     {
-      if( (ignitionSchedule1.Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule1.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[0].Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[0].endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule[0].endScheduleSetByDecoder = true; }
     }
     else if ( (currentTooth == ignition2EndTooth) )
     {
-      if( (ignitionSchedule2.Status == RUNNING) ) { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule2.endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule2.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[1].Status == RUNNING) ) { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[1].endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule[1].endScheduleSetByDecoder = true; }
     }
     else if ( (currentTooth == ignition3EndTooth) )
     {
-      if( (ignitionSchedule3.Status == RUNNING) ) { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule3.endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule3.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[2].Status == RUNNING) ) { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[2].endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule[2].endScheduleSetByDecoder = true; }
     }
     else if ( (currentTooth == ignition4EndTooth) )
     {
-      if( (ignitionSchedule4.Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[3].Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[3].endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule[3].endScheduleSetByDecoder = true; }
     }
 #if IGN_CHANNELS >= 5
     else if ( (currentTooth == ignition5EndTooth) )
     {
-      if( (ignitionSchedule5.Status == RUNNING) ) { IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule5.endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); ignitionSchedule5.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[4].Status == RUNNING) ) { IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[4].endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); ignitionSchedule[4].endScheduleSetByDecoder = true; }
     }
 #endif
 #if IGN_CHANNELS >= 6
     else if ( (currentTooth == ignition6EndTooth) )
     {
-      if( (ignitionSchedule6.Status == RUNNING) ) { IGN6_COMPARE = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule6.endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); ignitionSchedule6.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[5].Status == RUNNING) ) { IGN6_COMPARE = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[5].endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); ignitionSchedule[5].endScheduleSetByDecoder = true; }
     }
 #endif
 #if IGN_CHANNELS >= 7
     else if ( (currentTooth == ignition7EndTooth) )
     {
-      if( (ignitionSchedule7.Status == RUNNING) ) { IGN7_COMPARE = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule7.endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); ignitionSchedule7.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[6].Status == RUNNING) ) { IGN7_COMPARE = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[6].endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); ignitionSchedule[6].endScheduleSetByDecoder = true; }
     }
 #endif
 #if IGN_CHANNELS >= 8
     else if ( (currentTooth == ignition8EndTooth) )
     {
-      if( (ignitionSchedule8.Status == RUNNING) ) { IGN8_COMPARE = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule8.endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); ignitionSchedule8.endScheduleSetByDecoder = true; }
+      if( (ignitionSchedule[7].Status == RUNNING) ) { IGN8_COMPARE = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); }
+      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[7].endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); ignitionSchedule[7].endScheduleSetByDecoder = true; }
     }
 #endif
   }

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -299,56 +299,53 @@ Only if both these conditions are met will the schedule be updated with the late
 If it's the correct tooth, but the schedule is not yet started, calculate and an end compare value (This situation occurs when both the start and end of the ignition pulse happen after the end tooth, but before the next tooth)
 */
 #define MIN_CYCLES_FOR_ENDCOMPARE 6
+inline void refreshIgnitionTiming(int i, int16_t crankAngle, int ignitionEndAngle) {
+  if( (ignitionSchedule[i].Status == RUNNING) ) { setIgnitionCompare(i, getIgnitionCounter(i) + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignitionEndAngle - crankAngle) ) ) ) ); }
+  else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[i].endCompare = getIgnitionCounter(i) + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignitionEndAngle - crankAngle) ) ) ); ignitionSchedule[i].endScheduleSetByDecoder = true; }
+}
+
 static inline void checkPerToothTiming(int16_t crankAngle, uint16_t currentTooth)
 {
   if ( (fixedCrankingOverride == 0) && (currentStatus.RPM > 0) )
   {
     if ( (currentTooth == ignition1EndTooth) )
     {
-      if( (ignitionSchedule[0].Status == RUNNING) ) { IGN1_COMPARE = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[0].endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule[0].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(0, crankAngle, ignition1EndAngle);
     }
     else if ( (currentTooth == ignition2EndTooth) )
     {
-      if( (ignitionSchedule[1].Status == RUNNING) ) { IGN2_COMPARE = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[1].endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule[1].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(1, crankAngle, ignition2EndAngle);
     }
     else if ( (currentTooth == ignition3EndTooth) )
     {
-      if( (ignitionSchedule[2].Status == RUNNING) ) { IGN3_COMPARE = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[2].endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule[2].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(2, crankAngle, ignition3EndAngle);
     }
     else if ( (currentTooth == ignition4EndTooth) )
     {
-      if( (ignitionSchedule[3].Status == RUNNING) ) { IGN4_COMPARE = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[3].endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule[3].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(3, crankAngle, ignition4EndAngle);
     }
 #if IGN_CHANNELS >= 5
     else if ( (currentTooth == ignition5EndTooth) )
     {
-      if( (ignitionSchedule[4].Status == RUNNING) ) { IGN5_COMPARE = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[4].endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); ignitionSchedule[4].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(4, crankAngle, ignition5EndAngle);
     }
 #endif
 #if IGN_CHANNELS >= 6
     else if ( (currentTooth == ignition6EndTooth) )
     {
-      if( (ignitionSchedule[5].Status == RUNNING) ) { IGN6_COMPARE = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[5].endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); ignitionSchedule[5].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(5, crankAngle, ignition6EndAngle);
     }
 #endif
 #if IGN_CHANNELS >= 7
     else if ( (currentTooth == ignition7EndTooth) )
     {
-      if( (ignitionSchedule[6].Status == RUNNING) ) { IGN7_COMPARE = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[6].endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); ignitionSchedule[6].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(6, crankAngle, ignition7EndAngle);
     }
 #endif
 #if IGN_CHANNELS >= 8
     else if ( (currentTooth == ignition8EndTooth) )
     {
-      if( (ignitionSchedule[7].Status == RUNNING) ) { IGN8_COMPARE = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule[7].endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( fastDegreesToUS( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); ignitionSchedule[7].endScheduleSetByDecoder = true; }
+      refreshIgnitionTiming(7, crankAngle, ignition8EndAngle);
     }
 #endif
   }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1000,36 +1000,36 @@ void initialiseAll()
     {
     case IGN_MODE_WASTED:
         //Wasted Spark (Normal mode)
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
+        ignStartFunction[0] = beginCoil1Charge;
+        ignEndFunction[0] = endCoil1Charge;
+        ignStartFunction[1] = beginCoil2Charge;
+        ignEndFunction[1] = endCoil2Charge;
+        ignStartFunction[2] = beginCoil3Charge;
+        ignEndFunction[2] = endCoil3Charge;
+        ignStartFunction[3] = beginCoil4Charge;
+        ignEndFunction[3] = endCoil4Charge;
+        ignStartFunction[4] = beginCoil5Charge;
+        ignEndFunction[4] = endCoil5Charge;
         break;
 
     case IGN_MODE_SINGLE:
         //Single channel mode. All ignition pulses are on channel 1
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil1Charge;
-        ign2EndFunction = endCoil1Charge;
-        ign3StartFunction = beginCoil1Charge;
-        ign3EndFunction = endCoil1Charge;
-        ign4StartFunction = beginCoil1Charge;
-        ign4EndFunction = endCoil1Charge;
-        ign5StartFunction = beginCoil1Charge;
-        ign5EndFunction = endCoil1Charge;
-        ign6StartFunction = beginCoil1Charge;
-        ign6EndFunction = endCoil1Charge;
-        ign7StartFunction = beginCoil1Charge;
-        ign7EndFunction = endCoil1Charge;
-        ign8StartFunction = beginCoil1Charge;
-        ign8EndFunction = endCoil1Charge;
+        ignStartFunction[0] = beginCoil1Charge;
+        ignEndFunction[0] = endCoil1Charge;
+        ignStartFunction[1] = beginCoil1Charge;
+        ignEndFunction[1] = endCoil1Charge;
+        ignStartFunction[2] = beginCoil1Charge;
+        ignEndFunction[2] = endCoil1Charge;
+        ignStartFunction[3] = beginCoil1Charge;
+        ignEndFunction[3] = endCoil1Charge;
+        ignStartFunction[4] = beginCoil1Charge;
+        ignEndFunction[4] = endCoil1Charge;
+        ignStartFunction[5] = beginCoil1Charge;
+        ignEndFunction[5] = endCoil1Charge;
+        ignStartFunction[6] = beginCoil1Charge;
+        ignEndFunction[6] = endCoil1Charge;
+        ignStartFunction[7] = beginCoil1Charge;
+        ignEndFunction[7] = endCoil1Charge;
         break;
 
     case IGN_MODE_WASTEDCOP:
@@ -1037,118 +1037,118 @@ void initialiseAll()
         //Wasted COP mode for 4 cylinders. Ignition channels 1&3 and 2&4 are paired together
         if( configPage2.nCylinders <= 4 )
         {
-          ign1StartFunction = beginCoil1and3Charge;
-          ign1EndFunction = endCoil1and3Charge;
-          ign2StartFunction = beginCoil2and4Charge;
-          ign2EndFunction = endCoil2and4Charge;
+          ignStartFunction[0] = beginCoil1and3Charge;
+          ignEndFunction[0] = endCoil1and3Charge;
+          ignStartFunction[1] = beginCoil2and4Charge;
+          ignEndFunction[1] = endCoil2and4Charge;
 
-          ign3StartFunction = nullCallback;
-          ign3EndFunction = nullCallback;
-          ign4StartFunction = nullCallback;
-          ign4EndFunction = nullCallback;
+          ignStartFunction[2] = nullCallback;
+          ignEndFunction[2] = nullCallback;
+          ignStartFunction[3] = nullCallback;
+          ignEndFunction[3] = nullCallback;
         }
         //Wasted COP mode for 6 cylinders. Ignition channels 1&4, 2&5 and 3&6 are paired together
         else if( configPage2.nCylinders == 6 )
           {
-          ign1StartFunction = beginCoil1and4Charge;
-          ign1EndFunction = endCoil1and4Charge;
-          ign2StartFunction = beginCoil2and5Charge;
-          ign2EndFunction = endCoil2and5Charge;
-          ign3StartFunction = beginCoil3and6Charge;
-          ign3EndFunction = endCoil3and6Charge;
+          ignStartFunction[0] = beginCoil1and4Charge;
+          ignEndFunction[0] = endCoil1and4Charge;
+          ignStartFunction[1] = beginCoil2and5Charge;
+          ignEndFunction[1] = endCoil2and5Charge;
+          ignStartFunction[2] = beginCoil3and6Charge;
+          ignEndFunction[2] = endCoil3and6Charge;
 
-          ign4StartFunction = nullCallback;
-          ign4EndFunction = nullCallback;
-          ign5StartFunction = nullCallback;
-          ign5EndFunction = nullCallback;
-          ign6StartFunction = nullCallback;
-          ign6EndFunction = nullCallback;
+          ignStartFunction[3] = nullCallback;
+          ignEndFunction[3] = nullCallback;
+          ignStartFunction[4] = nullCallback;
+          ignEndFunction[4] = nullCallback;
+          ignStartFunction[5] = nullCallback;
+          ignEndFunction[5] = nullCallback;
         }
         //Wasted COP mode for 8 cylinders. Ignition channels 1&5, 2&6, 3&7 and 4&8 are paired together
         else if( configPage2.nCylinders == 8 )
           {
-          ign1StartFunction = beginCoil1and5Charge;
-          ign1EndFunction = endCoil1and5Charge;
-          ign2StartFunction = beginCoil2and6Charge;
-          ign2EndFunction = endCoil2and6Charge;
-          ign3StartFunction = beginCoil3and7Charge;
-          ign3EndFunction = endCoil3and7Charge;
-          ign4StartFunction = beginCoil4and8Charge;
-          ign4EndFunction = endCoil4and8Charge;
+          ignStartFunction[0] = beginCoil1and5Charge;
+          ignEndFunction[0] = endCoil1and5Charge;
+          ignStartFunction[1] = beginCoil2and6Charge;
+          ignEndFunction[1] = endCoil2and6Charge;
+          ignStartFunction[2] = beginCoil3and7Charge;
+          ignEndFunction[2] = endCoil3and7Charge;
+          ignStartFunction[3] = beginCoil4and8Charge;
+          ignEndFunction[3] = endCoil4and8Charge;
 
-          ign5StartFunction = nullCallback;
-          ign5EndFunction = nullCallback;
-          ign6StartFunction = nullCallback;
-          ign6EndFunction = nullCallback;
-          ign7StartFunction = nullCallback;
-          ign7EndFunction = nullCallback;
-          ign8StartFunction = nullCallback;
-          ign8EndFunction = nullCallback;
+          ignStartFunction[4] = nullCallback;
+          ignEndFunction[4] = nullCallback;
+          ignStartFunction[5] = nullCallback;
+          ignEndFunction[5] = nullCallback;
+          ignStartFunction[6] = nullCallback;
+          ignEndFunction[6] = nullCallback;
+          ignStartFunction[7] = nullCallback;
+          ignEndFunction[7] = nullCallback;
         }
         else
         {
           //If the person has inadvertantly selected this when running more than 4 cylinders or other than 6 cylinders, just use standard Wasted spark mode
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil2Charge;
-          ign2EndFunction = endCoil2Charge;
-          ign3StartFunction = beginCoil3Charge;
-          ign3EndFunction = endCoil3Charge;
-          ign4StartFunction = beginCoil4Charge;
-          ign4EndFunction = endCoil4Charge;
-          ign5StartFunction = beginCoil5Charge;
-          ign5EndFunction = endCoil5Charge;
+          ignStartFunction[0] = beginCoil1Charge;
+          ignEndFunction[0] = endCoil1Charge;
+          ignStartFunction[1] = beginCoil2Charge;
+          ignEndFunction[1] = endCoil2Charge;
+          ignStartFunction[2] = beginCoil3Charge;
+          ignEndFunction[2] = endCoil3Charge;
+          ignStartFunction[3] = beginCoil4Charge;
+          ignEndFunction[3] = endCoil4Charge;
+          ignStartFunction[4] = beginCoil5Charge;
+          ignEndFunction[4] = endCoil5Charge;
         }
         break;
 
     case IGN_MODE_SEQUENTIAL:
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
-        ign6StartFunction = beginCoil6Charge;
-        ign6EndFunction = endCoil6Charge;
-        ign7StartFunction = beginCoil7Charge;
-        ign7EndFunction = endCoil7Charge;
-        ign8StartFunction = beginCoil8Charge;
-        ign8EndFunction = endCoil8Charge;
+        ignStartFunction[0] = beginCoil1Charge;
+        ignEndFunction[0] = endCoil1Charge;
+        ignStartFunction[1] = beginCoil2Charge;
+        ignEndFunction[1] = endCoil2Charge;
+        ignStartFunction[2] = beginCoil3Charge;
+        ignEndFunction[2] = endCoil3Charge;
+        ignStartFunction[3] = beginCoil4Charge;
+        ignEndFunction[3] = endCoil4Charge;
+        ignStartFunction[4] = beginCoil5Charge;
+        ignEndFunction[4] = endCoil5Charge;
+        ignStartFunction[5] = beginCoil6Charge;
+        ignEndFunction[5] = endCoil6Charge;
+        ignStartFunction[6] = beginCoil7Charge;
+        ignEndFunction[6] = endCoil7Charge;
+        ignStartFunction[7] = beginCoil8Charge;
+        ignEndFunction[7] = endCoil8Charge;
         break;
 
     case IGN_MODE_ROTARY:
         if(configPage10.rotaryType == ROTARY_IGN_FC)
         {
           //Ignition channel 1 is a wasted spark signal for leading signal on both rotors
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil1Charge;
-          ign2EndFunction = endCoil1Charge;
+          ignStartFunction[0] = beginCoil1Charge;
+          ignEndFunction[0] = endCoil1Charge;
+          ignStartFunction[1] = beginCoil1Charge;
+          ignEndFunction[1] = endCoil1Charge;
 
-          ign3StartFunction = beginTrailingCoilCharge;
-          ign3EndFunction = endTrailingCoilCharge1;
-          ign4StartFunction = beginTrailingCoilCharge;
-          ign4EndFunction = endTrailingCoilCharge2;
+          ignStartFunction[2] = beginTrailingCoilCharge;
+          ignEndFunction[2] = endTrailingCoilCharge1;
+          ignStartFunction[3] = beginTrailingCoilCharge;
+          ignEndFunction[3] = endTrailingCoilCharge2;
         }
         else if(configPage10.rotaryType == ROTARY_IGN_FD)
         {
           //Ignition channel 1 is a wasted spark signal for leading signal on both rotors
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
-          ign2StartFunction = beginCoil1Charge;
-          ign2EndFunction = endCoil1Charge;
+          ignStartFunction[0] = beginCoil1Charge;
+          ignEndFunction[0] = endCoil1Charge;
+          ignStartFunction[1] = beginCoil1Charge;
+          ignEndFunction[1] = endCoil1Charge;
 
           //Trailing coils have their own channel each
           //IGN2 = front rotor trailing spark
-          ign3StartFunction = beginCoil2Charge;
-          ign3EndFunction = endCoil2Charge;
+          ignStartFunction[2] = beginCoil2Charge;
+          ignEndFunction[2] = endCoil2Charge;
           //IGN3 = rear rotor trailing spark
-          ign4StartFunction = beginCoil3Charge;
-          ign4EndFunction = endCoil3Charge;
+          ignStartFunction[3] = beginCoil3Charge;
+          ignEndFunction[3] = endCoil3Charge;
 
           //IGN4 not used
         }
@@ -1157,32 +1157,32 @@ void initialiseAll()
           //RX8 outputs are simply 1 coil and 1 output per plug
 
           //IGN1 is front rotor, leading spark
-          ign1StartFunction = beginCoil1Charge;
-          ign1EndFunction = endCoil1Charge;
+          ignStartFunction[0] = beginCoil1Charge;
+          ignEndFunction[0] = endCoil1Charge;
           //IGN2 is rear rotor, leading spark
-          ign2StartFunction = beginCoil2Charge;
-          ign2EndFunction = endCoil2Charge;
+          ignStartFunction[1] = beginCoil2Charge;
+          ignEndFunction[1] = endCoil2Charge;
           //IGN3 = front rotor trailing spark
-          ign3StartFunction = beginCoil3Charge;
-          ign3EndFunction = endCoil3Charge;
+          ignStartFunction[2] = beginCoil3Charge;
+          ignEndFunction[2] = endCoil3Charge;
           //IGN4 = rear rotor trailing spark
-          ign4StartFunction = beginCoil4Charge;
-          ign4EndFunction = endCoil4Charge;
+          ignStartFunction[3] = beginCoil4Charge;
+          ignEndFunction[3] = endCoil4Charge;
         }
         break;
 
     default:
         //Wasted spark (Shouldn't ever happen anyway)
-        ign1StartFunction = beginCoil1Charge;
-        ign1EndFunction = endCoil1Charge;
-        ign2StartFunction = beginCoil2Charge;
-        ign2EndFunction = endCoil2Charge;
-        ign3StartFunction = beginCoil3Charge;
-        ign3EndFunction = endCoil3Charge;
-        ign4StartFunction = beginCoil4Charge;
-        ign4EndFunction = endCoil4Charge;
-        ign5StartFunction = beginCoil5Charge;
-        ign5EndFunction = endCoil5Charge;
+        ignStartFunction[0] = beginCoil1Charge;
+        ignEndFunction[0] = endCoil1Charge;
+        ignStartFunction[1] = beginCoil2Charge;
+        ignEndFunction[1] = endCoil2Charge;
+        ignStartFunction[2] = beginCoil3Charge;
+        ignEndFunction[2] = endCoil3Charge;
+        ignStartFunction[3] = beginCoil4Charge;
+        ignEndFunction[3] = endCoil4Charge;
+        ignStartFunction[4] = beginCoil5Charge;
+        ignEndFunction[4] = endCoil5Charge;
         break;
     }
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -68,22 +68,8 @@ extern void (*inj8EndFunction)();
  * They are required for the various spark output modes.
  * @{
 */
-extern void (*ign1StartFunction)();
-extern void (*ign1EndFunction)();
-extern void (*ign2StartFunction)();
-extern void (*ign2EndFunction)();
-extern void (*ign3StartFunction)();
-extern void (*ign3EndFunction)();
-extern void (*ign4StartFunction)();
-extern void (*ign4EndFunction)();
-extern void (*ign5StartFunction)();
-extern void (*ign5EndFunction)();
-extern void (*ign6StartFunction)();
-extern void (*ign6EndFunction)();
-extern void (*ign7StartFunction)();
-extern void (*ign7EndFunction)();
-extern void (*ign8StartFunction)();
-extern void (*ign8EndFunction)();
+extern void (*ignStartFunction[8])();
+extern void (*ignEndFunction[8])();
 /** @} */
 
 void initialiseSchedulers();
@@ -208,7 +194,7 @@ extern FuelSchedule fuelSchedule6;
 extern FuelSchedule fuelSchedule7;
 extern FuelSchedule fuelSchedule8;
 
-extern Schedule ignitionSchedule[8];
+extern Schedule ignitionSchedule[IGN_CHANNELS];
 
 //IgnitionSchedule nullSchedule; //This is placed at the end of the queue. It's status will always be set to OFF and hence will never perform any action within an ISR
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -204,14 +204,7 @@ extern FuelSchedule fuelSchedule6;
 extern FuelSchedule fuelSchedule7;
 extern FuelSchedule fuelSchedule8;
 
-extern Schedule ignitionSchedule1;
-extern Schedule ignitionSchedule2;
-extern Schedule ignitionSchedule3;
-extern Schedule ignitionSchedule4;
-extern Schedule ignitionSchedule5;
-extern Schedule ignitionSchedule6;
-extern Schedule ignitionSchedule7;
-extern Schedule ignitionSchedule8;
+extern Schedule ignitionSchedule[8];
 
 //IgnitionSchedule nullSchedule; //This is placed at the end of the queue. It's status will always be set to OFF and hence will never perform any action within an ISR
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -108,6 +108,10 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
 
 inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((always_inline));
 
+inline COMPARE_TYPE getIgnitionCounter(int i);
+inline void setIgnitionCompare(int i, COMPARE_TYPE val);
+inline void setIgnitionTimerRunning(int i, bool enabled);
+
 //The ARM cores use seprate functions for their ISRs
 #if defined(ARDUINO_ARCH_STM32) || defined(CORE_TEENSY)
   static inline void fuelSchedule1Interrupt();

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -37,7 +37,7 @@ FuelSchedule fuelSchedule6;
 FuelSchedule fuelSchedule7;
 FuelSchedule fuelSchedule8;
 
-Schedule ignitionSchedule[8];
+Schedule ignitionSchedule[IGN_CHANNELS];
 
 void (*inj1StartFunction)();
 void (*inj1EndFunction)();
@@ -56,22 +56,8 @@ void (*inj7EndFunction)();
 void (*inj8StartFunction)();
 void (*inj8EndFunction)();
 
-void (*ign1StartFunction)();
-void (*ign1EndFunction)();
-void (*ign2StartFunction)();
-void (*ign2EndFunction)();
-void (*ign3StartFunction)();
-void (*ign3EndFunction)();
-void (*ign4StartFunction)();
-void (*ign4EndFunction)();
-void (*ign5StartFunction)();
-void (*ign5EndFunction)();
-void (*ign6StartFunction)();
-void (*ign6EndFunction)();
-void (*ign7StartFunction)();
-void (*ign7EndFunction)();
-void (*ign8StartFunction)();
-void (*ign8EndFunction)();
+void (*ignStartFunction[8])();
+void (*ignEndFunction[8])();
 
 void initialiseSchedulers()
 {
@@ -95,7 +81,7 @@ void initialiseSchedulers()
     fuelSchedule7.schedulesSet = 0;
     fuelSchedule8.schedulesSet = 0;
     
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < IGN_CHANNELS; i++) {
       ignitionSchedule[i].Status = OFF;
       setIgnitionTimerRunning(i, true);
       ignitionSchedule[i].schedulesSet = 0;

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -37,14 +37,7 @@ FuelSchedule fuelSchedule6;
 FuelSchedule fuelSchedule7;
 FuelSchedule fuelSchedule8;
 
-Schedule ignitionSchedule1;
-Schedule ignitionSchedule2;
-Schedule ignitionSchedule3;
-Schedule ignitionSchedule4;
-Schedule ignitionSchedule5;
-Schedule ignitionSchedule6;
-Schedule ignitionSchedule7;
-Schedule ignitionSchedule8;
+Schedule ignitionSchedule[8];
 
 void (*inj1StartFunction)();
 void (*inj1EndFunction)();
@@ -102,14 +95,14 @@ void initialiseSchedulers()
     fuelSchedule7.schedulesSet = 0;
     fuelSchedule8.schedulesSet = 0;
 
-    ignitionSchedule1.Status = OFF;
-    ignitionSchedule2.Status = OFF;
-    ignitionSchedule3.Status = OFF;
-    ignitionSchedule4.Status = OFF;
-    ignitionSchedule5.Status = OFF;
-    ignitionSchedule6.Status = OFF;
-    ignitionSchedule7.Status = OFF;
-    ignitionSchedule8.Status = OFF;
+    ignitionSchedule[0].Status = OFF;
+    ignitionSchedule[1].Status = OFF;
+    ignitionSchedule[2].Status = OFF;
+    ignitionSchedule[3].Status = OFF;
+    ignitionSchedule[4].Status = OFF;
+    ignitionSchedule[5].Status = OFF;
+    ignitionSchedule[6].Status = OFF;
+    ignitionSchedule[7].Status = OFF;
 
     IGN1_TIMER_ENABLE();
     IGN2_TIMER_ENABLE();
@@ -120,14 +113,14 @@ void initialiseSchedulers()
     IGN7_TIMER_ENABLE();
     IGN8_TIMER_ENABLE();
 
-    ignitionSchedule1.schedulesSet = 0;
-    ignitionSchedule2.schedulesSet = 0;
-    ignitionSchedule3.schedulesSet = 0;
-    ignitionSchedule4.schedulesSet = 0;
-    ignitionSchedule5.schedulesSet = 0;
-    ignitionSchedule6.schedulesSet = 0;
-    ignitionSchedule7.schedulesSet = 0;
-    ignitionSchedule8.schedulesSet = 0;
+    ignitionSchedule[0].schedulesSet = 0;
+    ignitionSchedule[1].schedulesSet = 0;
+    ignitionSchedule[2].schedulesSet = 0;
+    ignitionSchedule[3].schedulesSet = 0;
+    ignitionSchedule[4].schedulesSet = 0;
+    ignitionSchedule[5].schedulesSet = 0;
+    ignitionSchedule[6].schedulesSet = 0;
+    ignitionSchedule[7].schedulesSet = 0;
 }
 
 /*
@@ -485,11 +478,11 @@ void setFuelSchedule8(unsigned long timeout, unsigned long duration) //Uses time
 //Ignition schedulers use Timer 5
 void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule1.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[0].Status != RUNNING) //Check that we're not already part way through a schedule
   {
-    ignitionSchedule1.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule1.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule1.duration = duration;
+    ignitionSchedule[0].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[0].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[0].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -498,11 +491,11 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule1.startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule1.endScheduleSetByDecoder == false) { ignitionSchedule1.endCompare = ignitionSchedule1.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN1_COMPARE = (uint16_t)ignitionSchedule1.startCompare;
-    ignitionSchedule1.Status = PENDING; //Turn this schedule on
-    ignitionSchedule1.schedulesSet++;
+    ignitionSchedule[0].startCompare = IGN1_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+    if(ignitionSchedule[0].endScheduleSetByDecoder == false) { ignitionSchedule[0].endCompare = ignitionSchedule[0].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN1_COMPARE = (uint16_t)ignitionSchedule[0].startCompare;
+    ignitionSchedule[0].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[0].schedulesSet++;
     interrupts();
     IGN1_TIMER_ENABLE();
   }
@@ -512,9 +505,9 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule1.nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule1.nextEndCompare = ignitionSchedule1.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule1.hasNextSchedule = true;
+      ignitionSchedule[0].nextStartCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[0].nextEndCompare = ignitionSchedule[0].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[0].hasNextSchedule = true;
     }
 
   }
@@ -522,24 +515,24 @@ void setIgnitionSchedule1(void (*startCallback)(), unsigned long timeout, unsign
 
 inline void refreshIgnitionSchedule1(unsigned long timeToEnd)
 {
-  if( (ignitionSchedule1.Status == RUNNING) && (timeToEnd < ignitionSchedule1.duration) )
+  if( (ignitionSchedule[0].Status == RUNNING) && (timeToEnd < ignitionSchedule[0].duration) )
   //Must have the threshold check here otherwise it can cause a condition where the compare fires twice, once after the other, both for the end
-  //if( (timeToEnd < ignitionSchedule1.duration) && (timeToEnd > IGNITION_REFRESH_THRESHOLD) )
+  //if( (timeToEnd < ignitionSchedule[0].duration) && (timeToEnd > IGNITION_REFRESH_THRESHOLD) )
   {
     noInterrupts();
-    ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeToEnd);
-    IGN1_COMPARE = (uint16_t)ignitionSchedule1.endCompare;
+    ignitionSchedule[0].endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE(timeToEnd);
+    IGN1_COMPARE = (uint16_t)ignitionSchedule[0].endCompare;
     interrupts();
   }
 }
 
 void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule2.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[1].Status != RUNNING) //Check that we're not already part way through a schedule
   {
-    ignitionSchedule2.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule2.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule2.duration = duration;
+    ignitionSchedule[1].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[1].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[1].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -547,11 +540,11 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule2.startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule2.endScheduleSetByDecoder == false) { ignitionSchedule2.endCompare = ignitionSchedule2.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN2_COMPARE = (uint16_t)ignitionSchedule2.startCompare;
-    ignitionSchedule2.Status = PENDING; //Turn this schedule on
-    ignitionSchedule2.schedulesSet++;
+    ignitionSchedule[1].startCompare = IGN2_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+    if(ignitionSchedule[1].endScheduleSetByDecoder == false) { ignitionSchedule[1].endCompare = ignitionSchedule[1].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN2_COMPARE = (uint16_t)ignitionSchedule[1].startCompare;
+    ignitionSchedule[1].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[1].schedulesSet++;
     interrupts();
     IGN2_TIMER_ENABLE();
   }
@@ -561,20 +554,20 @@ void setIgnitionSchedule2(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule2.nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule2.nextEndCompare = ignitionSchedule2.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule2.hasNextSchedule = true;
+      ignitionSchedule[1].nextStartCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[1].nextEndCompare = ignitionSchedule[1].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[1].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule3.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[2].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule3.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule3.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule3.duration = duration;
+    ignitionSchedule[2].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[2].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[2].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -582,11 +575,11 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule3.startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
-    if(ignitionSchedule3.endScheduleSetByDecoder == false) { ignitionSchedule3.endCompare = ignitionSchedule3.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN3_COMPARE = (uint16_t)ignitionSchedule3.startCompare;
-    ignitionSchedule3.Status = PENDING; //Turn this schedule on
-    ignitionSchedule3.schedulesSet++;
+    ignitionSchedule[2].startCompare = IGN3_COUNTER + timeout_timer_compare; //As there is a tick every 4uS, there are timeout/4 ticks until the interrupt should be triggered ( >>2 divides by 4)
+    if(ignitionSchedule[2].endScheduleSetByDecoder == false) { ignitionSchedule[2].endCompare = ignitionSchedule[2].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN3_COMPARE = (uint16_t)ignitionSchedule[2].startCompare;
+    ignitionSchedule[2].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[2].schedulesSet++;
     interrupts();
     IGN3_TIMER_ENABLE();
   }
@@ -596,20 +589,20 @@ void setIgnitionSchedule3(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule3.nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule3.nextEndCompare = ignitionSchedule3.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule3.hasNextSchedule = true;
+      ignitionSchedule[2].nextStartCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[2].nextEndCompare = ignitionSchedule[2].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[2].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule4.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[3].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule4.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule4.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule4.duration = duration;
+    ignitionSchedule[3].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[3].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[3].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -617,11 +610,11 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule4.startCompare = IGN4_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule4.endScheduleSetByDecoder == false) { ignitionSchedule4.endCompare = ignitionSchedule4.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN4_COMPARE = (uint16_t)ignitionSchedule4.startCompare;
-    ignitionSchedule4.Status = PENDING; //Turn this schedule on
-    ignitionSchedule4.schedulesSet++;
+    ignitionSchedule[3].startCompare = IGN4_COUNTER + timeout_timer_compare;
+    if(ignitionSchedule[3].endScheduleSetByDecoder == false) { ignitionSchedule[3].endCompare = ignitionSchedule[3].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN4_COMPARE = (uint16_t)ignitionSchedule[3].startCompare;
+    ignitionSchedule[3].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[3].schedulesSet++;
     interrupts();
     IGN4_TIMER_ENABLE();
   }
@@ -631,20 +624,20 @@ void setIgnitionSchedule4(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule4.nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule4.nextEndCompare = ignitionSchedule4.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule4.hasNextSchedule = true;
+      ignitionSchedule[3].nextStartCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[3].nextEndCompare = ignitionSchedule[3].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[3].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule5.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[4].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule5.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule5.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule5.duration = duration;
+    ignitionSchedule[4].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[4].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[4].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -652,11 +645,11 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule5.startCompare = IGN5_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule5.endScheduleSetByDecoder == false) { ignitionSchedule5.endCompare = ignitionSchedule5.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN5_COMPARE = (uint16_t)ignitionSchedule5.startCompare;
-    ignitionSchedule5.Status = PENDING; //Turn this schedule on
-    ignitionSchedule5.schedulesSet++;
+    ignitionSchedule[4].startCompare = IGN5_COUNTER + timeout_timer_compare;
+    if(ignitionSchedule[4].endScheduleSetByDecoder == false) { ignitionSchedule[4].endCompare = ignitionSchedule[4].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN5_COMPARE = (uint16_t)ignitionSchedule[4].startCompare;
+    ignitionSchedule[4].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[4].schedulesSet++;
     interrupts();
     IGN5_TIMER_ENABLE();
   }
@@ -666,20 +659,20 @@ void setIgnitionSchedule5(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule5.nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule5.nextEndCompare = ignitionSchedule5.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule5.hasNextSchedule = true;
+      ignitionSchedule[4].nextStartCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[4].nextEndCompare = ignitionSchedule[4].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[4].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule6.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[5].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule6.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule6.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule6.duration = duration;
+    ignitionSchedule[5].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[5].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[5].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -687,11 +680,11 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule6.startCompare = IGN6_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule6.endScheduleSetByDecoder == false) { ignitionSchedule6.endCompare = ignitionSchedule6.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN6_COMPARE = (uint16_t)ignitionSchedule6.startCompare;
-    ignitionSchedule6.Status = PENDING; //Turn this schedule on
-    ignitionSchedule6.schedulesSet++;
+    ignitionSchedule[5].startCompare = IGN6_COUNTER + timeout_timer_compare;
+    if(ignitionSchedule[5].endScheduleSetByDecoder == false) { ignitionSchedule[5].endCompare = ignitionSchedule[5].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN6_COMPARE = (uint16_t)ignitionSchedule[5].startCompare;
+    ignitionSchedule[5].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[5].schedulesSet++;
     interrupts();
     IGN6_TIMER_ENABLE();
   }
@@ -701,20 +694,20 @@ void setIgnitionSchedule6(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule6.nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule6.nextEndCompare = ignitionSchedule6.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule6.hasNextSchedule = true;
+      ignitionSchedule[5].nextStartCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[5].nextEndCompare = ignitionSchedule[5].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[5].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule7.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[6].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule7.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule7.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule7.duration = duration;
+    ignitionSchedule[6].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[6].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[6].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -722,11 +715,11 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule7.startCompare = IGN7_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule7.endScheduleSetByDecoder == false) { ignitionSchedule7.endCompare = ignitionSchedule7.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN7_COMPARE = (uint16_t)ignitionSchedule7.startCompare;
-    ignitionSchedule7.Status = PENDING; //Turn this schedule on
-    ignitionSchedule7.schedulesSet++;
+    ignitionSchedule[6].startCompare = IGN7_COUNTER + timeout_timer_compare;
+    if(ignitionSchedule[6].endScheduleSetByDecoder == false) { ignitionSchedule[6].endCompare = ignitionSchedule[6].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN7_COMPARE = (uint16_t)ignitionSchedule[6].startCompare;
+    ignitionSchedule[6].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[6].schedulesSet++;
     interrupts();
     IGN7_TIMER_ENABLE();
   }
@@ -736,20 +729,20 @@ void setIgnitionSchedule7(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule7.nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule7.nextEndCompare = ignitionSchedule7.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule7.hasNextSchedule = true;
+      ignitionSchedule[6].nextStartCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[6].nextEndCompare = ignitionSchedule[6].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[6].hasNextSchedule = true;
     }
   }
 }
 void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsigned long duration, void(*endCallback)())
 {
-  if(ignitionSchedule8.Status != RUNNING) //Check that we're not already part way through a schedule
+  if(ignitionSchedule[7].Status != RUNNING) //Check that we're not already part way through a schedule
   {
 
-    ignitionSchedule8.StartCallback = startCallback; //Name the start callback function
-    ignitionSchedule8.EndCallback = endCallback; //Name the start callback function
-    ignitionSchedule8.duration = duration;
+    ignitionSchedule[7].StartCallback = startCallback; //Name the start callback function
+    ignitionSchedule[7].EndCallback = endCallback; //Name the start callback function
+    ignitionSchedule[7].duration = duration;
 
     //Need to check that the timeout doesn't exceed the overflow
     uint16_t timeout_timer_compare;
@@ -757,11 +750,11 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     else { timeout_timer_compare = uS_TO_TIMER_COMPARE(timeout); } //Normal case
 
     noInterrupts();
-    ignitionSchedule8.startCompare = IGN8_COUNTER + timeout_timer_compare;
-    if(ignitionSchedule8.endScheduleSetByDecoder == false) { ignitionSchedule8.endCompare = ignitionSchedule8.startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
-    IGN8_COMPARE = (uint16_t)ignitionSchedule8.startCompare;
-    ignitionSchedule8.Status = PENDING; //Turn this schedule on
-    ignitionSchedule8.schedulesSet++;
+    ignitionSchedule[7].startCompare = IGN8_COUNTER + timeout_timer_compare;
+    if(ignitionSchedule[7].endScheduleSetByDecoder == false) { ignitionSchedule[7].endCompare = ignitionSchedule[7].startCompare + uS_TO_TIMER_COMPARE(duration); } //The .endCompare value is also set by the per tooth timing in decoders.ino. The check here is so that it's not getting overridden. 
+    IGN8_COMPARE = (uint16_t)ignitionSchedule[7].startCompare;
+    ignitionSchedule[7].Status = PENDING; //Turn this schedule on
+    ignitionSchedule[7].schedulesSet++;
     interrupts();
     IGN8_TIMER_ENABLE();
   }
@@ -771,9 +764,9 @@ void setIgnitionSchedule8(void (*startCallback)(), unsigned long timeout, unsign
     //This is required in cases of high rpm and high DC where there otherwise would not be enough time to set the schedule
     if (timeout < MAX_TIMER_PERIOD)
     {
-      ignitionSchedule8.nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
-      ignitionSchedule8.nextEndCompare = ignitionSchedule8.nextStartCompare + uS_TO_TIMER_COMPARE(duration);
-      ignitionSchedule8.hasNextSchedule = true;
+      ignitionSchedule[7].nextStartCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE(timeout);
+      ignitionSchedule[7].nextEndCompare = ignitionSchedule[7].nextStartCompare + uS_TO_TIMER_COMPARE(duration);
+      ignitionSchedule[7].hasNextSchedule = true;
     }
   }
 }
@@ -1107,33 +1100,33 @@ ISR(TIMER5_COMPA_vect) //ignitionSchedule1
 static inline void ignitionSchedule1Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule1.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[0].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule1.StartCallback();
-      ignitionSchedule1.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule1.startTime = micros();
-      if(ignitionSchedule1.endScheduleSetByDecoder == true) { IGN1_COMPARE = (uint16_t)ignitionSchedule1.endCompare; }
-      else { IGN1_COMPARE = (uint16_t)(IGN1_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule1.duration)); } //Doing this here prevents a potential overflow on restarts
+      ignitionSchedule[0].StartCallback();
+      ignitionSchedule[0].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[0].startTime = micros();
+      if(ignitionSchedule[0].endScheduleSetByDecoder == true) { IGN1_COMPARE = (uint16_t)ignitionSchedule[0].endCompare; }
+      else { IGN1_COMPARE = (uint16_t)(IGN1_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[0].duration)); } //Doing this here prevents a potential overflow on restarts
     }
-    else if (ignitionSchedule1.Status == RUNNING)
+    else if (ignitionSchedule[0].Status == RUNNING)
     {
-      ignitionSchedule1.EndCallback();
-      ignitionSchedule1.Status = OFF; //Turn off the schedule
-      ignitionSchedule1.schedulesSet = 0;
-      ignitionSchedule1.endScheduleSetByDecoder = false;
+      ignitionSchedule[0].EndCallback();
+      ignitionSchedule[0].Status = OFF; //Turn off the schedule
+      ignitionSchedule[0].schedulesSet = 0;
+      ignitionSchedule[0].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
 
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule1.hasNextSchedule == true)
+      if(ignitionSchedule[0].hasNextSchedule == true)
       {
-        IGN1_COMPARE = (uint16_t)ignitionSchedule1.nextStartCompare;
-        ignitionSchedule1.Status = PENDING;
-        ignitionSchedule1.schedulesSet = 1;
-        ignitionSchedule1.hasNextSchedule = false;
+        IGN1_COMPARE = (uint16_t)ignitionSchedule[0].nextStartCompare;
+        ignitionSchedule[0].Status = PENDING;
+        ignitionSchedule[0].schedulesSet = 1;
+        ignitionSchedule[0].hasNextSchedule = false;
       }
       else{ IGN1_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule1.Status == OFF)
+    else if (ignitionSchedule[0].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN1_TIMER_DISABLE();
@@ -1148,33 +1141,33 @@ ISR(TIMER5_COMPB_vect) //ignitionSchedule2
 static inline void ignitionSchedule2Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule2.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[1].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule2.StartCallback();
-      ignitionSchedule2.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule2.startTime = micros();
-      if(ignitionSchedule2.endScheduleSetByDecoder == true) { IGN2_COMPARE = (uint16_t)ignitionSchedule2.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN2_COMPARE = (uint16_t)(IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule2.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      ignitionSchedule[1].StartCallback();
+      ignitionSchedule[1].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[1].startTime = micros();
+      if(ignitionSchedule[1].endScheduleSetByDecoder == true) { IGN2_COMPARE = (uint16_t)ignitionSchedule[1].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN2_COMPARE = (uint16_t)(IGN2_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[1].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
-    else if (ignitionSchedule2.Status == RUNNING)
+    else if (ignitionSchedule[1].Status == RUNNING)
     {
-      ignitionSchedule2.Status = OFF; //Turn off the schedule
-      ignitionSchedule2.EndCallback();
-      ignitionSchedule2.schedulesSet = 0;
-      ignitionSchedule2.endScheduleSetByDecoder = false;
+      ignitionSchedule[1].Status = OFF; //Turn off the schedule
+      ignitionSchedule[1].EndCallback();
+      ignitionSchedule[1].schedulesSet = 0;
+      ignitionSchedule[1].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
       
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule2.hasNextSchedule == true)
+      if(ignitionSchedule[1].hasNextSchedule == true)
       {
-        IGN2_COMPARE = (uint16_t)ignitionSchedule2.nextStartCompare;
-        ignitionSchedule2.Status = PENDING;
-        ignitionSchedule2.schedulesSet = 1;
-        ignitionSchedule2.hasNextSchedule = false;
+        IGN2_COMPARE = (uint16_t)ignitionSchedule[1].nextStartCompare;
+        ignitionSchedule[1].Status = PENDING;
+        ignitionSchedule[1].schedulesSet = 1;
+        ignitionSchedule[1].hasNextSchedule = false;
       }
       else{ IGN2_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule2.Status == OFF)
+    else if (ignitionSchedule[1].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN2_TIMER_DISABLE();
@@ -1189,33 +1182,33 @@ ISR(TIMER5_COMPC_vect) //ignitionSchedule3
 static inline void ignitionSchedule3Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule3.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[2].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule3.StartCallback();
-      ignitionSchedule3.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule3.startTime = micros();
-      if(ignitionSchedule3.endScheduleSetByDecoder == true) { IGN3_COMPARE = (uint16_t)ignitionSchedule3.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN3_COMPARE = (uint16_t)(IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule3.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
+      ignitionSchedule[2].StartCallback();
+      ignitionSchedule[2].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[2].startTime = micros();
+      if(ignitionSchedule[2].endScheduleSetByDecoder == true) { IGN3_COMPARE = (uint16_t)ignitionSchedule[2].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN3_COMPARE = (uint16_t)(IGN3_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[2].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow that can occur at low RPMs
     }
-    else if (ignitionSchedule3.Status == RUNNING)
+    else if (ignitionSchedule[2].Status == RUNNING)
     {
-       ignitionSchedule3.Status = OFF; //Turn off the schedule
-       ignitionSchedule3.EndCallback();
-       ignitionSchedule3.schedulesSet = 0;
-       ignitionSchedule3.endScheduleSetByDecoder = false;
+       ignitionSchedule[2].Status = OFF; //Turn off the schedule
+       ignitionSchedule[2].EndCallback();
+       ignitionSchedule[2].schedulesSet = 0;
+       ignitionSchedule[2].endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
 
        //If there is a next schedule queued up, activate it
-       if(ignitionSchedule3.hasNextSchedule == true)
+       if(ignitionSchedule[2].hasNextSchedule == true)
        {
-         IGN3_COMPARE = (uint16_t)ignitionSchedule3.nextStartCompare;
-         ignitionSchedule3.Status = PENDING;
-         ignitionSchedule3.schedulesSet = 1;
-         ignitionSchedule3.hasNextSchedule = false;
+         IGN3_COMPARE = (uint16_t)ignitionSchedule[2].nextStartCompare;
+         ignitionSchedule[2].Status = PENDING;
+         ignitionSchedule[2].schedulesSet = 1;
+         ignitionSchedule[2].hasNextSchedule = false;
        }
        else { IGN3_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule3.Status == OFF)
+    else if (ignitionSchedule[2].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN3_TIMER_DISABLE();
@@ -1230,33 +1223,33 @@ ISR(TIMER4_COMPA_vect) //ignitionSchedule4
 static inline void ignitionSchedule4Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule4.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[3].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule4.StartCallback();
-      ignitionSchedule4.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule4.startTime = micros();
-      if(ignitionSchedule4.endScheduleSetByDecoder == true) { IGN4_COMPARE = (uint16_t)ignitionSchedule4.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN4_COMPARE = (uint16_t)(IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule4.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
+      ignitionSchedule[3].StartCallback();
+      ignitionSchedule[3].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[3].startTime = micros();
+      if(ignitionSchedule[3].endScheduleSetByDecoder == true) { IGN4_COMPARE = (uint16_t)ignitionSchedule[3].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN4_COMPARE = (uint16_t)(IGN4_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[3].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
     }
-    else if (ignitionSchedule4.Status == RUNNING)
+    else if (ignitionSchedule[3].Status == RUNNING)
     {
-       ignitionSchedule4.Status = OFF; //Turn off the schedule
-       ignitionSchedule4.EndCallback();
-       ignitionSchedule4.schedulesSet = 0;
-       ignitionSchedule4.endScheduleSetByDecoder = false;
+       ignitionSchedule[3].Status = OFF; //Turn off the schedule
+       ignitionSchedule[3].EndCallback();
+       ignitionSchedule[3].schedulesSet = 0;
+       ignitionSchedule[3].endScheduleSetByDecoder = false;
        ignitionCount += 1; //Increment the igintion counter
 
        //If there is a next schedule queued up, activate it
-       if(ignitionSchedule4.hasNextSchedule == true)
+       if(ignitionSchedule[3].hasNextSchedule == true)
        {
-         IGN4_COMPARE = (uint16_t)ignitionSchedule4.nextStartCompare;
-         ignitionSchedule4.Status = PENDING;
-         ignitionSchedule4.schedulesSet = 1;
-         ignitionSchedule4.hasNextSchedule = false;
+         IGN4_COMPARE = (uint16_t)ignitionSchedule[3].nextStartCompare;
+         ignitionSchedule[3].Status = PENDING;
+         ignitionSchedule[3].schedulesSet = 1;
+         ignitionSchedule[3].hasNextSchedule = false;
        }
        else { IGN4_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule4.Status == OFF)
+    else if (ignitionSchedule[3].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN4_TIMER_DISABLE();
@@ -1271,33 +1264,33 @@ ISR(TIMER4_COMPC_vect) //ignitionSchedule5
 static inline void ignitionSchedule5Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule5.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[4].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule5.StartCallback();
-      ignitionSchedule5.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule5.startTime = micros();
-      if(ignitionSchedule5.endScheduleSetByDecoder == true) { IGN5_COMPARE = (uint16_t)ignitionSchedule5.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN5_COMPARE = (uint16_t)(IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule5.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
+      ignitionSchedule[4].StartCallback();
+      ignitionSchedule[4].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[4].startTime = micros();
+      if(ignitionSchedule[4].endScheduleSetByDecoder == true) { IGN5_COMPARE = (uint16_t)ignitionSchedule[4].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN5_COMPARE = (uint16_t)(IGN5_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[4].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
     }
-    else if (ignitionSchedule5.Status == RUNNING)
+    else if (ignitionSchedule[4].Status == RUNNING)
     {
-      ignitionSchedule5.Status = OFF; //Turn off the schedule
-      ignitionSchedule5.EndCallback();
-      ignitionSchedule5.schedulesSet = 0;
-      ignitionSchedule5.endScheduleSetByDecoder = false;
+      ignitionSchedule[4].Status = OFF; //Turn off the schedule
+      ignitionSchedule[4].EndCallback();
+      ignitionSchedule[4].schedulesSet = 0;
+      ignitionSchedule[4].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
 
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule5.hasNextSchedule == true)
+      if(ignitionSchedule[4].hasNextSchedule == true)
       {
-        IGN5_COMPARE = (uint16_t)ignitionSchedule5.nextStartCompare;
-        ignitionSchedule5.Status = PENDING;
-        ignitionSchedule5.schedulesSet = 1;
-        ignitionSchedule5.hasNextSchedule = false;
+        IGN5_COMPARE = (uint16_t)ignitionSchedule[4].nextStartCompare;
+        ignitionSchedule[4].Status = PENDING;
+        ignitionSchedule[4].schedulesSet = 1;
+        ignitionSchedule[4].hasNextSchedule = false;
       }
       else{ IGN5_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule5.Status == OFF)
+    else if (ignitionSchedule[4].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN5_TIMER_DISABLE();
@@ -1312,33 +1305,33 @@ ISR(TIMER4_COMPB_vect) //ignitionSchedule6
 static inline void ignitionSchedule6Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule6.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[5].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule6.StartCallback();
-      ignitionSchedule6.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule6.startTime = micros();
-      if(ignitionSchedule6.endScheduleSetByDecoder == true) { IGN6_COMPARE = (uint16_t)ignitionSchedule6.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN6_COMPARE = (uint16_t)(IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule6.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
+      ignitionSchedule[5].StartCallback();
+      ignitionSchedule[5].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[5].startTime = micros();
+      if(ignitionSchedule[5].endScheduleSetByDecoder == true) { IGN6_COMPARE = (uint16_t)ignitionSchedule[5].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN6_COMPARE = (uint16_t)(IGN6_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[5].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
     }
-    else if (ignitionSchedule6.Status == RUNNING)
+    else if (ignitionSchedule[5].Status == RUNNING)
     {
-      ignitionSchedule6.Status = OFF; //Turn off the schedule
-      ignitionSchedule6.EndCallback();
-      ignitionSchedule6.schedulesSet = 0;
-      ignitionSchedule6.endScheduleSetByDecoder = false;
+      ignitionSchedule[5].Status = OFF; //Turn off the schedule
+      ignitionSchedule[5].EndCallback();
+      ignitionSchedule[5].schedulesSet = 0;
+      ignitionSchedule[5].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
 
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule6.hasNextSchedule == true)
+      if(ignitionSchedule[5].hasNextSchedule == true)
       {
-        IGN6_COMPARE = (uint16_t)ignitionSchedule6.nextStartCompare;
-        ignitionSchedule6.Status = PENDING;
-        ignitionSchedule6.schedulesSet = 1;
-        ignitionSchedule6.hasNextSchedule = false;
+        IGN6_COMPARE = (uint16_t)ignitionSchedule[5].nextStartCompare;
+        ignitionSchedule[5].Status = PENDING;
+        ignitionSchedule[5].schedulesSet = 1;
+        ignitionSchedule[5].hasNextSchedule = false;
       }
       else{ IGN6_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule6.Status == OFF)
+    else if (ignitionSchedule[5].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN6_TIMER_DISABLE();
@@ -1353,33 +1346,33 @@ ISR(TIMER3_COMPC_vect) //ignitionSchedule6
 static inline void ignitionSchedule7Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule7.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[6].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule7.StartCallback();
-      ignitionSchedule7.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule7.startTime = micros();
-      if(ignitionSchedule7.endScheduleSetByDecoder == true) { IGN7_COMPARE = (uint16_t)ignitionSchedule7.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN7_COMPARE = (uint16_t)(IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule7.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
+      ignitionSchedule[6].StartCallback();
+      ignitionSchedule[6].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[6].startTime = micros();
+      if(ignitionSchedule[6].endScheduleSetByDecoder == true) { IGN7_COMPARE = (uint16_t)ignitionSchedule[6].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN7_COMPARE = (uint16_t)(IGN7_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[6].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
     }
-    else if (ignitionSchedule7.Status == RUNNING)
+    else if (ignitionSchedule[6].Status == RUNNING)
     {
-      ignitionSchedule7.Status = OFF; //Turn off the schedule
-      ignitionSchedule7.EndCallback();
-      ignitionSchedule7.schedulesSet = 0;
-      ignitionSchedule7.endScheduleSetByDecoder = false;
+      ignitionSchedule[6].Status = OFF; //Turn off the schedule
+      ignitionSchedule[6].EndCallback();
+      ignitionSchedule[6].schedulesSet = 0;
+      ignitionSchedule[6].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
 
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule7.hasNextSchedule == true)
+      if(ignitionSchedule[6].hasNextSchedule == true)
       {
-        IGN7_COMPARE = (uint16_t)ignitionSchedule7.nextStartCompare;
-        ignitionSchedule7.Status = PENDING;
-        ignitionSchedule7.schedulesSet = 1;
-        ignitionSchedule7.hasNextSchedule = false;
+        IGN7_COMPARE = (uint16_t)ignitionSchedule[6].nextStartCompare;
+        ignitionSchedule[6].Status = PENDING;
+        ignitionSchedule[6].schedulesSet = 1;
+        ignitionSchedule[6].hasNextSchedule = false;
       }
       else{ IGN7_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule7.Status == OFF)
+    else if (ignitionSchedule[6].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN7_TIMER_DISABLE();
@@ -1394,33 +1387,33 @@ ISR(TIMER3_COMPB_vect) //ignitionSchedule8
 static inline void ignitionSchedule8Interrupt() //Most ARM chips can simply call a function
 #endif
   {
-    if (ignitionSchedule8.Status == PENDING) //Check to see if this schedule is turn on
+    if (ignitionSchedule[7].Status == PENDING) //Check to see if this schedule is turn on
     {
-      ignitionSchedule8.StartCallback();
-      ignitionSchedule8.Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
-      ignitionSchedule8.startTime = micros();
-      if(ignitionSchedule8.endScheduleSetByDecoder == true) { IGN8_COMPARE = (uint16_t)ignitionSchedule8.endCompare; } //If the decoder has set the end compare value, assign it to the next compare
-      else { IGN8_COMPARE = (uint16_t)(IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule8.duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
+      ignitionSchedule[7].StartCallback();
+      ignitionSchedule[7].Status = RUNNING; //Set the status to be in progress (ie The start callback has been called, but not the end callback)
+      ignitionSchedule[7].startTime = micros();
+      if(ignitionSchedule[7].endScheduleSetByDecoder == true) { IGN8_COMPARE = (uint16_t)ignitionSchedule[7].endCompare; } //If the decoder has set the end compare value, assign it to the next compare
+      else { IGN8_COMPARE = (uint16_t)(IGN8_COUNTER + uS_TO_TIMER_COMPARE(ignitionSchedule[7].duration)); } //If the decoder based timing isn't set, doing this here prevents a potential overflow tha
     }
-    else if (ignitionSchedule8.Status == RUNNING)
+    else if (ignitionSchedule[7].Status == RUNNING)
     {
-      ignitionSchedule8.Status = OFF; //Turn off the schedule
-      ignitionSchedule8.EndCallback();
-      ignitionSchedule8.schedulesSet = 0;
-      ignitionSchedule8.endScheduleSetByDecoder = false;
+      ignitionSchedule[7].Status = OFF; //Turn off the schedule
+      ignitionSchedule[7].EndCallback();
+      ignitionSchedule[7].schedulesSet = 0;
+      ignitionSchedule[7].endScheduleSetByDecoder = false;
       ignitionCount += 1; //Increment the igintion counter
 
       //If there is a next schedule queued up, activate it
-      if(ignitionSchedule8.hasNextSchedule == true)
+      if(ignitionSchedule[7].hasNextSchedule == true)
       {
-        IGN8_COMPARE = (uint16_t)ignitionSchedule8.nextStartCompare;
-        ignitionSchedule8.Status = PENDING;
-        ignitionSchedule8.schedulesSet = 1;
-        ignitionSchedule8.hasNextSchedule = false;
+        IGN8_COMPARE = (uint16_t)ignitionSchedule[7].nextStartCompare;
+        ignitionSchedule[7].Status = PENDING;
+        ignitionSchedule[7].schedulesSet = 1;
+        ignitionSchedule[7].hasNextSchedule = false;
       }
       else{ IGN8_TIMER_DISABLE(); }
     }
-    else if (ignitionSchedule8.Status == OFF)
+    else if (ignitionSchedule[7].Status == OFF)
     {
       //Catch any spurious interrupts. This really shouldn't ever be called, but there as a safety
       IGN8_TIMER_DISABLE();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1004,7 +1004,7 @@ void loop()
         while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
-        if ( (ignition1StartAngle <= crankAngle) && (ignitionSchedule1.Status == RUNNING) ) { ignition1StartAngle += CRANK_ANGLE_MAX_IGN; }
+        if ( (ignition1StartAngle <= crankAngle) && (ignitionSchedule[0].Status == RUNNING) ) { ignition1StartAngle += CRANK_ANGLE_MAX_IGN; }
         //if ( (ignition1StartAngle > crankAngle) && (curRollingCut != 1) )
         if ( (ignition1StartAngle > crankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
         {
@@ -1019,7 +1019,7 @@ void loop()
 #endif
 
 #if defined(USE_IGN_REFRESH)
-        if( (ignitionSchedule1.Status == RUNNING) && (ignition1EndAngle > crankAngle) && (configPage4.StgCycles == 0) && (configPage2.perToothIgn != true) )
+        if( (ignitionSchedule[0].Status == RUNNING) && (ignition1EndAngle > crankAngle) && (configPage4.StgCycles == 0) && (configPage2.perToothIgn != true) )
         {
           unsigned long uSToEnd = 0;
 
@@ -1047,7 +1047,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition2StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule2.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[1].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition2StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition2StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition2StartTime = 0; }
@@ -1072,7 +1072,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition3StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule3.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[2].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition3StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition3StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition3StartTime = 0; }
@@ -1097,7 +1097,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition4StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule4.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[3].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition4StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition4StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition4StartTime = 0; }
@@ -1122,7 +1122,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition5StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule5.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[4].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition5StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition5StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition5StartTime = 0; }
@@ -1147,7 +1147,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition6StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule6.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[5].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition6StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition6StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition6StartTime = 0; }
@@ -1172,7 +1172,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition7StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule7.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[6].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition7StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition7StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition7StartTime = 0; }
@@ -1197,7 +1197,7 @@ void loop()
             if ( tempStartAngle < 0) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
 
             unsigned long ignition8StartTime = 0;
-            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule8.Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
+            if ( (tempStartAngle <= tempCrankAngle) && (ignitionSchedule[7].Status == RUNNING) ) { tempStartAngle += CRANK_ANGLE_MAX_IGN; }
             if(tempStartAngle > tempCrankAngle) { ignition8StartTime = angleToTime((tempStartAngle - tempCrankAngle), CRANKMATH_METHOD_INTERVAL_REV); }
             //else if (tempStartAngle < tempCrankAngle) { ignition8StartTime = ((long)(360 - tempCrankAngle + tempStartAngle) * (long)timePerDegree); }
             else { ignition8StartTime = 0; }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1009,11 +1009,11 @@ void loop()
         if ( (ignition1StartAngle > crankAngle) && (!BIT_CHECK(curRollingCut, IGN1_CMD_BIT)) )
         {
           
-          setIgnitionSchedule1(ign1StartFunction,
+          setIgnitionSchedule1(ignStartFunction[0],
                     //((unsigned long)(ignition1StartAngle - crankAngle) * (unsigned long)timePerDegree),
                     angleToTime((ignition1StartAngle - crankAngle), CRANKMATH_METHOD_INTERVAL_REV),
                     currentStatus.dwell + fixedCrankingOverride, //((unsigned long)((unsigned long)currentStatus.dwell* currentStatus.RPM) / newRPM) + fixedCrankingOverride,
-                    ign1EndFunction
+                    ignEndFunction[0]
                     );
         }
 #endif
@@ -1054,10 +1054,10 @@ void loop()
 
             if ( (ignition2StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN2_CMD_BIT)) )
             {
-              setIgnitionSchedule2(ign2StartFunction,
+              setIgnitionSchedule2(ignStartFunction[1],
                         ignition2StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign2EndFunction
+                        ignEndFunction[1]
                         );
             }
         }
@@ -1079,10 +1079,10 @@ void loop()
 
             if ( (ignition3StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN3_CMD_BIT)) )
             {
-              setIgnitionSchedule3(ign3StartFunction,
+              setIgnitionSchedule3(ignStartFunction[2],
                         ignition3StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign3EndFunction
+                        ignEndFunction[2]
                         );
             }
         }
@@ -1104,10 +1104,10 @@ void loop()
 
             if ( (ignition4StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN4_CMD_BIT)) )
             {
-              setIgnitionSchedule4(ign4StartFunction,
+              setIgnitionSchedule4(ignStartFunction[3],
                         ignition4StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign4EndFunction
+                        ignEndFunction[3]
                         );
             }
         }
@@ -1129,10 +1129,10 @@ void loop()
 
             if ( (ignition5StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN5_CMD_BIT)) )
             {
-              setIgnitionSchedule5(ign5StartFunction,
+              setIgnitionSchedule5(ignStartFunction[4],
                         ignition5StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign5EndFunction
+                        ignEndFunction[4]
                         );
             }
         }
@@ -1154,10 +1154,10 @@ void loop()
 
             if ( (ignition6StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN6_CMD_BIT)) )
             {
-              setIgnitionSchedule6(ign6StartFunction,
+              setIgnitionSchedule6(ignStartFunction[5],
                         ignition6StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign6EndFunction
+                        ignEndFunction[5]
                         );
             }
         }
@@ -1179,10 +1179,10 @@ void loop()
 
             if ( (ignition7StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN7_CMD_BIT)) )
             {
-              setIgnitionSchedule7(ign7StartFunction,
+              setIgnitionSchedule7(ignStartFunction[6],
                         ignition7StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign7EndFunction
+                        ignEndFunction[6]
                         );
             }
         }
@@ -1204,10 +1204,10 @@ void loop()
 
             if ( (ignition8StartTime > 0) && (!BIT_CHECK(curRollingCut, IGN8_CMD_BIT)) )
             {
-              setIgnitionSchedule8(ign8StartFunction,
+              setIgnitionSchedule8(ignStartFunction[7],
                         ignition8StartTime,
                         currentStatus.dwell + fixedCrankingOverride,
-                        ign8EndFunction
+                        ignEndFunction[7]
                         );
             }
         }

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -59,14 +59,14 @@ void oneMSInterval() //Most ARM chips can simply call a function
   bool isCrankLocked = configPage4.ignCranklock && (currentStatus.RPM < currentStatus.crankRPM); //Dwell limiter is disabled during cranking on setups using the locked cranking timing. WE HAVE to do the RPM check here as relying on the engine cranking bit can be potentially too slow in updating
   //Check first whether each spark output is currently on. Only check it's dwell time if it is
 
-  if(ignitionSchedule1.Status == RUNNING) { if( (ignitionSchedule1.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign1EndFunction(); ignitionSchedule1.Status = OFF; } }
-  if(ignitionSchedule2.Status == RUNNING) { if( (ignitionSchedule2.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign2EndFunction(); ignitionSchedule2.Status = OFF; } }
-  if(ignitionSchedule3.Status == RUNNING) { if( (ignitionSchedule3.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign3EndFunction(); ignitionSchedule3.Status = OFF; } }
-  if(ignitionSchedule4.Status == RUNNING) { if( (ignitionSchedule4.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign4EndFunction(); ignitionSchedule4.Status = OFF; } }
-  if(ignitionSchedule5.Status == RUNNING) { if( (ignitionSchedule5.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign5EndFunction(); ignitionSchedule5.Status = OFF; } }
-  if(ignitionSchedule6.Status == RUNNING) { if( (ignitionSchedule6.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign6EndFunction(); ignitionSchedule6.Status = OFF; } }
-  if(ignitionSchedule7.Status == RUNNING) { if( (ignitionSchedule7.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign7EndFunction(); ignitionSchedule7.Status = OFF; } }
-  if(ignitionSchedule8.Status == RUNNING) { if( (ignitionSchedule8.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign8EndFunction(); ignitionSchedule8.Status = OFF; } }
+  if(ignitionSchedule[0].Status == RUNNING) { if( (ignitionSchedule[0].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign1EndFunction(); ignitionSchedule[0].Status = OFF; } }
+  if(ignitionSchedule[1].Status == RUNNING) { if( (ignitionSchedule[1].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign2EndFunction(); ignitionSchedule[1].Status = OFF; } }
+  if(ignitionSchedule[2].Status == RUNNING) { if( (ignitionSchedule[2].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign3EndFunction(); ignitionSchedule[2].Status = OFF; } }
+  if(ignitionSchedule[3].Status == RUNNING) { if( (ignitionSchedule[3].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign4EndFunction(); ignitionSchedule[3].Status = OFF; } }
+  if(ignitionSchedule[4].Status == RUNNING) { if( (ignitionSchedule[4].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign5EndFunction(); ignitionSchedule[4].Status = OFF; } }
+  if(ignitionSchedule[5].Status == RUNNING) { if( (ignitionSchedule[5].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign6EndFunction(); ignitionSchedule[5].Status = OFF; } }
+  if(ignitionSchedule[6].Status == RUNNING) { if( (ignitionSchedule[6].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign7EndFunction(); ignitionSchedule[6].Status = OFF; } }
+  if(ignitionSchedule[7].Status == RUNNING) { if( (ignitionSchedule[7].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign8EndFunction(); ignitionSchedule[7].Status = OFF; } }
 
   //Tacho output check
   //Tacho is flagged as being ready for a pulse by the ignition outputs. 

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -59,14 +59,9 @@ void oneMSInterval() //Most ARM chips can simply call a function
   bool isCrankLocked = configPage4.ignCranklock && (currentStatus.RPM < currentStatus.crankRPM); //Dwell limiter is disabled during cranking on setups using the locked cranking timing. WE HAVE to do the RPM check here as relying on the engine cranking bit can be potentially too slow in updating
   //Check first whether each spark output is currently on. Only check it's dwell time if it is
 
-  if(ignitionSchedule[0].Status == RUNNING) { if( (ignitionSchedule[0].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign1EndFunction(); ignitionSchedule[0].Status = OFF; } }
-  if(ignitionSchedule[1].Status == RUNNING) { if( (ignitionSchedule[1].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign2EndFunction(); ignitionSchedule[1].Status = OFF; } }
-  if(ignitionSchedule[2].Status == RUNNING) { if( (ignitionSchedule[2].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign3EndFunction(); ignitionSchedule[2].Status = OFF; } }
-  if(ignitionSchedule[3].Status == RUNNING) { if( (ignitionSchedule[3].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign4EndFunction(); ignitionSchedule[3].Status = OFF; } }
-  if(ignitionSchedule[4].Status == RUNNING) { if( (ignitionSchedule[4].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign5EndFunction(); ignitionSchedule[4].Status = OFF; } }
-  if(ignitionSchedule[5].Status == RUNNING) { if( (ignitionSchedule[5].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign6EndFunction(); ignitionSchedule[5].Status = OFF; } }
-  if(ignitionSchedule[6].Status == RUNNING) { if( (ignitionSchedule[6].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign7EndFunction(); ignitionSchedule[6].Status = OFF; } }
-  if(ignitionSchedule[7].Status == RUNNING) { if( (ignitionSchedule[7].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign8EndFunction(); ignitionSchedule[7].Status = OFF; } }
+  for (int i = 0; i < IGN_CHANNELS; i++) {
+    if(ignitionSchedule[i].Status == RUNNING) { if( (ignitionSchedule[i].startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ignEndFunction[i](); ignitionSchedule[i].Status = OFF; } };
+  }
 
   //Tacho output check
   //Tacho is flagged as being ready for a pulse by the ignition outputs. 

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -114,7 +114,7 @@ void test_accuracy_duration_ign1(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule1(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule1.Status == PENDING) || (ignitionSchedule1.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[0].Status == PENDING) || (ignitionSchedule[0].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
 }
 
@@ -122,7 +122,7 @@ void test_accuracy_duration_ign2(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule2(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule2.Status == PENDING) || (ignitionSchedule2.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[1].Status == PENDING) || (ignitionSchedule[1].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -130,7 +130,7 @@ void test_accuracy_duration_ign3(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule3(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule3.Status == PENDING) || (ignitionSchedule3.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[2].Status == PENDING) || (ignitionSchedule[2].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -138,7 +138,7 @@ void test_accuracy_duration_ign4(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule4(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule4.Status == PENDING) || (ignitionSchedule4.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[3].Status == PENDING) || (ignitionSchedule[3].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -147,7 +147,7 @@ void test_accuracy_duration_ign5(void)
 #if IGN_CHANNELS >= 5
     initialiseSchedulers();
     setIgnitionSchedule5(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule5.Status == PENDING) || (ignitionSchedule5.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[4].Status == PENDING) || (ignitionSchedule[4].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -157,7 +157,7 @@ void test_accuracy_duration_ign6(void)
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule6.Status == PENDING) || (ignitionSchedule6.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[5].Status == PENDING) || (ignitionSchedule[5].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -167,7 +167,7 @@ void test_accuracy_duration_ign7(void)
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule7.Status == PENDING) || (ignitionSchedule7.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[6].Status == PENDING) || (ignitionSchedule[6].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -177,7 +177,7 @@ void test_accuracy_duration_ign8(void)
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(startCallback, TIMEOUT, DURATION, endCallback);
-    while( (ignitionSchedule8.Status == PENDING) || (ignitionSchedule8.Status == RUNNING) ) /*Wait*/ ;
+    while( (ignitionSchedule[7].Status == PENDING) || (ignitionSchedule[7].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -112,34 +112,42 @@ void test_accuracy_duration_inj8(void)
 
 void test_accuracy_duration_ign1(void)
 {
+#if IGN_CHANNELS >= 1
     initialiseSchedulers();
     setIgnitionSchedule1(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[0].Status == PENDING) || (ignitionSchedule[0].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+#endif
 }
 
 void test_accuracy_duration_ign2(void)
 {
+#if IGN_CHANNELS >= 2
     initialiseSchedulers();
     setIgnitionSchedule2(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[1].Status == PENDING) || (ignitionSchedule[1].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+#endif
 }
 
 void test_accuracy_duration_ign3(void)
 {
+#if IGN_CHANNELS >= 3
     initialiseSchedulers();
     setIgnitionSchedule3(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[2].Status == PENDING) || (ignitionSchedule[2].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+#endif
 }
 
 void test_accuracy_duration_ign4(void)
 {
+#if IGN_CHANNELS >= 4
     initialiseSchedulers();
     setIgnitionSchedule4(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[3].Status == PENDING) || (ignitionSchedule[3].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+#endif
 }
 
 void test_accuracy_duration_ign5(void)
@@ -154,7 +162,7 @@ void test_accuracy_duration_ign5(void)
 
 void test_accuracy_duration_ign6(void)
 {
-#if INJ_CHANNELS >= 6
+#if IGN_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[5].Status == PENDING) || (ignitionSchedule[5].Status == RUNNING) ) /*Wait*/ ;
@@ -164,7 +172,7 @@ void test_accuracy_duration_ign6(void)
 
 void test_accuracy_duration_ign7(void)
 {
-#if INJ_CHANNELS >= 7
+#if IGN_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[6].Status == PENDING) || (ignitionSchedule[6].Status == RUNNING) ) /*Wait*/ ;
@@ -174,7 +182,7 @@ void test_accuracy_duration_ign7(void)
 
 void test_accuracy_duration_ign8(void)
 {
-#if INJ_CHANNELS >= 8
+#if IGN_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(startCallback, TIMEOUT, DURATION, endCallback);
     while( (ignitionSchedule[7].Status == PENDING) || (ignitionSchedule[7].Status == RUNNING) ) /*Wait*/ ;

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -107,7 +107,7 @@ void test_accuracy_timeout_ign1(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule1(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[0].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -116,7 +116,7 @@ void test_accuracy_timeout_ign2(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule2(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[1].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -125,7 +125,7 @@ void test_accuracy_timeout_ign3(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule3(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[2].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -134,7 +134,7 @@ void test_accuracy_timeout_ign4(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule4(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[3].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
 
@@ -144,7 +144,7 @@ void test_accuracy_timeout_ign5(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule5(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[4].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -155,7 +155,7 @@ void test_accuracy_timeout_ign6(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule6(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[5].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -166,7 +166,7 @@ void test_accuracy_timeout_ign7(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule7(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[6].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }
@@ -177,7 +177,7 @@ void test_accuracy_timeout_ign8(void)
     initialiseSchedulers();
     start_time = micros();
     setIgnitionSchedule8(startCallback, TIMEOUT, DURATION, endCallback);
-    while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[7].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
 }

--- a/test/test_schedules/test_status_initial_off.cpp
+++ b/test/test_schedules/test_status_initial_off.cpp
@@ -56,49 +56,49 @@ void test_status_initial_off_inj8(void)
 void test_status_initial_off_ign1(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule1.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[0].Status);
 }
 
 void test_status_initial_off_ign2(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule2.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[1].Status);
 }
 
 void test_status_initial_off_ign3(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule3.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[2].Status);
 }
 
 void test_status_initial_off_ign4(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule4.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[3].Status);
 }
 
 void test_status_initial_off_ign5(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule5.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[4].Status);
 }
 
 void test_status_initial_off_ign6(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule6.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[5].Status);
 }
 
 void test_status_initial_off_ign7(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule7.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[6].Status);
 }
 
 void test_status_initial_off_ign8(void)
 {
     initialiseSchedulers();
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule8.Status);
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[7].Status);
 }
 
 void test_status_initial_off(void)

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -76,30 +76,38 @@ void test_status_off_to_pending_inj8(void)
 
 void test_status_off_to_pending_ign1(void)
 {
+#if IGN_CHANNELS >= 1
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[0].Status);
+#endif
 }
 
 void test_status_off_to_pending_ign2(void)
 {
+#if IGN_CHANNELS >= 2
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[1].Status);
+#endif
 }
 
 void test_status_off_to_pending_ign3(void)
 {
+#if IGN_CHANNELS >= 3
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[2].Status);
+#endif
 }
 
 void test_status_off_to_pending_ign4(void)
 {
+#if IGN_CHANNELS >= 4
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[3].Status);
+#endif
 }
 
 void test_status_off_to_pending_ign5(void)
@@ -113,7 +121,7 @@ void test_status_off_to_pending_ign5(void)
 
 void test_status_off_to_pending_ign6(void)
 {
-#if INJ_CHANNELS >= 6
+#if IGN_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[5].Status);
@@ -122,7 +130,7 @@ void test_status_off_to_pending_ign6(void)
 
 void test_status_off_to_pending_ign7(void)
 {
-#if INJ_CHANNELS >= 7
+#if IGN_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[6].Status);
@@ -131,7 +139,7 @@ void test_status_off_to_pending_ign7(void)
 
 void test_status_off_to_pending_ign8(void)
 {
-#if INJ_CHANNELS >= 8
+#if IGN_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[7].Status);

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -78,28 +78,28 @@ void test_status_off_to_pending_ign1(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule1.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[0].Status);
 }
 
 void test_status_off_to_pending_ign2(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule2.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[1].Status);
 }
 
 void test_status_off_to_pending_ign3(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule3.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[2].Status);
 }
 
 void test_status_off_to_pending_ign4(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule4.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[3].Status);
 }
 
 void test_status_off_to_pending_ign5(void)
@@ -107,7 +107,7 @@ void test_status_off_to_pending_ign5(void)
 #if IGN_CHANNELS >= 5
     initialiseSchedulers();
     setIgnitionSchedule5(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule5.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[4].Status);
 #endif
 }
 
@@ -116,7 +116,7 @@ void test_status_off_to_pending_ign6(void)
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule6.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[5].Status);
 #endif
 }
 
@@ -125,7 +125,7 @@ void test_status_off_to_pending_ign7(void)
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule7.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[6].Status);
 #endif
 }
 
@@ -134,7 +134,7 @@ void test_status_off_to_pending_ign8(void)
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule8.Status);
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[7].Status);
 #endif
 }
 

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -86,32 +86,32 @@ void test_status_pending_to_running_ign1(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule1.Status);
+    while(ignitionSchedule[0].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[0].Status);
 }
 
 void test_status_pending_to_running_ign2(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule2.Status);
+    while(ignitionSchedule[1].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[1].Status);
 }
 
 void test_status_pending_to_running_ign3(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule3.Status);
+    while(ignitionSchedule[2].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[2].Status);
 }
 
 void test_status_pending_to_running_ign4(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule4.Status);
+    while(ignitionSchedule[3].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[3].Status);
 }
 
 void test_status_pending_to_running_ign5(void)
@@ -119,8 +119,8 @@ void test_status_pending_to_running_ign5(void)
 #if IGN_CHANNELS >= 5
     initialiseSchedulers();
     setIgnitionSchedule5(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule5.Status);
+    while(ignitionSchedule[4].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[4].Status);
 #endif
 }
 
@@ -129,8 +129,8 @@ void test_status_pending_to_running_ign6(void)
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule6.Status);
+    while(ignitionSchedule[5].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[5].Status);
 #endif
 }
 
@@ -139,8 +139,8 @@ void test_status_pending_to_running_ign7(void)
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule7.Status);
+    while(ignitionSchedule[6].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[6].Status);
 #endif
 }
 
@@ -149,8 +149,8 @@ void test_status_pending_to_running_ign8(void)
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule8.Status);
+    while(ignitionSchedule[7].Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[7].Status);
 #endif
 }
 

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -84,34 +84,42 @@ void test_status_pending_to_running_inj8(void)
 
 void test_status_pending_to_running_ign1(void)
 {
+#if IGN_CHANNELS >= 1
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[0].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[0].Status);
+#endif
 }
 
 void test_status_pending_to_running_ign2(void)
 {
+#if IGN_CHANNELS >= 2
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[1].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[1].Status);
+#endif
 }
 
 void test_status_pending_to_running_ign3(void)
 {
+#if IGN_CHANNELS >= 3
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[2].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[2].Status);
+#endif
 }
 
 void test_status_pending_to_running_ign4(void)
 {
+#if IGN_CHANNELS >= 4
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[3].Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule[3].Status);
+#endif
 }
 
 void test_status_pending_to_running_ign5(void)
@@ -126,7 +134,7 @@ void test_status_pending_to_running_ign5(void)
 
 void test_status_pending_to_running_ign6(void)
 {
-#if INJ_CHANNELS >= 6
+#if IGN_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[5].Status == PENDING) /*Wait*/ ;
@@ -136,7 +144,7 @@ void test_status_pending_to_running_ign6(void)
 
 void test_status_pending_to_running_ign7(void)
 {
-#if INJ_CHANNELS >= 7
+#if IGN_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[6].Status == PENDING) /*Wait*/ ;
@@ -146,7 +154,7 @@ void test_status_pending_to_running_ign7(void)
 
 void test_status_pending_to_running_ign8(void)
 {
-#if INJ_CHANNELS >= 8
+#if IGN_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[7].Status == PENDING) /*Wait*/ ;

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -86,32 +86,32 @@ void test_status_running_to_off_ign1(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule1.Status == PENDING) || (ignitionSchedule1.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule1.Status);
+    while( (ignitionSchedule[0].Status == PENDING) || (ignitionSchedule[0].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[0].Status);
 }
 
 void test_status_running_to_off_ign2(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule2.Status == PENDING) || (ignitionSchedule2.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule2.Status);
+    while( (ignitionSchedule[1].Status == PENDING) || (ignitionSchedule[1].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[1].Status);
 }
 
 void test_status_running_to_off_ign3(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule3.Status == PENDING) || (ignitionSchedule3.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule3.Status);
+    while( (ignitionSchedule[2].Status == PENDING) || (ignitionSchedule[2].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[2].Status);
 }
 
 void test_status_running_to_off_ign4(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule4.Status == PENDING) || (ignitionSchedule4.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule4.Status);
+    while( (ignitionSchedule[3].Status == PENDING) || (ignitionSchedule[3].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[3].Status);
 }
 
 void test_status_running_to_off_ign5(void)
@@ -119,8 +119,8 @@ void test_status_running_to_off_ign5(void)
 #if IGN_CHANNELS >= 5
     initialiseSchedulers();
     setIgnitionSchedule5(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule5.Status == PENDING) || (ignitionSchedule5.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule5.Status);
+    while( (ignitionSchedule[4].Status == PENDING) || (ignitionSchedule[4].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[4].Status);
 #endif
 }
 
@@ -129,8 +129,8 @@ void test_status_running_to_off_ign6(void)
 #if IGN_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule6.Status == PENDING) || (ignitionSchedule6.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule6.Status);
+    while( (ignitionSchedule[5].Status == PENDING) || (ignitionSchedule[5].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[5].Status);
 #endif
 }
 
@@ -139,8 +139,8 @@ void test_status_running_to_off_ign7(void)
 #if IGN_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule7.Status == PENDING) || (ignitionSchedule7.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule7.Status);
+    while( (ignitionSchedule[6].Status == PENDING) || (ignitionSchedule[6].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[6].Status);
 #endif
 }
 
@@ -149,8 +149,8 @@ void test_status_running_to_off_ign8(void)
 #if IGN_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while( (ignitionSchedule8.Status == PENDING) || (ignitionSchedule8.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(OFF, ignitionSchedule8.Status);
+    while( (ignitionSchedule[7].Status == PENDING) || (ignitionSchedule[7].Status == RUNNING) ) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(OFF, ignitionSchedule[7].Status);
 #endif
 }
 

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -84,34 +84,42 @@ void test_status_running_to_off_inj8(void)
 
 void test_status_running_to_off_ign1(void)
 {
+#if IGN_CHANNELS >= 1
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while( (ignitionSchedule[0].Status == PENDING) || (ignitionSchedule[0].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule[0].Status);
+#endif
 }
 
 void test_status_running_to_off_ign2(void)
 {
+#if IGN_CHANNELS >= 2
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while( (ignitionSchedule[1].Status == PENDING) || (ignitionSchedule[1].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule[1].Status);
+#endif
 }
 
 void test_status_running_to_off_ign3(void)
 {
+#if IGN_CHANNELS >= 3
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while( (ignitionSchedule[2].Status == PENDING) || (ignitionSchedule[2].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule[2].Status);
+#endif
 }
 
 void test_status_running_to_off_ign4(void)
 {
+#if IGN_CHANNELS >= 4
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while( (ignitionSchedule[3].Status == PENDING) || (ignitionSchedule[3].Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule[3].Status);
+#endif
 }
 
 void test_status_running_to_off_ign5(void)

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -102,40 +102,40 @@ void test_status_running_to_pending_ign1(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[0].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule1(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule1.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule1.Status);
+    while(ignitionSchedule[0].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[0].Status);
 }
 
 void test_status_running_to_pending_ign2(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[1].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule2(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule2.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule2.Status);
+    while(ignitionSchedule[1].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[1].Status);
 }
 
 void test_status_running_to_pending_ign3(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[2].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule3(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule3.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule3.Status);
+    while(ignitionSchedule[2].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[2].Status);
 }
 
 void test_status_running_to_pending_ign4(void)
 {
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[3].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule4(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule4.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule4.Status);
+    while(ignitionSchedule[3].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[3].Status);
 }
 
 void test_status_running_to_pending_ign5(void)
@@ -143,10 +143,10 @@ void test_status_running_to_pending_ign5(void)
 #if IGN_CHANNELS >= 5
     initialiseSchedulers();
     setIgnitionSchedule5(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[4].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule5(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule5.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule5.Status);
+    while(ignitionSchedule[4].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[4].Status);
 #endif
 }
 
@@ -155,10 +155,10 @@ void test_status_running_to_pending_ign6(void)
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[5].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule6(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule6.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule6.Status);
+    while(ignitionSchedule[5].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[5].Status);
 #endif
 }
 
@@ -167,10 +167,10 @@ void test_status_running_to_pending_ign7(void)
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[6].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule7(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule7.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule7.Status);
+    while(ignitionSchedule[6].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[6].Status);
 #endif
 }
 
@@ -179,10 +179,10 @@ void test_status_running_to_pending_ign8(void)
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
+    while(ignitionSchedule[7].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule8(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
-    while(ignitionSchedule8.Status == RUNNING) /*Wait*/ ;
-    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule8.Status);
+    while(ignitionSchedule[7].Status == RUNNING) /*Wait*/ ;
+    TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[7].Status);
 #endif
 }
 

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -100,42 +100,50 @@ void test_status_running_to_pending_inj8(void)
 
 void test_status_running_to_pending_ign1(void)
 {
+#if IGN_CHANNELS >= 1
     initialiseSchedulers();
     setIgnitionSchedule1(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[0].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule1(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[0].Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[0].Status);
+#endif
 }
 
 void test_status_running_to_pending_ign2(void)
 {
+#if IGN_CHANNELS >= 2
     initialiseSchedulers();
     setIgnitionSchedule2(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[1].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule2(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[1].Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[1].Status);
+#endif
 }
 
 void test_status_running_to_pending_ign3(void)
 {
+#if IGN_CHANNELS >= 3
     initialiseSchedulers();
     setIgnitionSchedule3(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[2].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule3(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[2].Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[2].Status);
+#endif
 }
 
 void test_status_running_to_pending_ign4(void)
 {
+#if IGN_CHANNELS >= 4
     initialiseSchedulers();
     setIgnitionSchedule4(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[3].Status == PENDING) /*Wait*/ ;
     setIgnitionSchedule4(emptyCallback, 2*TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[3].Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule[3].Status);
+#endif
 }
 
 void test_status_running_to_pending_ign5(void)
@@ -152,7 +160,7 @@ void test_status_running_to_pending_ign5(void)
 
 void test_status_running_to_pending_ign6(void)
 {
-#if INJ_CHANNELS >= 6
+#if IGN_CHANNELS >= 6
     initialiseSchedulers();
     setIgnitionSchedule6(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[5].Status == PENDING) /*Wait*/ ;
@@ -164,7 +172,7 @@ void test_status_running_to_pending_ign6(void)
 
 void test_status_running_to_pending_ign7(void)
 {
-#if INJ_CHANNELS >= 7
+#if IGN_CHANNELS >= 7
     initialiseSchedulers();
     setIgnitionSchedule7(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[6].Status == PENDING) /*Wait*/ ;
@@ -176,7 +184,7 @@ void test_status_running_to_pending_ign7(void)
 
 void test_status_running_to_pending_ign8(void)
 {
-#if INJ_CHANNELS >= 8
+#if IGN_CHANNELS >= 8
     initialiseSchedulers();
     setIgnitionSchedule8(emptyCallback, TIMEOUT, DURATION, emptyCallback);
     while(ignitionSchedule[7].Status == PENDING) /*Wait*/ ;


### PR DESCRIPTION
This PR abstracts the 'timer functionality' out of the igntion scheduling functions, and creates a single common ignition scheduling function (`setIgnitionSchedule`) which is used for all ignitions.

This allows more flexibility for which/how timers are used, and will allow quicker/easier improvements to the scheduler. Not to mention, this is needed for the ESP32 port.

The same sort of abstraction could be added to the fuel scheduling functions.