### PR TITLE
don't manually set values for ADCFILTER defaults, use defines

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -530,7 +530,7 @@ page = 4
       ignBypassEnable = bits,   U08,  63, [0:0],      "Off",        "On"
       ignBypassPin    = bits,   U08,  63, [1:6],      "INVALID", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
       ignBypassHiLo   = bits,   U08,  63, [7:7],      "LOW",        "HIGH"
-;Analog input filter levels (Note max values are 254 so that default values of 255 can be overwirtten on bootup)
+;Analog input filter levels (Note max values are 240 so that default values of 255 can be overwritten on bootup)
       ADCFILTER_TPS   = scalar, U08,      64, "%",          1.0,  0.0,   0,     240,    0
       ADCFILTER_CLT   = scalar, U08,      65, "%",          1.0,  0.0,   0,     240,    0
       ADCFILTER_IAT   = scalar, U08,      66, "%",          1.0,  0.0,   0,     240,    0
@@ -1534,7 +1534,8 @@ page = 14
     defaultValue = ADCFILTER_BAT, 128
     defaultValue = ADCFILTER_MAP,  20 ;This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
     defaultValue = ADCFILTER_BARO, 64
-    defaultValue = FILTER_FLEX,   75
+    defaultValue = FILTER_FLEX,    75
+
     ;Again, force the setting from the controller for the trigger edges. This is particularly useful for the Oct 2018 update where the names of the dges changed
     controllerPriority = TrigEdge
     controllerPriority = TrigEdgeSec
@@ -2138,7 +2139,7 @@ menuDialog = main
   ADCFILTER_BAT   = "Recommended value: 128"
   ADCFILTER_MAP   = "This setting is only available when using the Instantaneious MAP sampling method. Recommended value: 20"
   ADCFILTER_BARO  = "This setting is only available when using an external Baro sensor. Recommended value: 64"
-  FILTER_FLEX     = "Higher values provide more filtering, but slower Eth% and fuel temp response"
+  FILTER_FLEX     = "Higher values provide more filtering, but slower Eth% and fuel temp response. Recommended value: 75"
 
   boostIntv       = "The closed loop control interval will run every this many ms. Generally values between 50% and 100% of the valve frequency work best"
   boostByGearEnabled = "Open loop -> Constant limit in Duty cycle %\nClosed Loop -> Constant limit in kPa\nIn both cases the multiplied option simply takes a percentage of the values in the boost table"
@@ -2874,8 +2875,8 @@ menuDialog = main
         field = "Higher values result in stronger filtering, but slower response times for readings"
         field = "#Most setups will NOT require changes to the default filter values"
         field = ""
-        slider = "Throttle Position Sensor",    ADCFILTER_TPS,  horizontal
-        slider = "Coolant Sensor",              ADCFILTER_CLT,  horizontal
+        slider = "Throttle Position sensor",    ADCFILTER_TPS,  horizontal
+        slider = "Coolant sensor",              ADCFILTER_CLT,  horizontal
         slider = "Inlet Air Temp sensor",       ADCFILTER_IAT,  horizontal
         slider = "O2 sensor",                   ADCFILTER_O2,   horizontal
         slider = "Battery voltage",             ADCFILTER_BAT,  horizontal

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -4,16 +4,18 @@
 #include "Arduino.h"
 
 // The following are alpha values for the ADC filters.
-// Their values are from 0 to 255 with 0 being no filtering and 255 being maximum
-/*
-#define ADCFILTER_TPS  128
-#define ADCFILTER_CLT  180
-#define ADCFILTER_IAT  180
-#define ADCFILTER_O2   128
-#define ADCFILTER_BAT  128
-#define ADCFILTER_MAP   20 //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
-#define ADCFILTER_BARO  64
-*/
+// Their values are from 0 to 240, with 0 being no filtering and 240 being maximum
+#define ADCFILTER_TPS_DEFAULT   50
+#define ADCFILTER_CLT_DEFAULT  180
+#define ADCFILTER_IAT_DEFAULT  180
+#define ADCFILTER_O2_DEFAULT   128
+#define ADCFILTER_BAT_DEFAULT  128
+#define ADCFILTER_MAP_DEFAULT   20 //This is only used on Instantaneous MAP readings and is intentionally very weak to allow for faster response
+#define ADCFILTER_BARO_DEFAULT  64
+
+#define ADCFILTER_PSI_DEFAULT  150 //not currently configurable at runtime, used for misc pressure sensors, oil, fuel, etc.
+
+#define FILTER_FLEX_DEFAULT     75
 
 #define BARO_MIN      65
 #define BARO_MAX      108

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -117,14 +117,14 @@ void initialiseADC()
   //Sanity checks to ensure none of the filter values are set above 240 (Which would include the 255 value which is the default on a new arduino)
   //If an invalid value is detected, it's reset to the default the value and burned to EEPROM. 
   //Each sensor has it's own default value
