### PR TITLE
can#.write func can exit without returning a value

### DIFF
--- a/speeduino/src/STM32_CAN/STM32_CAN.cpp
+++ b/speeduino/src/STM32_CAN/STM32_CAN.cpp
@@ -207,6 +207,7 @@ int STM32_CAN::write(CAN_message_t &CAN_tx_msg)
     }
   }
   #endif
+  return -1; // transmit failed, requested can channel not available
 }
 
 int STM32_CAN::write(CAN_MAILBOX mb_num, CAN_message_t &CAN_tx_msg)
@@ -235,6 +236,7 @@ int STM32_CAN::write(CAN_MAILBOX mb_num, CAN_message_t &CAN_tx_msg)
     }
   }
   #endif
+  return -1; // transmit failed, requested can channel not available
 }
 
 int STM32_CAN::read(CAN_message_t &CAN_rx_msg)


### PR DESCRIPTION
It doesn't look like speeduino actually checks whether can#.write actually succeeds anyway, and it already covers the channels that should be in use.