### PR TITLE
Small bug fix for poll-level cam decoder

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -383,7 +383,7 @@ void initialiseAll()
     staged_req_fuel_mult_sec = (100 * totalInjector) / configPage10.stagedInjSizeSec;
     }
 
-    if (configPage4.trigPatternSec == SEC_TRIGGER_POLL)
+    if (configPage4.trigPatternSec == SEC_TRIGGER_POLL && configPage4.TrigPattern == DECODER_MISSING_TOOTH)
     { configPage4.TrigEdgeSec = configPage4.PollLevelPolarity; } // set the secondary trigger edge automatically to correct working value with poll level mode to enable cam angle detection in closed loop vvt.
     //Explanation: currently cam trigger for VVT is only captured when revolution one == 1. So we need to make sure that the edge trigger happens on the first revolution. So now when we set the poll level to be low
     //on revolution one and it's checked at tooth #1. This means that the cam signal needs to go high during the first revolution to be high on next revolution at tooth #1. So poll level low = cam trigger edge rising.


### PR DESCRIPTION
This small fix will make the poll level cam decoder to change the cam trigger edge only in case of missing tooth decoder, so that it wont mess up other decoders, if poll level is accidentally selected for missing tooth before changing to other decoder type.