### PR TITLE
TPS or MAP load for AFR Target table

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -580,7 +580,7 @@ page = 5
 #endif
 
       rpmBinsAFR  = array,  U08,   256,[   16],    "RPM",   100.0,     0.0,   100,   25500,      0
-      loadBinsAFR  = array,  U08,   272,[   16],    { bitStringValue(algorithmUnits ,  algorithm) },        2.0,      0.0,   0.0,   {fuelLoadMax},      0
+      loadBinsAFR  = array,  U08,   272,[   16],    { bitStringValue(algorithmUnits ,  afrLoadSource) },        2.0,      0.0,   0.0,   {afrLoadMax},      0
 
 ;--------------------------------------------------
 ;Start page 6
@@ -618,7 +618,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      unused_bit  =   bits, U08,      14, [6:6],      "No", "Yes"
+      afrLoadSource  =   bits, U08,      14, [6:6],      "MAP", "TPS"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -1813,7 +1813,7 @@ menuDialog = main
   mapSwitchPoint    = "Below this RPM instantaneous map sample method is used, instead of selected one.\nSet 0 RPM to disable (Default)"
   stoich            = "The stoichiometric ration of the fuel being used. For flex fuel, choose the primary fuel"
   injLayout         = "The injector layout and timing to be used. Options are: \n 1. Paired - 2 injectors per output. Outputs active is equal to half the number of cylinders. Outputs are timed over 1 crank revolution. \n 2. Semi-sequential: Same as paired except that injector channels are mirrored (1&4, 2&3) meaning the number of outputs used are equal to the number of cylinders. Only valid for 4 cylinders or less. \n 3. Banked: 2 outputs only used. \n 4. Sequential: 1 injector per output and outputs used equals the number of cylinders. Injection is timed over full cycle. "
-
+  afrLoadSource     = "Allows you to select different load source for the AFR Target table based on the user preference"
   TrigPattern       = "The type of input trigger decoder to be used."
   useResync         = "If enabled, sync will be rechecked once every full cycle from the cam input. This is good for accuracy, however if your cam input is noisy then this can cause issues."
   trigPatternSec    = "Cam mode/type also known as Secondary Trigger Pattern."
@@ -2214,6 +2214,7 @@ menuDialog = main
         field = "Board Layout",             pinLayout
         field = "MAP Sample method",        mapSample
         field = "MAP Sample switch point",  mapSwitchPoint,      { mapSample >= 1 }
+        field = "AFR Target Load source",            afrLoadSource,
 
     dialog = engine_constants_west, ""
         panel = std_injection, North
@@ -4410,7 +4411,7 @@ cmdVSSratio6 =      "E\x99\x06"
     ;table = afrTbl,    afrTableMap,    "AFR Table", 5
     table = afrTable1Tbl, afrTable1Map, "AFR Table", 5
       xBins = rpmBinsAFR, rpm
-      yBins = loadBinsAFR, fuelLoad
+      yBins = loadBinsAFR, afrLoad
       zBins = afrTable
       gridHeight  = 1.0
       upDownLabel = "RICHER", "LEANER"
@@ -4941,7 +4942,8 @@ cmdVSSratio6 =      "E\x99\x06"
    ignLoadMax  = { (ignAlgorithm == 0 || ignAlgorithm == 2) ? 511 : 100 }
    fuel2LoadMax  = { (fuel2Algorithm == 0 || fuel2Algorithm == 2) ? 511 : 100 }
    ign2LoadMax  = { (spark2Algorithm == 0 || spark2Algorithm == 2) ? 511 : 100 }
-
+   afrLoadMax   = { (afrLoadSource == 0 ) ? 511 : 100 }
+   afrLoad     = { (afrLoadSource == 0) ? map : tps }
    fuelLoad2    = { fuel2Algorithm == 0 ? map : fuel2Algorithm == 1 ? tps : fuel2Algorithm == 2 ? 0 : 0 }
    ignLoad2     = { spark2Algorithm == 0 ? map : spark2Algorithm == 1 ? tps : spark2Algorithm == 2 ? 0 : ignLoad }
    vvtLoad      = { (vvtLoadSource == 0) ? map : tps }

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -598,7 +598,11 @@ byte correctionAFRClosedLoop()
 
     //Determine whether the Y axis of the AFR target table tshould be MAP (Speed-Density) or TPS (Alpha-N)
     //Note that this should only run after the sensor warmup delay when using Include AFR option, but on Incorporate AFR option it needs to be done at all times
-    if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
+    if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) 
+        { 
+          if (configPage6.afrLoad == 0) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.MAP, currentStatus.RPM); }
+            else { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.TPS, currentStatus.RPM); }
+        } //Perform the target lookup
   }
   
   if( configPage6.egoType > 0 ) //egoType of 0 means no O2 sensor

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1030,7 +1030,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte unused_bit : 1; //Previously was VVTasOnOff
+  byte afrLoad : 1; //Previously was VVTasOnOff
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -481,7 +481,7 @@ void doUpdates()
     configPage10.TrigEdgeThrd = 0;
 
     //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    //if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
 
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;


### PR DESCRIPTION
Allows the user to select MAP or TPS as the load source for AFR target table. It uses a single bit. 