### PR TITLE
Added idle advance start threshold

### DIFF
--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -5,6 +5,8 @@ All functions in the gamma file return
 #ifndef CORRECTIONS_H
 #define CORRECTIONS_H
 
+#define IGN_IDLE_THRESHOLD 200 //RPM threshold (below CL idle target) for when ign based idle control will engage
+
 void initialiseCorrections();
 
 uint16_t correctionsFuel();

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -776,7 +776,7 @@ int8_t correctionIdleAdvance(int8_t advance)
     else if( BIT_CHECK(LOOP_TIMER, BIT_TIMER_10HZ) ) { idleAdvStart = runSecsX10; } //Only copy time at runSecsX10 update rate
   }
 
-  if ( !idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN) && (currentStatus.RPM > (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)200)) ) { idleAdvActive = true; } //Active only after the engine is 200 RPM below target on first time
+  if ( !idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN) && (currentStatus.RPM > (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)IGN_IDLE_THRESHOLD)) ) { idleAdvActive = true; } //Active only after the engine is 200 RPM below target on first time
   else if (idleAdvActive && !BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) { idleAdvActive = false; } //Clear flag if engine isn't running anymore
 
   return ignIdleValue;


### PR DESCRIPTION
On lower temp and/or on ethanol the engine need to crank more time, without this my starter get a kick and the engine backfires.

This enable it only at 200 RPM below the target.