### PR TITLE
DFCO Enchancements

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -403,7 +403,7 @@ page = 1
 
       injAngRPM     = array,  U08,      95, [4],   "RPM",        100,       0.0,   100,    10000,    0
       idleTaperTime = scalar, U08,      99,    "S",         0.1,       0.0,   0.0,    25.5,      1
-      dfcoDelay     = scalar, U08,      100,   "S",         0.1,       0.0,   0.0,    25.5,      1 ;Remainder of DFCO settings are in page 4
+      dfcoStartDelay     = scalar, U08,      100,   "S",         0.1,       0.0,   0.0,    25.5,      1 ;Remainder of DFCO settings are in page 4
 #if CELSIUS
       dfcoMinCLT    = scalar,  U08,      101,    "C", 1.0,       -40,    -40,    215,      0
 #else
@@ -1027,7 +1027,22 @@ page = 9
       boostByGear6               = scalar, U08,     161, { bitStringValue(boostByGearLabels ,  boostByGearEnabled) },   2.0,   0.0,  0.0,  {boostTableLimit},      0
 
       PWMFanDuty                 = array,  U08,     162, [4],       "%", 0.5,    0,    0,    100,      1
-      unused10_160               = array,  U08,     166, [26],       "",       1, 0, 0, 255, 0
+      unused9_166                = array, U08,      166, [3],       "", 1,    0,    0,    255,      0
+      dfcoAdv                 = scalar, U08,     169,   "deg",       1.0,      -15,        -15,      50,         0
+      dfcoRampOutTime         = scalar, U08,     170,   "S",         0.1,       0.0,   0.0,    25.5,      1
+      dfcoExitFuel            = scalar, U08,     171,   "%",         1.0,       0.0,    50,     200,      0
+      dfcoRampInTime          = scalar, U08,     172,   "S",         0.1,       0.0,   0.0,    25.5,      1
+      dfcoMinVss              = scalar, U08,     173,   "km/h",      1.0,       0.0,   0.0,     255,      0
+      dfcoEnblGear1           = bits,   U08,     174,   [0:0], "Disabled",       "Enabled"
+      dfcoEnblGear2           = bits,   U08,     174,   [1:1], "Disabled",       "Enabled"
+      dfcoEnblGear3           = bits,   U08,     174,   [2:2], "Disabled",       "Enabled"
+      dfcoEnblGear4           = bits,   U08,     174,   [3:3], "Disabled",       "Enabled"
+      dfcoEnblGear5           = bits,   U08,     174,   [4:4], "Disabled",       "Enabled"
+      dfcoEnblGear6           = bits,   U08,     174,   [5:5], "Disabled",       "Enabled"
+      dfcoDsblwClutch         = bits,   U08,     174,   [6:6], "NoAction",       "Disable"
+      dfcoExitFuelTime        = bits,   U08,     174,   [7:7], "2Cycles",        "DFCO Exit Time"
+      
+      unused9_175             = array, U08,      175, [17],       "", 1,    0,    0,    255,      0
     
 page = 10
 #if CELSIUS
@@ -1503,9 +1518,9 @@ page = 14
     defaultValue = battVCorMode, 1
     defaultValue = idleAdvEnabled, 0 ;Idle advance control turned off
     defaultValue = aseTaperTime, 0.0
-    defaultValue = dfcoDelay, 0.1
+    defaultValue = dfcoRampInTime, 0.5
     defaultValue = idleTaperTime, 1.0
-    defaultValue = dfcoDelay, 0.1
+    defaultValue = dfcoRampOutTime, 0.4
     defaultValue = dfcoMinCLT, 25
     defaultValue = crankingEnrichTaper, 0.1
     defaultValue = boostCutEnabled,     1
@@ -1701,6 +1716,7 @@ menuDialog = main
    menu = "&Tuning"
       subMenu = std_realtime,       "Realtime Display"
       subMenu = accelEnrichments,   "Acceleration Enrichment"
+      subMenu = fuelCutoff,         "DFCO"
       subMenu = egoControl,         "AFR/O2", 3
       subMenu = RevLimiterS,        "Engine Protection",       2
       subMenu = flexFueling,        "Flex Fuel",        2
@@ -1902,9 +1918,15 @@ menuDialog = main
   aeColdTaperMax    = "AE cold adjustment taper end temperature. When coolant is above this value, no cold adjustment is applied."
   dfcoRPM           = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
   dfcoHyster        = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
