### PR TITLE
Encapsulate decoder initialization

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -324,11 +324,8 @@ void processSerialCommand()
       currentStatus.toothLogEnabled = false;
 
       //Disconnect the logger interrupts and attach the normal ones
-      detachInterrupt( digitalPinToInterrupt(pinTrigger) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger), triggerHandler, primaryTriggerEdge );
-
-      detachInterrupt( digitalPinToInterrupt(pinTrigger2) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger2), triggerSecondaryHandler, secondaryTriggerEdge );
+      attachDecoderIsrToPin(pinTrigger, getDecoder().primary);
+      attachDecoderIsrToPin(pinTrigger2, getDecoder().secondary);
       sendSerialReturnCode(SERIAL_RC_OK);
       break;
 
@@ -359,11 +356,8 @@ void processSerialCommand()
       currentStatus.compositeLogEnabled = false;
 
       //Disconnect the logger interrupts and attach the normal ones
-      detachInterrupt( digitalPinToInterrupt(pinTrigger) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger), triggerHandler, primaryTriggerEdge );
-
-      detachInterrupt( digitalPinToInterrupt(pinTrigger2) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger2), triggerSecondaryHandler, secondaryTriggerEdge );
+      attachDecoderIsrToPin(pinTrigger, getDecoder().primary);
+      attachDecoderIsrToPin(pinTrigger2, getDecoder().secondary);
       sendSerialReturnCode(SERIAL_RC_OK);
       break;
 

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -206,11 +206,8 @@ void legacySerialCommand()
       currentStatus.toothLogEnabled = false;
 
       //Disconnect the logger interrupts and attach the normal ones
-      detachInterrupt( digitalPinToInterrupt(pinTrigger) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger), triggerHandler, primaryTriggerEdge );
-
-      detachInterrupt( digitalPinToInterrupt(pinTrigger2) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger2), triggerSecondaryHandler, secondaryTriggerEdge );
+      attachDecoderIsrToPin(pinTrigger, getDecoder().primary);
+      attachDecoderIsrToPin(pinTrigger2, getDecoder().secondary);
       break;
 
     case 'J': //Start the composite logger
@@ -233,11 +230,8 @@ void legacySerialCommand()
       currentStatus.compositeLogEnabled = false;
 
       //Disconnect the logger interrupts and attach the normal ones
-      detachInterrupt( digitalPinToInterrupt(pinTrigger) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger), triggerHandler, primaryTriggerEdge );
-
-      detachInterrupt( digitalPinToInterrupt(pinTrigger2) );
-      attachInterrupt( digitalPinToInterrupt(pinTrigger2), triggerSecondaryHandler, secondaryTriggerEdge );
+      attachDecoderIsrToPin(pinTrigger, getDecoder().primary);
+      attachDecoderIsrToPin(pinTrigger2, getDecoder().secondary);
       break;
 
     case 'L': // List the contents of current page in human readable form

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -11,6 +11,9 @@
   #define READ_SEC_TRIGGER() digitalRead(pinTrigger2)
 #endif
 
+// This has to match the ordering & numbering in speeduino.ini
+//
+// TODO: generate this list from the ini file
 #define DECODER_MISSING_TOOTH     0
 #define DECODER_BASIC_DISTRIBUTOR 1
 #define DECODER_DUAL_WHEEL        2
@@ -42,168 +45,98 @@
 void loggerPrimaryISR();
 void loggerSecondaryISR();
 
-//All of the below are the 6 required functions for each decoder / pattern
+// A decoder Interrupt Service Routine
+struct decoderISR
+{
+  // Pointer to the ISR function
+  void (*triggerHandler)();
+
+  // The ISR function edge trigger 
+  // E.g. RISING, FALLING or CHANGE
+#if defined(CORE_SAMD21) // The Atmel SAM (ARM) boards use a specific type for the trigger edge values rather than a simple byte/int
+  PinStatus triggerEdge;
+#else
+  byte triggerEdge;
+#endif
+};
+
+inline void attachDecoderIsrToPin(byte pinTrigger, const decoderISR &isr)
+{
+  detachInterrupt(digitalPinToInterrupt(pinTrigger));
+  if (isr.triggerHandler!=NULL) {
+    attachInterrupt(digitalPinToInterrupt(pinTrigger), isr.triggerHandler, isr.triggerEdge);
+  }
+}
+
+// The decoder configuration. This will be initialised by a call to one of
+// the triggerSetup_xx() functions
+struct decoder_t
+{
+  decoderISR primary;
+  decoderISR secondary;
+  decoderISR tertiary;
+  
+  uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to the relevant decoder)
+  int (*getCrankAngle)(); //Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
+  void (*triggerSetEndTeeth)(); //Pointer to the triggerSetEndTeeth function of each decoder
+
+  // Other decoder specific data will eventually go here.
+};
+
+// External *read only* access to the decoder configuration
+//
+// This is just as fast as direct variable access - no drop in
+// loops/sec.
+const decoder_t& getDecoder();
+
+void triggerSetup_Default();
+
 void triggerSetup_missingTooth();
