### PR TITLE
A flat shift for AT transmission implementation.  

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -608,7 +608,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      unused_bit  =   bits, U08,      14, [6:6],      "No", "Yes"
+      ATFS_enable  =   bits, U08,      14, [6:6],      "No", "Yes"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -999,8 +999,18 @@ page = 9
       boostByGear4               = scalar, U08,     159, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
       boostByGear5               = scalar, U08,     160, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
       boostByGear6               = scalar, U08,     161, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  511.0,      0
+#ATFS here,  also ATFS_enable in page 6
 
-      unused10_160        = array, U08,    162, [30],       "",       1, 0, 0, 255, 0
+      ATFS_RPM_MIN = scalar, U08,      162,             "rpm",      100,    0.0,  100, 25500,  0
+      ATFS_RPM_MAX = scalar, U08,      163,             "rpm",      100,    0.0,  100, 25500,  0
+      ATFS_adv_when_min  = scalar, S08,      164,      "deg",       1.0,    0.0, -10.0,   40,   0
+      ATFS_adv_when_max  = scalar, S08,      165,      "deg",       1.0,    0.0, -10.0,   40,   0
+      ATFS_TPS_th  = scalar, U08,      166,      "%TPS",               1.0,    0.0, 0,   100,   0
+      ATFS_MAP_th  = scalar, U08,      167,      "kPa",             1.0,    0.0, 0,   255,   0
+      ATFS_RPM_drop = scalar, S08,      168,             "rpm/s",      100,   0.0,  -5000, -100,  0
+
+
+      unused10_160        = array, U08,    169, [23],       "",       1, 0, 0, 255, 0
     
 page = 10
 #if CELSIUS
@@ -1857,6 +1867,15 @@ menuDialog = main
   HardRevLim        = "The hard rev limit is the point that the fuel or ignition (or both) will be cut completely to reduce increasing RPMs"
   engineProtectMaxRPM = "The RPM point that engine protections will engage from. Below this RPM value, engine protections will NOT be active"
 
+  ATFS_enable = "Enable or Disable an algorithm, which can track when your automatic transmission in upshift state and limit ignition advance for a while to limit an engine torque. Helpfull with 722.3/4 MB trannys and some others."
+  ATFS_RPM_drop = "Amount of RPM drop (rpm/s) to tell if AT tranny is shifting up.  Usually somewhat aroud -500 rpm/s"
+  ATFS_RPM_MIN = "A lower  RPM limit. Below this RPM no advance retarding will be applied. Around 3000 rpm is a good number to start."
+  ATFS_RPM_MAX = "A  high RPM limit. Above this PRM a hard ignition cut-off will be aplied to limit torque. Somewhat closer to engine redline.  A 5000 rpm for example or so."
+  ATFS_adv_when_min = "This amount of advance will be applied when engine is on lower RPM. Advance values in between min and max will be interpolated. 10' BTDC is for example"
+  ATFS_adv_when_max = "This amount of advance will be applied when engine is on higher RPM. Advance values in between min and max will be interpolated. 5' BTDC is for example"
+  ATFS_TPS_th = "A minimum amount of TPS % to apply a limiting strategy. 10% is an example."
+  ATFS_MAP_th = "A minimum amount of MAP kpa to apply a limiting strategy. 40 kpa for example."
+
   fuel2InputPin     = "The Arduino pin that is being used to trigger the second fuel table to be active"
   fuel2InputPolarity = "Whether the 2nd fuel table should be active when input is high or low. This should be LOW for a typical ground switching input"
   fuel2InputPullup  = "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
@@ -2660,11 +2679,23 @@ menuDialog = main
         field = "Hard rev limit",               lnchHardLim,    { launchEnable }
         field = "Fuel adder during launch",     lnchFuelAdd,    { launchEnable }
 
-        ; Flat shift
-        field = "Flat Shift"
-        field = "Enable flat shift",            flatSEnable
+        ; Flat shift MT
+        field = "Flat Shift for MT transmission"
+        field = "Enable MT flat shift",            flatSEnable
         field = "Soft rev window",              flatSSoftWin,   { flatSEnable }
         field = "Soft limit absolute timing",   flatSRetard,    { flatSEnable }
+
+        ; Flat shift AT
+        field = "Flat Shift for AT transmission"
+        field = "Enable AT flat shift",         ATFS_enable
+        field = "RPM lower thresh",          ATFS_RPM_MIN,   { ATFS_enable }
+        field = "RPM upper thresh",          ATFS_RPM_MAX,   { ATFS_enable }
+        field = "Ign advance on lower rpm",     ATFS_adv_when_min,   { ATFS_enable }
+        field = "Ign advance on upper rpm",     ATFS_adv_when_max,   { ATFS_enable }
+        field = "TPS threshold",                ATFS_TPS_th,   { ATFS_enable }
+        field = "MAP threshold",                ATFS_MAP_th,   { ATFS_enable }
+        field = "RPM drop threshold to detect shift",           ATFS_RPM_drop,   { ATFS_enable }
+
 
     dialog = NitrousStage1,                 "Stage 1"
         field = "Nitrous Output Pin",           n2o_stage1_pin

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -35,6 +35,7 @@ int8_t correctionSoftRevLimit(int8_t);
 int8_t correctionNitrous(int8_t);
 int8_t correctionSoftLaunch(int8_t);
 int8_t correctionSoftFlatShift(int8_t);
