### PR TITLE
TS option to display pressure in bar #842

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -25,6 +25,11 @@
     ;settingGroup = boostUnits, "Boost table units"
     ;settingOption = DEFAULT, "kPa"
     ;settingOption = BOOSTPSI, "PSI"
+
+    settingGroup = pressure_units, "Pressure Display"
+    settingOption = DEFAULT, "PSI"
+    settingOption = pressure_bar, "BAR"
+
     settingGroup = enablehardware_test, "Enable Hardware Test Page"
 
     settingGroup = resetcontrol_group, "Reset Control Features"
@@ -1171,14 +1176,20 @@ page = 10
 
       fuelPressurePin     = bits,   U08,     136, [0:4], "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "A16", "A17", "A18", "A19", "A20", "A21", "A22", INVALID, INVALID, INVALID, INVALID, INVALID, INVALID, INVALID, INVALID, INVALID
       
-
+    #if pressure_bar
+      fuelPressureMin     = scalar, S08,     137,        "BAR",       0.0698,    0.0,  -7.0,     8.9,    2 ;Note signed int
+      fuelPressureMax     = scalar, U08,     138,        "BAR",       0.0698,    0.0,   0.0,     17.8,   2
+      oilPressureMin      = scalar, S08,     139,        "BAR",       0.0698,    0.0,  -7.0,     8.9,    2 ;Note signed int
+      oilPressureMax      = scalar, U08,     140,        "BAR",       0.0698,    0.0,   0.0,     17.8,   2
+      oilPressureProtMins = array,  U08,     145, [  4], "BAR",       0.0698     0.0,   0.0,     17.8,   2
+    #else
       fuelPressureMin     = scalar, S08,     137,        "psi",       1.0,       0.0,  -100,     127,    0 ;Note signed int
       fuelPressureMax     = scalar, U08,     138,        "psi",       1.0,       0.0,   0.0,     255,    0
       oilPressureMin      = scalar, S08,     139,        "psi",       1.0,       0.0,  -100,     127,    0 ;Note signed int
       oilPressureMax      = scalar, U08,     140,        "psi",       1.0,       0.0,   0.0,     255,    0
-
-      oilPressureProtRPM  = array,  U08,     141, [  4], "RPM",     100.0,       0.0,   100.0, 25500,    0
       oilPressureProtMins = array,  U08,     145, [  4], "psi",       1.0,       0.0,   0.0,     255,    0
+    #endif
+      oilPressureProtRPM  = array,  U08,     141, [  4], "RPM",     100.0,       0.0,   100.0, 25500,    0
       
       wmiEnabled          = bits,   U08,     149, [0:0], "Off", "On"
       wmiMode             = bits,   U08,     149, [1:2], "Simple", "Proportional", "Openloop", "Closedloop"
@@ -2988,26 +2999,46 @@ menuDialog = main
         field = "Enabled",                  fuelPressureEnable
         field = "Pin",                      fuelPressurePin,    { fuelPressureEnable }
         settingSelector = "Common Sensors",                     { fuelPressureEnable }
+            #if pressure_bar
+            settingOption = "0-10 BAR",  fuelPressureMin=-1.25,   fuelPressureMax=11.25 ; regular sensors give 0.5V to 4.5V for 0 bar to rated bar. Formula Vout = P x 4 / P_rated + 0.5
+            settingOption = "0-100 PSI",  fuelPressureMin=-0.1,   fuelPressureMax=7.1   ; these are just converted psi to bar. Kept because most off-shelf are in PSI
+            settingOption = "0-150 PSI",  fuelPressureMin=-1.25,   fuelPressureMax=11.58
+            #else
             settingOption = "0-100 PSI",  fuelPressureMin=-3,   fuelPressureMax=103 ; Vout = VCC x (P x .97 / 200 + 0.5)
             settingOption = "0-150 PSI",  fuelPressureMin=-18,   fuelPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png 
+            #endif
         field = "Pressure at 0v",           fuelPressureMin,    { fuelPressureEnable }
         field = "Pressure at 5v",           fuelPressureMax,    { fuelPressureEnable }
 
     dialog = fuelPressureDialog, "Fuel Pressure", xAxis
+        #if pressure_bar
+        gauge = fuelPressureBarGauge
+        #else
         gauge = fuelPressureGauge
+        #endif
         panel = fuelPressureSettings
 
     dialog = oilPressureSettings
         field = "Enabled",                  oilPressureEnable
         field = "Pin",                      oilPressurePin,    { oilPressureEnable }
         settingSelector = "Common Sensors",                     { oilPressureEnable }
