### PR TITLE
fix tuner studio comms STM32

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -215,7 +215,7 @@
     pageChunkWrite      = "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v"
     crc32CheckCommand   = "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i"
 
-    blockingFactor = 251 ; Serial buffer is 257 bytes and there are 6 bytes of overhead (2 for the size and 4 for the CRC). Total paload is therefore 257-6=251.
+    blockingFactor = 121 ; Serial buffer is 257 bytes and there are 6 bytes of overhead (2 for the size and 4 for the CRC). Total paload is therefore 257-6=251. Update 09/01/2021 smaller chunk write size needed for STM32
     ;tableBlockingFactor = 2048
     tableBlockingFactor = 244 ; Serial buffer is 257 bytes. There are 7 bytes overhead for the M command + 2 bytes for the size + 4 bytes for the CRC. 257 - 7 - 2 - 4 = 244 bytes.
     delayAfterPortOpen=1000


### PR DESCRIPTION
Smaller block size for communication with Tuner studio for STM32 to prevent communication issues.