### PR TITLE
Remove previousLoopTime global variable - never used

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -572,7 +572,6 @@ extern volatile bool injPrimed; //Tracks whether or not the injector priming has
 extern volatile unsigned int toothHistoryIndex;
 extern volatile byte toothHistorySerialIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
-extern unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 //The below shouldn't be needed and probably should be cleaned up, but the Atmel SAM (ARM) boards use a specific type for the trigger edge values rather than a simple byte/int
 #if defined(CORE_SAMD21)

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -136,7 +136,6 @@ volatile bool injPrimed = false; ///< Tracks whether or not the injectors primin
 volatile unsigned int toothHistoryIndex = 0; ///< Current index to @ref toothHistory array
 volatile byte toothHistorySerialIndex = 0;
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
-unsigned long previousLoopTime; /**< The time (in uS) that the previous mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
 #if defined(CORE_SAMD21)
   PinStatus primaryTriggerEdge;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -424,7 +424,6 @@ void initialiseAll()
     }
 
     //Initial values for loop times
-    previousLoopTime = 0;
     currentLoopTime = micros_safe();
     mainLoopCount = 0;
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -164,7 +164,6 @@ void loop()
     //Displays currently disabled
     // if (configPage2.displayType && (mainLoopCount & 255) == 1) { updateDisplay();}
 
-    previousLoopTime = currentLoopTime;
     currentLoopTime = micros_safe();
     unsigned long timeToLastTooth = (currentLoopTime - toothLastToothTime);
     if ( (timeToLastTooth < MAX_STALL_TIME) || (toothLastToothTime > currentLoopTime) ) //Check how long ago the last tooth was seen compared to now. If it was more than half a second ago then the engine is probably stopped. toothLastToothTime can be greater than currentLoopTime if a pulse occurs between getting the lastest time and doing the comparison


### PR DESCRIPTION
It's only ever assigned to, never read