### PR TITLE
Assignable auxiliary timers / PWM fan for Mega

### DIFF
--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -64,13 +64,11 @@ long boost_pwm_target_value;
 long boost_cl_target_boost;
 byte boostCounter;
 byte vvtCounter;
-#if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
 volatile bool fan_pwm_state;
 unsigned int fan_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int fan_pwm_cur_value;
 long fan_pwm_value;
 void fanInterrupt();
-#endif
 uint32_t vvtWarmTime;
 bool vvtIsHot;
 bool vvtTimeHold;

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -198,7 +198,7 @@ void initialiseAuxPWM()
     vvt1_pwm_value = 0;
     currentStatus.vvt2Duty = 0;
     vvt2_pwm_value = 0;
-    vvtTimer->Enable(); //Turn on the B compare unit (ie turn on the interrupt)
+    if (vvtTimer != nullptr) { vvtTimer->Enable(); } //Turn on the B compare unit (ie turn on the interrupt)
     BIT_CLEAR(currentStatus.status4, BIT_STATUS4_VVT1_ERROR);
     BIT_CLEAR(currentStatus.status4, BIT_STATUS4_VVT2_ERROR);
     vvtTimeHold = false;
@@ -215,7 +215,7 @@ void initialiseAuxPWM()
     BIT_CLEAR(currentStatus.status4, BIT_STATUS4_WMI_EMPTY);
     currentStatus.wmiPW = 0;
     vvt1_pwm_value = 0;
-    vvtTimer->Enable(); //Turn on the B compare unit (ie turn on the interrupt)
+    if (vvtTimer != nullptr) { vvtTimer->Enable(); } //Turn on the B compare unit (ie turn on the interrupt)
   }
 
   currentStatus.boostDuty = 0;
@@ -239,11 +239,11 @@ void boostControl()
       currentStatus.boostDuty = get3DTableValue(&boostTable, currentStatus.TPS, currentStatus.RPM) * 2 * 100;
 
       if(currentStatus.boostDuty > 10000) { currentStatus.boostDuty = 10000; } //Safety check