+int8_t correctionATFlatShift(int8_t);
 int8_t correctionKnock(int8_t);
 
 uint16_t correctionsDwell(uint16_t dwell);

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -679,6 +679,7 @@ int8_t correctionsIgn(int8_t base_advance)
   advance = correctionNitrous(advance);
   advance = correctionSoftLaunch(advance);
   advance = correctionSoftFlatShift(advance);
+  advance = correctionATFlatShift(advance);
   advance = correctionKnock(advance);
 
   //Fixed timing check must go last
@@ -838,6 +839,8 @@ int8_t correctionSoftLaunch(int8_t advance)
 
   return ignSoftLaunchValue;
 }
+
+
 /** Ignition correction for soft flat shift.
  */
 int8_t correctionSoftFlatShift(int8_t advance)
@@ -853,6 +856,38 @@ int8_t correctionSoftFlatShift(int8_t advance)
 
   return ignSoftFlatValue;
 }
+
+
+
+/** Ignition correction for soft flat shift for AT trans.
+ */
+int8_t correctionATFlatShift(int8_t advance)
+{
+  int8_t ignSoftFlatValue = advance;
+
+  if(configPage6.ATFS_enable && ATFS_shiftState && (currentStatus.RPM >= configPage9.ATFS_RPM_MIN*100) && (currentStatus.RPM <= configPage9.ATFS_RPM_MAX*100))
+  {
+    //int8_t temp_adv = FS_advance_when_min + int(FS_slope*(currentStatus.RPM-FS_RPM_MAX));
+    int8_t temp_adv = map(currentStatus.RPM, configPage9.ATFS_RPM_MIN*100, configPage9.ATFS_RPM_MAX*100, configPage9.ATFS_adv_when_min, configPage9.ATFS_adv_when_max);
+    if (temp_adv<advance){
+      BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
+      ignSoftFlatValue = temp_adv;
+    }
+    else{
+      BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_FLATSS);
+
+    }
+  }
+  else { BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_FLATSS); }
+
+  return ignSoftFlatValue;
+}
+
+
+
+
+
+
 /** Ignition knock (retard) correction.
  */
 int8_t correctionKnock(int8_t advance)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -546,6 +546,12 @@ extern volatile unsigned long ms_counter; //A counter that increments once per m
 extern uint16_t fixedCrankingOverride;
 extern bool clutchTrigger;
 extern bool previousClutchTrigger;
+
+//722 flatshiftvars  ATFS_
+extern bool ATFS_previousShiftState;
+extern bool ATFS_shiftState;
+extern uint16_t ATFS_shift_engaged_RPM;
+
 extern volatile uint32_t toothHistory[TOOTH_LOG_BUFFER];
 extern volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 extern volatile bool fpPrimed; //Tracks whether or not the fuel pump priming has been completed yet
@@ -1015,7 +1021,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte unused_bit : 1; //Previously was VVTasOnOff
+  byte ATFS_enable : 1; //Previously was VVTasOnOff
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage
@@ -1130,13 +1136,16 @@ struct config9 {
   byte boostByGear5;
   byte boostByGear6;
 
-  byte unused10_162;
-  byte unused10_163;
-  byte unused10_164;
-  byte unused10_165;
-  byte unused10_166;
-  byte unused10_167;
-  byte unused10_168;
+  // AT flatshift here ATFS_ prefix, also ATFS_enable in page 6
+  uint8_t ATFS_RPM_MIN;
+  uint8_t ATFS_RPM_MAX;
+  int8_t ATFS_adv_when_min;
+  int8_t ATFS_adv_when_max;
+  uint8_t ATFS_TPS_th;
+  uint8_t ATFS_MAP_th;
+  int8_t ATFS_RPM_drop;
+
+
   byte unused10_169;
   byte unused10_170;
   byte unused10_171;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -131,6 +131,12 @@ volatile unsigned long ms_counter = 0; //A counter that increments once per ms
 uint16_t fixedCrankingOverride = 0;
 bool clutchTrigger;
 bool previousClutchTrigger;
+
+//722 flatshift vars
+bool ATFS_previousShiftState = false;
+bool ATFS_shiftState = false;
+uint16_t ATFS_shift_engaged_RPM = 0;
+
 volatile uint32_t toothHistory[TOOTH_LOG_BUFFER]; ///< Tooth trigger history - delta time (in uS) from last tooth (Indexed by @ref toothHistoryIndex)
 volatile uint8_t compositeLogHistory[TOOTH_LOG_BUFFER];
 volatile bool fpPrimed = false; ///< Tracks whether or not the fuel pump priming has been completed yet

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -484,7 +484,8 @@ void doUpdates()
     configPage10.TrigEdgeThrd = 0;
 
     //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    //if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    // ATFS_enable bit is interfering with this. Have to comment out this line. ^^^
 
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;


### PR DESCRIPTION
This algorithm will detect if AT tranny in upshift event and set ignition to a certain retarded values.  A limitations will not be applied until ATFS_RPM_MIN reached,  then advance will be set as an interpolation between adv_when_min:adv_when_max in a ATFS_RPM_MIN:ATFS_RPM_MAX range.  above ATFS_RPM_MAX hard cutoff will be done.   To enable this in GUI a bit in configPage6 is used, the former  VVT_on/off bit.    Also 7 bytes in configPage9 is used to setup MAP/KPA/RPM thresholds.

This algorithm is used by me (XPbIM3) to drive an m104 3.2 mercedes engine paired with MB 722.4 automatic transmission.  Works nice.