### PR TITLE
Advance calculation improvements

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1197,15 +1197,17 @@ page = 10
       fuelTempValues      = array,  U08,      180, [6],    "%",    1.0,    0.0,      0,    255,      0
 
       ;Things for the 2nd spark table
-      spark2Algorithm      = bits,   U08,     186, [0:2], $loadSourceNames
-      spark2Mode           = bits,   U08,     186, [3:5], "Off", "Multiplied %", "Added", "Switched - Conditional", "Switched - Input based","INVALID","INVALID","INVALID"
-      spark2SwitchVariable = bits,   U08,     186, [6:7], "RPM", "MAP", "TPS", "ETH%"
-      spark2SwitchValue    = scalar, U16,     187, { bitStringValue(fuel2SwitchUnits,  spark2SwitchVariable) },  {(spark2SwitchVariable == 2) ? 0.5 : 1.0},       0.0,   0.0,     9000,    {(spark2SwitchVariable == 2) ? 1 : 0}
-      spark2InputPin       = bits ,  U08,     189, [0:5],           $IO_Pins_no_def
-      spark2InputPolarity  = bits ,  U08,     189, [6:6],           "LOW", "HIGH"
-      spark2InputPullup    = bits ,  U08,     189, [7:7],           "No", "Yes"
+      spark2Algorithm                     = bits,   U08, 186, [0:2], $loadSourceNames
+      spark2Mode                          = bits,   U08, 186, [3:5], "Off", "Multiplied %", "Added", "Switched - Conditional", "Switched - Input based","INVALID","INVALID","INVALID"
+      spark2SwitchVariable                = bits,   U08, 186, [6:7], "RPM", "MAP", "TPS", "ETH%"
+      spark2SwitchValue                   = scalar, U16, 187, { bitStringValue(fuel2SwitchUnits,  spark2SwitchVariable) },  {(spark2SwitchVariable == 2) ? 0.5 : 1.0},       0.0,   0.0,     9000,    {(spark2SwitchVariable == 2) ? 1 : 0}
+      spark2InputPin                      = bits,   U08, 189, [0:5], $IO_Pins_no_def
+      spark2InputPolarity                 = bits,   U08, 189, [6:6], "LOW", "HIGH"
+      spark2InputPullup                   = bits,   U08, 189, [7:7], "No", "Yes"
+      spark2correctedMultiplyAddedAdvance = bits,   U08, 190, [0:0], "No", "Yes"
 
-      unused11_190_191    = array,  U08,      190,  [2], "RPM",  100.0,      0.0,  100,     25500,    0
+      unused11_190_bits   = bits,   U08,      190, [1:7], "RPM",  100.0,      0.0,  100,     25500,    0
+      unused11_191        = array,  U08,      190, [1], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -1854,6 +1856,8 @@ menuDialog = main
   fixAngEnable      = "If enabled, timing will be locked/fixed and the ignition map will be ignored. Note that this value will be overriden by the fixed cranking value when cranking"
   FixAng            = "Timing will be locked at this value if the above is enabled"
 
+  spark2correctedMultiplyAddedAdvance = "Yes should be used for all new tunes. No is only intended to be used for old tunes that were tuned on the old calculation method.\nThis only affects the multiply or added secondary spark table modes. Changing this affects the advance calculations and requires retuning the secondary spark table and possibly ignition corrections.\nYes: Primary spark table -> Apply secondary spark table -> Apply ignition corrections. Ignition advance corrections are applied once.\nPrimary spark table -> Apply ignition corrections -> Apply secondary spark table -> Apply ignition corrections. Ignition advance corrections are applied twice."
+
   crankRPM          = "The cranking RPM threshold. When RPM is lower than this value (and above 0) the system will be considered to be cranking"
   tpsflood          = "Keep throttle over this value to disable the priming pulse and cranking fuel. Used to prevent flood or clear already flooded engine"
 
@@ -2468,6 +2472,7 @@ menuDialog = main
     dialog = sparkTable2Dialog_north, ""
       field = "Secondary advance table mode",       spark2Mode
       field = "Load source",                        spark2Algorithm,     { spark2Mode }
+      field = "Corrected multiply/added mode", spark2correctedMultiplyAddedAdvance, { spark2Mode == 1 || spark2Mode == 2 }
       panel = sparkTable2Dialog_switch,             { spark2Mode == 3 }
       panel = sparkTable2Dialog_input,              { spark2Mode == 4 }
 

