### PR TITLE
Table 3d: change X-axis orientation to match Y-axis

### DIFF
--- a/speeduino/pages.cpp
+++ b/speeduino/pages.cpp
@@ -467,6 +467,14 @@ table_axis_iterator x_begin(const page_iterator_t &it)
 }
 
 /**
+ * Convert page iterator to table x axis iterator.
+ */
+table_axis_iterator x_rbegin(const page_iterator_t &it)
+{
+  return x_rbegin(it.pData, it.table_key);
+}
+
+/**
  * Convert page iterator to table y axis iterator.
  */
 table_axis_iterator y_begin(const page_iterator_t &it)

--- a/speeduino/pages.h
+++ b/speeduino/pages.h
@@ -91,6 +91,11 @@ table_value_iterator rows_begin(const page_iterator_t &it);
 table_axis_iterator x_begin(const page_iterator_t &it);
 
 /**
+ * Convert page iterator to table x axis iterator.
+ */
+table_axis_iterator x_rbegin(const page_iterator_t &it);
+
+/**
  * Convert page iterator to table y axis iterator.
  */
 table_axis_iterator y_begin(const page_iterator_t &it);

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -134,7 +134,7 @@ static inline write_location write(table_axis_iterator it, write_location locati
 
 static inline write_location writeTable(const void *pTable, table_type_t key, write_location location)
 {
-  return write(y_begin(pTable, key).reverse(), 
+  return write(y_rbegin(pTable, key), 
                 write(x_begin(pTable, key), 
                   write(rows_begin(pTable, key), location)));
 }
@@ -396,7 +396,7 @@ static inline eeprom_address_t load(table_axis_iterator it, eeprom_address_t add
 
 static inline eeprom_address_t loadTable(const void *pTable, table_type_t key, eeprom_address_t address)
 {
-  return load(y_begin(pTable, key).reverse(),
+  return load(y_rbegin(pTable, key),
                 load(x_begin(pTable, key), 
                   load(rows_begin(pTable, key), address)));
 }

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -557,8 +557,8 @@ uint32_t readPageCRC32(uint8_t pageNum)
 }
 
 /** Same as above, but writes the CRC32 for the calibration page rather than tune data
-@param pageNum - Calibration page number
-@param crcValue - CRC32 checksum
+@param calibrationPageNum - Calibration page number
+@param calibrationCRC - CRC32 checksum
 */
 void storeCalibrationCRC32(uint8_t calibrationPageNum, uint32_t calibrationCRC)
 {
@@ -583,7 +583,7 @@ void storeCalibrationCRC32(uint8_t calibrationPageNum, uint32_t calibrationCRC)
 }
 
 /** Retrieves and returns the 4 byte CRC32 checksum for a given calibration page from EEPROM.
-@param pageNum - Config page number
+@param calibrationPageNum - Config page number
 */
 uint32_t readCalibrationCRC32(uint8_t calibrationPageNum)
 {

--- a/speeduino/table3d.cpp
+++ b/speeduino/table3d.cpp
@@ -21,6 +21,12 @@ table_axis_iterator x_begin(const void *pTable, table_type_t key)
   CONCRETE_TABLE_ACTION(key, CTA_GET_X_ITERATOR, pTable);
 }
 
+table_axis_iterator x_rbegin(const void *pTable, table_type_t key)
+{
+  #define CTA_GET_X_RITERATOR(size, xDomain, yDomain, pTable) \
+      return ((TABLE3D_TYPENAME_BASE(size, xDomain, yDomain)*)pTable)->axisX.rbegin();
+  CONCRETE_TABLE_ACTION(key, CTA_GET_X_RITERATOR, pTable);
+}
 
 /**
  * Convert page iterator to table y axis iterator.
@@ -30,4 +36,11 @@ table_axis_iterator y_begin(const void *pTable, table_type_t key)
   #define CTA_GET_Y_ITERATOR(size, xDomain, yDomain, pTable) \
       return ((TABLE3D_TYPENAME_BASE(size, xDomain, yDomain)*)pTable)->axisY.begin();
   CONCRETE_TABLE_ACTION(key, CTA_GET_Y_ITERATOR, pTable);
+}
+
+table_axis_iterator y_rbegin(const void *pTable, table_type_t key)
+{
+  #define CTA_GET_Y_RITERATOR(size, xDomain, yDomain, pTable) \
+      return ((TABLE3D_TYPENAME_BASE(size, xDomain, yDomain)*)pTable)->axisY.rbegin();
+  CONCRETE_TABLE_ACTION(key, CTA_GET_Y_RITERATOR, pTable);
 }

--- a/speeduino/table3d.h
+++ b/speeduino/table3d.h
@@ -118,6 +118,9 @@ table_value_iterator rows_begin(const void *pTable, table_type_t key);
 
 table_axis_iterator x_begin(const void *pTable, table_type_t key);
 
+table_axis_iterator x_rbegin(const void *pTable, table_type_t key);
+
 table_axis_iterator y_begin(const void *pTable, table_type_t key);
 
+table_axis_iterator y_rbegin(const void *pTable, table_type_t key);
 /** @} */

--- a/speeduino/table3d.h
+++ b/speeduino/table3d.h
@@ -74,16 +74,16 @@ enum table_type_t {
     /** @brief A 3D table with size x size dimensions, xDom x-axis and yDom y-axis */ \
     struct TABLE3D_TYPENAME_BASE(size, xDom, yDom) \
     { \
-        typedef TABLE3D_TYPENAME_XAXIS(size, xDom, yDom) xaxis_t; \
-        typedef TABLE3D_TYPENAME_YAXIS(size, xDom, yDom) yaxis_t; \
+        typedef TABLE3D_TYPENAME_AXIS(size, xDom) xaxis_t; \
+        typedef TABLE3D_TYPENAME_AXIS(size, yDom) yaxis_t; \
         typedef TABLE3D_TYPENAME_VALUE(size, xDom, yDom) value_t; \
         /* This will take up zero space unless we take the address somewhere */ \
         static constexpr table_type_t type_key = TO_TYPE_KEY(size, xDom, yDom); \
         \
         table3DGetValueCache get_value_cache; \
-        TABLE3D_TYPENAME_VALUE(size, xDom, yDom) values; \
-        TABLE3D_TYPENAME_XAXIS(size, xDom, yDom) axisX; \
-        TABLE3D_TYPENAME_YAXIS(size, xDom, yDom) axisY; \
+        value_t values; \
+        xaxis_t axisX; \
+        yaxis_t axisY; \
     };
 TABLE3D_GENERATOR(TABLE3D_GEN_TYPE)
 

--- a/speeduino/table3d.h
+++ b/speeduino/table3d.h
@@ -20,8 +20,11 @@
  * </pre>
  *
  * In memory, we store rows in reverse:
- *      - The X axis is conventional: <c>x[0]</c> stores \c X-Min
- *      - The Y-axis is inverted: <c>y[0]</c> stores \c Y-Max
+ *      - Both axes are inverted:
+ *        - <c>x[0]</c> stores \c X-Max
+ *        - <c>x[2]</c> stores \c X-Min
+ *        - <c>y[0]</c> stores \c Y-Max
+ *        - <c>y[2]</c> stores \c Y-Min
  *      - The value locations match the axes.
  *          - <c>value[0][0]</c> stores \c V6.
  *          - <c>value[2][0]</c> stores \c V0.

--- a/speeduino/table3d_axes.h
+++ b/speeduino/table3d_axes.h
@@ -88,18 +88,17 @@ private:
     axis_domain _domain;
 };
 
-#define TABLE3D_TYPENAME_XAXIS(size, xDom, yDom) CONCAT(TABLE3D_TYPENAME_BASE(size, xDom, yDom), _xaxis)
+#define TABLE3D_TYPENAME_AXIS(size, domain) table3d ## size ## domain ## _axis
 
-#define TABLE3D_GEN_XAXIS(size, xDom, yDom) \
-    /** @brief The x-axis for a 3D table with size x size dimensions, xDom x-axis and yDom y-axis */ \
-    struct TABLE3D_TYPENAME_XAXIS(size, xDom, yDom) { \
+#define TABLE3D_GEN_AXIS(size, dom) \
+    /** @brief The dxis for a 3D table with size x size dimensions and domain 'domain' */ \
+    struct TABLE3D_TYPENAME_AXIS(size, dom) { \
         /** @brief The length of the axis in elements */ \
         static constexpr table3d_dim_t length = size; \
         /** @brief The domain the axis represents */ \
-        static constexpr axis_domain domain = axis_domain_ ## xDom; \
+        static constexpr axis_domain domain = axis_domain_ ## dom; \
         /**
-          @brief The axis elements \
-          @details The x-axis is conventional: axis[0] is the minimum \
+          @brief The axis elements\
         */ \
         table3d_axis_t axis[size]; \
         \
@@ -109,29 +108,16 @@ private:
             return table_axis_iterator(axis+(size-1), axis-1, -1, domain); \
         } \
     };
-TABLE3D_GENERATOR(TABLE3D_GEN_XAXIS)
 
-#define TABLE3D_TYPENAME_YAXIS(size, xDom, yDom) CONCAT(TABLE3D_TYPENAME_BASE(size, xDom, yDom), _yaxis)
-
-#define TABLE3D_GEN_YAXIS(size, xDom, yDom) \
-    /** @brief The y-axis for a 3D table with size x size dimensions, xDom x-axis and yDom y-axis */ \
-    struct CONCAT(TABLE3D_TYPENAME_BASE(size, xDom, yDom), _yaxis) { \
-        /** @brief The length of the axis in elements */ \
-        static constexpr table3d_dim_t length = size; \
-        /** @brief The domain the axis represents */ \
-        static constexpr axis_domain domain = axis_domain_ ## yDom; \
-        /**
-          @brief The axis elements \
-          @details The y-axis is reversed: axis[n-1] is the minimum \
-        */ \
-        table3d_axis_t axis[size]; \
-        \
-        /** @brief Iterate over the axis elements */ \
-        inline table_axis_iterator begin() \
-        { \
-            return table_axis_iterator(axis+(size-1), axis-1, -1, domain); \
-        } \
-    };
-TABLE3D_GENERATOR(TABLE3D_GEN_YAXIS)
+// This generates the axis types for the following sizes & domains:
+TABLE3D_GEN_AXIS(6, Rpm)
+TABLE3D_GEN_AXIS(6, Load)
+TABLE3D_GEN_AXIS(4, Rpm)
+TABLE3D_GEN_AXIS(4, Load)
+TABLE3D_GEN_AXIS(8, Rpm)
+TABLE3D_GEN_AXIS(8, Load)
+TABLE3D_GEN_AXIS(8, Tps)
+TABLE3D_GEN_AXIS(16, Rpm)
+TABLE3D_GEN_AXIS(16, Load)
 
 /** @} */

--- a/speeduino/table3d_axes.h
+++ b/speeduino/table3d_axes.h
@@ -106,7 +106,7 @@ private:
         /** @brief Iterate over the axis elements */ \
         inline table_axis_iterator begin(void) \
         {  \
-            return table_axis_iterator(axis, axis+size, 1, domain); \
+            return table_axis_iterator(axis+(size-1), axis-1, -1, domain); \
         } \
     };
 TABLE3D_GENERATOR(TABLE3D_GEN_XAXIS)

--- a/speeduino/table3d_interpolate.cpp
+++ b/speeduino/table3d_interpolate.cpp
@@ -82,7 +82,7 @@ static inline table3d_dim_t find_bin_max(
 
 table3d_dim_t find_xbin(table3d_axis_t &value, const table3d_axis_t *pAxis, table3d_dim_t size, table3d_dim_t lastBin)
 {
-  return find_bin_max(value, pAxis, 0, size-1, lastBin);
+  return find_bin_max(value, pAxis, size-1, 0, lastBin);
 }
 
 table3d_dim_t find_ybin(table3d_axis_t &value, const table3d_axis_t *pAxis, table3d_dim_t size, table3d_dim_t lastBin)
@@ -185,11 +185,13 @@ table3d_value_t get3DTableValue(struct table3DGetValueCache *pValueCache,
               C          D
     */
     table3d_dim_t rowMax = pValueCache->lastYBinMax * axisSize;
-    table3d_dim_t rowMin = (pValueCache->lastYBinMax+1) * axisSize;
-    table3d_value_t A = pValues[rowMax + pValueCache->lastXBinMax-1];
-    table3d_value_t B = pValues[rowMax + pValueCache->lastXBinMax];
-    table3d_value_t C = pValues[rowMin + pValueCache->lastXBinMax-1];
-    table3d_value_t D = pValues[rowMin + pValueCache->lastXBinMax];
+    table3d_dim_t rowMin = rowMax + axisSize;
+    table3d_dim_t colMax = axisSize - pValueCache->lastXBinMax - 1;
+    table3d_dim_t colMin = colMax - 1;
+    table3d_value_t A = pValues[rowMax + colMin];
+    table3d_value_t B = pValues[rowMax + colMax];
+    table3d_value_t C = pValues[rowMin + colMin];
+    table3d_value_t D = pValues[rowMin + colMax];
 
     //Check that all values aren't just the same (This regularly happens with things like the fuel trim maps)
     if( (A == B) && (A == C) && (A == D) ) { pValueCache->lastOutput = A; }
@@ -197,7 +199,7 @@ table3d_value_t get3DTableValue(struct table3DGetValueCache *pValueCache,
     {
       //Create some normalised position values
       //These are essentially percentages (between 0 and 1) of where the desired value falls between the nearest bins on each axis
-      const QU1X8_t p = compute_bin_position(X_in, pValueCache->lastXBinMax, 1, pXAxis);
+      const QU1X8_t p = compute_bin_position(X_in, pValueCache->lastXBinMax, -1, pXAxis);
       const QU1X8_t q = compute_bin_position(Y_in, pValueCache->lastYBinMax, -1, pYAxis);
 
       const QU1X8_t m = mulQU1X8(QU1X8_ONE-p, q);

--- a/test/test_misc/tests_tables.cpp
+++ b/test/test_misc/tests_tables.cpp
@@ -30,9 +30,9 @@ const table3d_value_t values[] = {
 34,  35,  36,  37,  39,  41,  42,  43,  43,  44,  44,  44,  44,  44,  44,  44, 
 34,  34,  34,  34,  34,  34,  34,  34,  34,  35,  35,  35,  35,  35,  35,  35, 
   };
-static const table3d_axis_t tempXAxis[] = {500,700, 900, 1200, 1600, 2000, 2500, 3100, 3500, 4100, 4700, 5300, 5900, 6500, 6750, 7000};
-static const table3d_axis_t xMin = tempXAxis[0];
-static const table3d_axis_t xMax = tempXAxis[_countof(tempXAxis)-1];
+static const table3d_axis_t tempXAxis[] = {7000, 6750, 6500, 5900, 5300, 4700, 4100, 3500, 3100, 2500, 2000, 1600, 1200, 900, 700, 500};
+static const table3d_axis_t xMin = tempXAxis[_countof(tempXAxis)-1];
+static const table3d_axis_t xMax = tempXAxis[0];
 static const table3d_axis_t tempYAxis[] = {100, 96, 90, 86, 76, 70, 66, 60, 56, 50, 46, 40, 36, 30, 26, 16};
 static const table3d_axis_t yMin = tempYAxis[_countof(tempYAxis)-1];
 static const table3d_axis_t yMax = tempYAxis[0];
@@ -96,7 +96,7 @@ void test_tableLookup_50pct(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, 53, 2250); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 69);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)6);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)9);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)8);
 }
 
