### PR TITLE
Improve missing tooth decoder

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -416,8 +416,6 @@ void triggerPri_missingTooth()
           if(configPage4.triggerMissingTeeth == 1) { targetGap = (3 * (toothLastToothTime - toothLastMinusOneToothTime)) >> 1; } //Multiply by 1.5 (Checks for a gap 1.5x greater than the last one) (Uses bitshift to multiply by 3 then divide by 2. Much faster than multiplying by 1.5)
           else { targetGap = ((toothLastToothTime - toothLastMinusOneToothTime)) * configPage4.triggerMissingTeeth; } //Multiply by 2 (Checks for a gap 2x greater than the last one)
 
-          if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; }
-
           if ( (curGap > targetGap) || (toothCurrentCount > triggerActualTeeth) )
           {
             //Missing tooth detected

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -380,7 +380,6 @@ void triggerSetup_missingTooth()
   }
   secondDerivEnabled = false;
   decoderIsSequential = false;
-  checkSyncToothCount = (configPage4.triggerTeeth) >> 1; //50% of the total teeth.
   toothLastMinusOneToothTime = 0;
   toothCurrentCount = 0;
   secondaryToothCount = 0; 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -395,12 +395,12 @@ void triggerPri_missingTooth()
   curGap = curTime - toothLastToothTime;
   if ( curGap >= triggerFilterTime ) //Pulses should never be less than triggerFilterTime, so if they are it means a false trigger. (A 36-1 wheel at 8000pm will have triggers approx. every 200uS)
   {
-    toothCurrentCount++; //Increment the tooth counter
     validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
     if( lastGap > 0 )
     {
       bool isMissingTooth = false;
+      toothCurrentCount++; //Only increment the tooth counter when we can check if it's a missing tooth
 
       // Performance optimisation: Only check for missing tooth if we expect to find one
       if( currentStatus.hasSync == false || toothCurrentCount > triggerActualTeeth )

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -400,7 +400,7 @@ void triggerPri_missingTooth()
     if( lastGap > 0 )
     {
       bool isMissingTooth = false;
-      toothCurrentCount++; //Only increment the tooth counter when we can check if it's a missing tooth
+      toothCurrentCount++; //Only start increment the tooth counter after we can check if there's a missing tooth
 
       // Performance optimisation: Only check for missing tooth if we expect to find one
       if( currentStatus.hasSync == false || toothCurrentCount > triggerActualTeeth )

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -446,29 +446,25 @@ void triggerPri_missingTooth()
           }
           else { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); } //If nothing is using sequential, we have sync and also clear half sync bit
 
-          triggerFilterTime = 0; //This is used to prevent a condition where serious intermitent signals (Eg someone furiously plugging the sensor wire in and out) can leave the filter in an unrecoverable state
           triggerToothAngleIsCorrect = false; //The tooth angle is double at this point
         }
-        else {
-          // We end up with re-sync when:
-          // 1. We are not synced and find a tooth that isn't a missing tooth
-          // 2. We are synced and there isn't a missing tooth where we expected to find one
+        else if (toothCurrentCount > triggerActualTeeth) { // Syncloss when we expect a missing tooth but don't find one
           if (currentStatus.hasSync == true) { currentStatus.syncLossCounter++; }
           currentStatus.hasSync = false;
           BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
+          setFilter(0); //Reset the filter to prevent a condition where serious intermittent signals (Eg someone furiously plugging the sensor wire in and out) can leave the filter in an unrecoverable state
+        }
+        else if (currentStatus.hasSync == false) { //Found a normal tooth and don't have sync
+          setFilter(curGap);
         }
       }
-      
-      if(isMissingTooth == false)
-      {
-        //Regular (non-missing) tooth
+      else { //Found a normal tooth and have sync
         setFilter(curGap);
         triggerToothAngleIsCorrect = true;
       }
     }
     
     //Always update these when we find a tooth
-    
     if (toothLastToothTime > 0) { lastGap = curGap; }
     toothLastMinusOneToothTime = toothLastToothTime; //This is used by multiple other functions
     toothLastToothTime = curTime;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -399,7 +399,6 @@ void triggerPri_missingTooth()
 
     if( lastGap > 0 )
     {
-      bool isMissingTooth = false;
       toothCurrentCount++; //Only start increment the tooth counter after we can check if there's a missing tooth
 
       // Performance optimisation: Only check for missing tooth if we expect to find one
@@ -413,7 +412,6 @@ void triggerPri_missingTooth()
         if ( curGap > targetGap )
         {
           //Missing tooth detected
-          isMissingTooth = true;
           toothCurrentCount = 1;
           toothOneMinusOneTime = toothOneTime;
           toothOneTime = curTime;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -447,9 +447,6 @@ void triggerPri_missingTooth()
           else { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); } //If nothing is using sequential, we have sync and also clear half sync bit
 
           triggerFilterTime = 0; //This is used to prevent a condition where serious intermitent signals (Eg someone furiously plugging the sensor wire in and out) can leave the filter in an unrecoverable state
-          if (toothLastToothTime > 0) { lastGap = curGap; }
-          toothLastMinusOneToothTime = toothLastToothTime; //This is used by crankingGetRPM
-          toothLastToothTime = curTime;
           triggerToothAngleIsCorrect = false; //The tooth angle is double at this point
         }
         else {
@@ -466,20 +463,15 @@ void triggerPri_missingTooth()
       {
         //Regular (non-missing) tooth
         setFilter(curGap);
-        if (toothLastToothTime > 0) { lastGap = curGap; }
-        toothLastMinusOneToothTime = toothLastToothTime; //This is used by crankingGetRPM
-        toothLastToothTime = curTime;
         triggerToothAngleIsCorrect = true;
       }
     }
-    else
-    {
-      //We fall here on initial startup when enough teeth have not yet been seen
-      if (toothLastToothTime > 0) { lastGap = curGap; }
-      toothLastMinusOneToothTime = toothLastToothTime; //This is used by crankingGetRPM
-      toothLastToothTime = curTime;
-    }
     
+    //Always update these when we find a tooth
+    
+    if (toothLastToothTime > 0) { lastGap = curGap; }
+    toothLastMinusOneToothTime = toothLastToothTime; //This is used by multiple other functions
+    toothLastToothTime = curTime;
 
     //NEW IGNITION MODE
     if( (configPage2.perToothIgn == true) && (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) ) 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -449,12 +449,12 @@ void triggerPri_missingTooth()
 
         }
         else if (toothCurrentCount > triggerActualTeeth) { // Syncloss when we expect a missing tooth but don't find one
-          if (currentStatus.hasSync == true) { currentStatus.syncLossCounter++; }
+          if (currentStatus.hasSync == true || BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC) == true) { currentStatus.syncLossCounter++; }
           currentStatus.hasSync = false;
           BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
           setFilter(0); //Reset the filter to prevent a condition where serious intermittent signals (Eg someone furiously plugging the sensor wire in and out) can leave the filter in an unrecoverable state
         }
-        else if (currentStatus.hasSync == false) { //Found a normal tooth and don't have sync
+        else { //Found a normal tooth and don't have sync
           setFilter(curGap);
         }
       }


### PR DESCRIPTION
A set of improvements for the missing tooth decoder.

Bench-test with 0.4.3d and ardu-stim 60-2 pattern. 0,84% additional loops/sec at 1000RPM, 1,27% at 3k, 2,81% at 6k. 236 bytes smaller firmware.

The changes look bigger than they are, but the individual commits should clarify things.