### PR TITLE
Set onboard logging settings to zero(disable) in updates.ino

### DIFF
--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -579,6 +579,29 @@ void doUpdates()
 
     configPage4.vvtDelay = 0;
     configPage4.vvtMinClt = 0;
+
+    //Set SD logging related settings to zero.
+    configPage13.onboard_log_csv_separator = 0;
+    configPage13.onboard_log_file_style = 0;
+    configPage13.onboard_log_file_rate = 0;
+    configPage13.onboard_log_filenaming = 0;
+    configPage13.onboard_log_storage = 0;
+    configPage13.onboard_log_trigger_boot = 0;
+    configPage13.onboard_log_trigger_RPM = 0;
+    configPage13.onboard_log_trigger_prot = 0;
+    configPage13.onboard_log_trigger_Vbat = 0;
+    configPage13.onboard_log_trigger_Epin = 0;
+    configPage13.onboard_log_tr1_duration = 0;
+    configPage13.onboard_log_tr2_thr_on = 0;
+    configPage13.onboard_log_tr2_thr_off = 0;
+    configPage13.onboard_log_tr3_thr_RPM = 0;
+    configPage13.onboard_log_tr3_thr_MAP = 0;
+    configPage13.onboard_log_tr3_thr_Oil = 0;
+    configPage13.onboard_log_tr3_thr_AFR = 0;
+    configPage13.onboard_log_tr4_thr_on = 0;
+    configPage13.onboard_log_tr4_thr_off = 0;
+    configPage13.onboard_log_tr5_thr_on = 0;
+
     writeAllConfig();
     storeEEPROMVersion(19);
   }


### PR DESCRIPTION
This PR sets SD-logging related settings to zero (disable). I have had multiple issues at least on STM32 SD-logging because on fresh "EEPROM" the settings have non-valid values. This PR gets rid of those problems in new boards. Teensy doesn't seem to suffer this problem as much as STM32 does.

The changes are for 202202 release, because it's when SD-logging was introduced. Putting this on upcoming release would clear out SD-logging settings for people that are already using it.