### PR TITLE
integerPID improvements and negative values on VVT

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1159,8 +1159,8 @@ page = 10
       vvtCLKI             = scalar, U08,     128,      "%",        0.03125, 0.0,    0.0,   7.96,      2 ; * (  1 byte)
       vvtCLKD             = scalar, U08,     129,      "%",        0.00781, 0.0,    0.0,   1.99,      3 ; * (  1 byte)
       vvtCL0DutyAng       = scalar, S16,     130,    "deg",        1.0,     0.0, -360.0,  360.0,      0 ; * (  2 bytes)
-      vvtCLMinAng         = scalar, U08,     132,    "deg",        0.5,     0.0,    0.0,  100.0,      0 ; * (  1 byte)
-      vvtCLMaxAng         = scalar, U08,     133,    "deg",        0.5,     0.0,    0.0,  100.0,      0 ; * (  1 byte)
+      vvtCLMinAng         = scalar, S08,     132,    "deg",        1.0,     0.0,    -126.0,  126.0,      0 ; * (  1 byte)
+      vvtCLMaxAng         = scalar, S08,     133,    "deg",        1.0,     0.0,    -126.0,  126.0,      0 ; * (  1 byte)
 
       crankingEnrichTaper = scalar,  U08,    134,  "s",  0.1,      0.0,  0.0,     25.5,    1
 

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -510,7 +510,7 @@ void vvtControl()
 
         // safety check that the cam angles are ok. The engine will be totally undriveable if the cam sensor is faulty and giving wrong cam angles, so if that happens, default to 0 duty.
         // This also prevents using zero or negative current angle values for PID adjustment, because those don't work in integer PID.
-        if ( currentStatus.vvt1Angle <=  configPage10.vvtCLMinAng || currentStatus.vvt1Angle > configPage10.vvtCLMaxAng )
+        if ( currentStatus.vvt1Angle <=  (int16_t(configPage10.vvtCLMinAng)*2) || currentStatus.vvt1Angle > int16_t(configPage10.vvtCLMaxAng*2) )
         {
           currentStatus.vvt1Duty = 0;
           vvt1_pwm_value = halfPercentage(currentStatus.vvt1Duty, vvt_pwm_max_count);
@@ -549,7 +549,7 @@ void vvtControl()
 
           // safety check that the cam angles are ok. The engine will be totally undriveable if the cam sensor is faulty and giving wrong cam angles, so if that happens, default to 0 duty.
           // This also prevents using zero or negative current angle values for PID adjustment, because those don't work in integer PID.
-          if ( currentStatus.vvt2Angle <= configPage10.vvtCLMinAng || currentStatus.vvt2Angle > configPage10.vvtCLMaxAng )
+          if ( currentStatus.vvt2Angle <= int16_t(configPage10.vvtCLMinAng*2) || currentStatus.vvt2Angle > int16_t(configPage10.vvtCLMaxAng*2) )
           {
             currentStatus.vvt2Duty = 0;
             vvt2_pwm_value = halfPercentage(currentStatus.vvt2Duty, vvt_pwm_max_count);

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1294,8 +1294,8 @@ struct config10 {
   byte vvtCLKI; //Byte 128
   byte vvtCLKD; //Byte 129
   int16_t vvtCL0DutyAng; //Bytes 130-131
-  uint8_t vvtCLMinAng; //Byte 132
-  uint8_t vvtCLMaxAng; //Byte 133
+  int8_t vvtCLMinAng; //Byte 132
+  int8_t vvtCLMaxAng; //Byte 133
 
   byte crankingEnrichTaper; //Byte 134
 


### PR DESCRIPTION
Change the PID implementation, to allow negative values on the input, change the anti-windup machanism, remove the unused and undocumented pOnE condition. This will create a better integral action, for better control, the former implementation did had windup problems.

Allow negative values for vvtCLMinAng and vvtCLMaxAng, switch to signed variables and whole digit precision in tunerstudio