-  dfcoTPSThresh     = "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
-  dfcoDelay         = "Delay for activate DFCO."
-  dfcoMinCLT        = "Minimum temperature to enable DFCO."
+  dfcoTPSThresh     = "The TPS value below which DFCO will be active. Typical value is 1%-2%, but higher may be needed if TPS signal is noisy."
+  dfcoRampOutTime   = "DFCO exit spark ramp time also limits the maximum Fuel Enrichment time."
+  dfcoRampInTime    = "DFCO entry spark ramp time. Occurs after Entry Delay"
+  dfcoMinCLT        = "Minimum coolant temperature to enable DFCO."
+  dfcoAdv           = "Spark advance for DFCO entry/exit. Set to smooth the transition."
+  dfcoExitFuel      = "Fuel Modification used during DFCO exit time to recover wall wetting and assist Catalyst."
+  dfcoStartDelay    = "Delay from the time the enable conditions are met to start ramp of spark."
+  dfcoDsblwClutch   = "Disable DFCO if the clutch is pressed. Wired to the Launch Pin. Please setup in Launch Area"
+  dfcoMinVss        = "Minimum vehicle speed to enable DFCO. If no VSS input is used set to 0km/h."
 
   launchPin         = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
   launchHiLo        = "Whether the signal is High or Low when the clutch pedal is engaged. For a ground switching input (Most clutch switches), this should be LOW"
@@ -1984,11 +2006,6 @@ menuDialog = main
   aeColdPct       = "Acceleration enrichment adjustment for cold engine. Cold adjustment % is tapered between start and end temperatures.\n100% = no adjustment."
   aeColdTaperMin  = "AE cold adjustment taper start temperature. When coolant is below this value, full cold adjustment is applied."
   aeColdTaperMax  = "AE cold adjustment taper end temperature. When coolant is above this value, no cold adjustment is applied."
-  dfcoRPM         = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
-  dfcoHyster      = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
-  dfcoTPSThresh   = "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
-  dfcoDelay       = "Delay for activate DFCO."
-  dfcoMinCLT      = "Minimum temperature to enable DFCO."
   crankingEnrichTaper = "Taper time from cranking enrichment to ASE or run (after engine has started)."
 
   launchPin       = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
@@ -2388,14 +2405,7 @@ menuDialog = main
         field = "Cold adjustment",      aeColdPct
         field = "Cold adjustment taper start temperature",  aeColdTaperMin
         field = "Cold adjustment taper end temperature",  aeColdTaperMax
-
-    dialog = accelEnrichments_south, "Decelleration Fuel Cutoff (DFCO)"
-      field = "Enabled", dfcoEnabled
-      field = "TPS Threshold", dfcoTPSThresh,           { dfcoEnabled }
-      field = "Minimum engine temperature", dfcoMinCLT, { dfcoEnabled }
-      field = "Cutoff delay", dfcoDelay,                { dfcoEnabled }
-      field = "Cutoff RPM", dfcoRPM,                    { dfcoEnabled }
-      field = "RPM Hysteresis", dfcoHyster,             { dfcoEnabled }
+ 
 
     dialog = accelEnrichments_north_south, ""
       liveGraph = pump_ae_Graph, "AE Graph"
@@ -2420,7 +2430,34 @@ menuDialog = main
         panel = accelEnrichments_north, North
         panel = accelEnrichments_north_south, Center
         panel = accelEnrichments_center, Center
