### PR TITLE
Fix for EGO correcting in wrong direction in PID mode and not allowing for correction at WOT. 

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -36,7 +36,7 @@ long PID_O2, PID_output, PID_AFRTarget;
 * Needs to be global as it maintains state outside of each function call.
 * Comes from Arduino (?) PID library.
 */
-PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, REVERSE);
+PID egoPID(&PID_O2, &PID_output, &PID_AFRTarget, configPage6.egoKP, configPage6.egoKI, configPage6.egoKD, DIRECT);
 
 int MAP_rateOfChange;
 int TPS_rateOfChange;

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -677,7 +677,7 @@ byte correctionAFRClosedLoop()
       AFRnextCycle = ignitionCount + configPage6.egoCount; //Set the target ignition event for the next calculation
         
       //Check all other requirements for closed loop adjustments
-      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS < configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) )
+      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS <= configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) )
       {
 
         //Check which algorithm is used, simple or PID


### PR DESCRIPTION
Two very simple fixes for pretty important things. 

Currently, AFRvalue (perhaps paradoxically) increases fuel as it increases. The PID loop, which is updating AFRvalue with its output, should then be direct as opposed to reversed.

Secondly, you cannot set your TPS upper bound above 100%, yet currently EGO correction requires it to be explicitly below that bound to function. So if you're exactly at 100% such as in WOT, it doesn't allow you to run correction. Making the < a <= fixes that. 

This is tested and fixes the problems I had with PID EGO correction on my car.