### PR TITLE
WMI fixes

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1213,7 +1213,7 @@ page = 11
 ;Water methanol inejction and vvt2 maps (Page 12)
 ;--------------------------------------------------
 page = 12
-      wmiTable      = array,  U08,      0,[8x8],    "%",         1.0,      0.0,   0.0,      255.0,      0
+      wmiTable      = array,  U08,      0,[8x8],    "%",         1.0,      0.0,   0.0,  {wmiLoadMax},      0
       rpmBinsWMI    = array,  U08,     64,[  8],   "RPM",      100.0,      0.0,   100,      25500,      0
       mapBinsWMI    = array,  U08,     72,[  8],   "kPa",        2.0,      0.0,   0.0,      511.0,      0
       vvt2Table     = array,  U08,     80,[8x8],     "%",        0.5,      0.0,     0,        100,      1
@@ -2160,6 +2160,7 @@ menuDialog = main
   ANGLEFILTER_VVT = "Can be used to smooth out cam angle readings if needed. Only supported on specific decoders that have cam angle reading capability"
   vvtMinClt       = "Minimum coolant temp to activate VVT"
   vvtDelay        = "Time to wait after reaching minimum coolant temp (additional time for oil warmup)"
+  wmiMode         = "Simple mode - Output is turned on when preset boost level is reached. \nProportional Mode - Output PWM is proportionally controlled between two MAP values - MAP Value 1 = PWM:0% / MAP Value 2 = PWM:100% \nOpen loop - Output PWM follows 2D map value (RPM vs MAP) Cell value contains desired PWM% [range 0-100%] \nClosed loop - Output PWM follows injector duty cycle with 2D correction map applied (RPM vs MAP). Cell value contains correction value% [nom 100%]"
 
   stagedInjSizePri= "Size of the primary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
   stagedInjSizeSec= "Size of the secondary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
@@ -4904,8 +4905,8 @@ cmdVSSratio6 =      "E\x99\x06"
    gear             = scalar,   U08,    104, "",      1.000, 0.000
    fuelPressure     = scalar,   U08,    105, "PSI",   1.000, 0.000
    oilPressure      = scalar,   U08,    106, "PSI",   1.000, 0.000
-   wmiPW            = scalar,   U08,    107, "%",      1.000, 0.000
-   status4          = scalar,   U08,    108, "bits", 1.000, 0.000
+   wmiPW            = scalar,   U08,    107, "%",     1.000, 0.000
+   status4          = scalar,   U08,    108, "bits",  1.000, 0.000
     wmiEmptyBit     = bits,     U08,    108, [0:0]
     vvt1Error       = bits,     U08,    108, [1:1]
     vvt2Error       = bits,     U08,    108, [2:2]
@@ -4992,6 +4993,7 @@ cmdVSSratio6 =      "E\x99\x06"
    ignLoad2     = { spark2Algorithm == 0 ? map : spark2Algorithm == 1 ? tps : spark2Algorithm == 2 ? 0 : ignLoad }
    vvtLoad      = { (vvtLoadSource == 0) ? map : tps }
    vvtLoadMax   = { (vvtLoadSource == 0) ? 511 : 100.0 }
+   wmiLoadMax   = { (wmiMode == 2) ? 100.0 : 255 }
 
    ;Select data resolution and scale based on algorithm used
    vvtLoadRes   = { (vvtLoadSource == 0) ? 2.000 : 0.500 }
@@ -5097,8 +5099,9 @@ cmdVSSratio6 =      "E\x99\x06"
    entry = vvt2Angle,       "VVT2 Angle",       int,    "%.1f",        { vvt2Enabled > 0 }
    entry = vvt2Target,      "VVT2 Target Angle",int,    "%.1f",        { vvt2Enabled > 0 && vvtMode == 2 } ;;Only show when using close loop vvt
    entry = vvt2Duty,        "VVT2 Duty",        int,    "%.1f",        { vvt2Enabled > 0 && vvtMode == 2 }
-   entry = fanDuty,         "FAN Duty",         int,    "%d",          { fanEnable == 2 }
+   entry = fanDuty,         "FAN Duty",         int,    "%%.1f",       { fanEnable == 2 }
    entry = loopsPerSecond,  "Loops/s",          int,    "%d"
+   entry = wmiPW,           "WMI Duty Cycle",   int,    "%d",          { wmiEnabled == 1 }
 
    entry = auxin_gauge0,  { stringValue(AUXin00Alias) },  int,     "%d", {(caninput_sel0b != 0)}
    entry = auxin_gauge1,  { stringValue(AUXin01Alias) },  int,     "%d", { (caninput_sel1b != 0)}

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -41,7 +41,7 @@ void wmiControl();
 #define FAN_ON()         ((configPage6.fanInv) ? FAN_PIN_LOW() : FAN_PIN_HIGH())
 #define FAN_OFF()        ((configPage6.fanInv) ? FAN_PIN_HIGH() : FAN_PIN_LOW())
 
-#define WMI_TANK_IS_EMPTY() ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 0)
+#define WMI_TANK_IS_EMPTY() ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 1)
 
 volatile PORT_TYPE *boost_pin_port;
 volatile PINMASK_TYPE boost_pin_mask;

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -213,6 +213,7 @@ void initialiseAuxPWM()
     BIT_CLEAR(currentStatus.status4, BIT_STATUS4_WMI_EMPTY);
     currentStatus.wmiPW = 0;
     vvt1_pwm_value = 0;
+    vvt2_pwm_value = 0;
     ENABLE_VVT_TIMER(); //Turn on the B compare unit (ie turn on the interrupt)
   }
 
@@ -708,12 +709,13 @@ void wmiControl()
           wmiPW = 0;
           break;
         }
+        if (wmiPW > 100) { wmiPW = 100; } //without this the duty can get beyond 100%
       }
     }
     else { BIT_SET(currentStatus.status4, BIT_STATUS4_WMI_EMPTY); }
 
     currentStatus.wmiPW = wmiPW;
-    vvt1_pwm_value = wmiPW;
+    vvt1_pwm_value = percentage(currentStatus.wmiPW, vvt_pwm_max_count);
 
     if(wmiPW == 0)
     {


### PR DESCRIPTION
- Fix the non working "WMI tank empty" enable/disable switch
- Add the missing WMI duty to log file
- Add 100% duty limit check
- Fix WMI PWM output duty
- Add some description about WMI modes
- Add limits for WMI map values (can't put higher than 100% duty there anymore).