### PR TITLE
Faster better ADC reads

### DIFF
--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -31,6 +31,13 @@
   void doSystemReset();
   void jumpToBootloader();
 
+  void ADCinit_AVR2560();
+  bool ADC_start_AVR2560(uint32_t pin); //returns 1 when ADC succesfully started
+  bool ADC_CheckForConversionComplete_AVR2560();
+  uint16_t ADC_get_value_AVR2560();
+  
+  typedef uint32_t PinName;   // this really is not used in avr2560 portion, but required here for compatibility reasons
+
   #if defined(TIMER5_MICROS)
     /*#define micros() (((timer5_overflow_count << 16) + TCNT5) * 4) */ //Fast version of micros() that uses the 4uS tick of timer5. See timers.ino for the overflow ISR of timer5
     #define millis() (ms_counter) //Replaces the standard millis() function with this macro. It is both faster and more accurate. See timers.ino for its counter increment.

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -1,6 +1,5 @@
 #ifndef STM32OFFICIAL_H
 #define STM32OFFICIAL_H
-#include <Arduino.h>
 #if defined(STM32_CORE_VERSION_MAJOR)
 #include <HardwareTimer.h>
 #include <HardwareSerial.h>
@@ -44,6 +43,10 @@ HardwareSerial Serial1(PA10, PA9);
 extern STM32RTC& rtc;
 
 void initBoard();
+void ADCinit_STM32();
+bool ADC_start_STM32(uint32_t ulPin); //returns 1 when ADC succesfully started
+bool ADC_CheckForConversionComplete_STM32();
+uint16_t ADC_get_value_STM32();
 uint16_t freeRam();
 void doSystemReset();
 void jumpToBootloader();

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -1,10 +1,23 @@
-#include "board_stm32_official.h"
-#if defined(STM32_CORE_VERSION_MAJOR)
 #include "globals.h"
+#if defined(STM32_CORE_VERSION_MAJOR)
+#include <Arduino.h>
+#include "board_stm32_official.h"
 #include "auxiliaries.h"
 #include "idle.h"
 #include "scheduler.h"
 #include "HardwareTimer.h"
+#include "PinNames.h"
+
+//ADC defines 
+#define ADC_SAMPLINGTIME        ADC_SAMPLETIME_144CYCLES  //The longer the normal sampling time, the higher the acquired ADC accuracy.
+#define ADC_CLOCK_DIV       ADC_CLOCK_SYNC_PCLK_DIV4
+#ifndef ADC_REGULAR_RANK_1
+#define ADC_REGULAR_RANK_1  1
+#endif
+
+ADC_HandleTypeDef AdcHandle = {};
+ADC_ChannelConfTypeDef AdcChannelConf = {};
+
 
 #if HAL_CAN_MODULE_ENABLED
 //This activates CAN1 interface on STM32, but it's named as Can0, because that's how Teensy implementation is done
@@ -402,4 +415,231 @@ STM32RTC& rtc = STM32RTC::getInstance();
   void ignitionSchedule8Interrupt(HardwareTimer*){ignitionSchedule8Interrupt();}
   #endif
   #endif //End core<=1.8
+
+    /*
+    ***********************************************************************************************************
+    * ADC
+    */
+void ADCinit_STM32()
+{
+  AdcHandle.Instance                   = ADC1;         /* ADC1 can do all availavle channels on black_F407VE */
+  AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_DIV;           /* (A)synchronous clock mode, input ADC clock divided */
+  AdcHandle.Init.Resolution            = ADC_RESOLUTION_10B;      /* resolution for converted data */
+  AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;     /* Right-alignment for converted data */
+  AdcHandle.Init.ScanConvMode          = DISABLE;                 /* Sequencer disabled (ADC conversion on only 1 channel: channel set on rank 1) */
+  AdcHandle.Init.EOCSelection          = ADC_EOC_SINGLE_CONV;     /* EOC flag picked-up to indicate conversion end */
+  AdcHandle.Init.ContinuousConvMode    = DISABLE;                 /* Continuous mode disabled to have only 1 conversion at each conversion trig */
+  AdcHandle.Init.NbrOfConversion       = 1;                       /* Specifies the number of ranks that will be converted within the regular group sequencer. */
+  AdcHandle.Init.DiscontinuousConvMode = DISABLE;                 /* Parameter discarded because sequencer is disabled */
+  AdcHandle.Init.NbrOfDiscConversion   = 0;                       /* Parameter discarded because sequencer is disabled */
+  AdcHandle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;      /* Software start to trig the 1st conversion manually, without external event */
+  AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;/* Parameter discarded because software trigger chosen */
+  AdcHandle.Init.DMAContinuousRequests = DISABLE;
+
+  AdcHandle.State = HAL_ADC_STATE_RESET;
+  AdcHandle.DMA_Handle = NULL;
+  AdcHandle.Lock = HAL_UNLOCKED;
+  /* Some other ADC_HandleTypeDef fields exists but not required */
+
+  HAL_ADC_Init(&AdcHandle);
+}
+
+/*returns 1 when ADC succesfully started */
+bool ADC_start_STM32(uint32_t ulPin) 
+{
+  uint32_t channel = 0;
+  uint32_t bank = 0;
+  PinName pin;
+  
+  pin = analogInputToPinName(ulPin);
+  channel = get_adc_channel_STM32(pin);
+  AdcChannelConf.Channel      = channel;                          /* Specifies the channel to configure into ADC */
+  if (!IS_ADC_CHANNEL(AdcChannelConf.Channel)) {
+    return 0; /* Channel Configuration Error */
+  }
+  AdcChannelConf.Rank         = ADC_REGULAR_RANK_1;               /* Specifies the rank in the regular group sequencer */
+  AdcChannelConf.SamplingTime = ADC_SAMPLINGTIME;                     /* Sampling time value to be set for the selected channel */
+  AdcChannelConf.Offset = 0;                                      /* Parameter discarded because offset correction is disabled */
+  /* Configure ADC GPIO pin */
+  if (!(pin & PADC_BASE)) {
+    pinmap_pinout(pin, PinMap_ADC);
+  }
+  /*##-2- Configure ADC regular channel ######################################*/
+  if (HAL_ADC_ConfigChannel(&AdcHandle, &AdcChannelConf) != HAL_OK) {
+    /* Channel Configuration Error */
+    return 0;
+  } 
+    /*##-3- Start the conversion process ####################*/
+  if (HAL_ADC_Start(&AdcHandle) != HAL_OK) {
+    /* Start Conversation Error */
+    return 0;
+  }
+  return 1;  //success
+}
+
+bool ADC_CheckForConversionComplete_STM32(){
+  ADC_HandleTypeDef* hadc=&AdcHandle;
+
+  if (!(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC))){
+    return 0;
+  }
+    /* Clear regular group conversion flag */
+  __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_STRT | ADC_FLAG_EOC);
+
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+
+  /* Determine whether any further conversion upcoming on group regular       */
+  /* by external trigger, continuous mode or scan sequence on going.          */
+  /* Note: On STM32F4, there is no independent flag of end of sequence.       */
+  /*       The test of scan sequence on going is done either with scan        */
+  /*       sequence disabled or with end of conversion flag set to            */
+  /*       of end of sequence.                                                */
+  if(ADC_IS_SOFTWARE_START_REGULAR(hadc)                   &&
+     (hadc->Init.ContinuousConvMode == DISABLE)            &&
+     (HAL_IS_BIT_CLR(hadc->Instance->SQR1, ADC_SQR1_L) ||
+      HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_EOCS)  )   )
+  {
+    /* Set ADC state */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+    }
+  }
+  return 1;
+}
+
+uint16_t ADC_get_value_STM32()
+{
+  uint16_t temp = 0U;
+    /* Check if the continous conversion of regular channel is finished */
+  if ((HAL_ADC_GetState(&AdcHandle) & HAL_ADC_STATE_REG_EOC) == HAL_ADC_STATE_REG_EOC) {
+    /*##-5- Get the converted value of regular channel  ########################*/
+    temp = HAL_ADC_GetValue(&AdcHandle);
+  }
+  //  temp = AdcHandle.Instance->DR; //basically this is all that it does
+  return temp;
+}
+uint32_t get_adc_channel_STM32(PinName pin) //this really only needs to be here because it is made private in the HAL drivers
+{
+  uint32_t function = pinmap_function(pin, PinMap_ADC);
+  uint32_t channel = 0;
+  switch (STM_PIN_CHANNEL(function)) {
+#ifdef ADC_CHANNEL_0
+    case 0:
+      channel = ADC_CHANNEL_0;
+      break;
+#endif
+    case 1:
+      channel = ADC_CHANNEL_1;
+      break;
+    case 2:
+      channel = ADC_CHANNEL_2;
+      break;
+    case 3:
+      channel = ADC_CHANNEL_3;
+      break;
+    case 4:
+      channel = ADC_CHANNEL_4;
+      break;
+    case 5:
+      channel = ADC_CHANNEL_5;
+      break;
+    case 6:
+      channel = ADC_CHANNEL_6;
+      break;
+    case 7:
+      channel = ADC_CHANNEL_7;
+      break;
+    case 8:
+      channel = ADC_CHANNEL_8;
+      break;
+    case 9:
+      channel = ADC_CHANNEL_9;
+      break;
+    case 10:
+      channel = ADC_CHANNEL_10;
+      break;
+    case 11:
+      channel = ADC_CHANNEL_11;
+      break;
+    case 12:
+      channel = ADC_CHANNEL_12;
+      break;
+    case 13:
+      channel = ADC_CHANNEL_13;
+      break;
+    case 14:
+      channel = ADC_CHANNEL_14;
+      break;
+    case 15:
+      channel = ADC_CHANNEL_15;
+      break;
+#ifdef ADC_CHANNEL_16
+    case 16:
+      channel = ADC_CHANNEL_16;
+      break;
+#endif
+    case 17:
+      channel = ADC_CHANNEL_17;
+      break;
+#ifdef ADC_CHANNEL_18
+    case 18:
+      channel = ADC_CHANNEL_18;
+      break;
+#endif
+#ifdef ADC_CHANNEL_19
+    case 19:
+      channel = ADC_CHANNEL_19;
+      break;
+#endif
+#ifdef ADC_CHANNEL_20
+    case 20:
+      channel = ADC_CHANNEL_20;
+      break;
+    case 21:
+      channel = ADC_CHANNEL_21;
+      break;
+    case 22:
+      channel = ADC_CHANNEL_22;
+      break;
+    case 23:
+      channel = ADC_CHANNEL_23;
+      break;
+    case 24:
+      channel = ADC_CHANNEL_24;
+      break;
+    case 25:
+      channel = ADC_CHANNEL_25;
+      break;
+    case 26:
+      channel = ADC_CHANNEL_26;
+      break;
+#ifdef ADC_CHANNEL_27
+    case 27:
+      channel = ADC_CHANNEL_27;
+      break;
+    case 28:
+      channel = ADC_CHANNEL_28;
+      break;
+    case 29:
+      channel = ADC_CHANNEL_29;
+      break;
+    case 30:
+      channel = ADC_CHANNEL_30;
+      break;
+    case 31:
+      channel = ADC_CHANNEL_31;
+      break;
+#endif
+#endif
+    default:
+      channel = 0;
+      break;
+  }
+  return channel;
+}
+
 #endif

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -34,6 +34,7 @@
   #define PWM_FAN_AVAILABLE
   #define pinIsReserved(pin)  ( ((pin) == 0) || ((pin) == 1) || ((pin) == 3) || ((pin) == 4) ) //Forbiden pins like USB
 
