### PR TITLE
Add lock/unlock feature for temp/O2 calibrations

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -645,7 +645,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      unused_bit  =   bits, U08,      14, [6:6],      "No", "Yes"
+      cal_lock    =   bits, U08,      14, [6:6],      "Locked", "Unlocked"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -1806,8 +1806,11 @@ menuDialog = main
    menu = "Tools"
         subMenu = mapCal,           "Calibrate Pressure Sensors"
         subMenu = batCal,           "Calibrate Voltage Reading"
-        subMenu = std_ms2gentherm,  "Calibrate Temperature Sensors", 0
-        subMenu = std_ms2geno2,     "Calibrate AFR Sensor", { egoType > 0 }
+        subMenu = std_separator 
+        subMenu = cal_unlock,       "Unlock/Lock Calibrations"
+        subMenu = std_ms2gentherm,  "Calibrate Temperature Sensors", 0, {cal_lock}
+        subMenu = std_ms2geno2,     "Calibrate AFR Sensor", 0, {(egoType > 0) && cal_lock}
+        subMenu = std_separator 
         subMenu = sensorFilters,    "Set analog sensor filters"
 
     menu = "Data Logging"
@@ -2194,6 +2197,7 @@ menuDialog = main
   vvtMinClt       = "Minimum coolant temp to activate VVT"
   vvtDelay        = "Time to wait after reaching minimum coolant temp (additional time for oil warmup)"
   wmiMode         = "Simple mode - Output is turned on when preset boost level is reached. \nProportional Mode - Output PWM is proportionally controlled between two MAP values - MAP Value 1 = PWM:0% / MAP Value 2 = PWM:100% \nOpen loop - Output PWM follows 2D map value (RPM vs MAP) Cell value contains desired PWM% [range 0-100%] \nClosed loop - Output PWM follows injector duty cycle with 2D correction map applied (RPM vs MAP). Cell value contains correction value% [nom 100%]"
+  cal_lock        = "Locks or Unlocks temp sensor and AFR calibrations. Unlock to write new calibration. Lock after calibrations are done"
 
   stagedInjSizePri= "Size of the primary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
   stagedInjSizeSec= "Size of the secondary injectors. The sum of the Pri and Sec injectors values MUST match the value used in the req_fuel calculation"
@@ -4065,6 +4069,9 @@ menuDialog = main
       panel = engine_constants_warning, North
       panel = engine_constants_west, West
       panel = engine_constants_east, East
+
+  dialog = cal_unlock, "Unlock/Lock Calibrations"
+      field = "Sensor Calibrations", cal_lock
 
 ;   dialog = sdcard_datalog, "SD Card Datalogging", yAxis
 ;     panel = sdcard_top

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -387,9 +387,11 @@ void command()
       //The first 2 bytes sent represent the canID and tableID
       while (Serial.available() == 0) { }
       tableID = Serial.read(); //Not currently used for anything
-
-      receiveCalibration(tableID); //Receive new values and store in memory
-      writeCalibration(); //Store received values in EEPROM
+      if(configPage6.cal_lock == true) // Only read and apply new calibrations from TS if calibrations are unlocked. This should always be true.
+      {
+        receiveCalibration(tableID); //Receive new values and store in memory
+        writeCalibration(); //Store received values in EEPROM
+      }
 
       break;
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1042,7 +1042,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte unused_bit : 1; //Previously was VVTasOnOff
+  byte cal_lock : 1;
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage

