### PR TITLE
Change the newComms to wait for eeprom write to finish.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -239,7 +239,7 @@
     tableBlockingFactor = 244 ; Serial buffer is 257 bytes. There are 7 bytes overhead for the M command + 2 bytes for the size + 4 bytes for the CRC. 257 - 7 - 2 - 4 = 244 bytes.
     delayAfterPortOpen=1000
     ;validateArrayBounds = true
-    blockReadTimeout = 2000
+    blockReadTimeout = 3000
     tsWriteBlocks = on
     interWriteDelay = 10 ;Ignored when tsWriteBlocks is on
     pageActivationDelay = 10

--- a/speeduino/newComms.cpp
+++ b/speeduino/newComms.cpp
@@ -32,6 +32,7 @@ bool serialReceivePending = false; /**< Whether or not a serial request has only
 uint16_t serialBytesReceived = 0; /**< The number of bytes received in the serial buffer during the current command. */
 uint32_t serialCRC = 0; 
 bool serialWriteInProgress = false;
+bool serialReturnCodePending = false;
 uint16_t serialBytesTransmitted = 0;
 uint32_t serialReceiveStartTime = 0; /**< The time at which the serial receive started. Used for calculating whether a timeout has occurred */
 FastCRC32 CRC32_serial; //This instance of CRC32 is exclusively used on the comms envelope CRC validations. It is separate to those used for page or calibration calculations to prevent update calls clashing with one another
@@ -410,8 +411,8 @@ void processSerialCommand()
       }
       
       deferEEPROMWritesUntil = micros() + EEPROM_DEFER_DELAY;
-      
-      sendSerialReturnCode(SERIAL_RC_OK);
+      //We don't send return code yet. It will be done in main loop when page write has been actually done to EEPROM.
+      serialReturnCodePending = true;
       
       break;
     }  

--- a/speeduino/newComms.h
+++ b/speeduino/newComms.h
@@ -71,7 +71,7 @@
 
 extern bool serialWriteInProgress;
 extern bool serialReceivePending; /**< Whether or not a serial request has only been partially received. This occurs when a the length has been received in the serial buffer, but not all of the payload or CRC has yet been received. */
-
+extern bool serialReturnCodePending;
 
 void parseSerial();//This is the heart of the Command Line Interpeter.  All that needed to be done was to make it human readable.
 void processSerialCommand();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -319,6 +319,12 @@ void loop()
 
       //Check for any outstanding EEPROM writes.
       if( (isEepromWritePending() == true) && (serialReceivePending == false) && (micros() > deferEEPROMWritesUntil)) { writeAllConfig(); } 
+      //if no EEPROM writes to do anymore, send return code to TS.
+      if( (isEepromWritePending() == false) && serialReturnCodePending == true)
+      {
+        sendSerialReturnCode(SERIAL_RC_OK);
+        serialReturnCodePending = false;
+      }
     }
     if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_4HZ))
     {


### PR DESCRIPTION
This small PR changes the the newComms behavior so that the `SERIAL_RC_OK` return code is only send out once all the data has been actually burnt to eeprom. Without this, large tune burns appear to take only short time, but actually the speedy is writing the tune to eeprom for some time after that. Which is ok, but if speeduino is turned off during this time, the tune will corrupt. The change in this PR makes the "sending tune" -dialog show in TS for the whole time when tune is being burnt. Removing risk of corrupt tunes.

Tested on Mega 2560 and STM32 with internal flash eeprom emulation.