+typedef uint32_t PinName;   // this really is not used, but required here for compatibility reasons
 /*
 ***********************************************************************************************************
 * Schedules

--- a/speeduino/board_teensy41.h
+++ b/speeduino/board_teensy41.h
@@ -28,6 +28,8 @@
   #define PWM_FAN_AVAILABLE
   #define pinIsReserved(pin)  ( ((pin) == 0) ) //Forbiden pins like USB
 
+  typedef uint32_t PinName;   // this really is not used, but required here for compatibility reasons
+
 /*
 ***********************************************************************************************************
 * Schedules

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -39,10 +39,6 @@ int8_t correctionKnock(int8_t);
 
 uint16_t correctionsDwell(uint16_t dwell);
 
-extern int MAP_rateOfChange;
-extern int TPS_rateOfChange;
-extern byte activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
-extern byte activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
 
 extern uint16_t AFRnextCycle;
 extern unsigned long knockStartTime;

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -38,10 +38,6 @@ long PID_O2, PID_output, PID_AFRTarget;
 */
 PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE);
 
-int MAP_rateOfChange;
-int TPS_rateOfChange;
-byte activateMAPDOT; //The mapDOT value seen when the MAE was activated. 
-byte activateTPSDOT; //The tpsDOT value seen when the MAE was activated.
 
 uint16_t AFRnextCycle;
 unsigned long knockStartTime;