-        panel = accelEnrichments_south, South
+    
+    dialog = fuelCutoff_Enables "DFCO Enables"
+        field = "Enable DFCO", dfcoEnabled
+        field = "Minimum RPM ", dfcoRPM,                   { dfcoEnabled }
+        field = "RPM Hysteresis ", dfcoHyster,             { dfcoEnabled }
+        field = "TPS Threshold ", dfcoTPSThresh,           { dfcoEnabled }
+        field = "Exit DFCO with Clutch (Launch input) ", dfcoDsblwClutch { dfcoEnabled }
+        field = "Minimum engine temperature ", dfcoMinCLT, { dfcoEnabled }
+        field = "Minimum Vehicle Speed ", dfcoMinVss       { dfcoEnabled }
+        field = "Gear based Enables"
+        field = "Gear 1 ", dfcoEnblGear1                   { dfcoEnabled }
+        field = "Gear 2 ", dfcoEnblGear2                   { dfcoEnabled }
+        field = "Gear 3 ", dfcoEnblGear3                   { dfcoEnabled }
+        field = "Gear 4 ", dfcoEnblGear4                   { dfcoEnabled }
+        field = "Gear 5 ", dfcoEnblGear5                   { dfcoEnabled }
+        field = "Gear 6 ", dfcoEnblGear6                   { dfcoEnabled }
+      
+    dialog = fuelCutoff_Ramps "DFCO Control Ramps"
+        field = "DFCO Start Delay",       dfcoStartDelay,  { dfcoEnabled }
+        field = "DFCO Spark Advance ", dfcoAdv,            { dfcoEnabled }
+        field = "DFCO Entry Ramp Time ",  dfcoRampInTime,  { dfcoEnabled }
+        field = "DFCO Exit Ramp Time ",   dfcoRampOutTime, { dfcoEnabled }
+        field = "DFCO Exit Fuel Modification ", dfcoExitFuel, { dfcoEnabled }
+        field = "DFCO Exit Fuel Time ", dfcoExitFuelTime, { dfcoEnabled }
+    
+    dialog = fuelCutoff, "Decelleration Fuel Cutoff (DFCO)"
+        panel = fuelCutoff_Enables
+        panel = fuelCutoff_Ramps
 
     dialog = veTableDialog_north, ""
         panel = veTable1Tbl
@@ -2759,10 +2796,10 @@ menuDialog = main
         
 
     dialog = clutchInput,                   "Clutch input"
-        field = "Clutch Input Pin",             launchPin,      { launchEnable || flatSEnable }
-        field = "Clutch enabled when signal is",launchHiLo,     { launchEnable || flatSEnable }
-        field = "Clutch Pullup Resistor",       lnchPullRes,    { launchEnable || flatSEnable }
-        field = "Launch / Flat Shift switch RPM",flatSArm,      { launchEnable || flatSEnable }
+        field = "Clutch Input Pin",             launchPin,      { launchEnable || flatSEnable || dfcoDsblwClutch}
+        field = "Clutch enabled when signal is",launchHiLo,     { launchEnable || flatSEnable || dfcoDsblwClutch}
+        field = "Clutch Pullup Resistor",       lnchPullRes,    { launchEnable || flatSEnable || dfcoDsblwClutch}
+        field = "Launch / Flat Shift switch RPM",flatSArm,      { launchEnable || flatSEnable || dfcoDsblwClutch}
 
     dialog = LaunchControl,                   "Launch Control / Flat shift",      6
         topicHelp = "https://wiki.speeduino.com/en/configuration/Launch_Flatshift"
@@ -3716,7 +3753,7 @@ menuDialog = main
         displayOnlyField = "tachoPin", tachoPin, {tachoDuration}
         displayOnlyField = "idleUpPin", idleUpPin, {idleUpEnabled}
         displayOnlyField = "idleUpOutputPin", idleUpOutputPin, {idleUpEnabled && idleUpOutputEnabled}
-        displayOnlyField = "launchPin", launchPin, {launchEnable}
+        displayOnlyField = "launchPin", launchPin, {launchEnable ||  flatSEnable || dfcoDsblwClutch}
         displayOnlyField = "vvt1Pin", vvt1Pin, {vvtEnabled}
         displayOnlyField = "vssPin", vssPin, {vssMode > 1}
         displayOnlyField = "boostPin", boostPin, {boostEnabled}

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -20,7 +20,7 @@ byte correctionBatVoltage(); //Battery voltage correction
 byte correctionIATDensity(); //Inlet temp density correction
 byte correctionBaro(); //Barometric pressure correction
 byte correctionLaunch(); //Launch control correction
-bool correctionDFCO(); //Decelleration fuel cutoff
+byte correctionDFCO(); //Decelleration fuel cutoff
 
 
 int8_t correctionsIgn(int8_t advance);
@@ -30,6 +30,7 @@ int8_t correctionFlexTiming(int8_t);
 int8_t correctionWMITiming(int8_t);
 int8_t correctionIATretard(int8_t);
 int8_t correctionCLTadvance(int8_t);
+int8_t correctionDFCOEntryExit(int8_t);
 int8_t correctionIdleAdvance(int8_t);
 int8_t correctionSoftRevLimit(int8_t);
 int8_t correctionNitrous(int8_t);
