### PR TITLE
chore(stm32): set the RTC lib back to the PlatformIO library manager package

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ platform = ststm32
 framework = arduino
 ;board = genericSTM32F407VET6
 board = black_f407ve
-lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
+lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
@@ -74,7 +74,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f401cc
-lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
+lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
 upload_protocol = dfu
@@ -86,7 +86,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
+lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
 build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS
 upload_protocol = dfu
@@ -98,7 +98,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = https://github.com/stm32duino/STM32RTC#1.1.0
+lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
 build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
@@ -110,7 +110,7 @@ platform = ststm32
 framework = arduino
 ; framework-arduinoststm32
 board = bluepill_f103c8_128k
-lib_deps = EEPROM, https://github.com/stm32duino/STM32RTC#1.1.0
+lib_deps = EEPROM, stm32duino/STM32duino RTC
 ;build_flags = -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map
 build_flags = -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
 


### PR DESCRIPTION
Followup of #590 

My issue over at PlatformIO just got closed that is should have been fixed automatically and that indeed seems the case:
https://github.com/platformio/platformio-core/issues/3966#event-5320698911

The library now shows the `1.1.0` tag at the same date as they Git tag:

![image](https://user-images.githubusercontent.com/8994658/133846694-034aa17c-d054-46a5-b6e4-dba0566248e7.png)

https://platformio.org/lib/show/5502/STM32duino%20RTC

![image](https://user-images.githubusercontent.com/8994658/133846723-996a0d06-d3d3-4068-b5e2-64efbb682947.png)

https://github.com/stm32duino/STM32RTC/releases

There is nothing wrong with the current approach but it can be reverted back if needed :)