### PR TITLE
Added CRC to CAN serial output stream

### DIFF
--- a/speeduino/cancomms.h
+++ b/speeduino/cancomms.h
@@ -1,7 +1,12 @@
 #ifndef CANCOMMS_H
 #define CANCOMMS_H
 
-#define NEW_CAN_PACKET_SIZE   122
+#if defined(UseCRCOnCANSerialData)
+#define CAN_CRC_SIZE 4
+#else
+#define CAN_CRC_SIZE 0
+#endif
+#define NEW_CAN_PACKET_SIZE (122 + CAN_CRC_SIZE)
 #define CAN_PACKET_SIZE   75
 
 #if ( defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) )

--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -344,6 +344,17 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portTy
   fullStatus[120] = highByte(currentStatus.EMAP);
   fullStatus[121] = currentStatus.fanDuty;
 
+#if defined(UseCRCOnCANSerialData)
+  // Calculate the CRC from the actual data i.e. everything but the last four bytes
+  uint32_t canCRC = CRC32.crc32(fullStatus, (NEW_CAN_PACKET_SIZE - CAN_CRC_SIZE));
+
+  // Split the CRC into 4 bytes and add to the end of the buffer
+  fullStatus[NEW_CAN_PACKET_SIZE - 4] = (canCRC & 0xFF);
+  fullStatus[NEW_CAN_PACKET_SIZE - 3] = ((canCRC >> 8) & 0xFF);
+  fullStatus[NEW_CAN_PACKET_SIZE - 2] = ((canCRC >> 16) & 0xFF);
+  fullStatus[NEW_CAN_PACKET_SIZE - 1] = ((canCRC >> 24) & 0xFF);
+#endif
+
   for(byte x=0; x<packetLength; x++)
   {
       if (portType == 1){ CANSerial.write(fullStatus[offset+x]); }


### PR DESCRIPTION
Added a CRC to the end of the CAN serial stream so the recipient of the data can confirm it's good. 

Enabled with a conditional compile flag: UseCRCOnCANSerialData

This code shows how to process the CRC on the recipient board, tweak it to suit:

```

FastCRC32 CRC32;
#define AdditionalBufferForSerialCANStream 75
#define CAN_CRC_SIZE 4
#define CANDataBufferLength (122 + CAN_CRC_SIZE)

bool processSerialData(int IncommingBufferLength) // Returns True if the data is good
{
    bool rv = false;
    uint32_t bffrCANCRC = 0;
    uint32_t canCRC = 0;

    // Give the buffer more characters than amount of data we know about so if Speeduino sends more data than we're expecting we'll continue to work
    byte SpeedyResponse[CANDataBufferLength + AdditionalBufferForSerialCANStream];     

    for (int i = 0; i < IncommingBufferLength; i++)
    {
        SpeedyResponse[i] = SpeedySerial.read();
    }

    if (IncommingBufferLength >= 126)
    {
        // We added CRC checking when the CAN buffer was 122 characters long so a buffer of 126 should have CRC data, this might change to receive a marker with the data
        bffrCANCRC = (((uint32_t)SpeedyResponse[IncommingBufferLength - 3] << 0) & 0xFF) + (((uint32_t)SpeedyResponse[IncommingBufferLength - 2] << 8) & 0xFFFF) + (((uint32_t)SpeedyResponse[IncommingBufferLength - 1] << 16) & 0xFFFFFF) + (((uint32_t)SpeedyResponse[IncommingBufferLength] << 24) & 0xFFFFFFFF);
        canCRC = CRC32.crc32(SpeedyResponse, (IncommingBufferLength - CAN_CRC_SIZE));
    }

    if (canCRC == bffrCANCRC)
    {
        rv = true; // CRCs match or we're reading a pre CRC stream
        currentStatus.secl = SpeedyResponse[0];
        currentStatus.status1 = SpeedyResponse[1];
        currentStatus.engine = SpeedyResponse[2];
        currentStatus.dwell = SpeedyResponse[3];
        currentStatus.MAP = ((SpeedyResponse[5] << 8) | (SpeedyResponse[4]));
        currentStatus.IAT = SpeedyResponse[6];
        currentStatus.coolant = SpeedyResponse[7];
        currentStatus.batCorrection = SpeedyResponse[8];
        currentStatus.battery10 = SpeedyResponse[9];
        currentStatus.O2 = SpeedyResponse[10];
        currentStatus.egoCorrection = SpeedyResponse[11];
        currentStatus.iatCorrection = SpeedyResponse[12];
        currentStatus.wueCorrection = SpeedyResponse[13];
        currentStatus.RPM = ((SpeedyResponse[15] << 8) | (SpeedyResponse[14]));
        currentStatus.AEamount = SpeedyResponse[16];
        currentStatus.corrections = SpeedyResponse[17];
        currentStatus.VE = SpeedyResponse[18];
        currentStatus.afrTarget = SpeedyResponse[19];
        currentStatus.PW1 = ((SpeedyResponse[21] << 8) | (SpeedyResponse[20]));
        currentStatus.tpsDOT = SpeedyResponse[22];
        currentStatus.advance = SpeedyResponse[23];
        currentStatus.TPS = SpeedyResponse[24];
        currentStatus.loopsPerSecond = ((SpeedyResponse[26] << 8) | (SpeedyResponse[25]));
        currentStatus.freeRAM = ((SpeedyResponse[28] << 8) | (SpeedyResponse[27]));
        currentStatus.boostTarget = SpeedyResponse[29];
        currentStatus.boostDuty = SpeedyResponse[30];
        currentStatus.spark = SpeedyResponse[31];
        currentStatus.rpmDOT = ((SpeedyResponse[33] << 8) | (SpeedyResponse[32]));
        currentStatus.ethanolPct = SpeedyResponse[34];
        currentStatus.flexCorrection = SpeedyResponse[35];
        currentStatus.flexIgnCorrection = SpeedyResponse[36];
        currentStatus.idleLoad = SpeedyResponse[37];
        currentStatus.testOutputs = SpeedyResponse[38];
        currentStatus.O2_2 = SpeedyResponse[39];
        currentStatus.baro = SpeedyResponse[40];

        byte idx = 41;
        for (byte b = 0; b < 16; b++)
        {
            currentStatus.canin[b] = ((SpeedyResponse[idx + 1] << 8) | (SpeedyResponse[idx]));
            idx += 2;
        }
        currentStatus.tpsADC = SpeedyResponse[73];
        currentStatus.errorNumber = SpeedyResponse[74];
        currentStatus.launchCorrection = SpeedyResponse[75];
        currentStatus.PW2 = ((SpeedyResponse[77] << 8) | (SpeedyResponse[76]));
        currentStatus.PW3 = ((SpeedyResponse[79] << 8) | (SpeedyResponse[78]));
        currentStatus.PW4 = ((SpeedyResponse[81] << 8) | (SpeedyResponse[80]));
        currentStatus.status3 = SpeedyResponse[82];
        currentStatus.engineProtectStatus = SpeedyResponse[83];
        currentStatus.fuelLoad = ((SpeedyResponse[85] << 8) | (SpeedyResponse[84]));
        currentStatus.ignLoad = ((SpeedyResponse[87] << 8) | (SpeedyResponse[86]));
        currentStatus.injAngle = ((SpeedyResponse[89] << 8) | (SpeedyResponse[88]));
        currentStatus.CLIdleTarget = SpeedyResponse[91];
        currentStatus.mapDOT = SpeedyResponse[92];
        currentStatus.vvt1Angle = SpeedyResponse[93];
        currentStatus.vvt1TargetAngle = SpeedyResponse[94];
        currentStatus.vvt1Duty = SpeedyResponse[95];
        currentStatus.flexBoostCorrection = ((SpeedyResponse[97] << 8) | (SpeedyResponse[96]));
        currentStatus.baroCorrection = SpeedyResponse[98];
        currentStatus.ASEValue = SpeedyResponse[99];
        currentStatus.vss = ((SpeedyResponse[101] << 8) | (SpeedyResponse[100]));
        currentStatus.gear = SpeedyResponse[102];
        currentStatus.fuelPressure = SpeedyResponse[103];
        currentStatus.oilPressure = SpeedyResponse[104];
        currentStatus.wmiPW = SpeedyResponse[105];
        currentStatus.status4 = SpeedyResponse[106];
        currentStatus.vvt2Angle = SpeedyResponse[107];
        currentStatus.vvt2TargetAngle = SpeedyResponse[108];
        currentStatus.vvt2Duty = SpeedyResponse[109];
        currentStatus.outputsStatus = SpeedyResponse[110];
        currentStatus.fuelTemp = SpeedyResponse[111];
        currentStatus.fuelTempCorrection = SpeedyResponse[112];
        currentStatus.VE1 = SpeedyResponse[113];
        currentStatus.VE2 = SpeedyResponse[114];
        currentStatus.advance1 = SpeedyResponse[115];
        currentStatus.advance2 = SpeedyResponse[116];
        currentStatus.nitrous_status = SpeedyResponse[117];
        currentStatus.TS_SD_Status = SpeedyResponse[118];
        currentStatus.EMAP = ((SpeedyResponse[120] << 8) | (SpeedyResponse[119]));
        currentStatus.fanDuty = SpeedyResponse[121];
    }
    return rv;
}

```