### PR TITLE
Timers to millis(), tacho to timer2

### DIFF
--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -94,5 +94,23 @@ long vvt2_pid_current_angle;
 void boostInterrupt();
 void vvtInterrupt();
 
+//Tacho related 
+#define TACHO_PULSE_HIGH() *tach_pin_port |= (tach_pin_mask)
+#define TACHO_PULSE_LOW() *tach_pin_port &= ~(tach_pin_mask)
+
+enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tacho output pulse can have
+
+#ifdef CORE_AVR  //AVR chips use timer2 interrupt for this
+uint16_t tachoDwell; //Current tacho dwell time saved as ms*125 pre-calculated for atmega2560
+volatile uint16_t tachoInterval; //Holds Tacho interval timer data
+#else
+volatile TachoOutputStatus tachoOutputFlag;
+unsigned long tachoStartTime; //The time (in micros) that the tacho pulse started
+unsigned long lastTachoStartTime;
+#endif
+
+void setTacho(); //Sets tacho output
+void tachoControl();
+
 
 #endif

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -894,3 +894,62 @@ void boostDisable()
   }
 }
 #endif
+
+//Sets tacho output
+void setTacho()
+{
+  static bool tachoAlt=false; //tacho divider
+
+  if( (configPage2.tachoDiv == 0) || (tachoAlt == true) ) 
+  { 
+    TACHO_PULSE_LOW(); //start tacho pulse
+    #if defined(CORE_AVR) //avr chips use Timer2 for this
+      tachoInterval =tachoDwell;
+      TACHO_COMPARE =(uint8_t)(TACHO_COUNTER + lowByte(tachoInterval));
+      TACHO_TIMER_ENABLE();            //Timer2 Output Compare Match A Interrupt Enable
+    #else  //other chips use simply micros() for this      
+      tachoOutputFlag = ACTIVE;
+      lastTachoStartTime=tachoStartTime;
+      tachoStartTime=micros();       
+    #endif   
+  }
+  tachoAlt = !tachoAlt; //Flip the alternating value incase half speed tacho is in use. 
+}
+
+//Tacho output check
+//clears the tacho output when time is ready
+#if defined(CORE_AVR) //AVR chips use the ISR for this
+ISR(TIMER2_COMPA_vect)
+{
+  if(highByte(tachoInterval) > 0)
+  {
+    tachoInterval-= 0x100U;        //extends timing capabilities beyond timer overflow
+  }
+  else
+  {
+  TACHO_PULSE_HIGH(); //end tacho pulse
+  TACHO_TIMER_DISABLE();
+  }
+}
+#endif
+
+//Tacho output check
+//clears the tacho output when time is ready
+void tachoControl()  // ARM chips can simply call a function in the main loop
+{  
+  #ifdef CORE_AVR //AVR chips use the ISR for this  
+    tachoDwell = (uint8_t)configPage2.tachoDuration * (uint8_t)125U;
+  #else 
+  //Tacho is flagged as being ready for a pulse by the ignition outputs. 
+  if(tachoOutputFlag == ACTIVE)
+  {
+    if(((micros()-tachoStartTime) >= configPage2.tachoDuration*1000U) || ((micros()-tachoStartTime) > (tachoStartTime-lastTachoStartTime)/2) ) //also limits pulse to 50% duty cycle
+    {      
+      TACHO_PULSE_HIGH(); //end tacho pulse
+      tachoOutputFlag = DEACTIVE;
+    }
+  }
+  #endif
+}
+
+  

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -141,6 +141,10 @@
   #define VVT_TIMER_COMPARE     OCR1B
   #define VVT_TIMER_COUNTER     TCNT1
 