@@ -50,7 +51,12 @@ extern byte lastKnockCount;
 extern int16_t knockWindowMin; //The current minimum crank angle for a knock pulse to be valid
 extern int16_t knockWindowMax;//The current maximum crank angle for a knock pulse to be valid
 extern uint16_t aseTaperStart;
-extern uint16_t dfcoStart;
 extern uint16_t idleAdvStart;
+
+#define DFCO_OFF 0
+#define DFCO_ENABLE_DELAY 1
+#define DFCO_RAMP_IN 2
+#define DFCO_ACTIVE 3
+#define DFCO_RAMP_OUT 4
 
 #endif // CORRECTIONS_H

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -867,8 +867,8 @@ struct config2 {
   byte injAngRPM[4];
 
   byte idleTaperTime;
-  byte dfcoDelay;
-  byte dfcoMinCLT;
+  byte dfcoStartDelay; // Delay time before DFCO starts ramping in
+  byte dfcoMinCLT; // Minimum coolant temperature for DFCO
 
   //VSS Stuff
   byte vssMode : 2; ///< VSS (Vehicle speed sensor) mode (0=none, 1=CANbus, 2,3=Interrupt driven)
@@ -1156,12 +1156,20 @@ struct config9 {
   byte unused10_166;
   byte unused10_167;
   byte unused10_168;
-  byte unused10_169;
-  byte unused10_170;
-  byte unused10_171;
-  byte unused10_172;
-  byte unused10_173;
-  byte unused10_174;
+  byte dfcoAdv; // Spark advance for DFCO entry and exit
+  byte dfcoRampOutTime; // Delay time to ramp spark and apply enrichment on DFCO exit
+  byte dfcoExitFuel; // Fuel enrichment on DFCO exit.
+  byte dfcoRampInTime; // time to ramp spark on DFCO entry
+  byte dfcoMinVss; //Min vehicle speed for DFCO
+  byte dfcoEnblGear1: 1; //DFCO Enable Per Gear
+  byte dfcoEnblGear2: 1; //DFCO Enable Per Gear
+  byte dfcoEnblGear3: 1; //DFCO Enable Per Gear
+  byte dfcoEnblGear4: 1; //DFCO Enable Per Gear
+  byte dfcoEnblGear5: 1; //DFCO Enable Per Gear
+  byte dfcoEnblGear6: 1; //DFCO Enable Per Gear
+  byte dfcoDsblwClutch: 1; //DFCO Disable when clutch pressed (Launch Input)
+  byte dfcoExitFuelTime: 1; // Selects if short (two engine cycles) or long (dfcoRampInTime) for dfcoExitFuel;
+
   byte unused10_175;
   byte unused10_176;
   byte unused10_177;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -244,7 +244,7 @@ void loop()
       //Check for launching/flat shift (clutch) can be done around here too
       previousClutchTrigger = clutchTrigger;
       //Only check for pinLaunch if any function using it is enabled. Else pins might break starting a board
-      if(configPage6.flatSEnable || configPage6.launchEnabled){
+      if(configPage6.flatSEnable || configPage6.launchEnabled || (configPage9.dfcoDsblwClutch == true)){
         if(configPage6.launchHiLo > 0) { clutchTrigger = digitalRead(pinLaunch); }
         else { clutchTrigger = !digitalRead(pinLaunch); }
       }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -330,7 +330,7 @@ void doUpdates()
     configPage2.injAngRPM[3] = 65;
 
     //Introdced a DFCO delay option. Default it to 0
-    configPage2.dfcoDelay = 0;
+    configPage2.dfcoStartDelay = 0;
     //Introdced a minimum temperature for DFCO. Default it to 40C
     configPage2.dfcoMinCLT = 80; //CALIBRATION_TEMPERATURE_OFFSET is 40
 


### PR DESCRIPTION
Clear up the structure of DFCO code and add the following functions:

- Spark ramp into and out of DFCO to smooth transition.
- DFCO Exit Fuel enrichment options to recover wall wetting and catalyst to prevent hesitation and improve emissions.
- Enable conditions based on vehicle speed, gear and clutch input.

+ 5bytes of EEPROM in page 9.

![image](https://user-images.githubusercontent.com/87687708/150319226-e3e475b3-cc9b-4cfd-8343-314ee8b816a9.png)

