### PR TITLE
Update BMW PnP pin mapping

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1886,7 +1886,7 @@ void setPinMapping(byte boardID)
       pinWMIEmpty = PD15; //(placeholder)
       pinWMIIndicator = PD13; //(placeholder)
       pinWMIEnabled = PE15; //(placeholder)
-      pinIdleUp = PE14 //(placeholder)
+      pinIdleUp = PE14; //(placeholder)
       pinCTPS = PA6; //(placeholder)
      #endif
       break;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -1813,6 +1813,7 @@ void setPinMapping(byte boardID)
       pinTrigger3 = 20; //The Cam sensor 2 pin
       pinTPS = A2;//TPS input pin
       pinMAP = A3; //MAP sensor pin
+      pinEMAP = A15; //EMAP sensor pin
       pinIAT = A0; //IAT sensor pin
       pinCLT = A1; //CLT sensor pin
       pinO2 = A8; //O2 Sensor pin
@@ -1834,6 +1835,11 @@ void setPinMapping(byte boardID)
       pinFlex = 2; // Flex sensor
       pinResetControl = 43; //Reset control output
       pinVSS = 3; //VSS input pin
+      pinWMIEmpty = 31; //(placeholder)
+      pinWMIIndicator = 33; //(placeholder)
+      pinWMIEnabled = 35; //(placeholder)
+      pinIdleUp = 37; //(placeholder)
+      pinCTPS = A6; //(placeholder)
      #elif defined(STM32F407xx)
       pinInjector1 = PB15; //Output pin injector 1
       pinInjector2 = PB14; //Output pin injector 2
@@ -1855,6 +1861,7 @@ void setPinMapping(byte boardID)
       pinTrigger2 = PD4; //The Cam Sensor pin
       pinTPS = PA2;//TPS input pin
       pinMAP = PA3; //MAP sensor pin
+      pinEMAP = PC5; //EMAP sensor pin
       pinIAT = PA0; //IAT sensor pin
       pinCLT = PA1; //CLS sensor pin
       pinO2 = PB0; //O2 Sensor pin
@@ -1876,6 +1883,11 @@ void setPinMapping(byte boardID)
       pinFlex = PD7; // Flex sensor
       pinResetControl = PB7; //Reset control output
       pinVSS = PB6; //VSS input pin
+      pinWMIEmpty = PD15; //(placeholder)
+      pinWMIIndicator = PD13; //(placeholder)
+      pinWMIEnabled = PE15; //(placeholder)
+      pinIdleUp = PE14 //(placeholder)
+      pinCTPS = PA6; //(placeholder)
      #endif
       break;
 


### PR DESCRIPTION
Adding few more board default pins for BMW PnP pin mapping. These have "board default" as option in TS, so choosing that can cause possible problems when not set in init.ino