+  #define TACHO_TIMER_ENABLE() TIFR2 |= (1 << OCF2A);TIMSK2 |= (1<<OCIE2A) //Timer2 Compare Match A Interrupt enable
+  #define TACHO_TIMER_DISABLE() TIMSK2 &= ~(1<<OCIE2A)
+  #define TACHO_COUNTER TCNT2
+  #define TACHO_COMPARE OCR2A
 /*
 ***********************************************************************************************************
 * Idle

--- a/speeduino/board_avr2560.ino
+++ b/speeduino/board_avr2560.ino
@@ -43,10 +43,11 @@ void initBoard()
     ***********************************************************************************************************
     * Timers
     */
-    //Configure Timer2 for our low-freq interrupt code.
+    //Configure Timer2 for tacho signal generation.
     TCCR2B = TIMER_PRESCALER_OFF;   //Disbale Timer2 while we set it up
-    TCNT2  = 131;                   //Preload timer2 with 131 cycles, leaving 125 till overflow. As the timer runs at 125Khz, this causes overflow to occur at 1Khz = 1ms
-    TIMSK2 = (1<<TOIE2);            //Timer2 Set Overflow Interrupt enabled.
+    TCNT2  = 0;                   //Preload timer2 with 131 cycles, leaving 125 till overflow. As the timer runs at 125Khz, this causes overflow to occur at 1Khz = 1ms
+//    TIMSK2 = (1<<TOIE2);            //Timer2 Set Overflow Interrupt enabled.
+//    TIMSK2 |= (1<<OCIE2A);            //Timer2 Output Compare Match A Interrupt Enable
     TCCR2A = TIMER_MODE_NORMAL;     //Timer2 Control Reg A: Wave Gen Mode normal
     /* Now configure the prescaler to CPU clock divided by 128 = 125Khz */
     TCCR2B = (1<<CS22)  | (1<<CS20); // Set bits. This timer uses different prescaler values, thus we cannot use the defines above.

--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -129,14 +129,14 @@ STM32RTC& rtc = STM32RTC::getInstance();
       #endif
       Timer4.resume(); //Start Timer
     #else
-      Timer11.setOverflow(1000, MICROSEC_FORMAT);  // Set up period
-      #if ( STM32_CORE_VERSION_MAJOR < 2 )
-      Timer11.setMode(1, TIMER_OUTPUT_COMPARE);
-      Timer11.attachInterrupt(1, oneMSInterval);
-      #else
-      Timer11.attachInterrupt(oneMSInterval);
-      #endif
-      Timer11.resume(); //Start Timer
+//      Timer11.setOverflow(1000, MICROSEC_FORMAT);  // Set up period
+//      #if ( STM32_CORE_VERSION_MAJOR < 2 )
+//      Timer11.setMode(1, TIMER_OUTPUT_COMPARE);
+//      Timer11.attachInterrupt(1, oneMSInterval);
+//      #else
+//      Timer11.attachInterrupt(oneMSInterval);
+//      #endif
+//      Timer11.resume(); //Start Timer
     #endif
     pinMode(LED_BUILTIN, OUTPUT); //Visual WDT
 

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -241,7 +241,7 @@ byte correctionASE()
   //Two checks are requiredL:
   //1) Is the engine run time less than the configured ase time
   //2) Make sure we're not still cranking
