### PR TITLE
bug fix EGO PID controller + some improvements. 

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -676,7 +676,7 @@ byte correctionAFRClosedLoop()
     if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
   }
   
-  if( configPage6.egoType > 0  || (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1  ) ) //egoType of 0 means no O2 sensor. If DFCO is active do not run the ego controllers to prevent interator wind-up.
+  if((configPage6.egoType > 0)  & (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) != 1  ) ) //egoType of 0 means no O2 sensor. If DFCO is active do not run the ego controllers to prevent interator wind-up.
   {
     AFRValue = currentStatus.egoCorrection; //Need to record this here, just to make sure the correction stays 'on' even if the nextCycle count isn't ready
     

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -676,7 +676,7 @@ byte correctionAFRClosedLoop()
     if( (currentStatus.runSecs > configPage6.ego_sdelay) || (configPage2.incorporateAFR == true) ) { currentStatus.afrTarget = get3DTableValue(&afrTable, currentStatus.fuelLoad, currentStatus.RPM); } //Perform the target lookup
   }
   
-  if( configPage6.egoType > 0 ) //egoType of 0 means no O2 sensor
+  if( configPage6.egoType > 0  || (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 1  ) ) //egoType of 0 means no O2 sensor. If DFCO is active do not run the ego controllers to prevent interator wind-up.
   {
     AFRValue = currentStatus.egoCorrection; //Need to record this here, just to make sure the correction stays 'on' even if the nextCycle count isn't ready
     

--- a/speeduino/src/PID_v1/PID_v1.cpp
+++ b/speeduino/src/PID_v1/PID_v1.cpp
@@ -54,17 +54,17 @@ bool PID::Compute()
       /*Compute all the working error variables*/
 	  long input = *myInput;
       long error = *mySetpoint - input;
-      ITerm += (ki * error)/100;
+      ITerm += (ki * error);
       if(ITerm > outMax) ITerm= outMax;
-      else if(ITerm < outMin) ITerm= outMin;
+      else if(ITerm < outMin) ITerm = outMin;
       long dInput = (input - lastInput);
 
       /*Compute PID Output*/
-      long output = (kp * error)/100 + ITerm- (kd * dInput)/100;
+      long output = (kp * error) + ITerm- (kd * dInput);
 
 	  if(output > outMax) { output = outMax; }
       else if(output < outMin) { output = outMin; }
-	  *myOutput = output;
+	  *myOutput = output/1000;
 
       /*Remember some variables for next time*/
       lastInput = input;
@@ -90,10 +90,10 @@ void PID::SetTunings(byte Kp, byte Ki, byte Kd)
    ki = Ki * SampleTimeInSec;
    kd = Kd / SampleTimeInSec;
    */
-  long InverseSampleTimeInSec = 10000 / SampleTime;
+  long InverseSampleTimeInSec = 100;
   kp = Kp;
-  ki = (Ki * 100) / InverseSampleTimeInSec;
-  kd = (Kd * InverseSampleTimeInSec) / 100;
+  ki = Ki;
+  kd = Kd * 10;
 
   if(controllerDirection ==REVERSE)
    {
@@ -129,8 +129,8 @@ void PID::SetSampleTime(int NewSampleTime)
 void PID::SetOutputLimits(long Min, long Max)
 {
    if(Min >= Max) return;
-   outMin = Min;
-   outMax = Max;
+   outMin = Min*1000;
+   outMax = Max*1000;
 
    if(inAuto)
    {

--- a/speeduino/src/PID_v1/PID_v1.cpp
+++ b/speeduino/src/PID_v1/PID_v1.cpp
@@ -68,7 +68,7 @@ bool PID::Compute()
 
       /*Remember some variables for next time*/
       lastInput = input;
-      //lastTime = now;
+      lastTime = now;
 	  return true;
    }
    //else return false;
@@ -90,7 +90,7 @@ void PID::SetTunings(byte Kp, byte Ki, byte Kd)
    ki = Ki * SampleTimeInSec;
    kd = Kd / SampleTimeInSec;
    */
-  long InverseSampleTimeInSec = 100000 / SampleTime;
+  long InverseSampleTimeInSec = 10000 / SampleTime;
   kp = Kp;
   ki = (Ki * 100) / InverseSampleTimeInSec;
   kd = (Kd * InverseSampleTimeInSec) / 100;


### PR DESCRIPTION
A quick fix for a bug and some other quick improvements to make EGO PID atleast do something usefull. The next improvement steps would be to build a long and short term fuel trim table for Teensy and STM32. Mega probably has too little RAM for this, but who knows.  

Also the accuracy of the controller could be improved if the steps can be <1%. So making the EGO work with 0.1% steps can also be a next improvement step.

What i found and explained in Discord:

> ego PID control is a bit of a mess. I does not work (there is a bug) and probably never did work. The bug makes it so that the gains are varying over time. AFter X seconds the gains are effectively all zero. 
> 
> In PID_v1.ino: 
> Look at line 51. The SampleTime should be calculated here using lastTime and now
> Look at line 71. This is commented out. So lastTime is never updated. (this is done 7 year ago)
> Look at line 37 lastTime is set at the init time and wil keep this value forever
> 
> Look at line 93..96: the SampleTime is used there to change the gains. But now the gains are changing over time because of line 71 being commented out, making the  SampleTime increase with time. 
> 
> So after some time the ego control stops working because gains are zero or very small. It even has the change to be zero when millis() rollover and that would create div by zero errors! Un-commenting line 71 does not fix it, only P gain works then. The I gain remains unable to do anything.
> 
> Because the older version never worked I assume there would not be any setups using it successfully. So there is no point in retaining it?

What has been done is fixing the bugs:
- Make the gains fixed and not vary with Tsample. Changing the gains depending on the sample time (which depends on the RPM because it is calculated every X ignition cycles). The higher the RPM the faster the reaction of EGO can be. So reducing the gains with higher RPM negates that benefit. 

What has been done to improve the controller
- Choose gain scaling such that these fall in the realm of usable gains for a ICE engine. With the original scaling i could only use 1 to 2 I gain. The whole range for i gain is 0 to 200. 
- Disable PID control calculation when DFCO is active. (The out put was already disabled during DFCO but the interator kept running. So when coming out of DFCO the controller was full rich).
