### PR TITLE
Fix native unit test

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up GCC
+      uses: egor-tensin/setup-gcc@v1
+      with:
+        version: latest
+        platform: x32
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -38,6 +44,7 @@ jobs:
       run: | 
         platformio run -e megaatmega2560
         platformio remote test --force-remote --environment megaatmega2560
+        platformio test -e native
 
     - name: Slack Notification (Passed)
       uses: rtCamp/action-slack-notify@v2

--- a/platformio.ini
+++ b/platformio.ini
@@ -163,6 +163,6 @@ default_envs = megaatmega2560
 platform = native
 build_flags = -std=gnu++11
 debug_build_flags = -std=gnu++11 -O0 -g3
-test_ignore = test_misc, test_decoders, test_schedules
+test_ignore = test_misc, test_decoders, test_schedules, test_fuel
 debug_test = test_table3d_native
 build_type = debug


### PR DESCRIPTION
The native unit test was broken when test_fuel was added. It's much quicker to run than device bases tests & runs one more test ATM

Also, add it to the CI build