-void triggerPri_missingTooth();
-void triggerSec_missingTooth();
-void triggerThird_missingTooth();
-uint16_t getRPM_missingTooth();
-int getCrankAngle_missingTooth();
-extern void triggerSetEndTeeth_missingTooth();
 
 void triggerSetup_DualWheel();
-void triggerPri_DualWheel();
-void triggerSec_DualWheel();
-uint16_t getRPM_DualWheel();
-int getCrankAngle_DualWheel();
-void triggerSetEndTeeth_DualWheel();
 
 void triggerSetup_BasicDistributor();
-void triggerPri_BasicDistributor();
-void triggerSec_BasicDistributor();
-uint16_t getRPM_BasicDistributor();
-int getCrankAngle_BasicDistributor();
-void triggerSetEndTeeth_BasicDistributor();
 
 void triggerSetup_GM7X();
-void triggerPri_GM7X();
-void triggerSec_GM7X();
-uint16_t getRPM_GM7X();
-int getCrankAngle_GM7X();
-void triggerSetEndTeeth_GM7X();
 
 void triggerSetup_4G63();
-void triggerPri_4G63();
-void triggerSec_4G63();
-uint16_t getRPM_4G63();
-int getCrankAngle_4G63();
-void triggerSetEndTeeth_4G63();
 
 void triggerSetup_24X();
-void triggerPri_24X();
-void triggerSec_24X();
-uint16_t getRPM_24X();
-int getCrankAngle_24X();
-void triggerSetEndTeeth_24X();
 
 void triggerSetup_Jeep2000();
-void triggerPri_Jeep2000();
-void triggerSec_Jeep2000();
-uint16_t getRPM_Jeep2000();
-int getCrankAngle_Jeep2000();
-void triggerSetEndTeeth_Jeep2000();
 
 void triggerSetup_Audi135();
-void triggerPri_Audi135();
-void triggerSec_Audi135();
-uint16_t getRPM_Audi135();
-int getCrankAngle_Audi135();
-void triggerSetEndTeeth_Audi135();
 
 void triggerSetup_HondaD17();
-void triggerPri_HondaD17();
-void triggerSec_HondaD17();
-uint16_t getRPM_HondaD17();
-int getCrankAngle_HondaD17();
-void triggerSetEndTeeth_HondaD17();
 
 void triggerSetup_Miata9905();
-void triggerPri_Miata9905();
-void triggerSec_Miata9905();
-uint16_t getRPM_Miata9905();
-int getCrankAngle_Miata9905();
-void triggerSetEndTeeth_Miata9905();
-int getCamAngle_Miata9905();
 
 void triggerSetup_MazdaAU();
-void triggerPri_MazdaAU();
-void triggerSec_MazdaAU();
-uint16_t getRPM_MazdaAU();
-int getCrankAngle_MazdaAU();
-void triggerSetEndTeeth_MazdaAU();
 
 void triggerSetup_non360();
-void triggerPri_non360();
-void triggerSec_non360();
-uint16_t getRPM_non360();
-int getCrankAngle_non360();
-void triggerSetEndTeeth_non360();
 
 void triggerSetup_Nissan360();
-void triggerPri_Nissan360();
-void triggerSec_Nissan360();
-uint16_t getRPM_Nissan360();
-int getCrankAngle_Nissan360();
-void triggerSetEndTeeth_Nissan360();
 
 void triggerSetup_Subaru67();
-void triggerPri_Subaru67();
-void triggerSec_Subaru67();
-uint16_t getRPM_Subaru67();
-int getCrankAngle_Subaru67();
-void triggerSetEndTeeth_Subaru67();
 
 void triggerSetup_Daihatsu();
-void triggerPri_Daihatsu();
-void triggerSec_Daihatsu();
-uint16_t getRPM_Daihatsu();
-int getCrankAngle_Daihatsu();
-void triggerSetEndTeeth_Daihatsu();
 
 void triggerSetup_Harley();
-void triggerPri_Harley();
-void triggerSec_Harley();
-uint16_t getRPM_Harley();
-int getCrankAngle_Harley();
-void triggerSetEndTeeth_Harley();
 
 void triggerSetup_ThirtySixMinus222();
-void triggerPri_ThirtySixMinus222();
-void triggerSec_ThirtySixMinus222();
-uint16_t getRPM_ThirtySixMinus222();
-int getCrankAngle_ThirtySixMinus222();
-void triggerSetEndTeeth_ThirtySixMinus222();
 
 void triggerSetup_ThirtySixMinus21();