-      if(currentStatus.boostDuty == 0) { boostTimer->Disable(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
+      if(currentStatus.boostDuty == 0) { if (boostTimer != nullptr) { boostTimer->Disable(); } BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
       else
       {
         boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
-        boostTimer->Enable(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
+        if (boostTimer != nullptr) { boostTimer->Enable(); } //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
       }
     }
     else if (configPage4.boostType == CLOSED_LOOP_BOOST)
@@ -341,13 +341,13 @@ void boostControl()
           }
 
           bool PIDcomputed = boostPID.Compute(); //Compute() returns false if the required interval has not yet passed.
-          if(currentStatus.boostDuty == 0) { boostTimer->Disable(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
+          if(currentStatus.boostDuty == 0) { if (boostTimer != nullptr) { boostTimer->Disable(); } BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
           else
           {
             if(PIDcomputed == true)
             {
               boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multipled by 100) to a pwm count
-              boostTimer->Enable(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
+              if (boostTimer != nullptr) { boostTimer->Enable(); } //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
             }
           }
 
@@ -366,7 +366,7 @@ void boostControl()
     } //Open / Cloosed loop
   }
   else { // Disable timer channel and zero the flex boost correction status
-    boostTimer->Disable();
+    if (boostTimer != nullptr) { boostTimer->Disable(); }
     currentStatus.flexBoostCorrection = 0;
   }
 
@@ -502,7 +502,7 @@ void vvtControl()
         vvt1_max_pwm = false;
         vvt2_pwm_state = false;
         vvt2_max_pwm = false;
-        vvtTimer->Disable();
+        if (vvtTimer != nullptr) { vvtTimer->Disable(); }
       }
       else if( (currentStatus.vvt1Duty >= 200) && (currentStatus.vvt2Duty >= 200) )
       {
@@ -513,12 +513,12 @@ void vvtControl()
         vvt1_max_pwm = true;
         vvt2_pwm_state = true;
         vvt2_max_pwm = true;
-        vvtTimer->Disable();
+        if (vvtTimer != nullptr) { vvtTimer->Disable(); }
       }
       else
       {
         //Duty cycle is between 0 and 100. Make sure the timer is enabled
-        vvtTimer->Enable();
+        if (vvtTimer != nullptr) { vvtTimer->Enable(); }
         if(currentStatus.vvt1Duty < 200) { vvt1_max_pwm = false; }
         if(currentStatus.vvt2Duty < 200) { vvt2_max_pwm = false; }
       }
@@ -528,7 +528,7 @@ void vvtControl()
   else 
   { 
     // Disable timer channel
-    vvtTimer->Disable();
+    if (vvtTimer != nullptr) { vvtTimer->Disable(); }
     currentStatus.vvt1Duty = 0;
     vvt1_pwm_value = 0;
     currentStatus.vvt2Duty = 0;
@@ -644,7 +644,7 @@ void wmiControl()
     {
       // Make sure water pump is off
       VVT1_PIN_LOW();
-      vvtTimer->Disable();
+      if (vvtTimer != nullptr) { vvtTimer->Disable(); }
       digitalWrite(pinWMIEnabled, LOW);
     }
     else
@@ -654,11 +654,11 @@ void wmiControl()
       {
         // Make sure water pump is on (100% duty)
         VVT1_PIN_HIGH();
-        vvtTimer->Disable();
+        if (vvtTimer != nullptr) { vvtTimer->Disable(); }
       }
       else
       {
-        vvtTimer->Enable();
+        if (vvtTimer != nullptr) { vvtTimer->Enable(); }
       }
     }
   }
@@ -668,7 +668,7 @@ void boostDisable()
 {
   boostPID.Initialize(); //This resets the ITerm value to prevent rubber banding
   currentStatus.boostDuty = 0;
-  boostTimer->Disable(); //Turn off timer
+  if (boostTimer != nullptr) { boostTimer->Disable(); } //Turn off timer
   BOOST_PIN_LOW(); //Make sure solenoid is off (0% duty)
 }
 

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -125,27 +125,25 @@
 
 /*
 ***********************************************************************************************************
-* Auxilliaries
+* Auxiliary timers
 */
-  #define ENABLE_BOOST_TIMER()  TIMSK1 |= (1 << OCIE1A)
-  #define DISABLE_BOOST_TIMER() TIMSK1 &= ~(1 << OCIE1A)
-  #define ENABLE_VVT_TIMER()    TIMSK1 |= (1 << OCIE1B)
-  #define DISABLE_VVT_TIMER()   TIMSK1 &= ~(1 << OCIE1B)
 
-  #define BOOST_TIMER_COMPARE   OCR1A
-  #define BOOST_TIMER_COUNTER   TCNT1
-  #define VVT_TIMER_COMPARE     OCR1B
-  #define VVT_TIMER_COUNTER     TCNT1
+  #define AVAILABLE_AUX_TIMERS  3
+  #define AUX_TIMER1_ENABLE() TIMSK1 |= (1 << OCIE1A)
+  #define AUX_TIMER2_ENABLE() TIMSK1 |= (1 << OCIE1B)
+  #define AUX_TIMER3_ENABLE() TIMSK1 |= (1 << OCIE1C)
 
-/*
-***********************************************************************************************************
-* Idle
-*/
-  #define IDLE_COUNTER TCNT1
-  #define IDLE_COMPARE OCR1C
+  #define AUX_TIMER1_DISABLE() TIMSK1 &= ~(1 << OCIE1A)
+  #define AUX_TIMER2_DISABLE() TIMSK1 &= ~(1 << OCIE1B)
+  #define AUX_TIMER3_DISABLE() TIMSK1 &= ~(1 << OCIE1C)
 
-  #define IDLE_TIMER_ENABLE() TIMSK1 |= (1 << OCIE1C)
-  #define IDLE_TIMER_DISABLE() TIMSK1 &= ~(1 << OCIE1C)
+  #define AUX_TIMER1_COMPARE OCR1A
+  #define AUX_TIMER2_COMPARE OCR1B
+  #define AUX_TIMER3_COMPARE OCR1C
+
+  #define AUX_TIMER1_COUNTER TCNT1
+  #define AUX_TIMER2_COUNTER TCNT1
+  #define AUX_TIMER3_COUNTER TCNT1
 
 /*
 ***********************************************************************************************************

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -36,6 +36,7 @@ void initBoard()
 
     boost_pwm_max_count = 1000000L / (16 * configPage6.boostFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow freqneucies up to 511Hz
     vvt_pwm_max_count = 1000000L / (16 * configPage6.vvtFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle
+    fan_pwm_max_count = 1000000L / (16 * configPage6.fanFreq * 2); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle
     // put idle_pwm_max_count calculation here?
 
     /*

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -26,9 +26,8 @@ void initBoard()
 
     /*
     ***********************************************************************************************************
-    * Auxilliaries
+    * Auxiliary timers 1, 2, 3
     */
-    //PWM used by the Boost and VVT outputs. C Channel is used by ign5
     TCCR1B = TIMER_PRESCALER_OFF;   //Disbale Timer1 while we set it up
     TCNT1  = 0;                     //Reset Timer Count
     TCCR1A = TIMER_MODE_NORMAL;     //Timer1 Control Reg A: Wave Gen Mode normal (Simply counts up from 0 to 65535 (16-bit int)

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -22,9 +22,9 @@ integerPID idlePID(&currentStatus.longRPM, &idle_pid_target_value, &idle_cl_targ
 //Typically this is enabling the PWM interrupt
 static inline void enableIdle()
 {
-  if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) )
+  if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) )
   {
-    idleTimer->Enable();
+    if (idleTimer != nullptr) { idleTimer->Enable(); }
   }
   else if ( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) )
   {
@@ -35,7 +35,7 @@ static inline void enableIdle()
 void initialiseIdle()
 {
   //By default, turn off the PWM interrupt (It gets turned on below if needed)
-  idleTimer->Disable();
+  if (idleTimer != nullptr) { idleTimer->Disable(); }
 
   //Pin masks must always be initialized, regardless of whether PWM idle is used. This is required for STM32 to prevent issues if the IRQ function fires on restat/overflow
   idle_pin_port = portOutputRegister(digitalPinToPort(pinIdle1));
@@ -660,7 +660,7 @@ void disableIdle()
 {
   if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) )
   {
-    idleTimer->Disable();
+    if (idleTimer != nullptr) { idleTimer->Disable(); }
     digitalWrite(pinIdle1, LOW);
   }
   else if ((configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) )

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -22,7 +22,7 @@ integerPID idlePID(&currentStatus.longRPM, &idle_pid_target_value, &idle_cl_targ
 //Typically this is enabling the PWM interrupt
 static inline void enableIdle()
 {
-  if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) )
+  if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) )
   {
     if (idleTimer != nullptr) { idleTimer->Enable(); }
   }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -218,7 +218,7 @@ void loop()
 
       VVT1_PIN_LOW();
       VVT2_PIN_LOW();
