### PR TITLE
Add secondary serial selection to Tuner Studio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -64,7 +64,7 @@ framework = arduino
 board = black_f407ve
 lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
 board_build.core = stm32
-build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
+build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -156,6 +156,6 @@ default_envs = megaatmega2560
 ;env_default = LaunchPad_tm4c1294ncpdt
 ;env_default = genericSTM32F103RB
 ;env_default = bluepill_f103c8
-;env_default = black_F401CC
+;env_default = BlackPill_F411CE_USB
 
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -768,6 +768,7 @@ page = 9
       enable_secondarySerial    = bits,   U08,     0, [0:0], "Disable", "Enable"
       intcan_available          = bits,   U08,     0, [1:1], "Disable", "Enable"
       enable_intcan             = bits,   U08,     0, [2:2], "Disable", "Enable"
+      secondarySerialPort       = bits,   U08,     0, [3:4], "Serial", "Serial1", "Serial2", "Serial3"
     
       caninput_sel0a            = bits,   U08,     1, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel0b            = bits,   U08,     1, [2:3], "Off", "External Source", "Analog_local", "Digital_local"
@@ -1397,6 +1398,7 @@ page = 14
     requiresPowerCycle = caninput_sel15a
     requiresPowerCycle = caninput_sel15b
     requiresPowerCycle = outputPin
+    requiresPowerCycle = secondarySerialPort
 
     defaultValue = pinLayout,   1
     defaultValue = TrigPattern, 0
@@ -1476,6 +1478,7 @@ page = 14
     defaultValue = boostByGearEnabled, 0
     defaultValue = vvtMinClt, 160
     defaultValue = vvtDelay, 60
+    defaultValue = secondarySerialPort, 1
 
     ;Default pins
     defaultValue = fanPin,      0
@@ -1956,7 +1959,8 @@ menuDialog = main
   fuel2InputPolarity = "Whether the 2nd fuel table should be active when input is high or low. This should be LOW for a typical ground switching input"
   fuel2InputPullup= "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
 
-  enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
+  enable_secondarySerial = "This Enables the secondary serial port."
+  secondarySerialPort = "Select the hardware port that is used as secondary serial. The arduino Mega always uses Serial3=(15,14). For teensy3.5: Serial1=(0,1), Serial2=(9,10), Serial3=(7,8). For STM32F407: Serial1=(PA10,PA9), Serial2=(PD6, PD5), Serial3=(PB11, PB10). For STM32F4x1: Serial1=(PA10,PA9), Serial2=(PA12, PA11), Serial3=(PA3, PA2)"
   
   cltAdvValues    = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
 
@@ -3419,6 +3423,7 @@ menuDialog = main
       topicHelp = "http://speeduino.com/wiki/index.php/Serial3_IO_interface"
       field = "Enable Second Serial",       enable_secondarySerial
       field = "Enable Internal Canbus",     enable_intcan
+      field = "Select secondary serial port", secondarySerialPort, {enable_secondarySerial==1}
       ;  field = "Speeduino TsCanId", speeduino_tsCanId
       field = "True Canbus Address", true_address, {enable_secondarySerial||enable_intcan}
       field = "NOTE! Realtime Data Base Address MUST be at least 0x16 GREATER than the True Address as they are reserved for future expansion"

--- a/speeduino/board_same51.h
+++ b/speeduino/board_same51.h
@@ -187,7 +187,7 @@
 ***********************************************************************************************************
 * CAN / Second serial
 */
-  Uart CANSerial (&sercom3, 0, 1, SERCOM_RX_PAD_1, UART_TX_PAD_0);
+  // Uart CANSerial (&sercom3, 0, 1, SERCOM_RX_PAD_1, UART_TX_PAD_0);
 
 #endif //CORE_SAMD21
 #endif //SAMD21_H

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -69,6 +69,30 @@ HardwareTimer Timer11(TIM7);
 STM32RTC& rtc = STM32RTC::getInstance();
 #endif
 