@@ -287,7 +283,9 @@ uint16_t correctionAccel()
 {
   int16_t accelValue = 100;
   int16_t MAP_change = 0;
-  int8_t TPS_change = 0;
+  int MAP_rateOfChange;
+  static byte activateMAPDOT; //The mapDOT value seen when the MAE was activated.
+  static byte activateTPSDOT; //The tpsDOT value seen when the MAE was activated. 
 
   if(configPage2.aeMode == AE_MODE_MAP)
   {
@@ -298,22 +296,12 @@ uint16_t correctionAccel()
     if(MAP_rateOfChange >= 0) { currentStatus.mapDOT = MAP_rateOfChange / 10; } //The MAE bins are divided by 10 in order to allow them to be stored in a byte. Faster as this than divu10
     else { currentStatus.mapDOT = 0; } //Prevent overflow as mapDOT is signed
   }
-  else if(configPage2.aeMode == AE_MODE_TPS)
-  {
-    //Get the TPS rate change
-    TPS_change = (currentStatus.TPS - TPSlast);
-    //TPS_rateOfChange = ldiv(1000000, (TPS_time - TPSlast_time)).quot * TPS_change; //This is the % per second that the TPS has moved
-    TPS_rateOfChange = TPS_READ_FREQUENCY * TPS_change; //This is the % per second that the TPS has moved
-    if(TPS_rateOfChange >= 0) { currentStatus.tpsDOT = TPS_rateOfChange / 20; } //The TAE bins are divided by 10 in order to allow them to be stored in a byte and then by 2 due to TPS being 0.5% resolution (0-200)
-    else { currentStatus.tpsDOT = 0; } //Prevent overflow as tpsDOT is signed
-  }
-  
 
   //First, check whether the accel. enrichment is already running
   if( BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC) )
   {
     //If it is currently running, check whether it should still be running or whether it's reached it's end time
-    if( micros_safe() >= currentStatus.AEEndTime )
+    if( (micros_safe()- currentStatus.AEStartTime) >= ((unsigned long)configPage2.aeTime * 10000)) // taeTime is stored as mS / 10, so multiply it by 100 to get it in uS )
     {
       //Time to turn enrichment off
       BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC);
@@ -354,7 +342,7 @@ uint16_t correctionAccel()
         {
           BIT_SET(currentStatus.engine, BIT_ENGINE_ACC); //Mark accleration enrichment as active.
           activateMAPDOT = currentStatus.mapDOT;
-          currentStatus.AEEndTime = micros_safe() + ((unsigned long)configPage2.aeTime * 10000); //Set the time in the future where the enrichment will be turned off. taeTime is stored as mS / 10, so multiply it by 100 to get it in uS
+          currentStatus.AEStartTime = micros_safe(); 
           accelValue = table2D_getValue(&maeTable, currentStatus.mapDOT);
 
           //Apply the RPM taper to the above
@@ -401,7 +389,7 @@ uint16_t correctionAccel()
     
       //Check for deceleration (Deceleration adjustment not yet supported)
       //Also check for only very small movement (Movement less than or equal to 2% is ignored). This not only means we can skip the lookup, but helps reduce false triggering around 0-2% throttle openings
-      if (TPS_change <= 2)
+      if (configPage2.taeThresh <= 8)
       {
         accelValue = 100;
         currentStatus.tpsDOT = 0;
@@ -409,11 +397,11 @@ uint16_t correctionAccel()
       else
       {
         //If TAE isn't currently turned on, need to check whether it needs to be turned on
-        if (TPS_rateOfChange > configPage2.taeThresh)
+        if ((uint16_t)(currentStatus.tpsDOT * 10) > configPage2.taeThresh)
         {
           BIT_SET(currentStatus.engine, BIT_ENGINE_ACC); //Mark accleration enrichment as active.
           activateTPSDOT = currentStatus.tpsDOT;
-          currentStatus.AEEndTime = micros_safe() + ((unsigned long)configPage2.aeTime * 10000); //Set the time in the future where the enrichment will be turned off. taeTime is stored as mS / 10, so multiply it by 100 to get it in uS
+          currentStatus.AEStartTime = micros_safe();
           accelValue = table2D_getValue(&taeTable, currentStatus.tpsDOT);
 
           //Apply the RPM taper to the above

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -627,10 +627,10 @@ struct statuses {
   int16_t EMAP; ///< EMAP ... (See @ref config6.useEMAP for EMAP enablement)
   int16_t EMAPADC;
   byte baro;   ///< Barometric pressure is simply the inital MAP reading, taken before the engine is running. Alternatively, can be taken from an external sensor
-  byte TPS;    /**< The current TPS reading (0% - 100%). Is the tpsADC value after the calibration is applied */
-  byte tpsADC; /**< byte (valued: 0-255) representation of the TPS. Downsampled from the original 10-bit (0-1023) reading, but before any calibration is applied */
-  byte tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
-  byte mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte */
+  uint8_t TPS;    /**< The current TPS reading (0% - 100%).Stored x2 (100%TPS=200). Is the tpsADC value after the calibration is applied */
+  uint8_t tpsADC; /**< byte (valued: 0-255) representation of the TPS. Downsampled from the original 10-bit (0-1023) reading, but before any calibration is applied */
+  uint8_t tpsDOT; /**< TPS delta over time. Measures the % per second that the TPS is changing. Value is divided by 10 to be stored in a byte */
+  byte mapDOT; /**< MAP delta over time. Measures the kpa per second that the MAP is changing. Value is divided by 10 to be stored in a byte. Only positive values stored*/
   volatile int rpmDOT; /**< RPM delta over time (RPM increase / s ?) */
   byte VE;     /**< The current VE value being used in the fuel calculation. Can be the same as VE1 or VE2, or a calculated value of both. */
   byte VE1;    /**< The VE value from fuel table 1 */
@@ -668,7 +668,7 @@ struct statuses {
   bool CTPSActive;   /**< Whether the externally controlled closed throttle position sensor is currently active */
   volatile byte ethanolPct; /**< Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85. */
   volatile int8_t fuelTemp;
-  unsigned long AEEndTime; /**< The target end time used whenever AE (acceleration enrichment) is turned on */
+  unsigned long AEStartTime; /**< The stored time whenever AE (acceleration enrichment) was turned on */
   volatile byte status1; ///< Status bits (See BIT_STATUS1_* defines on top of this file)
   volatile byte spark;   ///< Spark status/control indicator bits (launch control, boost cut, spark errors, See BIT_SPARK_* defines)
   volatile byte spark2;  ///< Spark 2 ... (See also @ref config10 spark2* members and BIT_SPARK2_* defines)

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -24,6 +24,7 @@
   #include "SD_logger.h"
   #include "rtc_common.h"
 #endif
+#include "sensors.h"
 
 /** Initialize Speeduino for the main loop.
  * Top level init entrypoint for all initializations:
@@ -341,6 +342,9 @@ void initialiseAll()
     initialiseCorrections();
     BIT_CLEAR(currentStatus.engineProtectStatus, PROTECT_IO_ERROR); //Clear the I/O error bit. The bit will be set in initialiseADC() if there is problem in there.
     initialiseADC();
+    initializeAux();
+    initializeFlex();
+    initializeVSS();
     initialiseProgrammableIO();
 
     //Check whether the flex sensor is enabled and if so, attach an interrupt for it
@@ -408,8 +412,7 @@ void initialiseAll()
     toothLastToothTime = 0;
 
     //Lookup the current MAP reading for barometric pressure
-    instanteneousMAPReading();
-    readBaro();
+    initBaro();
     
     noInterrupts();
     initialiseTriggers();
@@ -1192,8 +1195,15 @@ void initialiseAll()
     else { fpPrimed = true; } //If the user has set 0 for the pump priming, immediately mark the priming as being completed
 
     interrupts();
-    readCLT(false); // Need to read coolant temp to make priming pulsewidth work correctly. The false here disables use of the filter
-    readTPS(false); // Need to read tps to detect flood clear state
+
+    if(readCLT(false,ADCidle) == ADCrunning){; // Need to read coolant temp to make priming pulsewidth work correctly. The false here disables use of the filter
+    while(ADC_CheckForConversionComplete() != true){} //poll for conversion
+    readCLT(false,ADCcomplete);//finish read
+    }    
+    if(readTPS(false,ADCidle) == ADCrunning){; // Need to read tps to detect flood clear state
+    while(ADC_CheckForConversionComplete() != true){} //poll for conversion
+    readTPS(false,ADCcomplete);//finish read
+    }
 
     initialisationComplete = true;
     digitalWrite(LED_BUILTIN, HIGH);

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -26,13 +26,32 @@
 #define VSS_GEAR_HYSTERESIS 10
 #define VSS_SAMPLES         4 //Must be a power of 2 and smaller than 255
 
-#define TPS_READ_FREQUENCY  30 //ONLY VALID VALUES ARE 15 or 30!!!
+#define TPS_INTERVAL 39  //[ms]TPS reading interval , (this is to be exactly 39 for TPSdot calculation to be super simple)
+#define TPS_READ_FREQUENCY 26 //Hz calculated from interval above and rounded to the nearest integer
+#define CLT_INTERVAL 250 //[ms] infrequent CLT readings are not an issue.
+#define BARO_INTERVAL 1000 //[ms] infrequent BARO readings are not an issue.
 
-/*
-#if defined(CORE_AVR)
-  #define ANALOG_ISR
+
+//enum ADCstates:uint8_t {ADCidle,ADCrunning,ADCcomplete};//ADC converter states {ADCidle,ADCrunning,ADCcomplete}
+enum ADCstates {ADCidle,ADCrunning,ADCcomplete};//ADC converter states {ADCidle,ADCrunning,ADCcomplete}
+
+/** define board specific ADC conversions functions, etc.
+ */
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
+#define ADC_start(ulPin) ADC_start_AVR2560(ulPin)
+#define ADC_CheckForConversionComplete() ADC_CheckForConversionComplete_AVR2560()
+#define ADC_get_value() ADC_get_value_AVR2560()
+#elif defined(ARDUINO_ARCH_STM32)
+#define ADC_start(ulPin) ADC_start_STM32(ulPin)
+#define ADC_CheckForConversionComplete() ADC_CheckForConversionComplete_STM32()
+#define ADC_get_value() ADC_get_value_STM32()
+#else
+// fallback to the analogRead()
+uint16_t tempADCreading; //global variable to store the reading between the calls
+#define ADC_start(ulPin) (tempADCreading=analogRead(ulPin)) || (1)
+#define ADC_CheckForConversionComplete() 1
+#define ADC_get_value() tempADCreading
 #endif
-*/
 
 volatile byte flexCounter = 0;
 volatile unsigned long flexStartTime;
@@ -47,14 +66,8 @@ volatile unsigned long flexPulseWidth;
 volatile byte knockCounter = 0;
 volatile uint16_t knockAngle;
 
-unsigned long MAPrunningValue; //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
-unsigned long EMAPrunningValue; //As above but for EMAP
-unsigned int MAPcount; //Number of samples taken in the current MAP cycle
-uint32_t MAPcurRev; //Tracks which revolution we're sampling on
+
 bool auxIsEnabled;
-byte TPSlast; /**< The previous TPS reading */
-unsigned long TPS_time; //The time the TPS sample was taken
-unsigned long TPSlast_time; //The time the previous TPS sample was taken
 byte MAPlast; /**< The previous MAP reading */
 unsigned long MAP_time; //The time the MAP sample was taken
 unsigned long MAPlast_time; //The time the previous MAP sample was taken
@@ -74,90 +87,33 @@ byte cltErrorCount = 0;
  */
 #define ADC_FILTER(input, alpha, prior) (((long)input * (256 - alpha) + ((long)prior * alpha))) >> 8
 
-static inline void instanteneousMAPReading() __attribute__((always_inline));
-static inline void readMAP() __attribute__((always_inline));
+
 static inline void validateMAP();
 void initialiseADC();
-void readTPS(bool=true); //Allows the option to override the use of the filter
-void readO2_2();
+void initializeAux();    /*Checks the aux inputs and initialises pins if required */
+void initializeVSS();    /*Vehicle speed sensor initialization */
+void initializeFlex();
+void initBaro();         //initialize baro
+ADCstates readTPS(bool useFilter, ADCstates adcState); //this is to be called repeatedly //Allows the option to override the use of the filter
 void flexPulse();
 uint32_t vssGetPulseGap(byte);
 void vssPulse();
 uint16_t getSpeed();
 byte getGear();
-byte getFuelPressure();
-byte getOilPressure();
 uint16_t readAuxanalog(uint8_t analogPin);
 uint16_t readAuxdigital(uint8_t digitalPin);
-void readCLT(bool=true); //Allows the option to override the use of the filter
-void readIAT();
-void readO2();
-void readBat();
-void readBaro();
+void ADC_sequencer();
+void instanteneousMAPReading(uint16_t adcReading);
+ADCstates readMAP(ADCstates adcState); //this is to be called repeatedly
+ADCstates readEMAP(ADCstates adcState); //this is to be called repeatedly
+ADCstates readCLT(bool useFilter,ADCstates adcState); //Allows the option to override the use of the filter
+ADCstates readIAT(ADCstates adcState);
+ADCstates readO2(ADCstates adcState);
+ADCstates readO2_2(ADCstates adcState);
+ADCstates readBat(ADCstates adcState);
+ADCstates readBaro(ADCstates adcState);
+ADCstates readOilpressure(ADCstates adcState);
+ADCstates readFuelpressure(ADCstates adcState);
 
-#if defined(ANALOG_ISR)
-volatile int AnChannel[15];
-
-//Analog ISR interrupt routine
-/*
-ISR(ADC_vect)
-{
-  byte nChannel;
-  int result = ADCL | (ADCH << 8);
-
-  //ADCSRA = 0x6E; - ADC disabled by clearing bit 7(ADEN)
-  //BIT_CLEAR(ADCSRA, ADIE);
-
-  nChannel = ADMUX & 0x07;
-  #if defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__)
-    if (nChannel==7) { ADMUX = 0x40; }
-  #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-    if(ADCSRB & 0x08) { nChannel += 8; }  //8 to 15
-    if(nChannel == 15)
-    {
-      ADMUX = 0x40; //channel 0
-      ADCSRB = 0x00; //clear MUX5 bit
-    }
-    else if (nChannel == 7) //channel 7
-    {
-      ADMUX = 0x40;
-      ADCSRB = 0x08; //Set MUX5 bit
-    }
-  #endif
-    else { ADMUX++; }
-  AnChannel[nChannel-1] = result;
-
-  //BIT_SET(ADCSRA, ADIE);
-  //ADCSRA = 0xEE; - ADC Interrupt Flag enabled
-}
-*/
-ISR(ADC_vect)
-{
-  byte nChannel = ADMUX & 0x07;
-  int result = ADCL | (ADCH << 8);
-
-  BIT_CLEAR(ADCSRA, ADEN); //Disable ADC for Changing Channel (see chapter 26.5 of datasheet)
-
-  #if defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__)
-    if (nChannel==7) { ADMUX = 0x40; }
-  #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-    if( (ADCSRB & 0x08) > 0) { nChannel += 8; }  //8 to 15
-    if(nChannel == 15)
-    {
-      ADMUX = 0x40; //channel 0
-      ADCSRB = 0x00; //clear MUX5 bit
-    }
-    else if (nChannel == 7) //channel 7
-    {
-      ADMUX = 0x40;
-      ADCSRB = 0x08; //Set MUX5 bit
-    }
-  #endif
-    else { ADMUX++; }
-  AnChannel[nChannel] = result;
-
-  BIT_SET(ADCSRA, ADEN); //Enable ADC
-}
-#endif
 
 #endif // SENSORS_H

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -18,53 +18,52 @@ A full copy of the license may be found in the projects root directory
 #include "pages.h"
 #include "decoders.h"
 
+
 /** Init all ADC conversions by setting resolutions, etc.
  */
 void initialiseADC()
 {
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) //AVR chips use the ISR for this
-
-  #if defined(ANALOG_ISR)
-    //This sets the ADC (Analog to Digitial Converter) to run at 250KHz, greatly reducing analog read times (MAP/TPS)
-    //the code on ISR run each conversion every 25 ADC clock, conversion run about 100KHz effectively
-    //making a 6250 conversions/s on 16 channels and 12500 on 8 channels devices.
-    noInterrupts(); //Interrupts should be turned off when playing with any of these registers
-
-    ADCSRB = 0x00; //ADC Auto Trigger Source is in Free Running mode
-    ADMUX = 0x40;  //Select AREF as reference, ADC Left Adjust Result, Starting at channel 0
-
-    //All of the below is the longhand version of: ADCSRA = 0xEE;
-    #define ADFR 5 //Why the HELL isn't this defined in the same place as everything else (wiring.h)?!?!
-    BIT_SET(ADCSRA,ADFR); //Set free running mode
-    BIT_SET(ADCSRA,ADIE); //Set ADC interrupt enabled
-    BIT_CLEAR(ADCSRA,ADIF); //Clear interrupt flag
-
-    // Set ADC clock to 125KHz (Prescaler = 128)
-    BIT_SET(ADCSRA,ADPS2);
-    BIT_SET(ADCSRA,ADPS1);
-    BIT_SET(ADCSRA,ADPS0);
-
-    BIT_SET(ADCSRA,ADEN); //Enable ADC
-
-    interrupts();
-    BIT_SET(ADCSRA,ADSC); //Start conversion
-
-  #else
-    //This sets the ADC (Analog to Digitial Converter) to run at 1Mhz, greatly reducing analog read times (MAP/TPS) when using the standard analogRead() function
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
+  //board specific initialization
+  ADCinit_AVR2560();
+  
+    //this sets the ADC (Analog to Digitial Converter) to run at 1Mhz, greatly reducing analog read times (MAP/TPS) when using the standard analogRead() function
     //1Mhz is the fastest speed permitted by the CPU without affecting accuracy
     //Please see chapter 11 of 'Practical Arduino' (books.google.com.au/books?id=HsTxON1L6D4C&printsec=frontcover#v=onepage&q&f=false) for more detail
-     BIT_SET(ADCSRA,ADPS2);
-     BIT_CLEAR(ADCSRA,ADPS1);
-     BIT_CLEAR(ADCSRA,ADPS0);
-  #endif
+     //BIT_SET(ADCSRA,ADPS2);
+    // BIT_CLEAR(ADCSRA,ADPS1);
+    // BIT_CLEAR(ADCSRA,ADPS0);
+    
 #elif defined(ARDUINO_ARCH_STM32) //STM32GENERIC core and ST STM32duino core, change analog read to 12 bit
-  analogReadResolution(10); //use 10bits for analog reading on STM32 boards
+//  analogReadResolution(10); //use 10bits for analog reading on STM32 boards
+  ADCinit_STM32(); // from board_stm32_official.ino file 
 #endif
-  MAPcurRev = 0;
-  MAPcount = 0;
-  MAPrunningValue = 0;
 
-  //The following checks the aux inputs and initialises pins if required
+  //Sanity checks to ensure none of the filter values are set above 240 (Which would include the 255 value which is the default on a new arduino)
+  //If an invalid value is detected, it's reset to the default the value and burned to EEPROM. 
+  //Each sensor has it's own default value
+  if(configPage4.ADCFILTER_TPS > 240) { configPage4.ADCFILTER_TPS = 50; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_CLT > 240) { configPage4.ADCFILTER_CLT = 180; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_IAT > 240) { configPage4.ADCFILTER_IAT = 180; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_O2  > 240) { configPage4.ADCFILTER_O2 = 100; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_BAT > 240) { configPage4.ADCFILTER_BAT = 128; writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_MAP > 240) { configPage4.ADCFILTER_MAP = 20;  writeConfig(ignSetPage); }
+  if(configPage4.ADCFILTER_BARO > 240) { configPage4.ADCFILTER_BARO = 64; writeConfig(ignSetPage); }
+      
+} //initialiseADC
+
+void initializeFlex(){
+  flexStartTime = micros();
+  if(configPage4.FILTER_FLEX > 240)   { configPage4.FILTER_FLEX = 75; writeConfig(ignSetPage); }
+}
+
+void initializeVSS()            /*Vehicle speed sensor initialization */
+{ 
+  vssIndex = 0;
+}
+
+void initializeAux()         //The following checks the aux inputs and initialises pins if required
+{    
   auxIsEnabled = false;
   for (byte AuxinChan = 0; AuxinChan <16 ; AuxinChan++)
   {
@@ -113,22 +112,134 @@ void initialiseADC()
 
     }
   } //For loop iterating through aux in lines
+}
 
-  //Sanity checks to ensure none of the filter values are set above 240 (Which would include the 255 value which is the default on a new arduino)
-  //If an invalid value is detected, it's reset to the default the value and burned to EEPROM. 
-  //Each sensor has it's own default value
-  if(configPage4.ADCFILTER_TPS  > 240) { configPage4.ADCFILTER_TPS   = ADCFILTER_TPS_DEFAULT;   writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_CLT  > 240) { configPage4.ADCFILTER_CLT   = ADCFILTER_CLT_DEFAULT;   writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_IAT  > 240) { configPage4.ADCFILTER_IAT   = ADCFILTER_IAT_DEFAULT;   writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_O2   > 240) { configPage4.ADCFILTER_O2    = ADCFILTER_O2_DEFAULT;    writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_BAT  > 240) { configPage4.ADCFILTER_BAT   = ADCFILTER_BAT_DEFAULT;   writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_MAP  > 240) { configPage4.ADCFILTER_MAP   = ADCFILTER_MAP_DEFAULT;   writeConfig(ignSetPage); }
-  if(configPage4.ADCFILTER_BARO > 240) { configPage4.ADCFILTER_BARO  = ADCFILTER_BARO_DEFAULT;  writeConfig(ignSetPage); }
-  if(configPage4.FILTER_FLEX    > 240) { configPage4.FILTER_FLEX     = FILTER_FLEX_DEFAULT;     writeConfig(ignSetPage); }
+/** ADC sequencer.
+ *  Should be called repeatedly.
+ *  Starts ADC coversions in sequence, 
+ *  deals with checking completed conversions and reads the results.
+ */
+void ADC_sequencer(){
 
-  flexStartTime = micros();
+static enum ADCoperations:uint8_t {MAPadc,EMAPadc,TPSadc,CLTadc,IATadc,O2adc,O2_2adc,BATadc,FuelpressureAdc,OilpressureAdc,BaroAdc} adcOperation =MAPadc; //current state of ADCsequence,initial state is MAPadc
+static ADCstates adcState = ADCidle; //current state of ADC,initial state is idle
+static unsigned long lastmillisTPS=0;
+static unsigned long lastmillisCLT=4;
+static unsigned long lastmillisBARO=0;
 
-  vssIndex = 0;
+if (ADC_CheckForConversionComplete() == true)
+{
+  adcState=ADCcomplete;
+}
+while(adcState !=ADCrunning) //do not leave the scene until we have gotten the ADC to run, also do nothing when ADC is still in progress
+  {
+    switch (adcOperation)
+    {
+    case MAPadc:
+      adcState = readMAP(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = EMAPadc; //specify next operation
+      }
+      break;
+    case EMAPadc:
+      adcState = readEMAP(adcState);
+      if (adcState == ADCidle)
+      {                         //when this channel done
+        adcOperation = TPSadc; //specify next operation
+      }
+      break;
+    case TPSadc:                                    //_26Hz
+      if (millis() - lastmillisTPS >= TPS_INTERVAL) //(any faster and it can upset the TPSdot sampling time)
+      {
+        adcState = readTPS(true, adcState); //read TPS
+        if (adcState == ADCidle)
+        {                         //when this channel done
+          adcOperation = CLTadc; //specify next operation
+          lastmillisTPS = millis();
+        }
+      }
+      else      
+      {
+        adcOperation = CLTadc; //skip to next operation
+      }      
+      break;
+    case CLTadc:                                    //_4Hz The IAT and CLT readings can be done less frequently (4 times per second)
+      if (millis() - lastmillisCLT >= CLT_INTERVAL) //Infrequent readings are not an issue.
+      {
+        adcState = readCLT(true, adcState);
+        if (adcState == ADCidle)
+        {                         //when this channel done
+          adcOperation = IATadc; //specify next operation
+          lastmillisCLT = millis();
+        }
+      }
+      else
+      {
+        adcOperation = BaroAdc; //jump right to Baro! IAT, O2, O2_2, Batt, Fuelpressure, OilPressure also have same interval
+      }      
+      break;
+    case IATadc: //_4HZ
+      adcState = readIAT(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = O2adc; //specify next operation
+      }
+      break;
+    case O2adc: //_4HZ
+      adcState = readO2(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = O2_2adc; //specify next operation
+      }
+      break;
+    case O2_2adc: //_4HZ
+      adcState = readO2_2(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = BATadc; //specify next operation
+      }
+      break;
+    case BATadc: //_4HZ
+      adcState = readBat(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = FuelpressureAdc; //specify next operation
+      }
+      break;
+    case FuelpressureAdc: //_4HZ
+      adcState = readFuelpressure(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = OilpressureAdc; //specify next operation
+      }
+      break;
+    case OilpressureAdc: //_4HZ
+      adcState = readOilpressure(adcState);
+      if (adcState == ADCidle)
+      {                          //when this channel done
+        adcOperation = BaroAdc; //specify next operation
+      }
+      break;
+    case BaroAdc:
+      if (millis() - lastmillisBARO >= BARO_INTERVAL) //Infrequent baro readings are not an issue.
+      {
+        adcState = readBaro(adcState);        
+        if (adcState == ADCidle)
+        {                         //when this channel done
+          adcOperation = MAPadc; //specify next operation
+          lastmillisBARO=millis();
+        }
+      }
+      else
+      {
+        adcOperation = MAPadc; //just specify next operation
+      }
+      break;
+    default:
+      adcOperation = MAPadc;
+    }
+  }
 }
 
 static inline void validateMAP()
@@ -157,8 +268,9 @@ static inline void validateMAP()
   }
 }
 
-static inline void instanteneousMAPReading()
+void instanteneousMAPReading(uint16_t adcReading)
 {
+  
   //Update the calculation times and last value. These are used by the MAP based Accel enrich
   MAPlast = currentStatus.MAP;
   MAPlast_time = MAP_time;
@@ -166,12 +278,7 @@ static inline void instanteneousMAPReading()
 
   unsigned int tempReading;
   //Instantaneous MAP readings
-  #if defined(ANALOG_ISR_MAP)
-    tempReading = AnChannel[pinMAP-A0];
-  #else
-    tempReading = analogRead(pinMAP);
-    tempReading = analogRead(pinMAP);
-  #endif
+  tempReading=adcReading;
   //Error checking
   if( (tempReading >= VALID_MAP_MAX) || (tempReading <= VALID_MAP_MIN) ) { mapErrorCount += 1; }
   else { mapErrorCount = 0; }
@@ -181,35 +288,38 @@ static inline void instanteneousMAPReading()
   else { currentStatus.mapADC = tempReading; } //Baro reading (No filter)
 
   currentStatus.MAP = fastMap10Bit(currentStatus.mapADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
-  if(currentStatus.MAP < 0) { currentStatus.MAP = 0; } //Sanity check
-  
-  //Repeat for EMAP if it's enabled
-  if(configPage6.useEMAP == true)
-  {
-    tempReading = analogRead(pinEMAP);
-    tempReading = analogRead(pinEMAP);
-
-    //Error check
-    if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
-      {
-        currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
-      }
-    else { mapErrorCount += 1; }
-    currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.EMAPMin, configPage2.EMAPMax);
-    if(currentStatus.EMAP < 0) { currentStatus.EMAP = 0; } //Sanity check
-  }
-
+  if(currentStatus.MAP < 0) { currentStatus.MAP = 0; } //Sanity check  
 }
 
-static inline void readMAP()
+ADCstates readMAP(ADCstates adcState)
 {
+
   unsigned int tempReading;
+  static unsigned long MAPrunningValue = 0;  //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
+  static uint32_t MAPcurRev = 0;             //Tracks which revolution we're sampling on
+  static unsigned int MAPcount =0;           //Number of samples taken in the current MAP cycle  
+
+  if(adcState == ADCidle ){
+    if(ADC_start(pinMAP) == 1){adcState=ADCrunning;}   //start ADC at required channel
+    return adcState;    //indicate that adc is busy now, and come back later...
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+
   //MAP Sampling system
+  if(currentStatus.RPM==0){
+    MAPcurRev = 0;
+    MAPcount =0;
+    MAPrunningValue=0;
+  }
   switch(configPage2.mapSample)
   {
     case 0:
       //Instantaneous MAP readings
-      instanteneousMAPReading();
+      instanteneousMAPReading(tempReading);
       break;
 
     case 1:
@@ -219,13 +329,6 @@ static inline void readMAP()
       {
         if( (MAPcurRev == currentStatus.startRevolutions) || ( (MAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
         {
-          #if defined(ANALOG_ISR_MAP)
-            tempReading = AnChannel[pinMAP-A0];
-          #else
-            tempReading = analogRead(pinMAP);
-            tempReading = analogRead(pinMAP);
-          #endif
-
           //Error check
           if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
           {
@@ -234,21 +337,6 @@ static inline void readMAP()
             MAPcount++;
           }
           else { mapErrorCount += 1; }
-
-          //Repeat for EMAP if it's enabled
-          if(configPage6.useEMAP == true)
-          {
-            tempReading = analogRead(pinEMAP);
-            tempReading = analogRead(pinEMAP);
-
-            //Error check
-            if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
-            {
-              currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
-              EMAPrunningValue += currentStatus.EMAPADC; //Add the current reading onto the total
-            }
-            else { mapErrorCount += 1; }
-          }
         }
         else
         {
@@ -264,31 +352,18 @@ static inline void readMAP()
             currentStatus.mapADC = ldiv(MAPrunningValue, MAPcount).quot;
             currentStatus.MAP = fastMap10Bit(currentStatus.mapADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
             validateMAP();
-
-            //If EMAP is enabled, the process is identical to the above
-            if(configPage6.useEMAP == true)
-            {
-              currentStatus.EMAPADC = ldiv(EMAPrunningValue, MAPcount).quot; //Note that the MAP count can be reused here as it will always be the same count.
-              currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.EMAPMin, configPage2.EMAPMax);
-              if(currentStatus.EMAP < 0) { currentStatus.EMAP = 0; } //Sanity check
-            }
           }
-          else { instanteneousMAPReading(); }
+          else { instanteneousMAPReading(tempReading); }
 
           MAPcurRev = currentStatus.startRevolutions; //Reset the current rev count
           MAPrunningValue = 0;
-          EMAPrunningValue = 0; //Can reset this even if EMAP not used
           MAPcount = 0;
         }
       }
       else 
       {
-        instanteneousMAPReading();
+        instanteneousMAPReading(tempReading);
         MAPrunningValue = currentStatus.mapADC; //Keep updating the MAPrunningValue to give it head start when switching to cycle average.
-        if(configPage6.useEMAP == true)
-        {
-          EMAPrunningValue = currentStatus.EMAPADC;
-        }
         MAPcount = 1;
       }
       break;
@@ -299,12 +374,6 @@ static inline void readMAP()
       {
         if( (MAPcurRev == currentStatus.startRevolutions) || ((MAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
         {
-          #if defined(ANALOG_ISR_MAP)
-            tempReading = AnChannel[pinMAP-A0];
-          #else
-            tempReading = analogRead(pinMAP);
-            tempReading = analogRead(pinMAP);
-          #endif
           //Error check
           if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
           {
@@ -331,7 +400,7 @@ static inline void readMAP()
       }
       else 
       {
-        instanteneousMAPReading();
+        instanteneousMAPReading(tempReading);
         MAPrunningValue = currentStatus.mapADC;  //Keep updating the MAPrunningValue to give it head start when switching to cycle minimum.
       }
       break;
@@ -342,12 +411,6 @@ static inline void readMAP()
       {
         if( (MAPcurRev == ignitionCount) ) //Watch for a change in the ignition counter to determine whether we're still on the same event
         {
-          #if defined(ANALOG_ISR_MAP)
-            tempReading = AnChannel[pinMAP-A0];
-          #else
-            tempReading = analogRead(pinMAP);
-            tempReading = analogRead(pinMAP);
-          #endif
 
           //Error check
           if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
@@ -373,7 +436,7 @@ static inline void readMAP()
             currentStatus.MAP = fastMap10Bit(currentStatus.mapADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
             validateMAP();
           }
-          else { instanteneousMAPReading(); }
+          else { instanteneousMAPReading(tempReading); }
 
           MAPcurRev = ignitionCount; //Reset the current event count
           MAPrunningValue = 0;
@@ -382,7 +445,7 @@ static inline void readMAP()
       }
       else 
       {
-        instanteneousMAPReading();
+        instanteneousMAPReading(tempReading);
         MAPrunningValue = currentStatus.mapADC; //Keep updating the MAPrunningValue to give it head start when switching to ignition event average.
         MAPcount = 1;
       }
@@ -390,31 +453,214 @@ static inline void readMAP()
 
     default:
     //Instantaneous MAP readings (Just in case)
-    instanteneousMAPReading();
+    instanteneousMAPReading(tempReading);
     break;
   }
+  return adcState;
 }
 
-void readTPS(bool useFilter)
+void instanteneousEMAPReading(uint16_t adcReading)
 {
-  TPSlast = currentStatus.TPS;
-  TPSlast_time = TPS_time;
-  #if defined(ANALOG_ISR)
-    byte tempTPS = fastMap1023toX(AnChannel[pinTPS-A0], 255); //Get the current raw TPS ADC value and map it into a byte
-  #else
-    analogRead(pinTPS);
-    byte tempTPS = fastMap1023toX(analogRead(pinTPS), 255); //Get the current raw TPS ADC value and map it into a byte
-  #endif
+  unsigned int tempReading;
+  //Instantaneous MAP readings
+  tempReading=adcReading;
+    //Error check
+    if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
+      {
+        currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
+      }
+    else { mapErrorCount += 1; }
+    currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.EMAPMin, configPage2.EMAPMax);
+    if(currentStatus.EMAP < 0) { currentStatus.EMAP = 0; } //Sanity check
+}
+
+ADCstates readEMAP(ADCstates adcState)
+{
+  unsigned int tempReading;
+  static unsigned long EMAPrunningValue = 0;  //Used for tracking either the total of all MAP readings in this cycle (Event average) or the lowest value detected in this cycle (event minimum)
+  static uint32_t EMAPcurRev = 0;             //Tracks which revolution we're sampling on
+  static unsigned int EMAPcount =0;           //Number of samples taken in the current MAP cycle  
+
+  if(configPage6.useEMAP != true){return adcState;} //skip all if disabled  
+
+  if(adcState == ADCidle ){
+    ADC_start(pinEMAP);   //start ADC at required channel
+    adcState=ADCrunning;
+    return adcState;    //indicate that adc is busy now, and come back later...
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else
+  {
+    return adcState;//when ADC is still busy or something, do nothing
+  }
+
+  //MAP Sampling system
+  if(currentStatus.RPM==0){
+    EMAPcurRev = 0;
+    EMAPcount =0;
+    EMAPrunningValue=0;
+  }
+  switch(configPage2.mapSample)
+  {
+    case 0:
+      //Instantaneous MAP readings
+      instanteneousEMAPReading(tempReading);
+      break;
+
+    case 1:
+      //Average of a cycle
+
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (currentStatus.hasSync == true) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
+      {
+        if( (EMAPcurRev == currentStatus.startRevolutions) || ( (EMAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
+        {
+            //Error check
+            if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
+            {
+              currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
+              EMAPrunningValue += currentStatus.EMAPADC; //Add the current reading onto the total
+            }
+            else { mapErrorCount += 1; }          
+        }
+        else
+        {
+          //Reaching here means that the last cylce has completed and the MAP value should be calculated
+          //Sanity check
+          if( (EMAPrunningValue != 0) && (EMAPcount != 0) )
+          {
+            {
+              currentStatus.EMAPADC = ldiv(EMAPrunningValue, EMAPcount).quot; //Note that the MAP count can be reused here as it will always be the same count.
+              currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.EMAPMin, configPage2.EMAPMax);
+              if(currentStatus.EMAP < 0) { currentStatus.EMAP = 0; } //Sanity check
+            }
+          }
+          EMAPcurRev = currentStatus.startRevolutions; //Reset the current rev count
+          EMAPrunningValue = 0;
+          EMAPcount = 0;
+        }
+      }
+      else 
+      {
+        EMAPrunningValue = currentStatus.EMAPADC;
+        EMAPcount = 1;
+      }
+      break;
+
+    case 2:
+      //Minimum reading in a cycle
+      if (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
+      {
+        if( (EMAPcurRev == currentStatus.startRevolutions) || ((EMAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
+        {
+          //Error check
+          if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
+          {
+            if( (unsigned long)tempReading < EMAPrunningValue ) { EMAPrunningValue = (unsigned long)tempReading; } //Check whether the current reading is lower than the running minimum
+          }
+          else { mapErrorCount += 1; }
+        }
+        else
+        {
+          //Reaching here means that the last cylce has completed and the MAP value should be calculated
+
+          currentStatus.EMAPADC = EMAPrunningValue;
+          currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
+          EMAPcurRev = currentStatus.startRevolutions; //Reset the current rev count
+          EMAPrunningValue = 1023; //Reset the latest value so the next reading will always be lower
+
+          //validateMAP();
+        }
+      }
+      else 
+      {
+        instanteneousEMAPReading(tempReading);
+        EMAPrunningValue = currentStatus.EMAPADC;  //Keep updating the MAPrunningValue to give it head start when switching to cycle minimum.
+      }
+      break;
+
+    case 3:
+      //Average of an ignition event
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (currentStatus.hasSync == true) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
+      {
+        if( (EMAPcurRev == ignitionCount) ) //Watch for a change in the ignition counter to determine whether we're still on the same event
+        {
+
+          //Error check
+          if( (tempReading < VALID_MAP_MAX) && (tempReading > VALID_MAP_MIN) )
+          {
+            currentStatus.EMAPADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_MAP, currentStatus.EMAPADC);
+            EMAPrunningValue += currentStatus.mapADC; //Add the current reading onto the total
+            EMAPcount++;
+          }
+          else { mapErrorCount += 1; }
+        }
+        else
+        {
+          //Reaching here means that the  next ignition event has occured and the MAP value should be calculated
+          //Sanity check
+          if( (EMAPrunningValue != 0) && (EMAPcount != 0) && (EMAPcurRev < ignitionCount) )
+          {
+            currentStatus.EMAPADC = ldiv(EMAPrunningValue, EMAPcount).quot;
+            currentStatus.EMAP = fastMap10Bit(currentStatus.EMAPADC, configPage2.mapMin, configPage2.mapMax); //Get the current MAP value
+            //validateMAP();
+          }
+          else { instanteneousEMAPReading(tempReading); }
+
+          EMAPcurRev = ignitionCount; //Reset the current event count
+          EMAPrunningValue = 0;
+          EMAPcount = 0;
+        }
+      }
+      else 
+      {
+        instanteneousEMAPReading(tempReading);
+        EMAPrunningValue = currentStatus.EMAPADC; //Keep updating the MAPrunningValue to give it head start when switching to ignition event average.
+        EMAPcount = 1;
+      }
+      break; 
+
+    default:
+    //Instantaneous MAP readings (Just in case)
+    instanteneousEMAPReading(tempReading);
+    break;
+  }
+  return adcState;
+}
+
+ADCstates readTPS(bool useFilter, ADCstates adcState) //this is to be called repeatedly
+{
+  uint16_t tempReading;
+  int TPSrateOfChange;
+  static uint8_t TPSlastADC; //The previous TPS reading
+  
+  if(adcState == ADCidle ){
+    if(ADC_start(pinTPS)==1){adcState=ADCrunning;}   //start ADC at required channel    
+    return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else
+  {
+    return adcState;//when ADC is still busy or something, do nothing
+  } 
+
+  tempReading = tempReading >> 2; //Get the current raw TPS ADC value and map it into a byte
   //The use of the filter can be overridden if required. This is used on startup to disable priming pulse if flood clear is wanted
-  if(useFilter == true) { currentStatus.tpsADC = ADC_FILTER(tempTPS, configPage4.ADCFILTER_TPS, currentStatus.tpsADC); }
-  else { currentStatus.tpsADC = tempTPS; }
-  byte tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
+  if(useFilter == true) { currentStatus.tpsADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_TPS, currentStatus.tpsADC); }
+  else { currentStatus.tpsADC = tempReading; }
+  uint8_t tempADC = currentStatus.tpsADC; //The tempADC value is used in order to allow TunerStudio to recover and redo the TPS calibration if this somehow gets corrupted
 
   if(configPage2.tpsMax > configPage2.tpsMin)
   {
     //Check that the ADC values fall within the min and max ranges (Should always be the case, but noise can cause these to fluctuate outside the defined range).
-    if (currentStatus.tpsADC < configPage2.tpsMin) { tempADC = configPage2.tpsMin; }
-    else if(currentStatus.tpsADC > configPage2.tpsMax) { tempADC = configPage2.tpsMax; }
+    //if (currentStatus.tpsADC < configPage2.tpsMin) { tempADC = configPage2.tpsMin; }
+    //else if(currentStatus.tpsADC > configPage2.tpsMax) { tempADC = configPage2.tpsMax; }
+    tempADC=constrain(currentStatus.tpsADC,configPage2.tpsMin,configPage2.tpsMax);
     currentStatus.TPS = map(tempADC, configPage2.tpsMin, configPage2.tpsMax, 0, 200); //Take the raw TPS ADC value and convert it into a TPS% based on the calibrated values
   }
   else
@@ -439,52 +685,72 @@ void readTPS(bool useFilter)
     else { currentStatus.CTPSActive = digitalRead(pinCTPS); } //Inverted mode (5v activates closed throttle position sensor)
   }
   else { currentStatus.CTPSActive = 0; }
-  TPS_time = micros();
+
+  //Get the TPS change rate 
+  //note here that TPS read frequency is specially chosen to get optimally fast and simple tpsDOT calculation
+  TPSrateOfChange= (tempADC-TPSlastADC); //this is about accurate for 8bit ADC(range 1024/4=256) and 39ms reading interval(25,6Hz), produces TPS change in %/s /10
+  currentStatus.tpsDOT=constrain(TPSrateOfChange, 0, 255); // cap the range to 8bit unsigned and store. Can it be any more simpler!?
+  TPSlastADC = tempADC; //use tempADC here so that reversed pot also works
+  
+  return adcState;
 }
 
-void readCLT(bool useFilter)
+ADCstates readCLT(bool useFilter,ADCstates adcState)
 {
   unsigned int tempReading;
-  #if defined(ANALOG_ISR)
-    tempReading = fastMap1023toX(AnChannel[pinCLT-A0], 511); //Get the current raw CLT value
-  #else
-    tempReading = analogRead(pinCLT);
-    tempReading = analogRead(pinCLT);
-    //tempReading = fastMap1023toX(analogRead(pinCLT), 511); //Get the current raw CLT value
-  #endif
+
+  if(adcState == ADCidle ){
+    if(ADC_start(pinCLT) == 1){adcState=ADCrunning;};   //start ADC at required channel    
+  return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+
   //The use of the filter can be overridden if required. This is used on startup so there can be an immediately accurate coolant value for priming
   if(useFilter == true) { currentStatus.cltADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_CLT, currentStatus.cltADC); }
   else { currentStatus.cltADC = tempReading; }
   
   currentStatus.coolant = table2D_getValue(&cltCalibrationTable, currentStatus.cltADC) - CALIBRATION_TEMPERATURE_OFFSET; //Temperature calibration values are stored as positive bytes. We subtract 40 from them to allow for negative temperatures
+  return adcState;
 }
 
-void readIAT()
+ADCstates readIAT(ADCstates adcState)
 {
-  unsigned int tempReading;
-  #if defined(ANALOG_ISR)
-    tempReading = fastMap1023toX(AnChannel[pinIAT-A0], 511); //Get the current raw IAT value
-  #else
-    tempReading = analogRead(pinIAT);
-    tempReading = analogRead(pinIAT);
-    //tempReading = fastMap1023toX(analogRead(pinIAT), 511); //Get the current raw IAT value
-  #endif
+  uint16_t tempReading;
+  if(adcState == ADCidle ){
+    ADC_start(pinIAT);   //start ADC at required channel
+    adcState=ADCrunning;
+    return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+
   currentStatus.iatADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_IAT, currentStatus.iatADC);
   currentStatus.IAT = table2D_getValue(&iatCalibrationTable, currentStatus.iatADC) - CALIBRATION_TEMPERATURE_OFFSET;
+  return adcState;
 }
 
-void readBaro()
+ADCstates readBaro(ADCstates adcState)
 {
+  uint16_t tempReading;
   if ( configPage6.useExtBaro != 0 )
-  {
-    int tempReading;
-    // readings
-    #if defined(ANALOG_ISR_MAP)
-      tempReading = AnChannel[pinBaro-A0];
-    #else
-      tempReading = analogRead(pinBaro);
-      tempReading = analogRead(pinBaro);
-    #endif
+  {      
+    if(adcState == ADCidle ){
+      ADC_start(pinBaro);   //start ADC at required channel
+      adcState=ADCrunning;
+      return adcState;    //indicate that adc is busy now
+    }
+    else if (adcState == ADCcomplete){
+      tempReading=ADC_get_value();  //grab the ADC result
+      adcState=ADCidle; // free the ADC
+    }
+    else{return adcState;}//when ADC is still busy or something, do nothing
 
     if(initialisationComplete == true) { currentStatus.baroADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_BARO, currentStatus.baroADC); }//Very weak filter
     else { currentStatus.baroADC = tempReading; } //Baro reading (No filter)
@@ -498,18 +764,10 @@ void readBaro()
     * 1. Verify that the engine is not running
     * 2. Verify that the reading from the MAP sensor is within the possible physical limits
     */
-
-    //Attempt to use the last known good baro reading from EEPROM as a starting point
-    byte lastBaro = readLastBaro();
-    if ((lastBaro >= BARO_MIN) && (lastBaro <= BARO_MAX)) //Make sure it's not invalid (Possible on first run etc)
-    { currentStatus.baro = lastBaro; } //last baro correction
-    else { currentStatus.baro = 100; } //Fall back position.
-
     //Verify the engine isn't running by confirming RPM is 0 and it has been at least 1 second since the last tooth was detected
     unsigned long timeToLastTooth = (micros() - toothLastToothTime);
-    if((currentStatus.RPM == 0) && (timeToLastTooth > 1000000UL))
-    {
-      instanteneousMAPReading(); //Get the current MAP value
+    if((currentStatus.RPM == 0) && (timeToLastTooth > 1000000UL) && (timeToLastTooth < 3000000UL) )
+    {      
       /* 
       * The highest sea-level pressure on Earth occurs in Siberia, where the Siberian High often attains a sea-level pressure above 105 kPa;
       * with record highs close to 108.5 kPa.
@@ -522,21 +780,35 @@ void readBaro()
       }
     }
   }
+  return adcState;
 }
 
-void readO2()
+void initBaro(){
+    //Attempt to use the last known good baro reading from EEPROM as a starting point
+    byte lastBaro = readLastBaro();
+    if ((lastBaro >= BARO_MIN) && (lastBaro <= BARO_MAX)) //Make sure it's not invalid (Possible on first run etc)
+    { currentStatus.baro = lastBaro; } //last baro correction
+    else { currentStatus.baro = 100; } //Fall back position.
+}
+
+ADCstates readO2(ADCstates adcState)
 {
+  unsigned int tempReading;
+
+   if(adcState == ADCidle ){
+    ADC_start(pinO2);   //start ADC at required channel
+    adcState=ADCrunning;
+    return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+
   //An O2 read is only performed if an O2 sensor type is selected. This is to prevent potentially dangerous use of the O2 readings prior to proper setup/calibration
   if(configPage6.egoType > 0)
   {
-    unsigned int tempReading;
-    #if defined(ANALOG_ISR)
-      tempReading = fastMap1023toX(AnChannel[pinO2-A0], 511); //Get the current O2 value.
-    #else
-      tempReading = analogRead(pinO2);
-      tempReading = analogRead(pinO2);
-      //tempReading = fastMap1023toX(analogRead(pinO2), 511); //Get the current O2 value.
-    #endif
     currentStatus.O2ADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_O2, currentStatus.O2ADC);
     //currentStatus.O2 = o2CalibrationTable[currentStatus.O2ADC];
     currentStatus.O2 = table2D_getValue(&o2CalibrationTable, currentStatus.O2ADC);
@@ -546,35 +818,47 @@ void readO2()
     currentStatus.O2ADC = 0;
     currentStatus.O2 = 0;
   }
-  
+  return adcState;
 }
 
-void readO2_2()
+ADCstates readO2_2(ADCstates adcState)
 {
   //Second O2 currently disabled as its not being used
   //Get the current O2 value.
   unsigned int tempReading;
-  #if defined(ANALOG_ISR)
-    tempReading = fastMap1023toX(AnChannel[pinO2_2-A0], 511); //Get the current O2 value.
-  #else
-    tempReading = analogRead(pinO2_2);
-    tempReading = analogRead(pinO2_2);
-    //tempReading = fastMap1023toX(analogRead(pinO2_2), 511); //Get the current O2 value.
-  #endif
+
+  if(adcState == ADCidle ){
+    ADC_start(pinO2_2);   //start ADC at required channel
+    adcState=ADCrunning;
+    return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+
   currentStatus.O2_2ADC = ADC_FILTER(tempReading, configPage4.ADCFILTER_O2, currentStatus.O2_2ADC);
   currentStatus.O2_2 = table2D_getValue(&o2CalibrationTable, currentStatus.O2_2ADC);
+  return adcState;
 }
 
-void readBat()
+ADCstates readBat(ADCstates adcState)
 {
   int tempReading;
-  #if defined(ANALOG_ISR)
-    tempReading = fastMap1023toX(AnChannel[pinBat-A0], 245); //Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
-  #else
-    tempReading = analogRead(pinBat);
-    tempReading = fastMap1023toX(analogRead(pinBat), 245); //Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
-  #endif
 
+  if(adcState == ADCidle ){
+    ADC_start(pinBat);   //start ADC at required channel
+    adcState=ADCrunning;
+    return adcState;    //indicate that adc is busy now
+  }
+  else if (adcState == ADCcomplete){
+    tempReading=ADC_get_value();  //grab the ADC result
+    adcState=ADCidle; // free the ADC
+  }
+  else{return adcState;}//when ADC is still busy or something, do nothing
+  
+  tempReading=fastMap1023toX(tempReading, 245); //Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
   //Apply the offset calibration value to the reading
   tempReading += configPage4.batVoltCorrect;
   if(tempReading < 0){
@@ -600,6 +884,7 @@ void readBat()
   }
 
   currentStatus.battery10 = ADC_FILTER(tempReading, configPage4.ADCFILTER_BAT, currentStatus.battery10);
+  return adcState;
 }
 
 /**
@@ -674,28 +959,36 @@ byte getGear()
   return tempGear;
 }
 
-byte getFuelPressure()
+ADCstates readFuelpressure(ADCstates adcState)
 {
   int16_t tempFuelPressure = 0;
   uint16_t tempReading;
 
   if(configPage10.fuelPressureEnable > 0)
-  {
+  { 
     //Perform ADC read
-    tempReading = analogRead(pinFuelPressure);
-    tempReading = analogRead(pinFuelPressure);
+    if(adcState == ADCidle ){
+      ADC_start(pinFuelPressure);   //start ADC at required channel
+      adcState=ADCrunning;
+      return adcState;    //indicate that adc is busy now
+    }
+    else if (adcState == ADCcomplete){
+      tempReading=ADC_get_value();  //grab the ADC result
+      adcState=ADCidle; // free the ADC
+    }
+    else{return adcState;}//when ADC is still busy or something, do nothing
 
     tempFuelPressure = fastMap10Bit(tempReading, configPage10.fuelPressureMin, configPage10.fuelPressureMax);
-    tempFuelPressure = ADC_FILTER(tempFuelPressure, ADCFILTER_PSI_DEFAULT, currentStatus.fuelPressure); //Apply smoothing factor
+    tempFuelPressure = ADC_FILTER(tempFuelPressure, 150, currentStatus.fuelPressure); //Apply speed smoothing factor
     //Sanity checks
     if(tempFuelPressure > configPage10.fuelPressureMax) { tempFuelPressure = configPage10.fuelPressureMax; }
     if(tempFuelPressure < 0 ) { tempFuelPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
   }
-
-  return (byte)tempFuelPressure;
+  currentStatus.fuelPressure=(byte)tempFuelPressure;
+  return adcState;
 }
 
-byte getOilPressure()
+ADCstates readOilpressure(ADCstates adcState)
 {
   int16_t tempOilPressure = 0;
   uint16_t tempReading;
@@ -703,19 +996,26 @@ byte getOilPressure()
   if(configPage10.oilPressureEnable > 0)
   {
     //Perform ADC read
-    tempReading = analogRead(pinOilPressure);
-    tempReading = analogRead(pinOilPressure);
-
+    if(adcState == ADCidle ){
+      ADC_start(pinOilPressure);   //start ADC at required channel
+      adcState=ADCrunning;
+      return adcState;    //indicate that adc is busy now
+    }
+    else if (adcState == ADCcomplete){
+      tempReading=ADC_get_value();  //grab the ADC result
+      adcState=ADCidle; // free the ADC
+    }
+    else{return adcState;}//when ADC is still busy or something, do nothing
 
     tempOilPressure = fastMap10Bit(tempReading, configPage10.oilPressureMin, configPage10.oilPressureMax);
-    tempOilPressure = ADC_FILTER(tempOilPressure, ADCFILTER_PSI_DEFAULT, currentStatus.oilPressure); //Apply smoothing factor
+    tempOilPressure = ADC_FILTER(tempOilPressure, 150, currentStatus.oilPressure); //Apply speed smoothing factor
     //Sanity check
     if(tempOilPressure > configPage10.oilPressureMax) { tempOilPressure = configPage10.oilPressureMax; }
     if(tempOilPressure < 0 ) { tempOilPressure = 0; } //prevent negative values, which will cause problems later when the values aren't signed.
   }
 
-
-  return (byte)tempOilPressure;
+  currentStatus.oilPressure=(byte)tempOilPressure;
+  return adcState;
 }
 
 /*
@@ -766,17 +1066,10 @@ void vssPulse()
   vssTimes[vssIndex] = micros();
 }
 
-uint16_t readAuxanalog(uint8_t analogPin)
+uint16_t readAuxanalog(uint8_t analogPin)   //currently inoperational
 {
   //read the Aux analog value for pin set by analogPin 
-  unsigned int tempReading;
-  #if defined(ANALOG_ISR)
-    tempReading = fastMap1023toX(AnChannel[analogPin-A0], 1023); //Get the current raw Auxanalog value
-  #else
-    tempReading = analogRead(analogPin);
-    tempReading = analogRead(analogPin);
-    //tempReading = fastMap1023toX(analogRead(analogPin), 511); Get the current raw Auxanalog value
-  #endif
+  unsigned int tempReading=0;
   return tempReading;
 } 
 


### PR DESCRIPTION
1. New non-blocking analog digital converter functions for STM32 and atmega2560. Each board have its own functions in the board definition files.
2. ADC_sequencer state machine to accomodate non blocking ADC reading in proper sequence, and at required intervals for reads that are not done very often.
3. in sensors.ino update all getXXX() functions to accommodate new style of read.
4. Separate EMAP read from MAP read becasue we can not do two conversions at the same time with non blocking manner.
5. Fix various initializations for analog reads: baro, etc.
6. Lowered(non overclocked) ADC frequency for atmega to get more accurate reads. ADC clock 125kHz (vs. 1MHz overclocked)
7.Increased sampling time for STM32, this gives more stable and accurate reads.
8.TPSdot calculations moved to readTPS() so that it is done only when there is new data. Also TPSdot largely optimized so that there is not heavy math involved.TPS read frequency 26Hz.  Increased loop speed about 50 more loops/s on atmega2560.
9. Loops/s on stm32 jump form 6000loops/s to 17000loops/s
10. Loops/s on atmega no big change. Only more steady analog readings because of lowered AD converter clock.
11. No increase in RAM or flash usage.