### PR TITLE
Added function: Reset eeprom with key

### DIFF
--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -27,7 +27,7 @@
 #define TIMER_RESOLUTION 4
 
 #if defined(USER_BTN) 
-  #define EEPROM_RESET_PIN USER_BTN //onboard key0 for black STM32F407 boards, keep pressed during boot to reset eeprom
+  #define EEPROM_RESET_PIN USER_BTN //onboard key0 for black STM32F407 boards and blackpills, keep pressed during boot to reset eeprom
 #endif
 
 #ifdef SD_LOGGING

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -26,6 +26,10 @@
 #define micros_safe() micros() //timer5 method is not used on anything but AVR, the micros_safe() macro is simply an alias for the normal micros()
 #define TIMER_RESOLUTION 4
 
+#if defined(USER_BTN) 
+  #define EEPROM_RESET_PIN USER_BTN //onboard key0 for black STM32F407 boards, keep pressed during boot to reset eeprom
+#endif
+
 #ifdef SD_LOGGING
 #define RTC_ENABLED
 #endif

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -84,11 +84,15 @@ void initialiseAll()
     #if defined(EEPROM_RESET_PIN)
     pinMode(EEPROM_RESET_PIN, INPUT_PULLUP);  
     if (digitalRead(EEPROM_RESET_PIN) != HIGH){
-      for (int i = 0 ; i < EEPROM.length() ; i++) {
-        EEPROM.write(i, 255);
-      }
-    }
-    #endif
+        #if defined(FLASH_AS_EEPROM_h)
+          EEPROM.clear(); 
+        #else 
+        for (int i = 0 ; i < EEPROM.length() ; i++) {
+          EEPROM.write(i, 255);
+        }
+        #endif
+     }
+     #endif
     
     loadConfig();
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -82,17 +82,35 @@ void initialiseAll()
     * EEPROM reset
     */
     #if defined(EEPROM_RESET_PIN)
+    uint32_t start_time = millis();
+    byte exit_erase_loop = false; 
     pinMode(EEPROM_RESET_PIN, INPUT_PULLUP);  
-    if (digitalRead(EEPROM_RESET_PIN) != HIGH){
-        #if defined(FLASH_AS_EEPROM_h)
-          EEPROM.clear(); 
-        #else 
-        for (int i = 0 ; i < EEPROM.length() ; i++) {
-          EEPROM.write(i, 255);
+
+    //only start routine when this pin is low because it is pulled low
+    while (digitalRead(EEPROM_RESET_PIN) != HIGH && (millis() - start_time)<1050)
+    {
+      //make sure the key is pressed for atleast 0.5 second 
+      if ((millis() - start_time)>500) {
+        //if key is pressed afterboot for 0.5 second make led turn off
+        digitalWrite(LED_BUILTIN, HIGH);
+
+        //see if the user reacts to the led turned off with removing the keypress within 1 second
+        while (((millis() - start_time)<1000) && (exit_erase_loop!=true)){
+
+          //if user let go of key within 1 second erase eeprom
+          if(digitalRead(EEPROM_RESET_PIN) != LOW){
+            #if defined(FLASH_AS_EEPROM_h)
+              EEPROM.clear(); 
+            #else 
+              for (int i = 0 ; i < EEPROM.length() ; i++) { EEPROM.write(i, 255);}
+            #endif
+            //if erase done exit while loop.
+            exit_erase_loop = true;
+          }
         }
-        #endif
-     }
-     #endif
+      } 
+    }
+    #endif
     
     loadConfig();
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -76,6 +76,19 @@ void initialiseAll()
     configPage9.intcan_available = 1;   // device has internal canbus
     //STM32 can not currently enabled
     #endif
+
+    /*
+    ***********************************************************************************************************
+    * EEPROM reset
+    */
+    #if defined(EEPROM_RESET_PIN)
+    pinMode(EEPROM_RESET_PIN, INPUT_PULLUP);  
+    if (digitalRead(EEPROM_RESET_PIN) != HIGH){
+      for (int i = 0 ; i < EEPROM.length() ; i++) {
+        EEPROM.write(i, 255);
+      }
+    }
+    #endif
     
     loadConfig();
     doUpdates(); //Check if any data items need updating (Occurs with firmware updates)


### PR DESCRIPTION
This PR adds a function to reset the EEPROM. 

The function engages when pressing the onboard key[0] of the STM32 boards (blackpill/black stm32F407) during boot/startup.  for the manual:

> Press the Key[0] and press->release the reset button
> The onboard led turns on
> When the led turns off release the key button within 0.5 seconds
> 
> This procedure resets the boards EEPROM

Lots of people asked for the eeprom reset Arduino script because boards gets bricked easily when selecting functions/pin outs that break communication or get the board in an infinite loop in other ways. This function makes it easy to reset back to factory defaults if needed. 

When the EEPROM_RESET_PIN macro is defined with a pin the function is active. So the function is NOT active for teensy and mega. Unless someone defines the EEPROM_RESET_PIN for those boards with a common pin.  

Now with increased robustness against accidental erase by noise or pulling the pin always low by some board components. Both will not erase the eeprom. 