### PR TITLE
fix free ram overflow

### DIFF
--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -306,8 +306,21 @@ STM32RTC& rtc = STM32RTC::getInstance();
 
   uint16_t freeRam()
   {
-      char top = 't';
-      return &top - reinterpret_cast<char*>(sbrk(0));
+    uint32_t freeRam;
+    uint32_t stackTop;
+    uint32_t heapTop;
+
+    // current position of the stack.
+    stackTop = (uint32_t)&stackTop;
+
+    // current position of heap.
+    void *hTop = malloc(1);
+    heapTop = (uint32_t)hTop;
+    free(hTop);
+    freeRam = stackTop - heapTop;
+
+    if(freeRam>0xFFFF){return 0xFFFF;}
+    else{return freeRam;}
   }
 
   void doSystemReset( void )

--- a/speeduino/board_teensy35.ino
+++ b/speeduino/board_teensy35.ino
@@ -385,6 +385,7 @@ void ftm2_isr(void)
 
 uint16_t freeRam()
 {
+    uint32_t freeRam;
     uint32_t stackTop;
     uint32_t heapTop;
 
@@ -395,9 +396,10 @@ uint16_t freeRam()
     void *hTop = malloc(1);
     heapTop = (uint32_t)hTop;
     free(hTop);
+    freeRam = stackTop - heapTop;
 
-    // The difference is the free, available ram.
-    return (uint16_t)stackTop - heapTop;
+    if(freeRam>0xFFFF){return 0xFFFF;}
+    else{return freeRam;}
 }
 
 //This function is used for attempting to set the RTC time during compile


### PR DESCRIPTION
Just a small fix for freeRam function overflowing on STM32 and Teensy. Now reports 65k free ram if there is more than 65k free instead over overflowing and reporting less free ram. 