-  if(configPage4.ADCFILTER_TPS > 240) { configPage4.ADCFILTER_TPS = 50; writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_CLT > 240) { configPage4.ADCFILTER_CLT = 180; writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_IAT > 240) { configPage4.ADCFILTER_IAT = 180; writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_O2  > 240) { configPage4.ADCFILTER_O2 = 100; writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_BAT > 240) { configPage4.ADCFILTER_BAT = 128; writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_MAP > 240) { configPage4.ADCFILTER_MAP = 20;  writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_BARO > 240) { configPage4.ADCFILTER_BARO = 64; writeConfig(ignSetPage); }
-  if(configPage4.FILTER_FLEX > 240)   { configPage4.FILTER_FLEX = 75; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_TPS  > 240) { configPage4.ADCFILTER_TPS   = ADCFILTER_TPS_DEFAULT;   writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_CLT  > 240) { configPage4.ADCFILTER_CLT   = ADCFILTER_CLT_DEFAULT;   writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_IAT  > 240) { configPage4.ADCFILTER_IAT   = ADCFILTER_IAT_DEFAULT;   writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_O2   > 240) { configPage4.ADCFILTER_O2    = ADCFILTER_O2_DEFAULT;    writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_BAT  > 240) { configPage4.ADCFILTER_BAT   = ADCFILTER_BAT_DEFAULT;   writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_MAP  > 240) { configPage4.ADCFILTER_MAP   = ADCFILTER_MAP_DEFAULT;   writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_BARO > 240) { configPage4.ADCFILTER_BARO  = ADCFILTER_BARO_DEFAULT;  writeConfig(ignSetPage); }
+  if(configPage4.FILTER_FLEX    > 240) { configPage4.FILTER_FLEX     = FILTER_FLEX_DEFAULT;     writeConfig(ignSetPage); }
 
   flexStartTime = micros();
 
@@ -408,7 +408,6 @@ void readTPS(bool useFilter)
   //The use of the filter can be overridden if required. This is used on startup to disable priming pulse if flood clear is wanted
   if(useFilter == true) { currentStatus.tpsADC = ADC_FILTER(tempTPS, configPage4.ADCFILTER_TPS, currentStatus.tpsADC); }
   else { currentStatus.tpsADC = tempTPS; }
-  //currentStatus.tpsADC = ADC_FILTER(tempTPS, 128, currentStatus.tpsADC);
   byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 
   if(configPage2.tpsMax > configPage2.tpsMin)
@@ -687,7 +686,7 @@ byte getFuelPressure()
     tempReading = analogRead(pinFuelPressure);
 
     tempFuelPressure = fastMap10Bit(tempReading, configPage10.fuelPressureMin, configPage10.fuelPressureMax);
-    tempFuelPressure = ADC_FILTER(tempFuelPressure, 150, currentStatus.fuelPressure); //Apply speed smoothing factor
+    tempFuelPressure = ADC_FILTER(tempFuelPressure, ADCFILTER_PSI_DEFAULT, currentStatus.fuelPressure); //Apply smoothing factor
     //Sanity checks
     if(tempFuelPressure > configPage10.fuelPressureMax) { tempFuelPressure = configPage10.fuelPressureMax; }
     if(tempFuelPressure < 0 ) { tempFuelPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
@@ -709,7 +708,7 @@ byte getOilPressure()
 
 
     tempOilPressure = fastMap10Bit(tempReading, configPage10.oilPressureMin, configPage10.oilPressureMax);
-    tempOilPressure = ADC_FILTER(tempOilPressure, 150, currentStatus.oilPressure); //Apply speed smoothing factor
+    tempOilPressure = ADC_FILTER(tempOilPressure, ADCFILTER_PSI_DEFAULT, currentStatus.oilPressure); //Apply smoothing factor
     //Sanity check
     if(tempOilPressure > configPage10.oilPressureMax) { tempOilPressure = configPage10.oilPressureMax; }
     if(tempOilPressure < 0 ) { tempOilPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -10,6 +10,7 @@
  */
 #include "globals.h"
 #include "storage.h"
+#include "sensors.h"
 #include EEPROM_LIB_H //This is defined in the board .h files
 
 void doUpdates()
@@ -160,13 +161,13 @@ void doUpdates()
     }
 
     //Ability to change the analog filter values was added. Set default values for these:
-    configPage4.ADCFILTER_TPS = 50;
-    configPage4.ADCFILTER_CLT = 180;
-    configPage4.ADCFILTER_IAT = 180;
-    configPage4.ADCFILTER_O2  = 128;
-    configPage4.ADCFILTER_BAT = 128;
-    configPage4.ADCFILTER_MAP = 20;
-    configPage4.ADCFILTER_BARO= 64;
+    configPage4.ADCFILTER_TPS  = ADCFILTER_TPS_DEFAULT;
+    configPage4.ADCFILTER_CLT  = ADCFILTER_CLT_DEFAULT;
+    configPage4.ADCFILTER_IAT  = ADCFILTER_IAT_DEFAULT;
+    configPage4.ADCFILTER_O2   = ADCFILTER_O2_DEFAULT;
+    configPage4.ADCFILTER_BAT  = ADCFILTER_BAT_DEFAULT;
+    configPage4.ADCFILTER_MAP  = ADCFILTER_MAP_DEFAULT;
+    configPage4.ADCFILTER_BARO = ADCFILTER_BARO_DEFAULT;
 
     writeAllConfig();
     storeEEPROMVersion(10);
@@ -541,7 +542,7 @@ void doUpdates()
     configPage13.outputPin[6] = 0;
     configPage13.outputPin[7] = 0;
 
-    configPage4.FILTER_FLEX = 75;
+    configPage4.FILTER_FLEX = FILTER_FLEX_DEFAULT;
 
     storeEEPROMVersion(CURRENT_DATA_VERSION);
   }


### PR DESCRIPTION
Fixes a few inconsistencies where defaults are set to different values, rename flex filter to match other filter ADC naming, expose flex filter adjustment in tunerstudio