### PR TITLE
AVR fast eeprom read - 45% speed up

### DIFF
--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -298,11 +298,18 @@ void resetConfigPages()
  */
 static inline eeprom_address_t load_range(eeprom_address_t address, byte *pFirst, const byte *pLast)
 {
+#if defined(CORE_AVR)
+  // The code below works but this provides a 45% speed up
+  size_t size = pLast-pFirst;
+  eeprom_read_block(pFirst, (void*)address, size);
+  return address+size;
+#else
   for (; pFirst != pLast; ++address, (void)++pFirst)
   {
     *pFirst = EEPROM.read(address);
   }
   return address;
+#endif
 }
 
 static inline eeprom_address_t load(table_row_iterator row, eeprom_address_t address)

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -299,7 +299,7 @@ void resetConfigPages()
 static inline eeprom_address_t load_range(eeprom_address_t address, byte *pFirst, const byte *pLast)
 {
 #if defined(CORE_AVR)
-  // The code below works but this provides a 45% speed up
+  // The generic code in the #else branch works but this provides a 45% speed up on AVR
   size_t size = pLast-pFirst;
   eeprom_read_block(pFirst, (void*)address, size);
   return address+size;


### PR DESCRIPTION
Use `eeprom_read_block()` on the AVR platform instead of reading individual bytes. Speeds up `loadConfig()` by 45%: test sketch calling `loadConfig()` 256 times dropped from 1843000uS to 1030000uS.