-      vvtTimer->Disable();
+      if (vvtTimer != nullptr) { vvtTimer->Disable(); }
       boostDisable();
       if(configPage4.ignBypassEnabled > 0) { digitalWrite(pinIgnBypass, LOW); } //Reset the ignition bypass ready for next crank attempt
     }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -218,7 +218,7 @@ void loop()
 
       VVT1_PIN_LOW();
       VVT2_PIN_LOW();
-      DISABLE_VVT_TIMER();
+      vvtTimer->Disable();
       boostDisable();
       if(configPage4.ignBypassEnabled > 0) { digitalWrite(pinIgnBypass, LOW); } //Reset the ignition bypass ready for next crank attempt
     }

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -52,6 +52,7 @@ inline void auxTimer3Disable();
 AuxTimer * boostTimer;
 AuxTimer * vvtTimer;
 AuxTimer * idleTimer;
+AuxTimer * fanTimer;
 
 volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
 volatile TachoOutputStatus tachoOutputFlag;

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -26,6 +26,33 @@ volatile bool tachoAlt = false;
 #define TACHO_PULSE_LOW() *tach_pin_port &= ~(tach_pin_mask)
 enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tacho output pulse can have
 
+struct AuxTimer {
+  void (*Enable)();
+  void (*Disable)();
+  void (*Interrupt)();
+  volatile typeof(AUX_TIMER1_COUNTER) * counter;
+  volatile typeof(AUX_TIMER1_COMPARE) * compare;
+};
+
+#if AVAILABLE_AUX_TIMERS > 0
+inline void auxTimer1Enable();
+inline void auxTimer1Disable();
+#endif
+
+#if AVAILABLE_AUX_TIMERS > 1
+inline void auxTimer2Enable();
+inline void auxTimer2Disable();
+#endif
+
+#if AVAILABLE_AUX_TIMERS > 2
+inline void auxTimer3Enable();
+inline void auxTimer3Disable();
+#endif
+
+AuxTimer * boostTimer;
+AuxTimer * vvtTimer;
+AuxTimer * idleTimer;
+
 volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
 volatile TachoOutputStatus tachoOutputFlag;
 

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -111,7 +111,7 @@ void initialiseTimers()
       boostTimer = &AuxTimers[i];
       boostTimer->Interrupt = boostInterrupt;
     }
