### PR TITLE
Fix full tune/large chucks of data for STM32. Next to this fix the co…

### DIFF
--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -13,7 +13,9 @@ A full copy of the license may be found in the projects root directory
 #include "pages.h"
 
 //The maximum number of write operations that will be performed in one go. If we try to write to the EEPROM too fast (Each write takes ~3ms) then the rest of the system can hang)
-#if defined(CORE_STM32) || defined(CORE_TEENSY) & !defined(USE_SPI_EEPROM)
+#if defined(CORE_STM32) & !defined(USE_SPI_EEPROM)
+#define EEPROM_MAX_WRITE_BLOCK 256
+#elif defined(CORE_TEENSY) & !defined(USE_SPI_EEPROM)
 #define EEPROM_MAX_WRITE_BLOCK 64
 #else
 #define EEPROM_MAX_WRITE_BLOCK 30


### PR DESCRIPTION
Next to these changes the Arduino core needs to be adjusted. The receive buffer size for the CDC usb serial interface needs to be larger. 

In the Arduino core for STM32 change line 57 in cdc_queue.h to: #define CDC_RECEIVE_QUEUE_BUFFER_SIZE ((uint16_t)(CDC_QUEUE_MAX_PACKET_SIZE * 8))