### PR TITLE
SD-Card logging for STM32 [EXPERIMENTAL] 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,7 +63,7 @@ platform = ststm32
 framework = arduino
 ;board = genericSTM32F407VET6
 board = black_f407ve
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = stm32duino/STM32duino RTC, greiman/SdFat
 board_build.core = stm32
 build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_CAN_MODULE_ENABLED
 upload_protocol = dfu

--- a/speeduino/SD_logger.h
+++ b/speeduino/SD_logger.h
@@ -3,7 +3,11 @@
 
 #ifdef SD_LOGGING
 
-#include <SD.h>
+#ifdef __SD_H__
+  #include <SD.h>
+#else
+  #include "SdFat.h"
+#endif
 //#include <SdSpiCard.h>
 #include "RingBuf.h"
 
@@ -30,8 +34,10 @@
 
 #define SD_SECTOR_SIZE              512 // Standard SD sector size
 
-#ifdef CORE_TEENSY
+#if defined CORE_TEENSY
     #define SD_CS_PIN BUILTIN_SDCARD
+#elif defined CORE_STM32
+    #define SD_CS_PIN PD2  //CS pin can be pretty much anything, but PD2 is one of the ones left unused from SDIO pins.
 #else
     #define SD_CS_PIN 10 //This is a made up value for now
 #endif

--- a/speeduino/SD_logger.ino
+++ b/speeduino/SD_logger.ino
@@ -1,6 +1,10 @@
 #ifdef SD_LOGGING
 #include <SPI.h>
-#include <SD.h>
+#ifdef __SD_H__
+  #include <SD.h>
+#else
+  #include "SdFat.h"
+#endif
 #include "SD_logger.h"
 #include "logger.h"
 #include "rtc_common.h"

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -5,6 +5,7 @@
 #include <HardwareTimer.h>
 #include <HardwareSerial.h>
 #include "STM32RTC.h"
+#include <SPI.h>
 
 #if defined(STM32F1)
 #include "stm32f1xx_ll_tim.h"
@@ -31,8 +32,13 @@
   #define EEPROM_RESET_PIN USER_BTN //onboard key0 for black STM32F407 boards and blackpills, keep pressed during boot to reset eeprom
 #endif
 
-#ifdef SD_LOGGING
-#define RTC_ENABLED
+//Uncomment this to enable SD logging for STM32:
+#define SD_LOGGING //SD logging not enabled by default because it uses SPI and there is no boards with SPI SD-slot available currently.
+
+#if defined SD_LOGGING
+  #define RTC_ENABLED
+  extern SPIClass SD_SPI; //SPI3_MOSI, SPI3_MISO, SPI3_SCK
+  #define SD_CONFIG SdSpiConfig(SD_CS_PIN, DEDICATED_SPI, SD_SCK_MHZ(50), &SD_SPI)
 #endif
 #define USE_SERIAL3
 

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -32,13 +32,18 @@
   #define EEPROM_RESET_PIN USER_BTN //onboard key0 for black STM32F407 boards and blackpills, keep pressed during boot to reset eeprom
 #endif
 
-//Uncomment this to enable SD logging for STM32:
-#define SD_LOGGING //SD logging not enabled by default because it uses SPI and there is no boards with SPI SD-slot available currently.
+#if defined(STM32F407xx)
+  //Comment out this to disable SD logging for STM32 if needed. Currently SD logging for STM32 is experimental feature for F407.
+  #define SD_LOGGING
+#endif
 
 #if defined SD_LOGGING
   #define RTC_ENABLED
+  //SD logging with STM32 uses SD card in SPI mode, because used SD library doesn't support SDIO implementation. By default SPI3 is used that uses same pins as SDIO also, but in different order.
   extern SPIClass SD_SPI; //SPI3_MOSI, SPI3_MISO, SPI3_SCK
   #define SD_CONFIG SdSpiConfig(SD_CS_PIN, DEDICATED_SPI, SD_SCK_MHZ(50), &SD_SPI)
+  //Alternatively same SPI bus can be used as there is for SPI flash. But this is not recommended due to slower speed and other possible problems.
+  //#define SD_CONFIG SdSpiConfig(SD_CS_PIN, SHARED_SPI, SD_SCK_MHZ(50), &SPI_for_flash)
 #endif
 #define USE_SERIAL3
 

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -17,6 +17,10 @@ Default CAN3 pins are PA8 & PA15. Alternative (ALT) pins are PB3 & PB4.
 */
 #endif
 
+#if defined SD_LOGGING
+    SPIClass SD_SPI(PC12, PC11, PC10); //SPI3_MOSI, SPI3_MISO, SPI3_SCK
+#endif
+
 #if defined(SRAM_AS_EEPROM)
     BackupSramAsEEPROM EEPROM;
 #elif defined(USE_SPI_EEPROM)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1792,7 +1792,7 @@ void setPinMapping(byte boardID)
       pinCoil6 = 34; //Pin for coil 6
       pinCoil7 = 46; //Pin for coil 7 (placeholder)
       pinCoil8 = 53; //Pin for coil 8 (placeholder)
-      pinTrigger = 19; //The CAS pin
+      pinTrigger = 18; //The CAS pin
       pinTrigger2 = 18; //The Cam Sensor pin
       pinTrigger3 = 20; //The Cam sensor 2 pin
       pinTPS = A2;//TPS input pin

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1792,7 +1792,7 @@ void setPinMapping(byte boardID)
       pinCoil6 = 34; //Pin for coil 6
       pinCoil7 = 46; //Pin for coil 7 (placeholder)
       pinCoil8 = 53; //Pin for coil 8 (placeholder)
-      pinTrigger = 18; //The CAS pin
+      pinTrigger = 19; //The CAS pin
       pinTrigger2 = 18; //The Cam Sensor pin
       pinTrigger3 = 20; //The Cam sensor 2 pin
       pinTPS = A2;//TPS input pin


### PR DESCRIPTION
This PR adds SD-Card logging for STM32F407 using current implementation in Speeduino FW. This SD Card logging uses SPI interface for SD card, instead of the SDIO commonly found on STM32F407 dev boards. For that reason the SD-Slot wiring needs to be changed to suit this. The SPI bus used is SPI3 which uses same pins as SDIO, but in different order. Here's what needs to be modified to get this working.

Default SDIO connection:
![image](https://user-images.githubusercontent.com/48950874/151581042-e5c85117-509c-48d8-8036-b8e5512d2f16.png)

SPI3 that this PR uses:
![image](https://user-images.githubusercontent.com/48950874/151581301-abf933e0-034a-40e0-857c-bf3f2791f3e2.png)

This PR is still highly experimental. I have tested that this doesn't break Teensy implementation and that it roughly works. But not recommended to use with actual running engines. Mostly this is to help others to test, find and fix problems related to this implementation.

Problems found so far:
- After writing the full 10Mb file, there is short hiccup.
- The full 10Mb file gets corrupted.