@@ -116,9 +116,9 @@ void test_tableLookup_exact2Axis(void)
   //Tests a lookup that exactly matches on both the X and Y axis
   setup_TestTable();
 
-  uint16_t tempVE = get3DTableValue(&testTable, testTable.axisY.axis[5], testTable.axisX.axis[6]); //Perform lookup into fuel map for RPM vs MAP value
+  uint16_t tempVE = get3DTableValue(&testTable, testTable.axisY.axis[5], testTable.axisX.axis[9]); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 86);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)6);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)9);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)5);
 }
 
@@ -129,7 +129,7 @@ void test_tableLookup_overMaxX(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, 73, xMax+100); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 89);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)15);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)0);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)4);
 }
 
@@ -140,7 +140,7 @@ void test_tableLookup_overMaxY(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, yMax+10, 600); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 110);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)1);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)14);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)0);
 }
 
@@ -151,7 +151,7 @@ void test_tableLookup_underMinX(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, 38, xMin-100); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 37);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)1);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)14);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)11);
 }
 
@@ -162,7 +162,7 @@ void test_tableLookup_underMinY(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, yMin-5, 600); //Perform lookup into fuel map for RPM vs MAP value
   TEST_ASSERT_EQUAL(tempVE, 34);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)1);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)14);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)14);
 }
 
