### PR TITLE
Fix STM32 hanging on boot

### DIFF
--- a/speeduino/board_stm32_official.ino
+++ b/speeduino/board_stm32_official.ino
@@ -94,7 +94,10 @@ STM32RTC& rtc = STM32RTC::getInstance();
     * Real Time clock for datalogging/time stamping
     */
     #ifdef RTC_ENABLED
-      rtc.setClockSource(STM32RTC::LSE_CLOCK); //Initialise external clock for RTC. That is the only clock running of VBAT
+      //Check if RTC time has been set earlier. If yes, RTC will use LSE_CLOCK. If not, default LSI_CLOCK is used, to prevent hanging on boot.
+      if (rtc.isTimeSet()) {
+        rtc.setClockSource(STM32RTC::LSE_CLOCK); //Initialise external clock for RTC if clock is set. That is the only clock running of VBAT
+      }
       rtc.begin(); // initialise RTC 24H format
     #endif
     /*

--- a/speeduino/rtc_common.ino
+++ b/speeduino/rtc_common.ino
@@ -114,6 +114,12 @@ void rtc_setTime(byte second, byte minute, byte hour, byte day, byte month, uint
     setTime(hour, minute, second, day, month, year);
     Teensy3Clock.set(now());
   #elif defined(CORE_STM32)
+    //If RTC time has not been set earlier (no battery etc.) we need to stop the RTC and restart it with LSE_CLOCK to have accurate RTC.
+    if (!rtc.isTimeSet()) {
+      rtc.end();
+      rtc.setClockSource(STM32RTC::LSE_CLOCK);
+      rtc.begin();
+    }
     rtc.setTime(hour, minute, second);
     //year in stm32 rtc is a byte. so subtract year 2000 to fit
     rtc.setDate(day, month, (year-2000));


### PR DESCRIPTION
In current master STM32 will hang on boot if no RTC battery is installed. The boot will either take long time or fails to boot completely. The reason for this is that the RTC will need to use external low speed clock (LSE_CLOCK) to be accurate. But "cold start" of the LSE_CLOCK takes up to 2 seconds and this is what causes the hanging. There seems to be no way around this long "cold start", so this PR basically moves the startup of the LSE_CLOCK to the moment of setting the RTC time. Otherwise internal low speed clock is used for RTC. Which is fast starting but not accurate (and also not powered by the battery).

I have tested that the board doesn't anymore hang up on booth with or without the RTC battery. RTC also keeps time normally with battery installed. Only slight problem is that when first time setting the RTC time, you will most likely get timeout in TS, because the timeout is set to 1500ms, when usually starting the LSE_CLOCK takes longer. But clicking set time again solves this.

Fixes #841 