--- a/speeduino/advance.cpp
+++ b/speeduino/advance.cpp
@@ -22,14 +22,23 @@ int8_t getAdvance() {
     BIT_SET(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Set the bit indicating that the 2nd spark table is in use.
     int16_t tempAdvance2 = getAdvance2(); // Advance from table 2
 
-    if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY)
+    if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY || configPage10.spark2Mode == SPARK2_MODE_ADD)
     {
-      if(tempAdvance2 < 0) { tempAdvance2 = 0; } //Negative values not supported
-      tempAdvance2 = (getAdvance1() * tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divded by 100
-    }
-    else if(configPage10.spark2Mode == SPARK2_MODE_ADD)
-    {
-      tempAdvance2 = getAdvance1() + tempAdvance2;
+      if(configPage10.spark2correctedMultiplyAddedAdvance == true) { //The new code applies the advance corrections only after after adding or multiplying
+        tempAdvance = getAdvance1();
+      }
+      else { //The old code applies the advance corrections before and after adding or multiplying
+        tempAdvance = correctionsIgn(getAdvance1());
+      }
+
+      if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY) {
+        if(tempAdvance2 < 0) { tempAdvance2 = 0; } //Negative values not supported
+        tempAdvance2 = (tempAdvance * tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divided by 100
+      }
+      else {
+        tempAdvance2 = tempAdvance + tempAdvance2;
+      }
+
     }
 
     if (tempAdvance2 > 127) { tempAdvance2 = 127; } //make sure we don't overflow and accidentally set negative timing, currentStatus.advance can only hold a signed 8 bit value

--- a/speeduino/advance.cpp
+++ b/speeduino/advance.cpp
@@ -102,7 +102,7 @@ int16_t getAdvance2()
   else if(configPage10.spark2Algorithm == LOAD_SOURCE_TPS)
   {
     //Alpha-N
-    currentStatus.ignLoad2 = currentStatus.TPS;
+    currentStatus.ignLoad2 = currentStatus.TPS * 2;
   }
   else if (configPage10.spark2Algorithm == LOAD_SOURCE_IMAPEMAP)
   {

--- a/speeduino/advance.cpp
+++ b/speeduino/advance.cpp
@@ -1,0 +1,135 @@
+/** \file advance.cpp
+ * @brief Functions for calculating degrees of ignition advance
+ * 
+ */
+
+#include "globals.h"
+#include "advance.h"
+#include "corrections.h"
+
+/** Gets the correct advance based on which table and corrections
+ * 
+ * @return byte The current target advance value in degrees
+ */
+
+int8_t getAdvance() {
+  int16_t tempAdvance = 0; // Result
+
+  if( shouldWeUseSparkTable2() == true ) //Spark table 2
+  {
+    currentStatus.advance1 = 0; // Since this isn't valid anymore reset it
+
+    BIT_SET(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Set the bit indicating that the 2nd spark table is in use.
+    int16_t tempAdvance2 = getAdvance2(); // Advance from table 2
+
+    if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY)
+    {
+      if(tempAdvance2 < 0) { tempAdvance2 = 0; } //Negative values not supported
+      tempAdvance2 = (getAdvance1() * tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divded by 100
+    }
+    else if(configPage10.spark2Mode == SPARK2_MODE_ADD)
+    {
+      tempAdvance2 = getAdvance1() + tempAdvance2;
+    }
+
+    if (tempAdvance2 > 127) { tempAdvance2 = 127; } //make sure we don't overflow and accidentally set negative timing, currentStatus.advance can only hold a signed 8 bit value
+
+    tempAdvance = currentStatus.advance2 = correctionsIgn(tempAdvance2); // Apply corrections
+  }
+  else { //Spark table 1
+    currentStatus.advance2 = 0; // Since this isn't valid anymore reset it
+
+    BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Clear the bit indicating that the 2nd spark table is in use.
+
+    tempAdvance = currentStatus.advance1 = correctionsIgn(getAdvance1()); // Apply corrections
+  }
+
+  return tempAdvance;
+}
+
+/** Lookup the ignition advance from 3D ignition table.
+ * The values used to look this up will be RPM and whatever load source the user has configured.
+ * 
+ * @return byte The current target advance value in degrees
+ */
+int16_t getAdvance1()
+{
+  int16_t tempAdvance = 0;
+  if (configPage2.ignAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
+  {
+    //Speed Density
+    currentStatus.ignLoad = currentStatus.MAP;
+  }
+  else if(configPage2.ignAlgorithm == LOAD_SOURCE_TPS)
+  {
+    //Alpha-N
+    currentStatus.ignLoad = currentStatus.TPS * 2;
+
+  }
+  else if (configPage2.fuelAlgorithm == LOAD_SOURCE_IMAPEMAP)
+  {
+    //IMAP / EMAP
+    currentStatus.ignLoad = (currentStatus.MAP * 100) / currentStatus.EMAP;
+  }
+
+  tempAdvance = get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
+
+  return tempAdvance;
+}
+
+/**
+ * @brief Performs a lookup of the second ignition advance table. The values used to look this up will be RPM and whatever load source the user has configured
+ * 
+ * @return byte The current target advance value in degrees
+ */
+int16_t getAdvance2()
+{
+  int16_t tempAdvance = 0;
+  if (configPage10.spark2Algorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
+  {
+    //Speed Density
+    currentStatus.ignLoad2 = currentStatus.MAP;
+  }
+  else if(configPage10.spark2Algorithm == LOAD_SOURCE_TPS)
+  {
+    //Alpha-N
+    currentStatus.ignLoad2 = currentStatus.TPS;
+  }
+  else if (configPage10.spark2Algorithm == LOAD_SOURCE_IMAPEMAP)
+  {
+    //IMAP / EMAP
+    currentStatus.ignLoad2 = (currentStatus.MAP * 100) / currentStatus.EMAP;
+  }
+  else { currentStatus.ignLoad2 = currentStatus.MAP; }
+
+  tempAdvance = get3DTableValue(&ignitionTable2, currentStatus.ignLoad2, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
+
+  return tempAdvance;
+}
+
+/** Checks if we should use spark table 2
+ * 
+ * @return bool Returns true if the settings and currentStatus says we should use spark table 2
+ */
+
+bool shouldWeUseSparkTable2() {
+  if (configPage10.spark2Mode <= 0)
+  { return false; }
+
+  if (configPage10.spark2Mode == SPARK2_MODE_MULTIPLY || configPage10.spark2Mode == SPARK2_MODE_ADD )
+  { return true; }
+
+  if (configPage10.spark2Mode == SPARK2_MODE_CONDITIONAL_SWITCH) {
+    if ( (configPage10.spark2SwitchVariable == SPARK2_CONDITION_RPM && currentStatus.RPM > configPage10.spark2SwitchValue       ) ||
+         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_MAP && currentStatus.MAP > configPage10.spark2SwitchValue       ) ||
+         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_TPS && currentStatus.TPS > configPage10.spark2SwitchValue       ) ||
+         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_ETH && currentStatus.ethanolPct > configPage10.spark2SwitchValue) )
+    { return true; }
+  }
+
+  else if ( configPage10.spark2Mode == SPARK2_MODE_INPUT_SWITCH && digitalRead(pinSpark2Input) == configPage10.spark2InputPolarity)
+  { return true; }
+
+  //Default
+  return false;
+}

--- a/speeduino/advance.cpp
+++ b/speeduino/advance.cpp
@@ -15,7 +15,7 @@
 int8_t getAdvance() {
   int16_t tempAdvance = 0; // Result
 
-  if( shouldWeUseSparkTable2() == true ) //Spark table 2
+  if( sparkTable2Enabled() == true ) //Spark table 2
   {
     currentStatus.advance1 = 0; // Since this isn't valid anymore reset it
 
@@ -112,7 +112,7 @@ int16_t getAdvance2()
  * @return bool Returns true if the settings and currentStatus says we should use spark table 2
  */
 
-bool shouldWeUseSparkTable2() {
+bool sparkTable2Enabled() {
   if (configPage10.spark2Mode <= 0)
   { return false; }
 

--- a/speeduino/advance.h
+++ b/speeduino/advance.h
@@ -1,0 +1,14 @@
+/** \file advance.h
+ * @brief Functions for calculating degrees of ignition advance
+ * 
+ */
+
+#ifndef ADVANCE_H
+#define ADVANCE_H
+
+int8_t getAdvance();
+int16_t getAdvance1();
+int16_t getAdvance2();
+bool shouldWeUseSparkTable2();
+
+#endif // ADVANCE_H

--- a/speeduino/advance.h
+++ b/speeduino/advance.h
@@ -9,6 +9,6 @@
 int8_t getAdvance();
 int16_t getAdvance1();
 int16_t getAdvance2();
-bool shouldWeUseSparkTable2();
+bool sparkTable2Enabled();
 
 #endif // ADVANCE_H

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1358,7 +1358,10 @@ struct config10 {
   byte spark2InputPolarity : 1;
   byte spark2InputPullup : 1;
 
-  byte unused11_187_191[2]; //Bytes 187-191
+  //Byte 190-191
+  byte spark2correctedMultiplyAddedAdvance : 1;
+  byte unused11_190_bits: 7;
+  byte unused11_191;
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/secondaryTables.h
+++ b/speeduino/secondaryTables.h
@@ -1,4 +1,2 @@
 void calculateSecondaryFuel();
-bool shouldWeUseSparkTable2();
 byte getVE2();
-int16_t getAdvance2();

--- a/speeduino/secondaryTables.h
+++ b/speeduino/secondaryTables.h
@@ -1,4 +1,4 @@
 void calculateSecondaryFuel();
 bool shouldWeUseSparkTable2();
 byte getVE2();
-byte getAdvance2();
+int16_t getAdvance2();

--- a/speeduino/secondaryTables.h
+++ b/speeduino/secondaryTables.h
@@ -1,4 +1,4 @@
 void calculateSecondaryFuel();
-void calculateSecondarySpark();
+bool shouldWeUseSparkTable2();
 byte getVE2();
 byte getAdvance2();

--- a/speeduino/secondaryTables.ino
+++ b/speeduino/secondaryTables.ino
@@ -137,9 +137,9 @@ byte getVE2()
  * 
  * @return byte The current target advance value in degrees
  */
-byte getAdvance2()
+int16_t getAdvance2()
 {
-  byte tempAdvance = 0;
+  int16_t tempAdvance = 0;
   if (configPage10.spark2Algorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
   {
     //Speed Density
@@ -157,6 +157,7 @@ byte getAdvance2()
     currentStatus.ignLoad2 = (currentStatus.MAP * 100) / currentStatus.EMAP;
   }
   else { currentStatus.ignLoad2 = currentStatus.MAP; }
+
   tempAdvance = get3DTableValue(&ignitionTable2, currentStatus.ignLoad2, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
 
   return tempAdvance;

--- a/speeduino/secondaryTables.ino
+++ b/speeduino/secondaryTables.ino
@@ -75,33 +75,6 @@ void calculateSecondaryFuel()
   }
 }
 
-/** Checks if we should use spark table 2
- * 
- * @return bool Returns true if the settings and currentStatus says we should use spark table 2
- */
-
-bool shouldWeUseSparkTable2() {
-  if (configPage10.spark2Mode <= 0)
-  { return false; }
-
-  if (configPage10.spark2Mode == SPARK2_MODE_MULTIPLY || configPage10.spark2Mode == SPARK2_MODE_ADD )
-  { return true; }
-
-  if (configPage10.spark2Mode == SPARK2_MODE_CONDITIONAL_SWITCH) {
-    if ( (configPage10.spark2SwitchVariable == SPARK2_CONDITION_RPM && currentStatus.RPM > configPage10.spark2SwitchValue       ) ||
-         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_MAP && currentStatus.MAP > configPage10.spark2SwitchValue       ) ||
-         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_TPS && currentStatus.TPS > configPage10.spark2SwitchValue       ) ||
-         (configPage10.spark2SwitchVariable == SPARK2_CONDITION_ETH && currentStatus.ethanolPct > configPage10.spark2SwitchValue) )
-    { return true; }
-  }
-
-  else if ( configPage10.spark2Mode == SPARK2_MODE_INPUT_SWITCH && digitalRead(pinSpark2Input) == configPage10.spark2InputPolarity)
-  { return true; }
-
-  //Default
-  return false;
-}
-
 /**
  * @brief Looks up and returns the VE value from the secondary fuel table
  * 
@@ -130,35 +103,4 @@ byte getVE2()
   tempVE = get3DTableValue(&fuelTable2, currentStatus.fuelLoad2, currentStatus.RPM); //Perform lookup into fuel map for RPM vs MAP value
 
   return tempVE;
-}
-
-/**
- * @brief Performs a lookup of the second ignition advance table. The values used to look this up will be RPM and whatever load source the user has configured
- * 
- * @return byte The current target advance value in degrees
- */
-int16_t getAdvance2()
-{
-  int16_t tempAdvance = 0;
-  if (configPage10.spark2Algorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
-  {
-    //Speed Density
-    currentStatus.ignLoad2 = currentStatus.MAP;
-  }
-  else if(configPage10.spark2Algorithm == LOAD_SOURCE_TPS)
-  {
-    //Alpha-N
-    currentStatus.ignLoad2 = currentStatus.TPS * 2;
-
-  }
-  else if (configPage10.spark2Algorithm == LOAD_SOURCE_IMAPEMAP)
-  {
-    //IMAP / EMAP
-    currentStatus.ignLoad2 = (currentStatus.MAP * 100) / currentStatus.EMAP;
-  }
-  else { currentStatus.ignLoad2 = currentStatus.MAP; }
-
-  tempAdvance = get3DTableValue(&ignitionTable2, currentStatus.ignLoad2, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
-
-  return tempAdvance;
 }

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -18,6 +18,7 @@ void loop();
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
 byte getVE1();
 byte getAdvance1();
+int8_t getAdvance();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);
 void calculateIgnitionAngle1(int);

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -17,7 +17,7 @@ void setup();
 void loop();
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
 byte getVE1();
-byte getAdvance1();
+int8_t getAdvance1();
 int8_t getAdvance();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -17,8 +17,6 @@ void setup();
 void loop();
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
 byte getVE1();
-int16_t getAdvance1();
-int8_t getAdvance();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);
 void calculateIgnitionAngle1(int);

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -17,7 +17,7 @@ void setup();
 void loop();
 uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
 byte getVE1();
-int8_t getAdvance1();
+int16_t getAdvance1();
 int8_t getAdvance();
 
 uint16_t calculateInjectorStartAngle(uint16_t, int16_t);

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1420,7 +1420,7 @@ int8_t getAdvance() {
 
   if( shouldWeUseSparkTable2() == true ) //Spark table 2
   {
-    if (currentStatus.advance1 != 0) { currentStatus.advance1 = 0; } // Since this isn't valid anymore reset it
+    currentStatus.advance1 = 0; // Since this isn't valid anymore reset it
 
     BIT_SET(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Set the bit indicating that the 2nd spark table is in use.
     int16_t tempAdvance2 = getAdvance2(); // Advance from table 2
@@ -1440,7 +1440,7 @@ int8_t getAdvance() {
     tempAdvance = currentStatus.advance2 = correctionsIgn(tempAdvance2); // Apply corrections
   }
   else { //Spark table 1
-    if (currentStatus.advance2 != 0) { currentStatus.advance2 = 0; } // Since this isn't valid anymore reset it
+    currentStatus.advance2 = 0; // Since this isn't valid anymore reset it
 
     BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Clear the bit indicating that the 2nd spark table is in use.
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -421,11 +421,9 @@ void loop()
     currentStatus.VE1 = getVE1();
     currentStatus.VE = currentStatus.VE1; //Set the final VE value to be VE 1 as a default. This may be changed in the section below
 
-    currentStatus.advance1 = getAdvance1();
-    currentStatus.advance = currentStatus.advance1; //Set the final advance value to be advance 1 as a default. This may be changed in the section below
-
+    currentStatus.advance = getAdvance();
+    
     calculateSecondaryFuel();
-    calculateSecondarySpark();
 
     //Always check for sync
     //Main loop runs within this clause
@@ -1407,7 +1405,47 @@ byte getAdvance1()
     currentStatus.ignLoad = (currentStatus.MAP * 100) / currentStatus.EMAP;
   }
   tempAdvance = get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
-  tempAdvance = correctionsIgn(tempAdvance);
+
+  return tempAdvance;
+}
+
+/** Gets the correct advance based on which table and corrections
+ * 
+ * @return byte The current target advance value in degrees
+ */
+
+int8_t getAdvance() {
+  int8_t tempAdvance = 0; // Result
+
+  if( shouldWeUseSparkTable2() == true )
+  {
+    BIT_SET(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Set the bit indicating that the 2nd spark table is in use.
+    int8_t tempAdvance2 = getAdvance2(); // Advance from table 2
+
+    if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY)
+    {
+      if(tempAdvance2 < 0) { tempAdvance2 = 0; } //make sure we don't have a negative value in the multiplier table (sharing a signed 8 bit table)
+      int16_t combinedAdvance = ((int16_t)getAdvance1() * (int16_t)tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divded by 100
+      if(combinedAdvance <= 127) { tempAdvance2 = combinedAdvance; } //make sure we don't overflow and accidentally set negative timing, currentStatus.advance can only hold a signed 8 bit value
+      else { tempAdvance2 = 127; }
+    }
+    else if(configPage10.spark2Mode == SPARK2_MODE_ADD)
+    {
+      int16_t combinedAdvance = (int16_t)getAdvance1() + (int16_t)tempAdvance2; //make sure we don't overflow and accidentally set negative timing, currentStatus.advance can only hold a signed 8 bit value
+      if(combinedAdvance <= 127) { tempAdvance2 = combinedAdvance; }
+      else { tempAdvance2 = 127; }
+    }
+
+    if (currentStatus.advance1 != 0) { currentStatus.advance1 = 0; }
+
+    tempAdvance = currentStatus.advance2 = correctionsIgn(tempAdvance2);
+  }
+  else {
+    BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_SPARK2_ACTIVE); //Clear the bit indicating that the 2nd spark table is in use.
+    if (currentStatus.advance2 != 0) { currentStatus.advance2 = 0; }
+
+    tempAdvance = currentStatus.advance1 = correctionsIgn(getAdvance1());
+  }
 
   return tempAdvance;
 }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1385,7 +1385,7 @@ byte getVE1()
  * 
  * @return byte The current target advance value in degrees
  */
-int8_t getAdvance1()
+int16_t getAdvance1()
 {
   int16_t tempAdvance = 0;
   if (configPage2.ignAlgorithm == LOAD_SOURCE_MAP) //Check which fuelling algorithm is being used
@@ -1406,7 +1406,6 @@ int8_t getAdvance1()
   }
 
   tempAdvance = get3DTableValue(&ignitionTable, currentStatus.ignLoad, currentStatus.RPM) - OFFSET_IGNITION; //As above, but for ignition advance
-  if (tempAdvance > 127) { tempAdvance = 127; }
 
   return tempAdvance;
 }
@@ -1429,11 +1428,11 @@ int8_t getAdvance() {
     if(configPage10.spark2Mode == SPARK2_MODE_MULTIPLY)
     {
       if(tempAdvance2 < 0) { tempAdvance2 = 0; } //Negative values not supported
-      tempAdvance2 = ((int16_t)getAdvance1() * tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divded by 100
+      tempAdvance2 = (getAdvance1() * tempAdvance2) / 100; //Spark 2 table is treated as a % value. Table 1 and 2 are multiplied together and divded by 100
     }
     else if(configPage10.spark2Mode == SPARK2_MODE_ADD)
     {
-      tempAdvance2 = (int16_t)getAdvance1() + tempAdvance2;
+      tempAdvance2 = getAdvance1() + tempAdvance2;
     }
 
     if (tempAdvance2 > 127) { tempAdvance2 = 127; } //make sure we don't overflow and accidentally set negative timing, currentStatus.advance can only hold a signed 8 bit value

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -16,7 +16,7 @@
 
 void doUpdates()
 {
-  #define CURRENT_DATA_VERSION    19
+  #define CURRENT_DATA_VERSION    20
   //Only the latest updat for small flash devices must be retained
    #ifndef SMALL_FLASH_MODE
 
@@ -581,6 +581,20 @@ void doUpdates()
     configPage4.vvtMinClt = 0;
     writeAllConfig();
     storeEEPROMVersion(19);
+  }
+
+  if(readEEPROMVersion() == 19)
+  {
+    // Set spark2correctedMultiplyAddedAdvance appropriately
+    if (configPage10.spark2Mode == SPARK2_MODE_MULTIPLY || configPage10.spark2Mode == SPARK2_MODE_ADD) {
+      configPage10.spark2correctedMultiplyAddedAdvance = false; // Use the old calculation for existing tunes that are affected
+    }
+    else {
+      configPage10.spark2correctedMultiplyAddedAdvance = true; // Use the new calculation for tunes that aren't affected. Prevents old calculation from being used if the spark2mode is changed.
+    }
+
+    writeAllConfig();
+    storeEEPROMVersion(20);
   }
 
   //Final check is always for 255 and 0 (Brand new arduino)


### PR DESCRIPTION
Fixes locked timing and cranking for multiply and added secondary table. The corrections were not applied last thus the degrees did not match.
Corrections are only applied once for add and multiply secondary table. This will probably mean those tunes will need to be modified, however I couldn't get the multiplied and added modes to work correctly on the previous build.
Advance1 and advance2 are only retrieved/calculated if required (meaning the table that isn't used will show 0 degrees in tunerstudio).
Performance improvements in some circumstances (unchanged when table 1 is active, 5-8% when table 2 is active).