-  if ( BIT_CHECK(TIMER_mask, BIT_TIMER_10HZ) || (currentStatus.ASEValue == 0) )
+  if ( BIT_CHECK(LOOP_TIMER, BIT_TIMER_10HZ) || (currentStatus.ASEValue == 0) )
   {
     if ( (currentStatus.runSecs < (table2D_getValue(&ASECountTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET))) && !(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) )
     {

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -326,7 +326,7 @@ static inline byte checkForStepping()
       timeCheck = iacCoolTime_uS;
     }
 
-    if(micros_safe() > (idleStepper.stepStartTime + timeCheck) )
+    if((unsigned long)(micros_safe() - idleStepper.stepStartTime) > timeCheck )
     {         
       if(idleStepper.stepperStatus == STEPPING)
       {
@@ -734,8 +734,10 @@ void idleControl()
       //Set or clear the idle active flag
       if(idleStepper.targetIdleStep != idleStepper.curIdleStep) { BIT_SET(currentStatus.spark, BIT_SPARK_IDLE); }
       else { BIT_CLEAR(currentStatus.spark, BIT_SPARK_IDLE); }
-      if (BIT_CHECK(LOOP_TIMER, BIT_TIMER_1HZ)) //Use timer flag instead idle count
+      static uint16_t previousMillisIdle1Hz=7;
+      if((uint16_t)((uint16_t)millis() - previousMillisIdle1Hz) >= (uint16_t)1000U )//Use millis() instead idle count
       {
+        previousMillisIdle1Hz+=(uint16_t)1000U;
         //This only needs to be run very infrequently, once per second
         idlePID.SetTunings(configPage6.idleKP, configPage6.idleKI, configPage6.idleKD);
         iacStepTime_uS = configPage6.iacStepTime * 1000;

--- a/speeduino/scheduledIO.ino
+++ b/speeduino/scheduledIO.ino
@@ -2,6 +2,7 @@
 #include "scheduler.h"
 #include "globals.h"
 #include "timers.h"
+#include "auxiliaries.h"
 #include "acc_mc33810.h"
 /** @file
  * Injector and Coil (toggle/open/close) control (under various situations, eg with particular cylinder count, rotary engine type or wasted spark ign, etc.).
@@ -67,28 +68,28 @@ void closeInjector3and7() { closeInjector3(); closeInjector7(); }
 void openInjector4and8() { openInjector4(); openInjector8(); }
 void closeInjector4and8() { closeInjector4(); closeInjector8(); }
 
-inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } setTacho(); }
 inline void endCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } }
 
-inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } setTacho(); }
 inline void endCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } }
 
-inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } setTacho(); }
 inline void endCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } }
 
-inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } setTacho(); }
 inline void endCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } }
 
-inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } setTacho(); }
 inline void endCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } }
 
-inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } setTacho(); }
 inline void endCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } }
 
-inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } setTacho(); }
 inline void endCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } }
 
-inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutputFlag = READY; }
+inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } setTacho(); }
 inline void endCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } }
 
 //The below 3 calls are all part of the rotary ignition mode
@@ -97,27 +98,27 @@ inline void endTrailingCoilCharge1() { endCoil2Charge(); beginCoil3Charge(); } /
 inline void endTrailingCoilCharge2() { endCoil2Charge(); endCoil3Charge(); } //sets ign3 (Trailing select) low
 
 //As above but for ignition (Wasted COP mode)
-void beginCoil1and3Charge() { beginCoil1Charge(); beginCoil3Charge(); tachoOutputFlag = READY; }
+void beginCoil1and3Charge() { beginCoil1Charge(); beginCoil3Charge(); setTacho(); }
 void endCoil1and3Charge()   { endCoil1Charge();  endCoil3Charge();  }
-void beginCoil2and4Charge() { beginCoil2Charge(); beginCoil4Charge(); tachoOutputFlag = READY; }
+void beginCoil2and4Charge() { beginCoil2Charge(); beginCoil4Charge(); setTacho(); }
 void endCoil2and4Charge()   { endCoil2Charge();  endCoil4Charge(); }
 
 //For 6cyl wasted COP mode)
-void beginCoil1and4Charge() { beginCoil1Charge(); beginCoil4Charge(); tachoOutputFlag = READY; }
+void beginCoil1and4Charge() { beginCoil1Charge(); beginCoil4Charge(); setTacho(); }
 void endCoil1and4Charge()   { endCoil1Charge();  endCoil4Charge(); }
-void beginCoil2and5Charge() { beginCoil2Charge(); beginCoil5Charge(); tachoOutputFlag = READY; }
+void beginCoil2and5Charge() { beginCoil2Charge(); beginCoil5Charge(); setTacho(); }
 void endCoil2and5Charge()   { endCoil2Charge();  endCoil5Charge(); }
-void beginCoil3and6Charge() { beginCoil3Charge(); beginCoil6Charge(); tachoOutputFlag = READY; }
+void beginCoil3and6Charge() { beginCoil3Charge(); beginCoil6Charge(); setTacho(); }
 void endCoil3and6Charge()   { endCoil3Charge(); endCoil6Charge();  }
 
 //For 8cyl wasted COP mode)
-void beginCoil1and5Charge() { beginCoil1Charge(); beginCoil5Charge(); tachoOutputFlag = READY; }
+void beginCoil1and5Charge() { beginCoil1Charge(); beginCoil5Charge(); setTacho(); }
 void endCoil1and5Charge()   { endCoil1Charge();  endCoil5Charge(); }
-void beginCoil2and6Charge() { beginCoil2Charge(); beginCoil6Charge(); tachoOutputFlag = READY; }
+void beginCoil2and6Charge() { beginCoil2Charge(); beginCoil6Charge(); setTacho(); }
 void endCoil2and6Charge()   { endCoil2Charge();  endCoil6Charge(); }
-void beginCoil3and7Charge() { beginCoil3Charge(); beginCoil7Charge(); tachoOutputFlag = READY; }
+void beginCoil3and7Charge() { beginCoil3Charge(); beginCoil7Charge(); setTacho(); }
 void endCoil3and7Charge()   { endCoil3Charge(); endCoil7Charge(); }
-void beginCoil4and8Charge() { beginCoil4Charge(); beginCoil8Charge(); tachoOutputFlag = READY; }
+void beginCoil4and8Charge() { beginCoil4Charge(); beginCoil8Charge(); setTacho(); }
 void endCoil4and8Charge()   { endCoil4Charge();  endCoil8Charge();  }
 
 void nullCallback() { return; }

--- a/speeduino/sensors.h
+++ b/speeduino/sensors.h
@@ -81,6 +81,7 @@ void initialiseADC();
 void readTPS(bool=true); //Allows the option to override the use of the filter
 void readO2_2();
 void flexPulse();
+void getFlex();
 uint32_t vssGetPulseGap(byte);
 void vssPulse();
 uint16_t getSpeed();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -116,8 +116,11 @@ inline uint16_t applyFuelTrimToPW(trimTable3d *pTrimTable, int16_t fuelLoad, int
 void loop()
 {
       mainLoopCount++;
+      TIMER_mask=getTimerFlags();
       LOOP_TIMER = TIMER_mask;
 
+      tachoControl();
+      
       //SERIAL Comms
       //Initially check that the last serial send values request is not still outstanding
       if (serialInProgress == true) 
@@ -401,6 +404,11 @@ void loop()
     {
       BIT_CLEAR(TIMER_mask, BIT_TIMER_1HZ);
       readBaro(); //Infrequent baro readings are not an issue.
+
+      currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10); //Infrequent crankRPM treshold updates are not an issue.
+      getFlex();
+      testOutputs();
+      fanControl();            // Fucntion to turn the cooling fan on/off
 
       if ( (configPage10.wmiEnabled > 0) && (configPage10.wmiIndicatorEnabled > 0) )
       {

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -21,19 +21,7 @@ Hence we will preload the timer with 131 cycles to leave 125 until overflow (1ms
 
 #define SET_COMPARE(compare, value) compare = (COMPARE_TYPE)(value) // It is important that we cast this to the actual overflow limit of the timer. The compare variables type can be bigger than the timer overflow.
 
-volatile bool tachoAlt = false;
-#define TACHO_PULSE_HIGH() *tach_pin_port |= (tach_pin_mask)
-#define TACHO_PULSE_LOW() *tach_pin_port &= ~(tach_pin_mask)
-enum TachoOutputStatus {DEACTIVE, READY, ACTIVE}; //The 3 statuses that the tacho output pulse can have
-
-volatile uint8_t tachoEndTime; //The time (in ms) that the tacho pulse needs to end at
-volatile TachoOutputStatus tachoOutputFlag;
-
-volatile byte loop33ms;
-volatile byte loop66ms;
-volatile byte loop100ms;
-volatile byte loop250ms;
-volatile int loopSec;
+char getTimerFlags();
 
 volatile unsigned int dwellLimit_uS;
 volatile uint16_t lastRPM_100ms; //Need to record this for rpmDOT calculation

--- a/speeduino/timers.ino
+++ b/speeduino/timers.ino
@@ -10,8 +10,8 @@ They should not be confused with Schedulers, which are for performing an action 
 
 Timers are typically low resolution (Compared to Schedulers), with maximum frequency currently being approximately every 10ms
 */
-#include "timers.h"
 #include "globals.h"
+#include "timers.h"
 #include "sensors.h"
 #include "scheduler.h"
 #include "scheduledIO.h"
@@ -27,11 +27,6 @@ Timers are typically low resolution (Compared to Schedulers), with maximum frequ
 void initialiseTimers()
 {
   lastRPM_100ms = 0;
-  loop33ms = 0;
-  loop66ms = 0;
-  loop100ms = 0;
-  loop250ms = 0;
-  loopSec = 0;
 }
 
 
@@ -42,83 +37,42 @@ ISR(TIMER2_OVF_vect, ISR_NOBLOCK) //This MUST be no block. Turning NO_BLOCK off 
 #else
 void oneMSInterval() //Most ARM chips can simply call a function
 #endif
+{}
+
+char getTimerFlags()
 {
-  ms_counter++;
+  static uint8_t previousMillis33ms=1;
+  static uint8_t previousMillis66ms=2;
+  static uint8_t previousMillis100ms=3;
+  static uint16_t previousMillis250ms=4;
+  static uint16_t previousMillis1000ms=6;
+  uint16_t currentMillis;
+  uint8_t interval;
+  byte timerflags=0;
 
-  //Increment Loop Counters
-  loop33ms++;
-  loop66ms++;
-  loop100ms++;
-  loop250ms++;
-  loopSec++;
-
-  unsigned long targetOverdwellTime;
-
-  //Overdwell check
-  targetOverdwellTime = micros() - dwellLimit_uS; //Set a target time in the past that all coil charging must have begun after. If the coil charge began before this time, it's been running too long
-  bool isCrankLocked = configPage4.ignCranklock && (currentStatus.RPM < currentStatus.crankRPM); //Dwell limiter is disabled during cranking on setups using the locked cranking timing. WE HAVE to do the RPM check here as relying on the engine cranking bit can be potentially too slow in updating
-  //Check first whether each spark output is currently on. Only check it's dwell time if it is
-
-  if(ignitionSchedule1.Status == RUNNING) { if( (ignitionSchedule1.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign1EndFunction(); ignitionSchedule1.Status = OFF; } }
-  if(ignitionSchedule2.Status == RUNNING) { if( (ignitionSchedule2.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign2EndFunction(); ignitionSchedule2.Status = OFF; } }
-  if(ignitionSchedule3.Status == RUNNING) { if( (ignitionSchedule3.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign3EndFunction(); ignitionSchedule3.Status = OFF; } }
-  if(ignitionSchedule4.Status == RUNNING) { if( (ignitionSchedule4.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign4EndFunction(); ignitionSchedule4.Status = OFF; } }
-  if(ignitionSchedule5.Status == RUNNING) { if( (ignitionSchedule5.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign5EndFunction(); ignitionSchedule5.Status = OFF; } }
-  if(ignitionSchedule6.Status == RUNNING) { if( (ignitionSchedule6.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign6EndFunction(); ignitionSchedule6.Status = OFF; } }
-  if(ignitionSchedule7.Status == RUNNING) { if( (ignitionSchedule7.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign7EndFunction(); ignitionSchedule7.Status = OFF; } }
-  if(ignitionSchedule8.Status == RUNNING) { if( (ignitionSchedule8.startTime < targetOverdwellTime) && (configPage4.useDwellLim) && (isCrankLocked != true) ) { ign8EndFunction(); ignitionSchedule8.Status = OFF; } }
-
-  //Tacho output check
-  //Tacho is flagged as being ready for a pulse by the ignition outputs. 
-  if(tachoOutputFlag == READY)
-  {
-    //Check for half speed tacho
-    if( (configPage2.tachoDiv == 0) || (tachoAlt == true) ) 
-    { 
-      TACHO_PULSE_LOW();
-      //ms_counter is cast down to a byte as the tacho duration can only be in the range of 1-6, so no extra resolution above that is required
-      tachoEndTime = (uint8_t)ms_counter + configPage2.tachoDuration;
-      tachoOutputFlag = ACTIVE;
-    }
-    else
-    {
-      //Don't run on this pulse (Half speed tacho)
-      tachoOutputFlag = DEACTIVE;
-    }
-    tachoAlt = !tachoAlt; //Flip the alternating value incase half speed tacho is in use. 
-  }
-  else if(tachoOutputFlag == ACTIVE)
-  {
-    //If the tacho output is already active, check whether it's reached it's end time
-    if((uint8_t)ms_counter == tachoEndTime)
-    {
-      TACHO_PULSE_HIGH();
-      tachoOutputFlag = DEACTIVE;
-    }
-  }
-  // Tacho sweep
-  
-
-
+  currentMillis =(uint16_t)millis(); // capture the latest value of millis()
   //30Hz loop
-  if (loop33ms == 33)
+  interval=lowByte(currentMillis) - previousMillis33ms;
+  if(interval >= (uint8_t)33U )
   {
-    loop33ms = 0;
-    BIT_SET(TIMER_mask, BIT_TIMER_30HZ);
+    previousMillis33ms=lowByte(currentMillis); 
+    BIT_SET(timerflags, BIT_TIMER_30HZ);
   }
 
   //15Hz loop
-  if (loop66ms == 66)
+  interval=lowByte(currentMillis) - previousMillis66ms;
+  if(interval >= (uint8_t)66U )
   {
-    loop66ms = 0;
-    BIT_SET(TIMER_mask, BIT_TIMER_15HZ);
+    previousMillis66ms=lowByte(currentMillis);
+    BIT_SET(timerflags, BIT_TIMER_15HZ);
   }
 
   //10Hz loop
-  if (loop100ms == 100)
+  interval=lowByte(currentMillis) - previousMillis100ms;
+  if(interval >= (uint8_t)100U )
   {
-    loop100ms = 0; //Reset counter
-    BIT_SET(TIMER_mask, BIT_TIMER_10HZ);
+    previousMillis100ms=lowByte(currentMillis);
+    BIT_SET(timerflags, BIT_TIMER_10HZ);
 
     currentStatus.rpmDOT = (currentStatus.RPM - lastRPM_100ms) * 10; //This is the RPM per second that the engine has accelerated/decelleratedin the last loop
     lastRPM_100ms = currentStatus.RPM; //Record the current RPM for next calc
@@ -131,10 +85,10 @@ void oneMSInterval() //Most ARM chips can simply call a function
   }
 
   //4Hz loop
-  if (loop250ms == 250)
+  if((uint16_t)(currentMillis - previousMillis250ms) >= (uint16_t)250U )
   {
-    loop250ms = 0; //Reset Counter
-    BIT_SET(TIMER_mask, BIT_TIMER_4HZ);
+    previousMillis250ms+=(uint16_t)250U;
+    BIT_SET(timerflags, BIT_TIMER_4HZ);
     #if defined(CORE_STM32) //debug purpose, only visual for running code
       digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
     #endif
@@ -150,10 +104,10 @@ void oneMSInterval() //Most ARM chips can simply call a function
   }
 
   //1Hz loop
-  if (loopSec == 1000)
+  if((uint16_t)(currentMillis - previousMillis1000ms) >= (uint16_t)1000U )
   {
-    loopSec = 0; //Reset counter.
-    BIT_SET(TIMER_mask, BIT_TIMER_1HZ);
+    previousMillis1000ms+=(uint16_t)1000U;
+    BIT_SET(timerflags, BIT_TIMER_1HZ);
 
     dwellLimit_uS = (1000 * configPage4.dwellLimit); //Update uS value incase setting has changed
     currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10);
@@ -174,12 +128,6 @@ void oneMSInterval() //Most ARM chips can simply call a function
     //increament secl (secl is simply a counter that increments every second and is used to track whether the system has unexpectedly reset
     currentStatus.secl++;
     //**************************************************************************************************************************************************
-    //Check the fan output status
-    if (configPage2.fanEnable >= 1)
-    {
-       fanControl();            // Fucntion to turn the cooling fan on/off
-    }
-
     //Check whether fuel pump priming is complete
     if(fpPrimed == false)
     {
@@ -195,79 +143,6 @@ void oneMSInterval() //Most ARM chips can simply call a function
         }
       }
     }
-    //**************************************************************************************************************************************************
-    //Set the flex reading (if enabled). The flexCounter is updated with every pulse from the sensor. If cleared once per second, we get a frequency reading
-    if(configPage2.flexEnabled == true)
-    {
-      byte tempEthPct = 0; 
-      if(flexCounter < 50)
-      {
-        tempEthPct = 0; //Standard GM Continental sensor reads from 50Hz (0 ethanol) to 150Hz (Pure ethanol). Subtracting 50 from the frequency therefore gives the ethanol percentage.
-        flexCounter = 0;
-      }
-      else if (flexCounter > 151) //1 pulse buffer
-      {
-
-        if(flexCounter < 169)
-        {
-          tempEthPct = 100;
-          flexCounter = 0;
-        }
-        else
-        {
-          //This indicates an error condition. Spec of the sensor is that errors are above 170Hz)
-          tempEthPct = 0;
-          flexCounter = 0;
-        }
-      }
-      else
-      {
-        tempEthPct = flexCounter - 50; //Standard GM Continental sensor reads from 50Hz (0 ethanol) to 150Hz (Pure ethanol). Subtracting 50 from the frequency therefore gives the ethanol percentage.
-        flexCounter = 0;
-      }
-
-      //Off by 1 error check
-      if (tempEthPct == 1) { tempEthPct = 0; }
-
-      currentStatus.ethanolPct = ADC_FILTER(tempEthPct, configPage4.FILTER_FLEX, currentStatus.ethanolPct);
-
-      //Continental flex sensor fuel temperature can be read with following formula: (Temperature = (41.25 * pulse width(ms)) - 81.25). 1000μs = -40C and 5000μs = 125C
-      if(flexPulseWidth > 5000) { flexPulseWidth = 5000; }
-      else if(flexPulseWidth < 1000) { flexPulseWidth = 1000; }
-      currentStatus.fuelTemp = (((4224 * (long)flexPulseWidth) >> 10) - 8125) / 100;
-    }
-
-    //**************************************************************************************************************************************************
-    //Handle any of the hardware testing outputs
-    if( BIT_CHECK(currentStatus.testOutputs, 1) )
-    {
-      //Check whether any of the fuel outputs is on
-
-      //Check for injector outputs on 50%
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ1_CMD_BIT)) { injector1Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ2_CMD_BIT)) { injector2Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ3_CMD_BIT)) { injector3Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ4_CMD_BIT)) { injector4Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ5_CMD_BIT)) { injector5Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ6_CMD_BIT)) { injector6Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ7_CMD_BIT)) { injector7Toggle(); }
-      if(BIT_CHECK(HWTest_INJ_50pc, INJ8_CMD_BIT)) { injector8Toggle(); }
-
-      //Check for ignition outputs on 50%
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN1_CMD_BIT)) { coil1Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN2_CMD_BIT)) { coil2Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN3_CMD_BIT)) { coil3Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN4_CMD_BIT)) { coil4Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN5_CMD_BIT)) { coil5Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN6_CMD_BIT)) { coil6Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN7_CMD_BIT)) { coil7Toggle(); }
-      if(BIT_CHECK(HWTest_IGN_50pc, IGN8_CMD_BIT)) { coil8Toggle(); }
-    }
-
   }
