### PR TITLE
VVT fixes

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -729,7 +729,7 @@ page = 7
       tpsBinsBoost  = array,  U08,    72,[  8],   "TPS",      0.5,        0.0,   0.0,     127.0,      1
       vvtTable      = array,  U08,    80,[8x8],    "%",        0.5,        0.0,   0,       100,      1
       rpmBinsVVT    = array,  U08,    144,[  8],   "RPM",      100.0,      0.0,   100,     25500,      0
-      loadBinsVVT   = array,  U08,    152,[  8],   { bitStringValue(algorithmUnits ,  vvtLoadSource) },  vvtLoadRes,        0.0,   0.0,     255.0,      vvtDecimalRes
+      loadBinsVVT   = array,  U08,    152,[  8],   { bitStringValue(algorithmUnits ,  vvtLoadSource) },  vvtLoadRes,        0.0,   0.0,     {vvtLoadMax},      vvtDecimalRes
 ;Fuel staging Table
       stagingTable  = array,  U08,    160, [8x8], "%",          1.0,      0.0,   0.0,   100.0,      0
       rpmBinsStaging= array,  U08,    224, [  8], "RPM",      100.0,      0.0,   100.0, 25500.0,      0
@@ -1218,7 +1218,7 @@ page = 12
       mapBinsWMI    = array,  U08,     72,[  8],   "kPa",        2.0,      0.0,   0.0,      511.0,      0
       vvt2Table     = array,  U08,     80,[8x8],     "%",        0.5,      0.0,     0,        100,      1
       rpmBinsVVT2   = array,  U08,    144,[  8],   "RPM",      100.0,      0.0,   100,      25500,      0
-      loadBinsVVT2  = array,  U08,    152,[  8],   { bitStringValue(algorithmUnits ,  vvtLoadSource) }, vvtLoadRes,        0.0,   0.0,     255.0,      vvtDecimalRes
+      loadBinsVVT2  = array,  U08,    152,[  8],   { bitStringValue(algorithmUnits ,  vvtLoadSource) }, vvtLoadRes,        0.0,   0.0,     {vvtLoadMax},      vvtDecimalRes
       dwellTable    = array,  U08,    160,[4x4],    "ms",        0.1,      0.0,   0.1,        8.0,      1
       rpmBinsDwell  = array,  U08,    176,[  4],   "RPM",      100.0,      0.0,   100,      25500,      0
       mapBinsDwell  = array,  U08,    180,[  4],   "kPa",        2.0,      0.0,   0.0,      511.0,      0
@@ -1509,7 +1509,11 @@ page = 14
     defaultValue = ANGLEFILTER_VVT, 0
     defaultValue = idleAdvStartDelay, 0.2 ;0.2S for a quick gear change without change the table advance
     defaultValue = boostByGearEnabled, 0
+    #if CELSIUS
+    defaultValue = vvtMinClt, 70
+    #else
     defaultValue = vvtMinClt, 160
+    #endif
     defaultValue = vvtDelay, 60
 
     ;Default pins
@@ -4987,6 +4991,7 @@ cmdVSSratio6 =      "E\x99\x06"
    fuelLoad2    = { fuel2Algorithm == 0 ? map : fuel2Algorithm == 1 ? tps : fuel2Algorithm == 2 ? 0 : 0 }
    ignLoad2     = { spark2Algorithm == 0 ? map : spark2Algorithm == 1 ? tps : spark2Algorithm == 2 ? 0 : ignLoad }
    vvtLoad      = { (vvtLoadSource == 0) ? map : tps }
+   vvtLoadMax   = { (vvtLoadSource == 0) ? 511 : 100.0 }
 
    ;Select data resolution and scale based on algorithm used
    vvtLoadRes   = { (vvtLoadSource == 0) ? 2.000 : 0.500 }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -568,6 +568,8 @@ void doUpdates()
       updateTableY(&vvt2Table, vvt2Table.type_key);
     }
 
+    configPage4.vvtDelay = 0;
+    configPage4.vvtMinClt = 0;
     writeAllConfig();
     storeEEPROMVersion(19);
   }


### PR DESCRIPTION
- Fix VVT load axis reading error for MAP and TPS.
- Add default values in updates.ino for VVT min temp and delay values, to not break old tunes.
- Add also sensible VVT min temp Celsius value in speeduino.ini
- Remove copy-paste mistakes.
- Change VVT MAP axis to go up to 511kPa.
- Correct VVT load axis max values based on load source.
- Minor code duplication cleanup.

NOTE! This is missing the update to VVT MAP load axis in old tunes. The values need to be divided by 2, but no idea how to do that.