### PR TITLE
Added option to fix tacho signal to coil dwell

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -646,7 +646,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      dwellTacho  =   bits, U08,      14, [6:6],      "No", "Yes"
+      tachoMode   =   bits, U08,      14, [6:6],      "Fixed Duration", "Match Dwell"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -2238,7 +2238,9 @@ menuDialog = main
   battVCorMode    = "The Battery Voltage Correction value from the table below can either be applied on the whole injection Pulse Width value, or only on the Open Time value."
   dwellTable      = "Sets the dwell time in milliseconds based on RPM/load. This can be used to reduce stress/wear on ignition system where long dwell is not needed. And other areas can use longer dwell value if needed for stronger spark. Battery voltage correction is applied for these dwell values."
   useDwellMap     = "In normal operation mode this is set to No and speeduino will use fixed running dwell value. But if different dwell values are required across engine RPM/load range, this can be set to Yes and separate Dwell table defines running dwell value."
-  dwellTacho      = "Fixes the tacho output signal to coil dwell. If enabled the tacho pulse duration and timing is same as coil dwell. Also the number of pulses is same as number of ignition events. This ensures accurate tacho pulse timing, but the pulse duration might become problem on higher cylinder number engines."
+  tachoMode       = "The output mode for the tacho pulse. Fixed timing will produce a pulse that is always of the same duration, which works better with mode modern digital tachos. Dwell based output creates a pulse that is matched to the coil/s dwell time. If enabled the tacho pulse duration and timing is same as coil dwell and the number of pulses is same as number of ignition events. This can work better on some styles of tacho but note that the pulse duration might become problem on higher cylinder number engines."
+  canBMWCluster   = "Enables CAN broadcasting for BMW E46, E39 and E38 instrument clusters with message ID's 0x316, 0x329 and 0x545"
+  canVAGCluster   = "Enables CAN broadcasting for VAG instrument clusters with message ID's 0x280 and 0x5A0"
 
 [UserDefined]
 
@@ -2402,9 +2404,9 @@ menuDialog = main
 
     dialog = tacho, "Tacho"
         field = "Output pin",                tachoPin
-        field = "Tacho fixed to coil dwell", dwellTacho
-        field = "Output speed",              tachoDiv,  { dwellTacho == 0 }
-        field = "Pulse duration",            tachoDuration,  { dwellTacho == 0 }
+        field = "Tacho pulse mode",          tachoMode
+        field = "Output speed",              tachoDiv,  { tachoMode == 0 }
+        field = "Pulse duration",            tachoDuration,  { tachoMode == 0 }
         ;field = "Tacho sweep on boot",      useTachoSweep
         ;field = "Tacho sweep Max RPM",      tachoSweepMaxRPM, { useTachoSweep }
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2238,6 +2238,7 @@ menuDialog = main
   battVCorMode    = "The Battery Voltage Correction value from the table below can either be applied on the whole injection Pulse Width value, or only on the Open Time value."
   dwellTable      = "Sets the dwell time in milliseconds based on RPM/load. This can be used to reduce stress/wear on ignition system where long dwell is not needed. And other areas can use longer dwell value if needed for stronger spark. Battery voltage correction is applied for these dwell values."
   useDwellMap     = "In normal operation mode this is set to No and speeduino will use fixed running dwell value. But if different dwell values are required across engine RPM/load range, this can be set to Yes and separate Dwell table defines running dwell value."
+  dwellTacho      = "Fixes the tacho output signal to coil dwell. If enabled the tacho pulse duration and timing is same as coil dwell. Also the number of pulses is same as number of ignition events. This ensures accurate tacho pulse timing, but the pulse duration might become problem on higher cylinder number engines."
 
 [UserDefined]
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -646,7 +646,7 @@ page = 6
       useExtBaro  =   bits, U08,      13, [6:6],      "No", "Yes"
       boostMode   =   bits, U08,      13, [7:7],      "Simple", "Full"
       boostPin    =   bits, U08,      14, [0:5],      "Board Default", "INVALID", "INVALID", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
-      unused_bit  =   bits, U08,      14, [6:6],      "No", "Yes"
+      dwellTacho  =   bits, U08,      14, [6:6],      "No", "Yes"
       useEMAP     =   bits, U08,      14, [7:7],      "No", "Yes"
       brvBins     = array,  U08,      15, [6],        "V",        0.1,    0,    6,    24,         1 ; Bins for the battery reference voltage
       injBatRates = array,  U08,      21, [6],        "%",        1,      0,    0,    255,        0 ;Values for injector pulsewidth vs voltage
