### PR TITLE
fixing sram eeprom emulation

### DIFF
--- a/speeduino/src/BackupSram/BackupSramAsEEPROM.cpp
+++ b/speeduino/src/BackupSram/BackupSramAsEEPROM.cpp
@@ -1,6 +1,7 @@
 #if defined(STM32F407xx)
 #include "BackupSramAsEEPROM.h"
 
+
     BackupSramAsEEPROM::BackupSramAsEEPROM(){
           //Enable the power interface clock
           RCC->APB1ENR |= RCC_APB1ENR_PWREN;
@@ -25,6 +26,7 @@
           //Wait until the backup power regulator is ready
           while ((PWR->CSR & PWR_CSR_BRR) == 0);
     }
+    uint16_t BackupSramAsEEPROM::length(){ return 4096; }
     int8_t BackupSramAsEEPROM::write_byte( uint8_t *data, uint16_t bytes, uint16_t offset ) {
         uint8_t* base_addr = (uint8_t *) BKPSRAM_BASE;
         uint16_t i;

--- a/speeduino/src/BackupSram/BackupSramAsEEPROM.h
+++ b/speeduino/src/BackupSram/BackupSramAsEEPROM.h
@@ -17,6 +17,7 @@ class BackupSramAsEEPROM {
     uint8_t read(uint16_t address);  
     int8_t write(uint16_t address, uint8_t val);
     int8_t update(uint16_t address, uint8_t val);
+    uint16_t length();
     template< typename T > T &get( int idx, T &t ){
         uint16_t e = idx;
         uint8_t *ptr = (uint8_t*) &t;


### PR DESCRIPTION
Fix for battery backed sram on STM32F407 boards with battery. 