-void triggerPri_ThirtySixMinus21();
-void triggerSec_ThirtySixMinus21();
-uint16_t getRPM_ThirtySixMinus21();
-int getCrankAngle_ThirtySixMinus21();
-void triggerSetEndTeeth_ThirtySixMinus21();
 
 void triggerSetup_420a();
-void triggerPri_420a();
-void triggerSec_420a();
-uint16_t getRPM_420a();
-int getCrankAngle_420a();
-void triggerSetEndTeeth_420a();
 
-void triggerPri_Webber();
-void triggerSec_Webber();
+void triggerSetup_Webber();
 
 void triggerSetup_FordST170();
-void triggerSec_FordST170();
-uint16_t getRPM_FordST170();
-int getCrankAngle_FordST170();
-void triggerSetEndTeeth_FordST170();
 
 void triggerSetup_DRZ400();
-void triggerSec_DRZ400();
 
 void triggerSetup_NGC();
-void triggerPri_NGC();
-void triggerSec_NGC4();
-void triggerSec_NGC68();
-uint16_t getRPM_NGC();
-void triggerSetEndTeeth_NGC();
-
-extern void (*triggerHandler)(); //Pointer for the trigger function (Gets pointed to the relevant decoder)
-extern void (*triggerSecondaryHandler)(); //Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
-extern void (*triggerTertiaryHandler)(); //Pointer for the tertiary trigger function (Gets pointed to the relevant decoder)
-
-extern uint16_t (*getRPM)(); //Pointer to the getRPM function (Gets pointed to the relevant decoder)
-extern int (*getCrankAngle)(); //Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
-extern void (*triggerSetEndTeeth)(); //Pointer to the triggerSetEndTeeth function of each decoder
+void triggerSetup_Vmax();
 
 extern volatile unsigned long curTime;
 extern volatile unsigned long curGap;
@@ -243,7 +176,6 @@ extern volatile bool triggerToothAngleIsCorrect; //Whether or not the triggerToo
 extern bool secondDerivEnabled; //The use of the 2nd derivative calculation is limited to certain decoders. This is set to either true or false in each decoders setup routine
 extern bool decoderIsSequential; //Whether or not the decoder supports sequential operation
 extern bool decoderIsLowRes; //Is set true, certain extra calculations are performed for better timing accuracy
-extern bool decoderHasSecondary; //Whether or not the pattern uses a secondary input
 extern bool decoderHasFixedCrankingTiming; //Whether or not the decoder supports fixed cranking timing
 extern byte checkSyncToothCount; //How many teeth must've been seen on this revolution before we try to confirm sync (Useful for missing tooth type decoders)
 extern unsigned long elapsedTime;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -153,7 +153,7 @@ static inline void addToothLogEntry(unsigned long toothTime, bool whichTooth)
   } //Tooth/Composite log enabled
 }
 