@@ -2400,11 +2400,12 @@ menuDialog = main
         panel = vss_gear_detection
 
     dialog = tacho, "Tacho"
-        field = "Output pin",           tachoPin
-        field = "Output speed",         tachoDiv
-        field = "Pulse duration",       tachoDuration
-        ;field = "Tacho sweep on boot",  useTachoSweep
-        ;field = "Tacho sweep Max RPM",  tachoSweepMaxRPM, { useTachoSweep }
+        field = "Output pin",                tachoPin
+        field = "Tacho fixed to coil dwell", dwellTacho
+        field = "Output speed",              tachoDiv,  { dwellTacho == 0 }
+        field = "Pulse duration",            tachoDuration,  { dwellTacho == 0 }
+        ;field = "Tacho sweep on boot",      useTachoSweep
+        ;field = "Tacho sweep Max RPM",      tachoSweepMaxRPM, { useTachoSweep }
 
     dialog = accelEnrichments_aeSettings, ""
         field = "Enrichment mode",      aeMode

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1044,7 +1044,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte unused_bit : 1; //Previously was VVTasOnOff
+  byte dwellTacho : 1; /// If enabled, fixes tacho pulse duration to dwell duration
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1044,7 +1044,7 @@ struct config6 {
   byte useExtBaro : 1;
   byte boostMode : 1; /// Boost control mode: 0=Simple (BOOST_MODE_SIMPLE) or 1=full (BOOST_MODE_FULL)
   byte boostPin : 6;
-  byte dwellTacho : 1; /// If enabled, fixes tacho pulse duration to dwell duration
+  byte tachoMode : 1; /// Whether to use fixed tacho pulse duration or match to dwell duration
   byte useEMAP : 1;    ///< Enable EMAP
   byte voltageCorrectionBins[6]; //X axis bins for voltage correction tables
   byte injVoltageCorrectionValues[6]; //Correction table for injector PW vs battery voltage

--- a/speeduino/scheduledIO.h
+++ b/speeduino/scheduledIO.h
@@ -125,6 +125,9 @@ void coil6Toggle();
 void coil7Toggle();
 void coil8Toggle();
 
+void tachoOutputOn();
+void tachoOutputOff();
+
 /*
 #ifndef USE_MC33810
 #define openInjector1() *inj1_pin_port |= (inj1_pin_mask); BIT_SET(currentStatus.status1, BIT_STATUS1_INJ1)

--- a/speeduino/scheduledIO.ino
+++ b/speeduino/scheduledIO.ino
@@ -73,29 +73,29 @@ void closeInjector3and7() { closeInjector3(); closeInjector7(); }
 void openInjector4and8() { openInjector4(); openInjector8(); }
 void closeInjector4and8() { closeInjector4(); closeInjector8(); }
 
-inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutput(); }
-inline void endCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutput(); }
-inline void endCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutput(); }
-inline void endCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutput(); }
-inline void endCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutput(); }
-inline void endCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutput(); }
-inline void endCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutput(); }
-inline void endCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } tachoOutputOff(); }
 
-inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutput(); }
-inline void endCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutputOn(); }
+inline void endCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } tachoOutputOff(); }
 
 //The below 3 calls are all part of the rotary ignition mode
 inline void beginTrailingCoilCharge() { beginCoil2Charge(); }
@@ -126,6 +126,7 @@ void endCoil3and7Charge()   { endCoil3Charge(); endCoil7Charge(); }
 void beginCoil4and8Charge() { beginCoil4Charge(); beginCoil8Charge(); }
 void endCoil4and8Charge()   { endCoil4Charge();  endCoil8Charge(); }
 
-void tachoOutput() { if(configPage6.dwellTacho) { TACHO_PULSE_LOW(); } else { tachoOutputFlag = READY; } }
+void tachoOutputOn() { if(configPage6.dwellTacho) { TACHO_PULSE_LOW(); } else { tachoOutputFlag = READY; } }
+void tachoOutputOff() { if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
 void nullCallback() { return; }

--- a/speeduino/scheduledIO.ino
+++ b/speeduino/scheduledIO.ino
@@ -126,7 +126,7 @@ void endCoil3and7Charge()   { endCoil3Charge(); endCoil7Charge(); }
 void beginCoil4and8Charge() { beginCoil4Charge(); beginCoil8Charge(); }
 void endCoil4and8Charge()   { endCoil4Charge();  endCoil8Charge(); }
 
-void tachoOutputOn() { if(configPage6.dwellTacho) { TACHO_PULSE_LOW(); } else { tachoOutputFlag = READY; } }
-void tachoOutputOff() { if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
+void tachoOutputOn() { if(configPage6.tachoMode) { TACHO_PULSE_LOW(); } else { tachoOutputFlag = READY; } }
+void tachoOutputOff() { if(configPage6.tachoMode) { TACHO_PULSE_HIGH(); } }
 
 void nullCallback() { return; }

--- a/speeduino/scheduledIO.ino
+++ b/speeduino/scheduledIO.ino
@@ -73,29 +73,29 @@ void closeInjector3and7() { closeInjector3(); closeInjector7(); }
 void openInjector4and8() { openInjector4(); openInjector8(); }
 void closeInjector4and8() { closeInjector4(); closeInjector8(); }
 
-inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } }
+inline void beginCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutput(); }
+inline void endCoil1Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } }
+inline void beginCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutput(); }
+inline void endCoil2Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } }
+inline void beginCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutput(); }
+inline void endCoil3Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } }
+inline void beginCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutput(); }
+inline void endCoil4Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } }
+inline void beginCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutput(); }
+inline void endCoil5Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } }
+inline void beginCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutput(); }
+inline void endCoil6Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } }
+inline void beginCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutput(); }
+inline void endCoil7Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
-inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutputFlag = READY; }
-inline void endCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } }
+inline void beginCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutput(); }
+inline void endCoil8Charge() { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } if(configPage6.dwellTacho) { TACHO_PULSE_HIGH(); } }
 
 //The below 3 calls are all part of the rotary ignition mode
 inline void beginTrailingCoilCharge() { beginCoil2Charge(); }
@@ -125,5 +125,7 @@ void beginCoil3and7Charge() { beginCoil3Charge(); beginCoil7Charge();  }
 void endCoil3and7Charge()   { endCoil3Charge(); endCoil7Charge(); }
 void beginCoil4and8Charge() { beginCoil4Charge(); beginCoil8Charge(); }
 void endCoil4and8Charge()   { endCoil4Charge();  endCoil8Charge(); }
+
+void tachoOutput() { if(configPage6.dwellTacho) { TACHO_PULSE_LOW(); } else { tachoOutputFlag = READY; } }
 
 void nullCallback() { return; }

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -491,7 +491,7 @@ void doUpdates()
     configPage10.TrigEdgeThrd = 0;
 
     //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.dwellTacho == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    if(configPage6.tachoMode == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
 
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;
@@ -587,7 +587,11 @@ void doUpdates()
   {
     //202204
     configPage9.hardRevMode = 1; //Set hard rev limiter to Fixed mode
-    configPage6.dwellTacho = 0;
+    configPage6.tachoMode = 0;
+
+    //CAN broadcast introduced
+    configPage2.canBMWCluster = 0;
+    configPage2.canVAGCluster = 0;
     
     writeAllConfig();
     storeEEPROMVersion(20);

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -491,7 +491,7 @@ void doUpdates()
     configPage10.TrigEdgeThrd = 0;
 
     //Old use as On/Off selection is removed, so change VVT mode to On/Off based on that
-    if(configPage6.unused_bit == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
+    if(configPage6.dwellTacho == 1) { configPage6.vvtMode = VVT_MODE_ONOFF; }
 
     //Closed loop VVT improvements. Set safety limits to max/min working values and filter to minimum.
     configPage10.vvtCLMinAng = 0;
@@ -587,6 +587,7 @@ void doUpdates()
   {
     //202204
     configPage9.hardRevMode = 1; //Set hard rev limiter to Fixed mode
+    configPage6.dwellTacho = 0;
     
     writeAllConfig();
     storeEEPROMVersion(20);


### PR DESCRIPTION
In 201903 release there was addition for configurable tacho pulse duration to prevent issues where long dwell times in higher cyl engines caused problems like missing pulses etc. Unfortunately the new method uses 1ms interval in the code for the tacho pulse, causing the tacho pulses to be in 1ms grid. This causes significant accuracy loss for the tacho pulses and lot of jitter in the pulses. 
https://user-images.githubusercontent.com/48950874/163122189-b382abcb-6db0-44e8-8df8-9362f82685c4.mp4

This might or might not be problem depending on the used tachometer, but in worst case the tacho needle can have very jittery behavior.  This PR adds option to use the old method of using coil dwell for tacho pulses that was in use before 201903 release.
 