-#if defined(CORE_AVR) //AVR chips use the ISR for this
-    //Reset Timer2 to trigger in another ~1ms
-    TCNT2 = 131;            //Preload timer2 with 100 cycles, leaving 156 till overflow.
-#endif
+return timerflags;
 }
-

--- a/speeduino/utilities.h
+++ b/speeduino/utilities.h
@@ -36,6 +36,7 @@ byte pinTranslateAnalog(byte);
 void initialiseProgrammableIO();
 void checkProgrammableIO();
 int16_t ProgrammableIOGetData(uint16_t index);
+void testOutputs();
 
 #if !defined(UNUSED)
 #define UNUSED(x) (void)(x)

--- a/speeduino/utilities.ino
+++ b/speeduino/utilities.ino
@@ -13,6 +13,7 @@
 #include "decoders.h"
 #include "comms.h"
 #include "logger.h"
+#include "scheduledIO.h"
 
 uint8_t ioDelay[sizeof(configPage13.outputPin)];
 uint8_t ioOutDelay[sizeof(configPage13.outputPin)];
@@ -279,4 +280,32 @@ int16_t ProgrammableIOGetData(uint16_t index)
   else if ( index == 239U ) { result = (int16_t)max((uint32_t)runSecsX10, (uint32_t)32768); } //STM32 used std lib
   else { result = -1; } //Index is bigger than fullStatus array
   return result;
