### PR TITLE
Fix building for STM32F407

### DIFF
--- a/speeduino/newComms.cpp
+++ b/speeduino/newComms.cpp
@@ -20,7 +20,7 @@ A full copy of the license may be found in the projects root directory
 #include "logger.h"
 #include "comms.h"
 #include "src/FastCRC/FastCRC.h"
-#include <EEPROM.h>
+#include EEPROM_LIB_H //This is defined in the board .h files
 #ifdef RTC_ENABLED
   #include "rtc_common.h"
 #endif


### PR DESCRIPTION
Use EEPROM_LIB_H instead of <EEPROM.h>