+            #if pressure_bar
+            settingOption = "0-10 BAR",  oilPressureMin=-1.25,   oilPressureMax=11.25 ; regular sensors give 0.5V to 4.5V for 0 bar to rated bar. Formula Vout = P x 4 / P_rated + 0.5
+            settingOption = "0-100 PSI",  oilPressureMin=-0.1,   oilPressureMax=7.1   ; these are just converted psi to bar. Kept because most off-shelf are in PSI
+            settingOption = "0-150 PSI",  oilPressureMin=-1.25,   oilPressureMax=11.58
+            #else
             settingOption = "0-100 PSI",  oilPressureMin=-3,   oilPressureMax=103 ; Vout = VCC x (P x .97 / 200 + 0.5)
             settingOption = "0-150 PSI",  oilPressureMin=-18,   oilPressureMax=168 ; Vout = VCC x (P x 0.8 / 150 + 0.1) https://aftermarketindustries.com.au/image/cache/data/aftermarket%20industries%20fuel%20pressure%20sensor%20data%202-500x500.png 
+            #endif
         field = "Pressure at 0v",           oilPressureMin,    { oilPressureEnable }
         field = "Pressure at 5v",           oilPressureMax,    { oilPressureEnable }
 
     dialog = oilPressureDialog, "Oil Pressure", xAxis
+        #if pressure_bar
+        gauge = oilPressureBarGauge
+        #else
         gauge = oilPressureGauge
+        #endif
         panel = oilPressureSettings
 
     dialog = pressureSensors, "Pressure Transducers"
@@ -4469,9 +4500,13 @@ cmdVSSratio6 =      "E\x99\x06"
 
 ; Oil Pressure protection curve
         curve = oil_pressure_prot_curve, "Oil Pressure Protection"
-          columnLabel     = "RPM", "Minimum PSI"
+          columnLabel     = "RPM", "Minimum"
           xAxis           = 0, 8000, 9
-          yAxis           = 0, 150, 3
+          #if pressure_bar
+            yAxis           = 0, 10.0, 3
+          #else
+            yAxis           = 0, 150, 3
+          #endif
           xBins           = oilPressureProtRPM, rpm
           yBins           = oilPressureProtMins
           size            = 400, 200
@@ -4806,8 +4841,13 @@ cmdVSSratio6 =      "E\x99\x06"
     #endif
     flexGauge         = flex,          "Flex sensor",        "%",       0,   100,     -1,    -1,  999,  999, 0, 0
 
-    fuelPressureGauge = fuelPressure,  "Fuel Pressure",       "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
-    oilPressureGauge  = oilPressure,   "Oil Pressure",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
+    fuelPressureGauge    = fuelPressure,    "Fuel Pressure (PSI)", "PSI",    -15,    100,   0,       20,   200,   245, 0, 0
+    oilPressureGauge     = oilPressure,     "Oil Pressure (PSI)",  "PSI",    -15,    100,   0,       20,   200,   245, 0, 0
+    fuelPressureBarGauge = fuelPressure_bar,"Fuel Pressure (BAR)", "BAR",   -1.0,    7.0,   0.5,    1.4,  14.0,  17.0, 1, 1
+    oilPressureBarGauge  = oilPressure_bar, "Oil Pressure (BAR)",  "BAR",   -1.0,    7.0,   0.5,    1.4,  14.0,  17.0, 1, 1
+    fuelPressurekPaGauge = fuelPressure_kpa,"Fuel Pressure (kPa)", "kPa",   -100,    700,   50,     140,  1400,  1700, 0, 0
+    oilPressurekPaGauge  = oilPressure_kpa, "Oil Pressure (kPa)",  "kPa",   -100,    700,   50,     140,  1400,  1700, 0, 0
+
 
     gaugeCategory     = "Auxiliary Input Channels"
     AuxInGauge0       = auxin_gauge0,    { stringValue(AUXin00Alias) },        "",             0,    1024,  -1,    -1,  1025,    1025,  0,  0
@@ -5078,6 +5118,11 @@ cmdVSSratio6 =      "E\x99\x06"
 #endif
    time             = { timeNow                                       }
    seconds          = { secl                                          }
+
+   fuelPressure_bar = { fuelPressure * 0.06894757                     }
+   oilPressure_bar  = { oilPressure * 0.06894757                      }
+   fuelPressure_kpa = { fuelPressure * 6.894757                       }
+   oilPressure_kpa  = { oilPressure  * 6.894757                       }
 
    throttle         = { tps }, "%"
 


### PR DESCRIPTION
Adds options in TunerStudio project settings to have default units for fuel and oil pressure in bar. Adds gauge in kPa. This only adds conversion from psi to bar, not affecting firmware.