### PR TITLE
Bug fix: soft and hard rev limiter.

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -785,7 +785,7 @@ int8_t correctionSoftRevLimit(int8_t advance)
 
   if (configPage6.engineProtectType == PROTECT_CUT_IGN || configPage6.engineProtectType == PROTECT_CUT_BOTH) 
   {
-    if (currentStatus.RPM > ((unsigned int)(configPage4.SoftRevLim) * 100) ) //Softcut RPM limit
+    if (currentStatus.RPMdiv100 >= configPage4.SoftRevLim) //Softcut RPM limit
     {
       if( (runSecsX10 - softStartTime) < configPage4.SoftLimMax )
       {

--- a/speeduino/engineProtection.ino
+++ b/speeduino/engineProtection.ino
@@ -22,7 +22,7 @@ byte checkRevLimit()
 
   if (configPage6.engineProtectType != PROTECT_CUT_OFF) 
   {
-    if ( (currentStatus.RPMdiv100 > configPage4.HardRevLim) || ((runSecsX10 - softStartTime) >= configPage4.SoftLimMax) )
+    if ( (currentStatus.RPMdiv100 >= configPage4.HardRevLim) || (((runSecsX10 - softStartTime) > configPage4.SoftLimMax) && (currentStatus.RPMdiv100 >= configPage4.SoftRevLim)) )
     { 
       BIT_SET(currentStatus.spark, BIT_SPARK_HRDLIM); //Legacy and likely to be removed at some point
       BIT_SET(currentStatus.engineProtectStatus, ENGINE_PROTECT_BIT_RPM);


### PR DESCRIPTION
This PR fixes #812 

This also fixes couple of other problems I noticed. For example if you set hard limit to 7000, it activates at 7100. So 100 RPM offset there. With this PR the hard rev limiter activates correctly at set RPM. Also if the soft limit max time was set to 0.0 seconds, it was activating hard rev limiter at randomly for really short periods at any RPM. This is also fixed in this PR.