### PR TITLE
Changes to the Dual wheel decoder

### DIFF
--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -209,6 +209,7 @@ extern volatile byte toothSystemCount; //Used for decoders such as Audi 135 wher
 extern volatile unsigned long toothSystemLastToothTime; //As below, but used for decoders where not every tooth count is used for calculation
 extern volatile unsigned long toothLastToothTime; //The time (micros()) that the last tooth was registered
 extern volatile unsigned long toothLastSecToothTime; //The time (micros()) that the last tooth was registered on the secondary input
+extern volatile unsigned long lastSecActiveEdgeTime; //The time (micros()) that the last active edge was registered on the secondary input, still to be filtered
 extern volatile unsigned long toothLastThirdToothTime; //The time (micros()) that the last tooth was registered on the second cam input
 extern volatile unsigned long toothLastMinusOneToothTime; //The time (micros()) that the tooth before the last tooth was registered
 extern volatile unsigned long toothLastMinusOneSecToothTime; //The time (micros()) that the tooth before the last tooth was registered on secondary input

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -62,6 +62,7 @@ volatile byte toothSystemCount = 0; //Used for decoders such as Audi 135 where n
 volatile unsigned long toothSystemLastToothTime = 0; //As below, but used for decoders where not every tooth count is used for calculation
 volatile unsigned long toothLastToothTime = 0; //The time (micros()) that the last tooth was registered
 volatile unsigned long toothLastSecToothTime = 0; //The time (micros()) that the last tooth was registered on the secondary input
+volatile unsigned long lastSecActiveEdgeTime =0; //The time (micros()) that the last active edge was registered on the secondary input, still to be filtered
 volatile unsigned long toothLastThirdToothTime = 0; //The time (micros()) that the last tooth was registered on the second cam input
 volatile unsigned long toothLastMinusOneToothTime = 0; //The time (micros()) that the tooth before the last tooth was registered
 volatile unsigned long toothLastMinusOneSecToothTime = 0; //The time (micros()) that the tooth before the last tooth was registered on secondary input
@@ -713,76 +714,141 @@ void triggerSetup_DualWheel()
  * 
  * */
 void triggerPri_DualWheel()
