### PR TITLE
Enable internal pressure sensor for Baro updates

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -617,7 +617,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      unused_bit  =   bits, U08,      14, [6:6],      "No", "Yes"
+      useIntBaro  =   bits, U08,      14, [6:6],      "No", "Yes"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -1848,6 +1848,7 @@ menuDialog = main
   includeAFR        = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed. "
   incorporateAFR    = "When enabled, the AFR stoich/AFR target -ratio is incorporated directly in the pulsewidth calculation. When enabled, AFR target table affects pulsewidth even with EGO disabled. VE table must be retuned when this value is changed."
   useExtBaro        = "By Default, Speeduino will measure barometric pressure upon startup. Optionally however, a 2nd pressure sensor can be used to perform live barometric readings whilst the system is on."
+  useIntBaro        = "Use the internal MAP sensor for BARO updates. Make sure Internal MAP Sensor is not connected to the engine. Use with TPS only setup."
 
   flexEnabled       = "Turns on readings from the Flex sensor and enables the below adjustments"
   flexFreqLow       = "The frequency of the sensor at 0% ethanol (50Hz for standard GM/Continental sensor)"
@@ -2748,6 +2749,7 @@ menuDialog = main
 
         field = "#Baro Sensor"
         field = "Use external Baro sensor", useExtBaro
+        field = "Use Internal MAP Sensor for Baro", useIntBaro, { (useExtBaro == 0) }
         field = "Analog pin to use for ext. Baro sensor", baroPin,  { useExtBaro }
 
         settingSelector = "Common Pressure Sensors",  { useExtBaro }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1015,7 +1015,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte unused_bit : 1; //Previously was VVTasOnOff
+  byte useIntBaro : 1; /// Use internal MAP sensor for Baro.
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -323,7 +323,7 @@ void initialiseAll()
     //Lookup the current MAP reading for barometric pressure
     instanteneousMAPReading();
     //barometric reading can be taken from either an external sensor if enabled, or simply by using the initial MAP value
-    if ( configPage6.useExtBaro != 0 )
+    if ( configPage6.useExtBaro == true )
     {
       readBaro();
       storeLastBaro(currentStatus.baro);

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -475,7 +475,7 @@ void readIAT()
 
 void readBaro()
 {
-  if ( configPage6.useExtBaro != 0 )
+  if ( configPage6.useExtBaro == true )
   {
     int tempReading;
     // readings
@@ -490,6 +490,11 @@ void readBaro()
 
     currentStatus.baro = fastMap10Bit(currentStatus.baroADC, configPage2.baroMin, configPage2.baroMax); //Get the current MAP value
   }
+  else if ( configPage6.useIntBaro == true )
+  {// This logic is to only update baro at 1kpa per sec, this slow filter helps prevent any noise or dropout on MAP causing issues with fueling.
+    if ( (currentStatus.baro < currentStatus.MAP) && (currentStatus.MAP < BARO_MAX) ) { currentStatus.baro++; }
+    else if ( (currentStatus.baro > currentStatus.MAP) && (currentStatus.MAP > BARO_MIN) ) { currentStatus.baro--; }
+  }    
 }
 
 void readO2()

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -480,9 +480,6 @@ void doUpdates()
     configPage4.vvt2PWMdir = 0;
     configPage10.TrigEdgeThrd = 0;
 
-    //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
-
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;
     configPage10.vvtCLMaxAng = 200;


### PR DESCRIPTION
Intended for TPS only configurations. This re-purposes the **unused_bit** in VVT control which was obsolete and not available for calibration. 
This memory location is now used for enabling the internal pressure sensor for Baro updates. This setting is mutually exclusive with the existing **Use external Baro** setting so that it is not possible to enable both.

Baro updates are limited to valid ranges of the MAP sensor and only update at 1kpa per sec to limit any effects of noise or sensor dropout on the baro signal.

![image](https://user-images.githubusercontent.com/87687708/135258890-27f3ed73-8449-4e4b-8faa-dc5ac6685548.png)
