### PR TITLE
Bugfix Axis scaling for secondary igniton and fuel tables when using TPS

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1043,7 +1043,7 @@ page = 10
       EMAPPin             = bits,   U08,       8, [4:7],      "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
 
       rotarySplitValues   = array,  U08,       9, [8],   "degrees", 1.0,    0.0,   0.0,     40,         0
-      rotarySplitBins     = array,  U08,      17, [8],     { bitStringValue(algorithmUnits ,  algorithm) }, fuelLoadRes,      0.0,   0.0,   {fuelLoadMax},      fuelDecimalRes
+      rotarySplitBins     = array,  U08,      17, [8],     { bitStringValue(algorithmUnits ,  ignAlgorithm) },     ignLoadRes,      0.0,   0.0,   {ignLoadMax},      ignDecimalRes
 
       boostSens           = scalar, U16,      25,      "",       1, 0, 0, 5000, 0
       boostIntv           = scalar, U08,      27,      "ms",     1, 0,  0,  250, 0
@@ -1229,7 +1229,7 @@ page = 12
       loadBinsVVT2  = array,  U08,    152,[  8],   { bitStringValue(algorithmUnits ,  vvtLoadSource) }, vvtLoadRes,        0.0,   0.0,     {vvtLoadMax},      vvtDecimalRes
       dwellTable    = array,  U08,    160,[4x4],    "ms",        0.1,      0.0,   0.1,        8.0,      1
       rpmBinsDwell  = array,  U08,    176,[  4],   "RPM",      100.0,      0.0,   100,      25500,      0
-      mapBinsDwell  = array,  U08,    180,[  4],   "kPa",        2.0,      0.0,   0.0,      511.0,      0
+      loadBinsDwell  = array,  U08,    180,[  4],   { bitStringValue(algorithmUnits ,  ignAlgorithm) },     ignLoadRes,      0.0,   0.0,   {ignLoadMax},      ignDecimalRes
 
 ;Page 13 is the programmable outputs
 page = 13
@@ -4284,10 +4284,10 @@ cmdVSSratio6 =      "E\x99\x06"
             size  = 450, 200
 
         curve = rotaryTrailing_curve, "Rotary Trailing Split"
-            columnLabel = "Engine load", "Split"
+            columnLabel = "Ignition load", "SplitDegrees"
             yAxis = 0, 40, 4
-            xBins = rotarySplitBins, fuelLoad
-            xAxis = 0, { fuelLoadMax }, 5
+            xBins = rotarySplitBins, ignLoad
+            xAxis = 0, { ignLoadMax }, 5
             yBins = rotarySplitValues
 
 ; Warmup enrichment curve
@@ -4590,7 +4590,7 @@ cmdVSSratio6 =      "E\x99\x06"
 
     table = dwell_map, dwell_tblMap, "Dwell map", 12
       xBins = rpmBinsDwell, rpm
-      yBins = mapBinsDwell, map
+      yBins = loadBinsDwell, ignLoad
       zBins = dwellTable
       xyLabels    = "RPM", "Load: "
       gridHeight  = 3.0

--- a/speeduino/secondaryTables.ino
+++ b/speeduino/secondaryTables.ino
@@ -172,7 +172,7 @@ byte getVE2()
   else if (configPage10.fuel2Algorithm == LOAD_SOURCE_TPS)
   {
     //Alpha-N
-    currentStatus.fuelLoad2 = currentStatus.TPS;
+    currentStatus.fuelLoad2 = currentStatus.TPS * 2;
   }
   else if (configPage10.fuel2Algorithm == LOAD_SOURCE_IMAPEMAP)
   {
@@ -201,7 +201,7 @@ byte getAdvance2()
   else if(configPage10.spark2Algorithm == LOAD_SOURCE_TPS)
   {
     //Alpha-N
-    currentStatus.ignLoad2 = currentStatus.TPS;
+    currentStatus.ignLoad2 = currentStatus.TPS * 2;
 
   }
   else if (configPage10.spark2Algorithm == LOAD_SOURCE_IMAPEMAP)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -765,7 +765,7 @@ void loop()
       {
         if ( configPage2.useDwellMap == true )
         {
-          currentStatus.dwell = (get3DTableValue(&dwellTable, currentStatus.MAP, currentStatus.RPM) * 100); //use running dwell from map
+          currentStatus.dwell = (get3DTableValue(&dwellTable, currentStatus.ignLoad, currentStatus.RPM) * 100); //use running dwell from map
         }
         else
         {
@@ -1543,8 +1543,7 @@ void calculateIgnitionAngles(int dwellAngle)
       else if(configPage4.sparkMode == IGN_MODE_ROTARY)
       {
         byte splitDegrees = 0;
-        if (configPage2.fuelAlgorithm == LOAD_SOURCE_MAP) { splitDegrees = table2D_getValue(&rotarySplitTable, currentStatus.MAP/2); }
-        else { splitDegrees = table2D_getValue(&rotarySplitTable, currentStatus.TPS); }
+        splitDegrees = table2D_getValue(&rotarySplitTable, currentStatus.ignLoad);
 
         //The trailing angles are set relative to the leading ones
         calculateIgnitionAngle3(dwellAngle, splitDegrees);


### PR DESCRIPTION
Update secondary tables to have tps * 2 in their lookup of fuelload2 and ignload2.
Dwell table axis to be ignload instead of fixed to MAP only.
Rotary split ignition tables to match ignition load rather than fuelload.