### PR TITLE
Packed enums: use compiler flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ platform=atmelavr
 board=megaatmega2560
 framework=arduino
 build_unflags = -Os
-build_flags = -O3 -ffast-math -funroll-loops -Wall -Wextra -std=c99
+build_flags = -O3 -ffast-math -fshort-enums -funroll-loops -Wall -Wextra -std=c99
 lib_deps = EEPROM, Time
 test_build_project_src = true
 debug_tool = simavr

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -17,9 +17,7 @@
 #define STEPPER_BACKWARD 1
 #define IDLE_TABLE_SIZE 10
 
-typedef enum __attribute__ ((__packed__)) /* Packed is required to minimize to 8-bit */ {
-  SOFF, STEPPING, COOLING
-} StepperStatus; //The 2 statuses that a stepper can have. STEPPING means that a high pulse is currently being sent and will need to be turned off at some point.
+enum StepperStatus {SOFF, STEPPING, COOLING}; //The 2 statuses that a stepper can have. STEPPING means that a high pulse is currently being sent and will need to be turned off at some point.
 
 struct StepperIdle
 {

--- a/speeduino/pages.h
+++ b/speeduino/pages.h
@@ -51,12 +51,12 @@ void setPageValue(  byte pageNum,       /**< [in] The page number to retrieve da
 // over those entities.
 
 // Type of entity
-typedef enum __attribute__ ((__packed__)) /* Packed is required to minimize to 8-bit */ { 
+enum entity_type { 
     Raw,        // A block of memory
     Table,      // A 3D table
     NoEntity,   // No entity, but a valid offset
     End         // The offset was past any known entity for the page
-} entity_type;
+};
 
 // A entity on a logical page.
 struct page_iterator_t {

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -157,9 +157,8 @@ inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((alw
  * - STAGED - (???, Not used)
  * - RUNNING - Schedule is currently running
  */
-typedef enum __attribute__ ((__packed__)) /* Packed is required to minimize to 8-bit */ {  
-  OFF, PENDING, STAGED, RUNNING
-} ScheduleStatus; //The statuses that a schedule can have
+enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The statuses that a schedule can have
+
 /** Ignition schedule.
  */
 struct Schedule {

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -22,9 +22,8 @@ Hence we will preload the timer with 131 cycles to leave 125 until overflow (1ms
 volatile bool tachoAlt = false;
 #define TACHO_PULSE_HIGH() *tach_pin_port |= (tach_pin_mask)
 #define TACHO_PULSE_LOW() *tach_pin_port &= ~(tach_pin_mask)
-typedef enum __attribute__ ((__packed__)) /* Packed is required to minimize to 8-bit */ {
-  DEACTIVE, READY, ACTIVE
-} TachoOutputStatus; //The 3 statuses that the tacho output pulse can have
+enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tacho output pulse can have
+
 volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
 volatile TachoOutputStatus tachoOutputFlag;
 


### PR DESCRIPTION
Use -fshort-enums instead of packing individual enums.

- This is future proof - devs don't have to remember to add the `packed `attribute to any new enums
- It's compatible with Doxygen