### PR TITLE
Replace toothLastMinusOneToothTime calculations with lastGap

### DIFF
--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -30,7 +30,7 @@ unsigned long angleToTime(int16_t angle, byte method)
         if(triggerToothAngleIsCorrect == true)
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          unsigned long toothTime = lastGap;
           interrupts();
           
           returnTime = ( (toothTime / triggerToothAngle) * angle );
@@ -65,7 +65,7 @@ uint16_t timeToAngle(unsigned long time, byte method)
         if(triggerToothAngleIsCorrect == true)
         {
           noInterrupts();
-          unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          unsigned long toothTime = lastGap;
           interrupts();
 
           returnAngle = ( (unsigned long)(time * triggerToothAngle) / toothTime );
@@ -131,14 +131,13 @@ void doCrankSpeedCalcs()
       {
         //If we can, attempt to get the timePerDegree by comparing the times of the last two teeth seen. This is only possible for evenly spaced teeth
         noInterrupts();
-        if( (triggerToothAngleIsCorrect == true) && (toothLastToothTime > toothLastMinusOneToothTime) && (abs(currentStatus.rpmDOT) > 30) )
+        if( (triggerToothAngleIsCorrect == true) && (lastGap > 0) && (abs(currentStatus.rpmDOT) > 30) )
         {
           //noInterrupts();
-          unsigned long tempToothLastToothTime = toothLastToothTime;
-          unsigned long tempToothLastMinusOneToothTime = toothLastMinusOneToothTime;
+          unsigned long tempLastGap = lastGap;
           uint16_t tempTriggerToothAngle = triggerToothAngle;
           interrupts();
-          timePerDegreex16 = (unsigned long)( (tempToothLastToothTime - tempToothLastMinusOneToothTime)*16) / tempTriggerToothAngle;
+          timePerDegreex16 = (unsigned long)(tempLastGap*16) / tempTriggerToothAngle;
           timePerDegree = timePerDegreex16 / 16;
         }
         else

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1070,7 +1070,7 @@ void loop()
           if(ignition1EndAngle > crankAngle) { uSToEnd = fastDegreesToUS( (ignition1EndAngle - crankAngle) ); }
           else { uSToEnd = fastDegreesToUS( (360 + ignition1EndAngle - crankAngle) ); }
           //*********
-          //uSToEnd = ((ignition1EndAngle - crankAngle) * (toothLastToothTime - toothLastMinusOneToothTime)) / triggerToothAngle;
+          //uSToEnd = ((ignition1EndAngle - crankAngle) * lastGap) / triggerToothAngle;
           //*********
 
           refreshIgnitionSchedule1( uSToEnd + fixedCrankingOverride );


### PR DESCRIPTION
*work in progress (only Missing Tooth and Dual Wheel decoders updated, more coming)*

toothLastMinusOneToothTime is only used to calculate the gap between the last two triggers/edges/teeth and this is done in quite a few places throughout the code. Use lastGap variable instead and set it to the already calculated curGap.

Bench-tested 0.4.3d Missing Tooth 60-2 gives 4% loopsPerSec increase at 6000RPM.