### PR TITLE
Allow logging of loopsPerSecond

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5031,6 +5031,7 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = vvt2Angle,       "VVT2 Angle",       int,    "%.1f",        { vvt2Enabled > 0 }
    entry = vvt2Target,      "VVT2 Target Angle",int,    "%.1f",        { vvt2Enabled > 0 && vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Duty,        "VVT2 Duty",        int,    "%.1f",        { vvt2Enabled > 0 && vvtMode == 2 }
+   entry = loopsPerSecond,  "Loops/s",         int,     "%d"
 
    entry = auxin_gauge0,  { stringValue(AUXin00Alias) },  int,     "%d", {(caninput_sel0b != 0)}
    entry = auxin_gauge1,  { stringValue(AUXin01Alias) },  int,     "%d", { (caninput_sel1b != 0)}


### PR DESCRIPTION
The loopsPerSecond measurement has quite a bit of 'noise' - it varies over time even with a rock steady RPM from Ardustim. Allowing it to be logged seems like a useful way to compare performance of code change

Example below:
![graph](https://user-images.githubusercontent.com/13982343/140627237-33bc686f-f2cd-4119-91fa-ed57d6036bbf.png)
s