-static inline bool isTrggered(const decoderISR &decoder, const uint8_t triggerState)
+static inline bool isTriggered(const decoderISR &decoder, const uint8_t triggerState)
 {
   return ( (decoder.triggerEdge == RISING) && (triggerState == HIGH) ) || 
          ( (decoder.triggerEdge == FALLING) && (triggerState == LOW) ) || 
@@ -169,7 +169,7 @@ void loggerPrimaryISR()
 {
   validTrigger = false; //This value will be set to the return value of the decoder function, indicating whether or not this pulse passed the filters
   // Need to still call the standard decoder primary trigger. 
-  bool validEdge = isTrggered(decoder.primary, READ_PRI_TRIGGER());
+  bool validEdge = isTriggered(decoder.primary, READ_PRI_TRIGGER());
   if (validEdge)
   {
     decoder.primary.triggerHandler();
@@ -196,7 +196,7 @@ void loggerSecondaryISR()
   validTrigger = true;
 
   // Need to still call the standard decoder secondary trigger. 
-  if(isTrggered(decoder.secondary, READ_SEC_TRIGGER()))
+  if(isTriggered(decoder.secondary, READ_SEC_TRIGGER()))
   {
     decoder.secondary.triggerHandler();
   }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -543,10 +543,6 @@ extern volatile PINMASK_TYPE triggerPri_pin_mask;
 extern volatile PORT_TYPE *triggerSec_pin_port;
 extern volatile PINMASK_TYPE triggerSec_pin_mask;
 
-extern byte triggerInterrupt;
-extern byte triggerInterrupt2;
-extern byte triggerInterrupt3;
-
 //These need to be here as they are used in both speeduino.ino and scheduler.ino
 extern bool channel1InjEnabled;
 extern bool channel2InjEnabled;
@@ -592,16 +588,6 @@ extern volatile bool injPrimed; //Tracks whether or not the injector priming has
 extern volatile unsigned int toothHistoryIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-//The below shouldn't be needed and probably should be cleaned up, but the Atmel SAM (ARM) boards use a specific type for the trigger edge values rather than a simple byte/int
-#if defined(CORE_SAMD21)
-  extern PinStatus primaryTriggerEdge;
-  extern PinStatus secondaryTriggerEdge;
-  extern PinStatus tertiaryTriggerEdge;
-#else
-  extern byte primaryTriggerEdge;
-  extern byte secondaryTriggerEdge;
-  extern byte tertiaryTriggerEdge;
-#endif
 extern int CRANK_ANGLE_MAX;
 extern int CRANK_ANGLE_MAX_IGN;
 extern int CRANK_ANGLE_MAX_INJ;       ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -141,15 +141,6 @@ volatile bool injPrimed = false; ///< Tracks whether or not the injectors primin
 volatile unsigned int toothHistoryIndex = 0; ///< Current index to @ref toothHistory array
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-#if defined(CORE_SAMD21)
-  PinStatus primaryTriggerEdge;
-  PinStatus secondaryTriggerEdge;
-  PinStatus tertiaryTriggerEdge;
-#else
-  byte primaryTriggerEdge;
-  byte secondaryTriggerEdge;
-  byte tertiaryTriggerEdge;
-#endif
 int CRANK_ANGLE_MAX = 720;
 int CRANK_ANGLE_MAX_IGN = 360;
 int CRANK_ANGLE_MAX_INJ = 360; ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -404,7 +404,6 @@ void initialiseAll()
     currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10); //Crank RPM limit (Saves us calculating this over and over again. It's updated once per second in timers.ino)
     currentStatus.fuelPumpOn = false;
     currentStatus.engineProtectStatus = 0;
-    triggerFilterTime = 0; //Trigger filter time is the shortest possible time (in uS) that there can be between crank teeth (ie at max RPM). Any pulses that occur faster than this time will be discarded as noise. This is simply a default value, the actual values are set in the setup() functions of each decoder
     dwellLimit_uS = (1000 * configPage4.dwellLimit);
     currentStatus.nChannels = ((uint8_t)INJ_CHANNELS << 4) + IGN_CHANNELS; //First 4 bits store the number of injection channels, 2nd 4 store the number of ignition channels
     fpPrimeTime = 0;
@@ -2843,391 +2842,80 @@ void setPinMapping(byte boardID)
   flex_pin_mask = digitalPinToBitMask(pinFlex);
 
 }
-/** Initialise the chosen trigger decoder.
- * - Set Interrupt numbers @ref triggerInterrupt, @ref triggerInterrupt2 and @ref triggerInterrupt3  by pin their numbers (based on board CORE_* define)
- * - Call decoder specific setup function triggerSetup_*() (by @ref config4.TrigPattern, set to one of the DECODER_* defines) and do any additional initialisations needed.
- * 
- * @todo Explain why triggerSetup_*() alone cannot do all the setup, but there's ~10+ lines worth of extra init for each of decoders.
- */
+
+
+/** Initialize the user chosen trigger decoder */
 void initialiseTriggers()
 {
-  byte triggerInterrupt = 0; // By default, use the first interrupt
-  byte triggerInterrupt2 = 1;
-  byte triggerInterrupt3 = 2;
-
-  #if defined(CORE_AVR)
-    switch (pinTrigger) {
-      //Arduino Mega 2560 mapping
-      case 2:
-        triggerInterrupt = 0; break;
-      case 3:
-        triggerInterrupt = 1; break;
-      case 18:
-        triggerInterrupt = 5; break;
-      case 19:
-        triggerInterrupt = 4; break;
-      case 20:
-        triggerInterrupt = 3; break;
-      case 21:
-        triggerInterrupt = 2; break;
-      default:
-        triggerInterrupt = 0; break; //This should NEVER happen
-    }
-  #else
-    triggerInterrupt = pinTrigger;
-  #endif
-
-  #if defined(CORE_AVR)
-    switch (pinTrigger2) {
-      //Arduino Mega 2560 mapping
-      case 2:
-        triggerInterrupt2 = 0; break;
-      case 3:
-        triggerInterrupt2 = 1; break;
-      case 18:
-        triggerInterrupt2 = 5; break;
-      case 19:
-        triggerInterrupt2 = 4; break;
-      case 20:
-        triggerInterrupt2 = 3; break;
-      case 21:
-        triggerInterrupt2 = 2; break;
-      default:
-        triggerInterrupt2 = 0; break; //This should NEVER happen
-    }
-  #else
-    triggerInterrupt2 = pinTrigger2;
-  #endif
-
-  #if defined(CORE_AVR)
-    switch (pinTrigger3) {
-      //Arduino Mega 2560 mapping
-      case 2:
-        triggerInterrupt3 = 0; break;
-      case 3:
-        triggerInterrupt3 = 1; break;
-      case 18:
-        triggerInterrupt3 = 5; break;
-      case 19:
-        triggerInterrupt3 = 4; break;
-      case 20:
-        triggerInterrupt3 = 3; break;
-      case 21:
-        triggerInterrupt3 = 2; break;
-      default:
-        triggerInterrupt3 = 0; break; //This should NEVER happen
-    }
-  #else
-    triggerInterrupt3 = pinTrigger3;
-  #endif
-
-  pinMode(pinTrigger, INPUT);
-  pinMode(pinTrigger2, INPUT);
-  pinMode(pinTrigger3, INPUT);
-  //digitalWrite(pinTrigger, HIGH);
-  detachInterrupt(triggerInterrupt);
-  detachInterrupt(triggerInterrupt2);
-  detachInterrupt(triggerInterrupt3);
-  //The default values for edges
-  primaryTriggerEdge = 0; //This should ALWAYS be changed below
-  secondaryTriggerEdge = 0; //This is optional and may not be changed below, depending on the decoder in use
-  tertiaryTriggerEdge = 0; //This is even more optional and may not be changed below, depending on the decoder in use
-
   //Set the trigger function based on the decoder in the config
   switch (configPage4.TrigPattern)
   {
     case DECODER_MISSING_TOOTH:
-      //Missing tooth decoder
       triggerSetup_missingTooth();
-      triggerHandler = triggerPri_missingTooth;
-      triggerSecondaryHandler = triggerSec_missingTooth;
-      triggerTertiaryHandler = triggerThird_missingTooth;
-      decoderHasSecondary = true;
-      getRPM = getRPM_missingTooth;
-      getCrankAngle = getCrankAngle_missingTooth;
-      triggerSetEndTeeth = triggerSetEndTeeth_missingTooth;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-      if(configPage10.TrigEdgeThrd == 0) { tertiaryTriggerEdge = RISING; }
-      else { tertiaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
-      if(configPage10.vvt2Enabled > 0) { attachInterrupt(triggerInterrupt3, triggerTertiaryHandler, tertiaryTriggerEdge); } // we only need this for vvt2, so not really needed if it's not used
-
-      /*
-      if(configPage4.TrigEdge == 0) { attachInterrupt(triggerInterrupt, triggerHandler, RISING); }
-      else { attachInterrupt(triggerInterrupt, triggerHandler, FALLING); }
-      if(configPage4.TrigEdgeSec == 0) { attachInterrupt(triggerInterrupt2, triggerSec_missingTooth, RISING); }
-      else { attachInterrupt(triggerInterrupt2, triggerSec_missingTooth, FALLING); }
-      */
       break;
 
     case DECODER_BASIC_DISTRIBUTOR:
-      // Basic distributor
       triggerSetup_BasicDistributor();
-      triggerHandler = triggerPri_BasicDistributor;
-      getRPM = getRPM_BasicDistributor;
-      getCrankAngle = getCrankAngle_BasicDistributor;
-      triggerSetEndTeeth = triggerSetEndTeeth_BasicDistributor;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
-    case 2:
+    case DECODER_DUAL_WHEEL:
       triggerSetup_DualWheel();
-      triggerHandler = triggerPri_DualWheel;
-      triggerSecondaryHandler = triggerSec_DualWheel;
-      decoderHasSecondary = true;
-      getRPM = getRPM_DualWheel;
-      getCrankAngle = getCrankAngle_DualWheel;
-      triggerSetEndTeeth = triggerSetEndTeeth_DualWheel;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_GM7X:
       triggerSetup_GM7X();
-      triggerHandler = triggerPri_GM7X;
-      getRPM = getRPM_GM7X;
-      getCrankAngle = getCrankAngle_GM7X;
-      triggerSetEndTeeth = triggerSetEndTeeth_GM7X;
-
-      if(configPage4.TrigEdge == 0) { attachInterrupt(triggerInterrupt, triggerHandler, RISING); } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { attachInterrupt(triggerInterrupt, triggerHandler, FALLING); }
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
     case DECODER_4G63:
       triggerSetup_4G63();
-      triggerHandler = triggerPri_4G63;
-      triggerSecondaryHandler = triggerSec_4G63;
-      decoderHasSecondary = true;
-      getRPM = getRPM_4G63;
-      getCrankAngle = getCrankAngle_4G63;
-      triggerSetEndTeeth = triggerSetEndTeeth_4G63;
-
-      primaryTriggerEdge = CHANGE;
-      secondaryTriggerEdge = FALLING;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_24X:
       triggerSetup_24X();
-      triggerHandler = triggerPri_24X;
-      triggerSecondaryHandler = triggerSec_24X;
-      decoderHasSecondary = true;
-      getRPM = getRPM_24X;
-      getCrankAngle = getCrankAngle_24X;
-      triggerSetEndTeeth = triggerSetEndTeeth_24X;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = CHANGE; //Secondary is always on every change
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_JEEP2000:
       triggerSetup_Jeep2000();
-      triggerHandler = triggerPri_Jeep2000;
-      triggerSecondaryHandler = triggerSec_Jeep2000;
-      decoderHasSecondary = true;
-      getRPM = getRPM_Jeep2000;
-      getCrankAngle = getCrankAngle_Jeep2000;
-      triggerSetEndTeeth = triggerSetEndTeeth_Jeep2000;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = CHANGE;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_AUDI135:
       triggerSetup_Audi135();
-      triggerHandler = triggerPri_Audi135;
-      triggerSecondaryHandler = triggerSec_Audi135;
-      decoderHasSecondary = true;
-      getRPM = getRPM_Audi135;
-      getCrankAngle = getCrankAngle_Audi135;
-      triggerSetEndTeeth = triggerSetEndTeeth_Audi135;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = RISING; //always rising for this trigger
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_HONDA_D17:
       triggerSetup_HondaD17();
-      triggerHandler = triggerPri_HondaD17;
-      triggerSecondaryHandler = triggerSec_HondaD17;
-      decoderHasSecondary = true;
-      getRPM = getRPM_HondaD17;
-      getCrankAngle = getCrankAngle_HondaD17;
-      triggerSetEndTeeth = triggerSetEndTeeth_HondaD17;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = CHANGE;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_MIATA_9905:
       triggerSetup_Miata9905();
-      triggerHandler = triggerPri_Miata9905;
-      triggerSecondaryHandler = triggerSec_Miata9905;
-      decoderHasSecondary = true;
-      getRPM = getRPM_Miata9905;
-      getCrankAngle = getCrankAngle_Miata9905;
-      triggerSetEndTeeth = triggerSetEndTeeth_Miata9905;
-
-      //These may both need to change, not sure
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_MAZDA_AU:
       triggerSetup_MazdaAU();
-      triggerHandler = triggerPri_MazdaAU;
-      triggerSecondaryHandler = triggerSec_MazdaAU;
-      decoderHasSecondary = true;
-      getRPM = getRPM_MazdaAU;
-      getCrankAngle = getCrankAngle_MazdaAU;
-      triggerSetEndTeeth = triggerSetEndTeeth_MazdaAU;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = FALLING;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_NON360:
       triggerSetup_non360();
-      triggerHandler = triggerPri_DualWheel; //Is identical to the dual wheel decoder, so that is used. Same goes for the secondary below
-      triggerSecondaryHandler = triggerSec_DualWheel; //Note the use of the Dual Wheel trigger function here. No point in having the same code in twice.
-      decoderHasSecondary = true;
-      getRPM = getRPM_non360;
-      getCrankAngle = getCrankAngle_non360;
-      triggerSetEndTeeth = triggerSetEndTeeth_non360;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = FALLING;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_NISSAN_360:
       triggerSetup_Nissan360();
-      triggerHandler = triggerPri_Nissan360;
-      triggerSecondaryHandler = triggerSec_Nissan360;
-      decoderHasSecondary = true;
-      getRPM = getRPM_Nissan360;
-      getCrankAngle = getCrankAngle_Nissan360;
-      triggerSetEndTeeth = triggerSetEndTeeth_Nissan360;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = CHANGE;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_SUBARU_67:
       triggerSetup_Subaru67();
-      triggerHandler = triggerPri_Subaru67;
-      triggerSecondaryHandler = triggerSec_Subaru67;
-      decoderHasSecondary = true;
-      getRPM = getRPM_Subaru67;
-      getCrankAngle = getCrankAngle_Subaru67;
-      triggerSetEndTeeth = triggerSetEndTeeth_Subaru67;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = FALLING;
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_DAIHATSU_PLUS1:
       triggerSetup_Daihatsu();
-      triggerHandler = triggerPri_Daihatsu;
-      getRPM = getRPM_Daihatsu;
-      getCrankAngle = getCrankAngle_Daihatsu;
-      triggerSetEndTeeth = triggerSetEndTeeth_Daihatsu;
-
-      //No secondary input required for this pattern
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
     case DECODER_HARLEY:
       triggerSetup_Harley();
-      triggerHandler = triggerPri_Harley;
-      //triggerSecondaryHandler = triggerSec_Harley;
-      getRPM = getRPM_Harley;
-      getCrankAngle = getCrankAngle_Harley;
-      triggerSetEndTeeth = triggerSetEndTeeth_Harley;
-
-      primaryTriggerEdge = RISING; //Always rising
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
       break;
 
     case DECODER_36_2_2_2:
-      //36-2-2-2
       triggerSetup_ThirtySixMinus222();
-      triggerHandler = triggerPri_ThirtySixMinus222;
-      triggerSecondaryHandler = triggerSec_ThirtySixMinus222;
-      decoderHasSecondary = true;
-      getRPM = getRPM_ThirtySixMinus222;
-      getCrankAngle = getCrankAngle_missingTooth; //This uses the same function as the missing tooth decoder, so no need to duplicate code
-      triggerSetEndTeeth = triggerSetEndTeeth_ThirtySixMinus222;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_36_2_1:
@@ -3237,123 +2925,39 @@ void initialiseTriggers()
     case DECODER_420A:
       //DSM 420a
       triggerSetup_420a();
-      triggerHandler = triggerPri_420a;
-      triggerSecondaryHandler = triggerSec_420a;
-      decoderHasSecondary = true;
-      getRPM = getRPM_420a;
-      getCrankAngle = getCrankAngle_420a;
-      triggerSetEndTeeth = triggerSetEndTeeth_420a;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      secondaryTriggerEdge = FALLING; //Always falling edge
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_WEBER:
       //Weber-Marelli
-      triggerSetup_DualWheel();
-      triggerHandler = triggerPri_Webber;
-      triggerSecondaryHandler = triggerSec_Webber;
-      decoderHasSecondary = true;
-      getRPM = getRPM_DualWheel;
-      getCrankAngle = getCrankAngle_DualWheel;
-      triggerSetEndTeeth = triggerSetEndTeeth_DualWheel;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
+      triggerSetup_Webber();
       break;
 
     case DECODER_ST170:
       //Ford ST170
       triggerSetup_FordST170();
-      triggerHandler = triggerPri_missingTooth;
-      triggerSecondaryHandler = triggerSec_FordST170;
-      decoderHasSecondary = true;
-      getRPM = getRPM_FordST170;
-      getCrankAngle = getCrankAngle_FordST170;
-      triggerSetEndTeeth = triggerSetEndTeeth_FordST170;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
-
       break;
 
     case DECODER_DRZ400:
       triggerSetup_DRZ400();
-      triggerHandler = triggerPri_DualWheel;
-      triggerSecondaryHandler = triggerSec_DRZ400;
-      decoderHasSecondary = true;
-      getRPM = getRPM_DualWheel;
-      getCrankAngle = getCrankAngle_DualWheel;
-      triggerSetEndTeeth = triggerSetEndTeeth_DualWheel;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = RISING; } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { primaryTriggerEdge = FALLING; }
-      if(configPage4.TrigEdgeSec == 0) { secondaryTriggerEdge = RISING; }
-      else { secondaryTriggerEdge = FALLING; }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_NGC:
       //Chrysler NGC - 4, 6 and 8 cylinder
       triggerSetup_NGC();
-      triggerHandler = triggerPri_NGC;
-      decoderHasSecondary = true;
-      getRPM = getRPM_NGC;
-      getCrankAngle = getCrankAngle_missingTooth;
-      triggerSetEndTeeth = triggerSetEndTeeth_NGC;
-
-      primaryTriggerEdge = CHANGE;
-      if (configPage2.nCylinders == 4) {
-        triggerSecondaryHandler = triggerSec_NGC4;
-        secondaryTriggerEdge = CHANGE;
-      }
-      else {
-        triggerSecondaryHandler = triggerSec_NGC68;
-        secondaryTriggerEdge = FALLING;
-      }
-
-      attachInterrupt(triggerInterrupt, triggerHandler, primaryTriggerEdge);
-      attachInterrupt(triggerInterrupt2, triggerSecondaryHandler, secondaryTriggerEdge);
       break;
 
     case DECODER_VMAX:
       triggerSetup_Vmax();
-      triggerHandler = triggerPri_Vmax;
-      getRPM = getRPM_Vmax;
-      getCrankAngle = getCrankAngle_Vmax;
-      triggerSetEndTeeth = triggerSetEndTeeth_Vmax;
-
-      if(configPage4.TrigEdge == 0) { primaryTriggerEdge = true; } // set as boolean so we can directly use it in decoder.
-      else { primaryTriggerEdge = false; }
-      
-      attachInterrupt(triggerInterrupt, triggerHandler, CHANGE); //Hardcoded change, the primaryTriggerEdge will be used in the decoder to select if it`s an inverted or non-inverted signal.
       break;
 
     default:
-      triggerHandler = triggerPri_missingTooth;
-      getRPM = getRPM_missingTooth;
-      getCrankAngle = getCrankAngle_missingTooth;
-
-      if(configPage4.TrigEdge == 0) { attachInterrupt(triggerInterrupt, triggerHandler, RISING); } // Attach the crank trigger wheel interrupt (Hall sensor drags to ground when triggering)
-      else { attachInterrupt(triggerInterrupt, triggerHandler, FALLING); }
+      triggerSetup_Default();
       break;
   }
+
+  attachDecoderIsrToPin(pinTrigger, getDecoder().primary);
+  attachDecoderIsrToPin(pinTrigger2, getDecoder().secondary);
+  attachDecoderIsrToPin(pinTrigger3, getDecoder().tertiary);
 }
 
 /** Change injectors or/and ignition angles to 720deg.

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -188,7 +188,7 @@ void loop()
     unsigned long timeToLastTooth = (currentLoopTime - toothLastToothTime);
     if ( (timeToLastTooth < MAX_STALL_TIME) || (toothLastToothTime > currentLoopTime) ) //Check how long ago the last tooth was seen compared to now. If it was more than half a second ago then the engine is probably stopped. toothLastToothTime can be greater than currentLoopTime if a pulse occurs between getting the latest time and doing the comparison
     {
-      currentStatus.longRPM = getRPM(); //Long RPM is included here
+      currentStatus.longRPM = getDecoder().getRPM(); //Long RPM is included here
       currentStatus.RPM = currentStatus.longRPM;
       currentStatus.RPMdiv100 = div100(currentStatus.RPM);
       FUEL_PUMP_ON();
@@ -795,7 +795,7 @@ void loop()
       //If ignition timing is being tracked per tooth, perform the calcs to get the end teeth
       //This only needs to be run if the advance figure has changed, otherwise the end teeth will still be the same
       //if( (configPage2.perToothIgn == true) && (lastToothCalcAdvance != currentStatus.advance) ) { triggerSetEndTeeth(); }
-      if( (configPage2.perToothIgn == true) ) { triggerSetEndTeeth(); }
+      if( (configPage2.perToothIgn == true) ) { getDecoder().triggerSetEndTeeth(); }
 
       //***********************************************************************************************
       //| BEGIN FUEL SCHEDULES
@@ -804,7 +804,7 @@ void loop()
       //This may potentially be called a number of times as we get closer and closer to the opening time
 
       //Determine the current crank angle
-      int crankAngle = getCrankAngle();
+      int crankAngle = getDecoder().getCrankAngle();
       while(crankAngle > CRANK_ANGLE_MAX_INJ ) { crankAngle = crankAngle - CRANK_ANGLE_MAX_INJ; } //Continue reducing the crank angle by the max injection amount until it's below the required limit. This will usually only run (at most) once, but in cases where there is sequential ignition and more than 2 squirts per cycle, it may run up to 4 times. 
 
       // if(Serial && false)
@@ -1065,7 +1065,7 @@ void loop()
       {
         //Refresh the current crank angle info
         //ignition1StartAngle = 335;
-        crankAngle = getCrankAngle(); //Refresh with the latest crank angle
+        crankAngle = getDecoder().getCrankAngle(); //Refresh with the latest crank angle
         while (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= CRANK_ANGLE_MAX_IGN; }
 
 #if IGN_CHANNELS >= 1
@@ -1088,7 +1088,7 @@ void loop()
         {
           unsigned long uSToEnd = 0;
 
-          crankAngle = getCrankAngle(); //Refresh with the latest crank angle
+          crankAngle = getDecoder().getCrankAngle(); //Refresh with the latest crank angle
           if (crankAngle > CRANK_ANGLE_MAX_IGN ) { crankAngle -= 360; }
           
           //ONLY ONE OF THE BELOW SHOULD BE USED (PROBABLY THE FIRST):


### PR DESCRIPTION
This is the first of multiple PRs to separate out the encoders from each other. This will make adding new encoders easier and minimize memory (.bss) usage.

Encapsulate decoder initialization into the existing `triggerSetup_xx()` functions. This essentially moves code from `init.ino` to `decoders.ino` so each decoder self configures it's internal and external state.

- 20 byte reduction in RAM
- 2688 byte reduction in Flash
- No loss in performance. Tested on Ardustim using 4G63, Missing Tooth 60-2 & Basic Distributor. Comparison logs below (bright green is master, dark green is this PR):

4G63:
![4G63 at 4500 rpm](https://user-images.githubusercontent.com/13982343/141649597-ecd88f94-6232-4bed-a37c-3999a27d1214.png)

4 cylinder distributor
![Basic Dizzy at 4500 rpm](https://user-images.githubusercontent.com/13982343/141649598-9baae498-a62b-43e5-ad35-98e6d40873e9.png)

Missing Tooth 60-2:
![Missing Tooth 60-2 at 4500 rpm](https://user-images.githubusercontent.com/13982343/141649599-93a307da-4971-4d07-b74c-0aaeb7f62852.png)

