### PR TITLE
VVT Min Coolant Condition & Timed Delay

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -556,8 +556,12 @@ page = 4
       unusedBits4-123 = bits,   U08,      123, [1:7]
       ANGLEFILTER_VVT = scalar, U08,      124, "%",          1.0,  0.0,   0,     100,    0
       FILTER_FLEX     = scalar, U08,      125, "%",          1.0,  0.0,   0,     240,    0
-
-      unused4-124     = array,  U08,      126, [2],     "%",  1.0,  0.0,   0.0,     255,      0
+      #if CELSIUS
+      vvtMinClt    = array,  U08,      126, "C",        1.0,    -40,    -40,    215,      0     
+      #else
+      vvtMinClt    = scalar,  U08,      126, "F",        1.8,    -22.23,    -40,    215,      0
+      #endif
+      vvtDelay     = scalar,  U08,      127, "S",        5.0,  0.0,   0,     1275,    0
 ;--------------------------------------------------
 
 ;Start AFR page
@@ -1466,6 +1470,8 @@ page = 14
     defaultValue = ANGLEFILTER_VVT, 0
     defaultValue = idleAdvStartDelay, 0.2 ;0.2S for a quick gear change without change the table advance
     defaultValue = boostByGearEnabled, 0
+    defaultValue = vvtMinClt, 160
+    defaultValue = vvtDelay, 60
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -2088,6 +2094,8 @@ menuDialog = main
   vvtCLMinAng     = "Safety limit for minimum expected cam angle value. If cam angle gets smaller or equal to this, it triggers VVT error state, closed loop adjustment is disabled and VVT output duty drops to 0%"
   vvtCLMaxAng     = "Safety limit for maximum expected cam angle value. If cam angle gets bigger than this, it triggers VVT error state, closed loop adjustment is disabled and VVT output duty drops to 0%"
   ANGLEFILTER_VVT = "Can be used to smooth out cam angle readings if needed. Only supported on specific decoders that have cam angle reading capability"
+  vvtMinClt = "Minimum coolant temp to activate VVT"
+  vvtDelay = "Time to wait after reaching minimum coolant temp (additional time for oil warmup)"
 
   stagedInjSizePri= "Size of the primary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
   stagedInjSizeSec= "Size of the secondary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
@@ -2860,6 +2868,8 @@ menuDialog = main
 
     dialog = vvtSettings, "VVT Control"
         field = "VVT Control Enabled",    vvtEnabled
+        field = "VVT Minimum CLT",  vvtMinClt, { vvtEnabled }
+        field = "VVT Delay",  vvtDelay, { vvtEnabled }
         field = "VVT Mode",               vvtMode,          { vvtEnabled }
         field = "#Please note that closed loop is currently experimental for Miata and missing tooth patterns ONLY"
         field = "Load source",            vvtLoadSource,    { vvtEnabled }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -974,8 +974,8 @@ struct config4 {
   byte unusedBits4 : 7;
   byte ANGLEFILTER_VVT;
   byte FILTER_FLEX;
-
-  byte unused4_124[2];
+  byte vvtMinClt;
+  byte vvtDelay;
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
This PR adds a condition for minimum coolant temp before activating VVT. I also added a configurable delay from 0 to 1275 seconds for the purpose of oil warmup. 

If car is started below min coolant temp, it will wait until engine reaches min coolant temp, then starts counting the delay, before then activating VVT.
If the car is restarted while hot, it will skip the timed delay.
If car (somehow) goes below min coolant temp, VVT will deactivate. Once it goes back over, VVT will reactivate.