@@ -175,7 +175,7 @@ void test_tableLookup_roundUp(void)
 
   uint16_t tempVE = get3DTableValue(&testTable, 17, 600);
   TEST_ASSERT_EQUAL(tempVE, 34);
-  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)1);
+  TEST_ASSERT_EQUAL(testTable.get_value_cache.lastXBinMax, (table3d_dim_t)14);
   TEST_ASSERT_EQUAL(testTable.get_value_cache.lastYBinMax, (table3d_dim_t)14);
 }
 

--- a/test/test_misc/tests_tables.cpp
+++ b/test/test_misc/tests_tables.cpp
@@ -13,29 +13,29 @@ const PROGMEM table3d_value_t values[] = {
 const table3d_value_t values[] = {
 #endif
  //0    1    2   3     4    5    6    7    8    9   10   11   12   13    14   15
-109, 111, 112, 113, 114, 114, 114, 115, 115, 115, 114, 114, 114, 114, 114, 114, 
-104, 106, 107, 108, 109, 109, 110, 110, 110, 110, 110, 110, 110, 110, 110, 110, 
-98,  101, 103, 103, 104, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 
-93,  96,  98,  99,  99,  100, 100, 101, 101, 101, 101, 101, 101, 101, 101, 101, 
-81,  86,  88,  89,  90,  91,  91,  91,  91,  91,  91,  91,  91,  91,  91,  91, 
-74,  80,  83,  84,  85,  86,  86,  86,  87,  87,  87,  87,  87,  87,  87,  87, 
-68,  75,  78,  79,  81,  81,  81,  82,  82,  82,  82,  82,  82,  82,  82,  82, 
-61,  69,  72,  74,  76,  76,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77, 
-54,  62,  66,  69,  71,  71,  72,  72,  72,  72,  72,  72,  72,  72,  72,  72, 
-48,  56,  60,  64,  66,  66,  68,  68,  68,  68,  68,  68,  68,  68,  68,  68, 
-42,  49,  54,  58,  61,  62,  62,  63,  63,  63,  63,  63,  63,  63,  63,  63, 
-38,  43,  48,  52,  55,  56,  57,  58,  58,  58,  58,  58,  58,  58,  58,  58, 
-36,  39,  42,  46,  50,  51,  52,  53,  53,  53,  53,  53,  53,  53,  53,  53, 
-35,  36,  38,  41,  44,  46,  47,  48,  48,  49,  49,  49,  49,  49,  49,  49, 
-34,  35,  36,  37,  39,  41,  42,  43,  43,  44,  44,  44,  44,  44,  44,  44, 
 34,  34,  34,  34,  34,  34,  34,  34,  34,  35,  35,  35,  35,  35,  35,  35, 
+34,  35,  36,  37,  39,  41,  42,  43,  43,  44,  44,  44,  44,  44,  44,  44, 
+35,  36,  38,  41,  44,  46,  47,  48,  48,  49,  49,  49,  49,  49,  49,  49, 
+36,  39,  42,  46,  50,  51,  52,  53,  53,  53,  53,  53,  53,  53,  53,  53, 
+38,  43,  48,  52,  55,  56,  57,  58,  58,  58,  58,  58,  58,  58,  58,  58, 
+42,  49,  54,  58,  61,  62,  62,  63,  63,  63,  63,  63,  63,  63,  63,  63, 
+48,  56,  60,  64,  66,  66,  68,  68,  68,  68,  68,  68,  68,  68,  68,  68, 
+54,  62,  66,  69,  71,  71,  72,  72,  72,  72,  72,  72,  72,  72,  72,  72, 
+61,  69,  72,  74,  76,  76,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77, 
+68,  75,  78,  79,  81,  81,  81,  82,  82,  82,  82,  82,  82,  82,  82,  82, 
+74,  80,  83,  84,  85,  86,  86,  86,  87,  87,  87,  87,  87,  87,  87,  87, 
+81,  86,  88,  89,  90,  91,  91,  91,  91,  91,  91,  91,  91,  91,  91,  91, 
+93,  96,  98,  99,  99,  100, 100, 101, 101, 101, 101, 101, 101, 101, 101, 101, 
+98,  101, 103, 103, 104, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 
+104, 106, 107, 108, 109, 109, 110, 110, 110, 110, 110, 110, 110, 110, 110, 110, 
+109, 111, 112, 113, 114, 114, 114, 115, 115, 115, 114, 114, 114, 114, 114, 114, 
   };
-static const table3d_axis_t tempXAxis[] = {7000, 6750, 6500, 5900, 5300, 4700, 4100, 3500, 3100, 2500, 2000, 1600, 1200, 900, 700, 500};
-static const table3d_axis_t xMin = tempXAxis[_countof(tempXAxis)-1];
-static const table3d_axis_t xMax = tempXAxis[0];
-static const table3d_axis_t tempYAxis[] = {100, 96, 90, 86, 76, 70, 66, 60, 56, 50, 46, 40, 36, 30, 26, 16};
-static const table3d_axis_t yMin = tempYAxis[_countof(tempYAxis)-1];
-static const table3d_axis_t yMax = tempYAxis[0];
+static const table3d_axis_t tempXAxis[] = {500, 700, 900, 1200, 1600, 2000, 2500, 3100, 3500, 4100, 4700, 5300, 5900, 6500, 6750, 7000};
+static const table3d_axis_t xMin = tempXAxis[0];
+static const table3d_axis_t xMax = tempXAxis[_countof(tempXAxis)-1];
+static const table3d_axis_t tempYAxis[] = { 16, 26, 30, 36, 40, 46, 50, 56, 60, 66, 70, 76, 86, 90, 96, 100};
+static const table3d_axis_t yMin = tempYAxis[0];
+static const table3d_axis_t yMax = tempYAxis[_countof(tempYAxis)-1];
 
 
 static table3d16RpmLoad testTable;
@@ -64,15 +64,51 @@ void setup_TestTable(void)
       ----------------------------------------------------------------------------------------------------------------
          500 |  700 |  900 | 1200 | 1600 | 2000 | 2500 | 3100 | 3500 | 4100 | 4700 | 5300 | 5900 | 6500 | 6750 | 7000
   */
-  
-  memcpy(testTable.axisX.axis, tempXAxis, sizeof(testTable.axisX));
-  memcpy(testTable.axisY.axis, tempYAxis, sizeof(testTable.axisY));
+
+  //
+  // NOTE: USE OF ITERATORS HERE IS DELIBERATE. IT INCLUDES THEM IN THE UNIT TESTS, giving
+  // them some coverage
+  //
+  {
+    table_axis_iterator itX = testTable.axisX.begin();
+    const table3d_axis_t *pXValue = tempXAxis;
+    while (!itX.at_end())
+    {
+      *itX = *pXValue;
+      ++pXValue;
+      ++itX;
+    }
+  }
+  {
+    table_axis_iterator itY = testTable.axisY.begin();
+    const table3d_axis_t *pYValue = tempYAxis;
+    while (!itY.at_end())
+    {
+      *itY = *pYValue;
+      ++pYValue;
+      ++itY;
+    }
+  }
+
+  {
+    table_value_iterator itZ = testTable.values.begin();
+    const table3d_value_t *pZValue = values;
+    while (!itZ.at_end())
+    {
+      table_row_iterator itRow = *itZ;
+      while (!itRow.at_end())
+      {
 #if defined(PROGMEM)
-  memcpy_P
+        *itRow = pgm_read_byte(pZValue);
 #else
-  memcpy
+        *itRow = *pZValue;
 #endif
-        (testTable.values.values, values, sizeof(testTable.values));
+        ++pZValue;
+        ++itRow;
+      }
+      ++itZ;
+    }
+  }
 }
 
 void testTables()


### PR DESCRIPTION
### Summary
Simplify the table 3d axis code by changing the X-axis so its in-memory (.bss, not EEPROM) orientation matches Y-axis.

### Detail
Prior to this PR, the x-axis stored the minimum value at index 0 and the maximum at index size-1. The y-axis used the opposite layout. By using the same layout, we can use the same data types (classes) for both X & Y axes which simplifies the code base.

- No visible change in performance
- No change in free memory

This extends PR #767