+#if defined(STM32F407xx)
+  #ifndef ENABLE_HWSERIAL1
+    HardwareSerial Serial1(PA10, PA9); //RX ,TX
+  #endif
+  #ifndef ENABLE_HWSERIAL2
+    HardwareSerial Serial2(PD6, PD5);
+  #endif
+  #ifndef ENABLE_HWSERIAL3
+    HardwareSerial Serial3(PB11, PB10);
+  #endif
+#endif
+
+#if defined(STM32F411xE) || defined(STM32F401xC)
+  #ifndef ENABLE_HWSERIAL1
+    HardwareSerial Serial1(PA10, PA9); //RX ,TX
+  #endif
+  #ifndef ENABLE_HWSERIAL2
+    HardwareSerial Serial2(PA12, PA11);
+  #endif
+  #ifndef ENABLE_HWSERIAL3
+    HardwareSerial Serial3(PA3, PA2);
+  #endif
+#endif
+
   void initBoard()
   {
     /*

--- a/speeduino/cancomms.h
+++ b/speeduino/cancomms.h
@@ -4,22 +4,8 @@
 #define NEW_CAN_PACKET_SIZE   119
 #define CAN_PACKET_SIZE   75
 
-#if ( defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) )
+#if ( defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_STM32) || defined(CORE_TEENSY))
   #define CANSerial_AVAILABLE
-  extern HardwareSerial &CANSerial;
-#elif defined(CORE_STM32)
-  #define CANSerial_AVAILABLE
-  #ifndef HAVE_HWSERIAL2 //Hack to get the code to compile on BlackPills
-    #define Serial2 Serial1
-  #endif
-  #if defined(STM32GENERIC) // STM32GENERIC core
-    extern SerialUART &CANSerial;
-  #else //libmaple core aka STM32DUINO
-    extern HardwareSerial &CANSerial;
-  #endif
-#elif defined(CORE_TEENSY)
-  #define CANSerial_AVAILABLE
-  extern HardwareSerial &CANSerial;
 #endif
 
 void secondserial_Command();//This is the heart of the Command Line Interpeter.  All that needed to be done was to make it human readable.

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -39,6 +39,7 @@ bool serialInProgress = false;
 bool toothLogSendInProgress = false;
 bool compositeLogSendInProgress = false;
 
+extern  Stream *CANSerial;
 /** Processes the incoming data on the serial buffer based on the command sent.
 Can be either data for a new command or a continuation of data for command that is already in progress:
 - cmdPending = If a command has started but is wairing on further data to complete
@@ -942,10 +943,10 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
     #if defined(USE_SERIAL3)
       if (cmd == 30)
       {
-        CANSerial.write("r");         //confirm cmd type
-        CANSerial.write(cmd);
+        CANSerial->write("r");         //confirm cmd type
+        CANSerial->write(cmd);
       }
-      else if (cmd == 31) { CANSerial.write("A"); }        //confirm cmd type
+      else if (cmd == 31) { CANSerial->write("A"); }        //confirm cmd type
     #else
       UNUSED(cmd);
     #endif
@@ -962,7 +963,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
   {
     if (portNum == 0) { Serial.write(getStatusEntry(offset+x)); }
     #if defined(CANSerial_AVAILABLE)
-      else if (portNum == 3){ CANSerial.write(getStatusEntry(offset+x)); }
+      else if (portNum == 3){ CANSerial->write(getStatusEntry(offset+x)); }
     #endif
 
     //Check whether the tx buffer still has space

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -581,6 +581,8 @@ extern byte resetControl; ///< resetControl needs to be here (as global) because
 extern volatile byte TIMER_mask;
 extern volatile byte LOOP_TIMER;
 
+extern Stream *CANSerial;
+
 //These functions all do checks on a pin to determine if it is already in use by another (higher importance) function
 #define pinIsInjector(pin)  ( ((pin) == pinInjector1) || ((pin) == pinInjector2) || ((pin) == pinInjector3) || ((pin) == pinInjector4) || ((pin) == pinInjector5) || ((pin) == pinInjector6) || ((pin) == pinInjector7) || ((pin) == pinInjector8) )
 #define pinIsIgnition(pin)  ( ((pin) == pinCoil1) || ((pin) == pinCoil2) || ((pin) == pinCoil3) || ((pin) == pinCoil4) || ((pin) == pinCoil5) || ((pin) == pinCoil6) || ((pin) == pinCoil7) || ((pin) == pinCoil8) )
@@ -1092,6 +1094,7 @@ struct config9 {
   byte enable_secondarySerial:1;            //enable secondary serial
   byte intcan_available:1;                     //enable internal can module
   byte enable_intcan:1;
+  byte secondarySerial:2;
   byte caninput_sel[16];                    //bit status on/Can/analog_local/digtal_local if input is enabled
   uint16_t caninput_source_can_address[16];        //u16 [15] array holding can address of input
   uint8_t caninput_source_start_byte[16];     //u08 [15] array holds the start byte number(value of 0-7)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -93,7 +93,37 @@ void initialiseAll()
 
     Serial.begin(115200);
     #if defined(CANSerial_AVAILABLE)
-      if (configPage9.enable_secondarySerial == 1) { CANSerial.begin(115200); }
+    if (configPage9.enable_secondarySerial == 1) {
+    //Mega2560 lacks the ram to make secondary serial selectable with pointers. (Each serial port is instantiated taking up ram) 
+    #if !defined(__AVR_ATmega2560__) 
+       switch (configPage9.secondarySerial)
+       {
+        case 0/* Serial USB or 1 */:
+          Serial.begin(115200);
+          CANSerial = &Serial;
+          break;
+        case 1/* Serial 1 */:
+          Serial1.begin(115200);
+          CANSerial = &Serial1;
+          break;
+        case 2/* Serial 2 */:
+          Serial2.begin(115200);
+          CANSerial = &Serial2;
+          break;
+        case 3/* Serial 3 */:
+          Serial3.begin(115200);
+          CANSerial = &Serial3;
+          break;
+         default: /* Serial 3 */
+          Serial3.begin(115200);
+          CANSerial = &Serial3;
+          break;
+      }
+    #else //if it is the Mega select the default serial 3
+    Serial3.begin(115200);
+    CANSerial = &Serial3;
+    #endif
+    }
     #endif
 
     //Repoint the 2D table structs to the config pages that were just loaded

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -137,9 +137,9 @@ void loop()
         //if can or secondary serial interface is enabled then check for requests.
         if (configPage9.enable_secondarySerial == 1)  //secondary serial interface enabled
         {
-          if ( ((mainLoopCount & 31) == 1) or (CANSerial.available() > SERIAL_BUFFER_THRESHOLD) )
+          if ( ((mainLoopCount & 31) == 1) or (CANSerial->available() > SERIAL_BUFFER_THRESHOLD) )
           {
-            if (CANSerial.available() > 0)  { secondserial_Command(); }
+            if (CANSerial->available() > 0)  { secondserial_Command(); }
           }
         }
       #endif


### PR DESCRIPTION
This PR adds the function where the user can select the serial port used for secondary serial. For the arduino MEGA it is still hard coded to serial3 because it will take to much ram to have serial1 and serial2 on standby for Tuner studio selection. 