### PR TITLE
Use libdivide in angletotime

### DIFF
--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -2,6 +2,7 @@
 #include "crankMaths.h"
 #include "decoders.h"
 #include "timers.h"
+#include "maths.h"
 
 /*
 * Converts a crank angle into a time from or since that angle occurred.
@@ -21,7 +22,11 @@ unsigned long angleToTime(int16_t angle, byte method)
 
     if( (method == CRANKMATH_METHOD_INTERVAL_REV) || (method == CRANKMATH_METHOD_INTERVAL_DEFAULT) )
     {
+      #ifdef USE_LIBDIVIDE
+        returnTime = libdivide::libdivide_u32_do(angle * revolutionTime, &libdiv_u32_360);
+      #else
         returnTime = ((angle * revolutionTime) / 360);
+      #endif
         //returnTime = angle * (unsigned long)timePerDegree;
     }
     else if (method == CRANKMATH_METHOD_INTERVAL_TOOTH)

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -21,6 +21,8 @@ uint32_t divu10(uint32_t);
 //This is a new version that allows for out_min
 #define fastMap10Bit(x, out_min, out_max) ( ( ((unsigned long)x * (out_max-out_min)) >> 10 ) + out_min)
 
-
+#ifdef USE_LIBDIVIDE
+extern struct libdivide::libdivide_u32_t libdiv_u32_360;
+#endif
 
 #endif

--- a/speeduino/maths.ino
+++ b/speeduino/maths.ino
@@ -8,6 +8,7 @@
   struct libdivide::libdivide_u32_t libdiv_u32_100 = libdivide::libdivide_u32_gen(100);
   struct libdivide::libdivide_s32_t libdiv_s32_100 = libdivide::libdivide_s32_gen(100);
   struct libdivide::libdivide_u32_t libdiv_u32_200 = libdivide::libdivide_u32_gen(200);
+  struct libdivide::libdivide_u32_t libdiv_u32_360 = libdivide::libdivide_u32_gen(360);
 #endif
 
 //Replace the standard arduino map() function to use the div function instead


### PR DESCRIPTION
More performance for 100 bytes bigger firmware and 5 bytes more of heap. Loop/s sec increase across the RPM range of ~2% for single channel and ~5,4% for quad channel (4 cyl seq). The tests in #790 validate this change. Tested on Speeduino 0.4.3d and ignition output timing is unchanged on the oscilloscope.