-{
-    curTime = micros();
-    curGap = curTime - toothLastToothTime;
-    if ( curGap >= triggerFilterTime )
-    {
+{  
+  byte trig2;
+  static byte lastEdge; //indicates that the last detected edge was RISING or FALLING or unknown(0) (to detect missing edges)   
+  static unsigned long lastInterruptTime;
+  static unsigned long lastActiveEdgeTime;
+
+  curTime = micros();  //take timestamp    
+  curGap = curTime - lastInterruptTime;
+  lastInterruptTime = curTime;
+  curGap2 = curTime -lastSecActiveEdgeTime; //gap with the secondary trigger, used for sync
+
+  //Confirm secondary trigger. For filtering secondary properly
+  if(curGap2 >= triggerSecFilterTime && toothLastSecToothTime!=lastSecActiveEdgeTime){ //apply high frequency filter on secondary trigger
+    trig2=READ_SEC_TRIGGER();
+    if ((secondaryTriggerEdge==RISING && trig2==HIGH) || (secondaryTriggerEdge==FALLING && trig2==LOW) ){ //check if there is uncorfimed edge on the secondary
+      toothLastSecToothTime=lastSecActiveEdgeTime; //confirm new noise free tooth on the secondary
+    }
+  }
+
+  validTrigger = false;//(set that again later)
+
+  bool a=READ_PRI_TRIGGER();       //Determine edge type
+  bool b=READ_PRI_TRIGGER();
+  bool c=READ_PRI_TRIGGER();
+  
+  if((a&&b&&c)){      //rising edge    
+    if(curGap >= triggerFilterTime && lastEdge == FALLING ){ //High frequency filter
+      if (primaryTriggerEdge == RISING){
+      lastActiveEdgeTime=curTime; //Save timestamp. Rising edge gets identified as tooth on the next falling edge to avoid instantaneous update on the noise.      
+      }
+      else{
+      toothLastMinusOneToothTime = toothLastToothTime; //promote falling edge timestamp to tooth.
+      toothLastToothTime = lastActiveEdgeTime;
+      toothCurrentCount++; //Increment the tooth counter             
+      }
+      validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters) 
+      setFilter_DualWheel(curGap);
+    }
+    lastEdge = RISING;     
+  }
+  else if (!(a|b|c)){ //falling edge
+    if(curGap >= triggerFilterTime && lastEdge == RISING){ //High frequency filter
+      if (primaryTriggerEdge == FALLING){
+      lastActiveEdgeTime=curTime; //Save timestamp. Edge gets identified as tooth on the next rising edge to avoid instantaneous update on the noise.      
+      }
+      else{    
+      toothLastMinusOneToothTime = toothLastToothTime; //promote rising edge timestamp to tooth.
+      toothLastToothTime = lastActiveEdgeTime;
       toothCurrentCount++; //Increment the tooth counter
-      validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
-
-      toothLastMinusOneToothTime = toothLastToothTime;
-      toothLastToothTime = curTime;
-
-      if ( currentStatus.hasSync == true )
-      {
-        if ( (toothCurrentCount == 1) || (toothCurrentCount > configPage4.triggerTeeth) )
-        {
-          toothCurrentCount = 1;
-          revolutionOne = !revolutionOne; //Flip sequential revolution tracker
-          toothOneMinusOneTime = toothOneTime;
-          toothOneTime = curTime;
-          currentStatus.startRevolutions++; //Counter
-        }
-
-        setFilter(curGap); //Recalc the new filter value
       }
-
-      //NEW IGNITION MODE
-      if( (configPage2.perToothIgn == true) && (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) ) 
-      {
-        int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
-        if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) )
-        {
-          crankAngle += 360;
-          checkPerToothTiming(crankAngle, (configPage4.triggerTeeth + toothCurrentCount)); 
+      validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters) 
+      setFilter_DualWheel(curGap);
+    }
+    lastEdge = FALLING;
+  }
+  else{ //unstable state on the port, this means high frequency noise.
+    lastEdge = 0;
+  }
+  //loop back tooth count if needed 
+  if (toothCurrentCount > configPage4.triggerTeeth){      
+    toothCurrentCount = 1;
+    revolutionOne = !revolutionOne; //Flip sequential revolution tracker
+    toothOneMinusOneTime = toothOneTime;
+    toothOneTime = toothLastToothTime;
+    currentStatus.startRevolutions++; //Counter
+    //check for sync loss          
+    if(revolutionOne==0 && configPage4.useResync == 0){ 
+      if((curTime-toothLastToothTime) < (curTime-toothLastSecToothTime) && (curTime-toothLastSecToothTime)< (curTime-toothLastMinusOneToothTime) ){ //Check if secondary trigger happened within this primary tooth interval
+        currentStatus.hasSync = true;
+     }
+      else{
+        currentStatus.syncLossCounter++;//indicates sync loss
+         currentStatus.hasSync = false;
         }
-        else{ checkPerToothTiming(crankAngle, toothCurrentCount); }
-      }
-   } //Trigger filter
+    }      
+  }
+  //pure resync stuff
+  else if ((configPage4.useResync == 1 || currentStatus.hasSync == false) && validTrigger==true){ 
+    if((curTime-toothLastToothTime) < (curTime-toothLastSecToothTime) && (curTime-toothLastSecToothTime)< (curTime-toothLastMinusOneToothTime) ){ //Check if secondary trigger happened within this primary tooth interval(overflow proof)
+    //      gap to last tooth       <    gap to last secondary tooth  &&    gap to last secondary tooth <   gap to last minus one tooth
+      if(toothCurrentCount != 1 || revolutionOne != 0 ){currentStatus.syncLossCounter++;}//indicates sync loss
+      toothCurrentCount = 1;
+      revolutionOne = 0;
+      toothOneTime = toothLastToothTime;
+      currentStatus.hasSync = true;
+    }        
+  }  
 }
 /** Dual Wheel Secondary.
  * 
  * */
 void triggerSec_DualWheel()
 {
+  static unsigned long lastSecInterruptTime;
+  static byte lastEdge; //indicates that the last detected edge was RISING or FALLING (to detect missing edges)
+
   curTime2 = micros();
-  curGap2 = curTime2 - toothLastSecToothTime;
-  if ( curGap2 >= triggerSecFilterTime )
-  {
-    toothLastSecToothTime = curTime2;
-    triggerSecFilterTime = curGap2 >> 2; //Set filter at 25% of the current speed
+  curGap2 = curTime2 - lastSecInterruptTime;
+  lastSecInterruptTime = curTime2;
 
-    if(currentStatus.hasSync == false)
-    {
-      toothLastToothTime = micros();
-      toothLastMinusOneToothTime = micros() - (6000000 / configPage4.triggerTeeth); //Fixes RPM at 10rpm until a full revolution has taken place
-      toothCurrentCount = configPage4.triggerTeeth;
+  bool a=digitalRead(pinTrigger2);       //Determine edge type
+  bool b=digitalRead(pinTrigger2);
+  bool c=digitalRead(pinTrigger2);
 
-      currentStatus.hasSync = true;
+  if((a&&b&&c)){      //rising edge    
+    if ( curGap2 >= triggerSecFilterTime && lastEdge == FALLING ){ //High frequency filter
+      if (secondaryTriggerEdge == RISING){
+        lastSecActiveEdgeTime=curTime2;
+      }
+      else{
+        toothLastSecToothTime=lastSecActiveEdgeTime; //noise free tooth confirm
+      }        
     }
-    else 
-    {
-      if ( (toothCurrentCount != configPage4.triggerTeeth) && (currentStatus.startRevolutions > 2)) { currentStatus.syncLossCounter++; } //Indicates likely sync loss.
-      if (configPage4.useResync == 1) { toothCurrentCount = configPage4.triggerTeeth; }
-    }
-
-    revolutionOne = 1; //Sequential revolution reset
+    lastEdge=RISING;
   }
-  else 
-  {
-    triggerSecFilterTime = revolutionTime >> 1; //Set filter at 25% of the current cam speed. This needs to be performed here to prevent a situation where the RPM and triggerSecFilterTime get out of alignment and curGap2 never exceeds the filter value
-  } //Trigger filter
+  else if (!(a|b|c)){ //falling edge    
+    if ( curGap2 >= triggerSecFilterTime && lastEdge == RISING ){ //High frequency filter
+      if (secondaryTriggerEdge == FALLING){
+        lastSecActiveEdgeTime=curTime2;
+      }
+      else{
+        toothLastSecToothTime=lastSecActiveEdgeTime; //noise free tooth confirm
+      }
+    }
+    lastEdge=FALLING;
+  }
+  else{lastEdge=0;} //unstable state on the port, this means high frequency noise.
+//  {currentStatus.syncLossCounter++;} //Indicates likely sync loss.
+}
+void setFilter_DualWheel(unsigned long curGap) //only continously variable cap level filters are set here (others in the main loop).
+{
+  if (configPage4.triggerFilter == 3) {
+    triggerFilterTime = curGap >> 1;  //Aggressive filter level is 50% of previous gap
+    if (triggerFilterTime<10 ){triggerFilterTime=10;} //also set minimum limit
+  } 
 }
 /** Dual Wheel - Get RPM.
  * 
@@ -804,24 +870,28 @@ int getCrankAngle_DualWheel()
 {
     //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
     unsigned long tempToothLastToothTime;
+    unsigned long tempToothOneTime;
+    unsigned long tempToothOneMinusOneTime;
     int tempToothCurrentCount;
+    int extraCrankAngle; // crank angle past the latest tooth
     bool tempRevolutionOne;
     //Grab some variables that are used in the trigger code and assign them to temp variables.
     noInterrupts();
     tempToothCurrentCount = toothCurrentCount;
     tempToothLastToothTime = toothLastToothTime;
-    tempRevolutionOne = revolutionOne;
+    tempToothOneTime=toothOneTime;
+    tempToothOneMinusOneTime=toothOneMinusOneTime;
+    tempRevolutionOne = revolutionOne; //revolutionOne=0 during the first revolution, revolutionOne=1 during the second revoluiton
     lastCrankAngleCalc = micros();
     interrupts();
-
-    //Handle case where the secondary tooth was the last one seen
-    if(tempToothCurrentCount == 0) { tempToothCurrentCount = configPage4.triggerTeeth; }
 
     int crankAngle = ((tempToothCurrentCount - 1) * triggerToothAngle) + configPage4.triggerAngle; //Number of teeth that have passed since tooth 1, multiplied by the angle each tooth represents, plus the angle that tooth 1 is ATDC. This gives accuracy only to the nearest tooth.
 
     elapsedTime = (lastCrankAngleCalc - tempToothLastToothTime);
+//    revolutionTime= (tempToothOneMinusOneTime-tempToothOneTime);
     crankAngle += timeToAngle(elapsedTime, CRANKMATH_METHOD_INTERVAL_REV);
-
+//    extraCrankAngle=360*elapsedTime/revolutionTime;
+//    crankAngle +=extraCrankAngle;
     //Sequential check (simply sets whether we're on the first or 2nd revoltuion of the cycle)
     if (tempRevolutionOne) { crankAngle += 360; }
 

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -2906,7 +2906,7 @@ void initialiseTriggers()
       attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
-    case 2:
+    case DECODER_DUAL_WHEEL:
       triggerSetup_DualWheel();
       triggerHandler = triggerPri_DualWheel;
       triggerSecondaryHandler = triggerSec_DualWheel;
@@ -2920,8 +2920,8 @@ void initialiseTriggers()
       if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
       else { secondaryTriggerEdge = FALLING; }
 
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
+      attachInterrupt(triggerInterrupt, triggerHandler, CHANGE); 
+      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, CHANGE);
       break;
 
     case DECODER_GM7X:

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -367,6 +367,26 @@ void loop()
       BIT_CLEAR(TIMER_mask, BIT_TIMER_1HZ);
       readBaro(); //Infrequent baro readings are not an issue.
 
+          //Infrequent trigger setting updates are not an issue
+      switch (configPage4.TrigPattern)
+      {
+        case DECODER_DUAL_WHEEL:
+        //triggerSetup_DualWheel();
+          if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
+          else { primaryTriggerEdge = FALLING; }
+          if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
+          else { secondaryTriggerEdge = FALLING; }
+
+            if(configPage4.triggerFilter == 0) { triggerFilterTime = 0; triggerSecFilterTime=0;} //trigger filter is turned off.
+            else if(configPage4.triggerFilter == 1) {triggerFilterTime = (1000000 / (MAX_RPM / 60 * configPage4.triggerTeeth))/8;triggerSecFilterTime=20;} //Lite filter level is 25% of shortest possible time
+            else if(configPage4.triggerFilter == 2) {triggerFilterTime = (1000000 / (MAX_RPM / 60 * configPage4.triggerTeeth))/2;triggerSecFilterTime=40;} //Medium filter level: Trigger filter time is the shortest possible time (in uS) that there can be between crank teeth (ie at max RPM). Any pulses that occur faster than this time will be disgarded as noise
+            else if (configPage4.triggerFilter == 3) {triggerSecFilterTime=40;} //Aggressive filter level(primary configured in separate function)
+            else { triggerFilterTime = 0; } //trigger filter is turned off.
+
+        break;
+        default:
+        break;
+      }
       if ( (configPage10.wmiEnabled > 0) && (configPage10.wmiIndicatorEnabled > 0) )
       {
         // water tank empty


### PR DESCRIPTION
Changes to the Dual Wheel decoder mainly to improve high frequency noise rejection, and stability under noisy conditions.
New filtering scheme designed to effectively filter out high frequency pulses (that usually come from ignition system).

Improvement is done by filtering out all small pulses before and after active trigger edge. Prior art was to filter only for some time after the active trigger edge. Testing was showing big improvement in stability with system that previously was struggling with noise issues.

New filter level descriptions:
Off level is off as usual.
Lite level is fixed small level dependent of the trigger tooth count.
Medium level is fixed shortest possible time that there can be between crank teeth (ie at max RPM).
Agressive level is variable 50% of the last gap.

Per tooth ignition mode is dropped in this implementation! Mainly because the trigger edge is timestamped with exact time, but is not latched(or confirmed) after determined filtering time to avoid triggering on false small noise impulses. Because of this the per tooth ignition is also slightly delayed and needs to be reimplemented. 