--- a/speeduino/newComms.cpp
+++ b/speeduino/newComms.cpp
@@ -615,124 +615,129 @@ void processSerialCommand()
 
     case 't': // receive new Calibration info. Command structure: "t", <tble_idx> <data array>.
     {
-      uint8_t cmd = serialPayload[2];
-      uint16_t valueOffset = word(serialPayload[3], serialPayload[4]);
-      uint16_t calibrationLength = word(serialPayload[5], serialPayload[6]); // Should be 256
-      uint32_t calibrationCRC = 0;
-
-      if(cmd == O2_CALIBRATION_PAGE)
+    if(configPage6.cal_lock == true) // Only read and apply new calibrations from TS if calibrations are unlocked. This should always be true.
       {
-        //TS sends a total of 1024 bytes of calibration data, broken up into 256 byte chunks
-        //As we're using an interpolated 2D table, we only need to store 32 values out of this 1024
-        void* pnt_TargetTable_values = (uint8_t *)&o2Calibration_values; //Pointer that will be used to point to the required target table values
-        uint16_t* pnt_TargetTable_bins = (uint16_t *)&o2Calibration_bins; //Pointer that will be used to point to the required target table bins
+        uint8_t cmd = serialPayload[2];
+        uint16_t valueOffset = word(serialPayload[3], serialPayload[4]);
+        uint16_t calibrationLength = word(serialPayload[5], serialPayload[6]); // Should be 256
+        uint32_t calibrationCRC = 0;
 
-        //Read through the current chunk (Should be 256 bytes long)
-        for(uint16_t x = 0; x < calibrationLength; x++)
+        if(cmd == O2_CALIBRATION_PAGE)
         {
-          uint16_t totalOffset = valueOffset + x;
-          //Only apply every 32nd value
-          if( (x % 32) == 0 )
+          //TS sends a total of 1024 bytes of calibration data, broken up into 256 byte chunks
+          //As we're using an interpolated 2D table, we only need to store 32 values out of this 1024
+          void* pnt_TargetTable_values = (uint8_t *)&o2Calibration_values; //Pointer that will be used to point to the required target table values
+          uint16_t* pnt_TargetTable_bins = (uint16_t *)&o2Calibration_bins; //Pointer that will be used to point to the required target table bins
+
+          //Read through the current chunk (Should be 256 bytes long)
+          for(uint16_t x = 0; x < calibrationLength; x++)
           {
-            ((uint8_t*)pnt_TargetTable_values)[(totalOffset/32)] = serialPayload[x+7]; //O2 table stores 8 bit values
-            pnt_TargetTable_bins[(totalOffset/32)] = (totalOffset);
+            uint16_t totalOffset = valueOffset + x;
+            //Only apply every 32nd value
+            if( (x % 32) == 0 )
+            {
+              ((uint8_t*)pnt_TargetTable_values)[(totalOffset/32)] = serialPayload[x+7]; //O2 table stores 8 bit values
+              pnt_TargetTable_bins[(totalOffset/32)] = (totalOffset);
+            }
 
+            //Update the CRC
+            if(totalOffset == 0)
+            {
+              calibrationCRC = CRC32.crc32(&serialPayload[7], 1, false);
+            }
+            else
+            {
+              calibrationCRC = CRC32.crc32_upd(&serialPayload[x+7], 1, false);
+            }
+            //Check if CRC is finished
+            if(totalOffset == 1023) 
+            {
+              //apply CRC reflection
+              calibrationCRC = ~calibrationCRC;
+              storeCalibrationCRC32(O2_CALIBRATION_PAGE, calibrationCRC);
+            }
           }
-
-          //Update the CRC
-          if(totalOffset == 0)
-          {
-            calibrationCRC = CRC32.crc32(&serialPayload[7], 1, false);
-          }
-          else
-          {
-            calibrationCRC = CRC32.crc32_upd(&serialPayload[x+7], 1, false);
-          }
-          //Check if CRC is finished
-          if(totalOffset == 1023) 
-          {
-            //apply CRC reflection
-            calibrationCRC = ~calibrationCRC;
-            storeCalibrationCRC32(O2_CALIBRATION_PAGE, calibrationCRC);
-          }
-        }
-        sendSerialReturnCode(SERIAL_RC_OK);
-        Serial.flush(); //This is safe because engine is assumed to not be running during calibration
-
-        //Check if this is the final chunk of calibration data
-        #ifdef CORE_STM32
-          //STM32 requires TS to send 16 x 64 bytes chunk rather than 4 x 256 bytes. 
-          if(valueOffset == (64*15)) { writeCalibrationPage(cmd); } //Store received values in EEPROM if this is the final chunk of calibration
-        #else
-          if(valueOffset == (256*3)) { writeCalibrationPage(cmd); } //Store received values in EEPROM if this is the final chunk of calibration
-        #endif
-      }
-      else if(cmd == IAT_CALIBRATION_PAGE)
-      {
-        void* pnt_TargetTable_values = (uint16_t *)&iatCalibration_values;
-        uint16_t* pnt_TargetTable_bins = (uint16_t *)&iatCalibration_bins;
-
-        //Temperature calibrations are sent as 32 16-bit values (ie 64 bytes total)
-        if(calibrationLength == 64)
-        {
-          for (uint16_t x = 0; x < 32; x++)
-          {
-            int16_t tempValue = (int16_t)(word(serialPayload[((2 * x) + 8)], serialPayload[((2 * x) + 7)])); //Combine the 2 bytes into a single, signed 16-bit value
-            tempValue = div(tempValue, 10).quot; //TS sends values multipled by 10 so divide back to whole degrees. 
-            tempValue = ((tempValue - 32) * 5) / 9; //Convert from F to C
-            
-            //Apply the temp offset and check that it results in all values being positive
-            tempValue = tempValue + CALIBRATION_TEMPERATURE_OFFSET;
-            if (tempValue < 0) { tempValue = 0; }
-
-            
-            ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
-            pnt_TargetTable_bins[x] = (x * 32U);
-          }
-          //Update the CRC
-          calibrationCRC = CRC32.crc32(&serialPayload[7], 64);
-          storeCalibrationCRC32(IAT_CALIBRATION_PAGE, calibrationCRC);
-
-          writeCalibration();
           sendSerialReturnCode(SERIAL_RC_OK);
-        }
-        else { sendSerialReturnCode(SERIAL_RC_RANGE_ERR); }
-        
-      }
-      else if(cmd == CLT_CALIBRATION_PAGE)
-      {
-        void* pnt_TargetTable_values = (uint16_t *)&cltCalibration_values;
-        uint16_t* pnt_TargetTable_bins = (uint16_t *)&cltCalibration_bins;
+          Serial.flush(); //This is safe because engine is assumed to not be running during calibration
 
-        //Temperature calibrations are sent as 32 16-bit values
-        if(calibrationLength == 64)
+          //Check if this is the final chunk of calibration data
+          #ifdef CORE_STM32
+            //STM32 requires TS to send 16 x 64 bytes chunk rather than 4 x 256 bytes. 
+            if(valueOffset == (64*15)) { writeCalibrationPage(cmd); } //Store received values in EEPROM if this is the final chunk of calibration
+          #else
+            if(valueOffset == (256*3)) { writeCalibrationPage(cmd); } //Store received values in EEPROM if this is the final chunk of calibration
+          #endif
+        }
+        else if(cmd == IAT_CALIBRATION_PAGE)
         {
-          for (uint16_t x = 0; x < 32; x++)
+          void* pnt_TargetTable_values = (uint16_t *)&iatCalibration_values;
+          uint16_t* pnt_TargetTable_bins = (uint16_t *)&iatCalibration_bins;
+
+          //Temperature calibrations are sent as 32 16-bit values (ie 64 bytes total)
+          if(calibrationLength == 64)
           {
-            int16_t tempValue = (int16_t)(word(serialPayload[((2 * x) + 8)], serialPayload[((2 * x) + 7)])); //Combine the 2 bytes into a single, signed 16-bit value
-            tempValue = div(tempValue, 10).quot; //TS sends values multipled by 10 so divide back to whole degrees. 
-            tempValue = ((tempValue - 32) * 5) / 9; //Convert from F to C
-            
-            //Apply the temp offset and check that it results in all values being positive
-            tempValue = tempValue + CALIBRATION_TEMPERATURE_OFFSET;
-            if (tempValue < 0) { tempValue = 0; }
+            for (uint16_t x = 0; x < 32; x++)
+            {
+              int16_t tempValue = (int16_t)(word(serialPayload[((2 * x) + 8)], serialPayload[((2 * x) + 7)])); //Combine the 2 bytes into a single, signed 16-bit value
+              tempValue = div(tempValue, 10).quot; //TS sends values multipled by 10 so divide back to whole degrees. 
+              tempValue = ((tempValue - 32) * 5) / 9; //Convert from F to C
+
+              //Apply the temp offset and check that it results in all values being positive
+              tempValue = tempValue + CALIBRATION_TEMPERATURE_OFFSET;
+              if (tempValue < 0) { tempValue = 0; }
 
             
-            ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
-            pnt_TargetTable_bins[x] = (x * 32U);
+              ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
+              pnt_TargetTable_bins[x] = (x * 32U);
+            }
+            //Update the CRC
+            calibrationCRC = CRC32.crc32(&serialPayload[7], 64);
+            storeCalibrationCRC32(IAT_CALIBRATION_PAGE, calibrationCRC);
+
+            writeCalibration();
+            sendSerialReturnCode(SERIAL_RC_OK);
           }
-          //Update the CRC
-          calibrationCRC = CRC32.crc32(&serialPayload[7], 64);
-          storeCalibrationCRC32(CLT_CALIBRATION_PAGE, calibrationCRC);
+          else { sendSerialReturnCode(SERIAL_RC_RANGE_ERR); }
 
-          writeCalibration();
-          sendSerialReturnCode(SERIAL_RC_OK);
         }
-        else { sendSerialReturnCode(SERIAL_RC_RANGE_ERR); }
+        else if(cmd == CLT_CALIBRATION_PAGE)
+        {
+          void* pnt_TargetTable_values = (uint16_t *)&cltCalibration_values;
+          uint16_t* pnt_TargetTable_bins = (uint16_t *)&cltCalibration_bins;
+
+          //Temperature calibrations are sent as 32 16-bit values
+          if(calibrationLength == 64)
+          {
+            for (uint16_t x = 0; x < 32; x++)
+            {
+              int16_t tempValue = (int16_t)(word(serialPayload[((2 * x) + 8)], serialPayload[((2 * x) + 7)])); //Combine the 2 bytes into a single, signed 16-bit value
+              tempValue = div(tempValue, 10).quot; //TS sends values multipled by 10 so divide back to whole degrees. 
+              tempValue = ((tempValue - 32) * 5) / 9; //Convert from F to C
+
+              //Apply the temp offset and check that it results in all values being positive
+              tempValue = tempValue + CALIBRATION_TEMPERATURE_OFFSET;
+              if (tempValue < 0) { tempValue = 0; }
+
+              ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
+              pnt_TargetTable_bins[x] = (x * 32U);
+            }
+            //Update the CRC
+            calibrationCRC = CRC32.crc32(&serialPayload[7], 64);
+            storeCalibrationCRC32(CLT_CALIBRATION_PAGE, calibrationCRC);
+
+            writeCalibration();
+            sendSerialReturnCode(SERIAL_RC_OK);
+          }
+          else { sendSerialReturnCode(SERIAL_RC_RANGE_ERR); }
+        }
+        else
+        {
+          sendSerialReturnCode(SERIAL_RC_RANGE_ERR);
+        }
       }
       else
       {
-        sendSerialReturnCode(SERIAL_RC_RANGE_ERR);
+        sendSerialReturnCode(SERIAL_RC_UKWN_ERR); // If for some reason the calibration write manages to happen when calibrations are locked, we send error to TS. (calibration dialog is disabled if calibrations are locked)
       }
       break;
     }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -492,7 +492,7 @@ void doUpdates()
     configPage10.TrigEdgeThrd = 0;
 
     //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    if(configPage6.cal_lock == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
 
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;
@@ -588,6 +588,7 @@ void doUpdates()
   {
     //202204
     configPage9.coolantProtEnbl = false;
+    configPage6.cal_lock = 0;
     
     writeAllConfig();
     storeEEPROMVersion(20);


### PR DESCRIPTION
This is safety feature to prevent accidentally writing new temp/O2 calibrations. This might also prevent wiping the calibrations in case of strange comms issues.

Changes in newComms.ino might seem big, but Git is just showing that weirdly, and there is really only that one if-else added.