+}
+    //Handle any of the hardware testing outputs
+void testOutputs()
+{
+    if( BIT_CHECK(currentStatus.testOutputs, 1) )
+    {
+      //Check whether any of the fuel outputs is on
+
+      //Check for injector outputs on 50%
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ1_CMD_BIT)) { injector1Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ2_CMD_BIT)) { injector2Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ3_CMD_BIT)) { injector3Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ4_CMD_BIT)) { injector4Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ5_CMD_BIT)) { injector5Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ6_CMD_BIT)) { injector6Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ7_CMD_BIT)) { injector7Toggle(); }
+      if(BIT_CHECK(HWTest_INJ_50pc, INJ8_CMD_BIT)) { injector8Toggle(); }
+
+      //Check for ignition outputs on 50%
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN1_CMD_BIT)) { coil1Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN2_CMD_BIT)) { coil2Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN3_CMD_BIT)) { coil3Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN4_CMD_BIT)) { coil4Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN5_CMD_BIT)) { coil5Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN6_CMD_BIT)) { coil6Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN7_CMD_BIT)) { coil7Toggle(); }
+      if(BIT_CHECK(HWTest_IGN_50pc, IGN8_CMD_BIT)) { coil8Toggle(); }
+    }
 }


### PR DESCRIPTION
Interval timers converted to using only millis(). And now freed timer2 used with compare interrupt for tacho output dwell time on atmega2560.
Beautiful tacho timer macros.
All other platforms use micros() and function in the main loop for this, with their sub microsecond loop times.
Logic analyser waveforms observation promices some jitter reduction. (because of cleaned up interrupts)
About 50% jitter reduction for ignition timing  on atmega when combined with improved schedulers form PR #804. 