-    else if (configPage6.vvtEnabled > 0 && vvtTimer == nullptr) {
+    else if ( (configPage6.vvtEnabled > 0 || configPage10.wmiEnabled > 0) && vvtTimer == nullptr) {
       vvtTimer = &AuxTimers[i];
       vvtTimer->Interrupt = vvtInterrupt;
     }

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -100,18 +100,19 @@ void initialiseTimers()
   #endif
 
   //TODO: Give warning about number of used/available timers in tunerstudio
-  //TODO: Check boost/vvt/idleTimer are assigned before interacting with them
+  //TODO: Check vvt/idleTimer are assigned before interacting with them
+  //TODO: Change wmi/fan to use these timers too
 
   for (int i = 0; i < AVAILABLE_AUX_TIMERS; i++) {
-    if (configPage6.boostEnabled == 1 && !boostTimer) {
+    if (configPage6.boostEnabled == 1 && boostTimer == nullptr) {
       boostTimer = &AuxTimers[i];
       boostTimer->Interrupt = boostInterrupt;
     }
-    else if (configPage6.vvtEnabled > 0 && !vvtTimer) {
+    else if (configPage6.vvtEnabled > 0 && vvtTimer == nullptr) {
       vvtTimer = &AuxTimers[i];
       vvtTimer->Interrupt = vvtInterrupt;
     }
-    else if ( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) && !idleTimer) {
+    else if ( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) && idleTimer == nullptr) {
       idleTimer = &AuxTimers[i];
       idleTimer->Interrupt = idleInterrupt;
     }

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -100,9 +100,12 @@ void initialiseTimers()
   #endif
 
   //TODO: Give warning about number of used/available timers in tunerstudio
-  //TODO: Check vvt/idleTimer are assigned before interacting with them
   //TODO: Change wmi/fan to use these timers too
+  //TODO: Update timers for other platforms / expand available_aux_timers
+  //TODO: Give compile time warning if available aux timers is higher than code enables
+  //TODO: Move pwn value and max value to AuxTimer
 
+  //Assign available timers to enabled features
   for (int i = 0; i < AVAILABLE_AUX_TIMERS; i++) {
     if (configPage6.boostEnabled == 1 && boostTimer == nullptr) {
       boostTimer = &AuxTimers[i];
@@ -115,6 +118,10 @@ void initialiseTimers()
     else if ( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL || configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL) && idleTimer == nullptr) {
       idleTimer = &AuxTimers[i];
       idleTimer->Interrupt = idleInterrupt;
+    }
+    else if (configPage2.fanEnable == 2 && fanTimer == nullptr) {
+      fanTimer = &AuxTimers[i];
+      fanTimer->Interrupt = fanInterrupt;
     }
     else {
       break;


### PR DESCRIPTION
Request for comments.

Change the Boost/Idle/VVT timers into general "auxiliary" timers to be used for any feature. Timers are only assigned to enabled features. This makes a timer available for PWM fan on Mega. Currently WMI uses VVT timer but should be freed from that constraint and included in this auxiliary timer functionality. This will be cross-MCU and those with more timers will be able to run more timer features at the same time.

This is just a proof of concept but the code is working for mega. Needs more work, especially in updating the board files. Tunerstudio needs to warn if too many timer features are enabled. I'll continue development if there is interest.

Question 1: Currently xxxTimer pointers are checked before accessing (except for in interrupts). This could cause issues if this check is missed. Executing a nullptr callback probably causes issues? For a small memory tradeoff of one dummy AuxTimer assigned to unused feature could be used instead of all the checks.

Question 2: I know there were some discussions on Slack about using some kind of software timer which can trigger multiple timers. Perhaps that is a more future-proof solution if it's not too expensive in terms of performance/memory usage.