### PR TITLE
Add new CANbus display,

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -452,9 +452,9 @@ page = 1
       canBMWCluster             = bits,   U08,  126, [0:0], "Off", "On"
       canVAGCluster             = bits,   U08,  126, [1:1], "Off", "On"
       ;These are reserved for future use, in case of more CAN broadcasting features are added
-      enable1Cluster            = bits,   U08,  126, [2:2], "Off", "On"
+      canGaugeSCluster            = bits,   U08,  126, [2:2], "Off", "On"
       enable2Cluster            = bits,   U08,  126, [3:3], "Off", "On"
-      unusedClusterBits         = bits,   U08,  126, [4:7], "Off","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID"
+      unusedClusterBits         = bits,   U08,  126, [4:7], "Off","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID"
 
       unused2-95                = scalar, U08,  127,        "RPM",      100,       0.0,   0.0,     16320,    0
 
@@ -2310,7 +2310,7 @@ menuDialog = main
   tachoMode       = "The output mode for the tacho pulse. Fixed timing will produce a pulse that is always of the same duration, which works better with mode modern digital tachos. Dwell based output creates a pulse that is matched to the coil/s dwell time. If enabled the tacho pulse duration and timing is same as coil dwell and the number of pulses is same as number of ignition events. This can work better on some styles of tacho but note that the pulse duration might become problem on higher cylinder number engines."
   canBMWCluster   = "Enables CAN broadcasting for BMW E46, E39 and E38 instrument clusters with message ID's 0x316, 0x329 and 0x545"
   canVAGCluster   = "Enables CAN broadcasting for VAG instrument clusters with message ID's 0x280 and 0x5A0"
-
+  canGaugeSCluster = "Enable CAN broadcasting for Gauge.S information panel"
   boostControlEnable          = "Set the trigger to enable/disable the closedloop boost controller. When set to: \n 'fixed': if the fuel load exceeds the threshold closedloop boost controller is enbaled.\n 'baro': if the fuel load exceeds the baro the controller is enabled (legacy)  "
   boostDCWhenDisabled         = "When the closedloop boost controller is disabled by 'enable trigger', this is the Duty cycle set on the boost selenoid. Ususally this is 99% because it keeps the waste gate firmly closed until the threshold and builds boost as fast as possible (no wastegate leak)"
   boostControlEnableThreshold = "When the 'Boost control enable trigger' is set to 'fixed', this value is used as threshold. Usually the value is set just below the wastgate pressure of the used turbo setup. For example 130kpa for a 0.3 bar wastegate actuator. Below this value the ECU has no control over the boost anyway."

--- a/speeduino/canBroadcast.h
+++ b/speeduino/canBroadcast.h
@@ -14,8 +14,13 @@
 #define CAN_VAG_RPM 0x280
 #define CAN_VAG_VSS 0x5A0
 
+#define CAN_GAUGES_1 0x9A0
+#define CAN_GAUGES_2 0x7A0
+#define CAN_GAUGES_3 0x6A0
+
 void sendBMWCluster();
 void sendVAGCluster();
+void sendGaugeSCluster();
 void DashMessages(uint16_t DashMessageID);
 #endif
 #endif // CANBROADCAST_H

--- a/speeduino/canBroadcast.ino
+++ b/speeduino/canBroadcast.ino
@@ -28,6 +28,16 @@ void sendVAGCluster()
   Can0.write(outMsg);
 }
 
+void sendGaugeSCluster()
+{
+    DashMessage(CAN_GAUGES_1);
+    Can0.write(outMsg);
+    DashMessage(CAN_GAUGES_2);
+    Can0.write(outMsg);
+    DashMessage(CAN_GAUGES_3);
+    Can0.write(outMsg);
+}
+
 // switch case for gathering all data to message based on CAN Id.
 void DashMessage(uint16_t DashMessageID)
 {
@@ -107,6 +117,49 @@ void DashMessage(uint16_t DashMessageID)
       outMsg.buf[5] = 0x00;
       outMsg.buf[6] = 0x00;
       outMsg.buf[7] = 0xAD;
+    break;
+
+    
+    case CAN_GAUGES_1:
+      //9a0 (2464)
+      outMsg.id = DashMessageID;
+      outMsg.len = 8;
+      outMsg.buf[0] = currentStatus.VE;
+      outMsg.buf[1] = currentStatus.advance;
+      outMsg.buf[2] = currentStatus.RPM;
+      outMsg.buf[3] = currentStatus.TPS;
+      outMsg.buf[4] = currentStatus.coolant;
+      outMsg.buf[5] = currentStatus.IAT;
+      outMsg.buf[6] = currentStatus.MAP;
+      outMsg.buf[7] = currentStatus.vss;
+    break;
+
+    case CAN_GAUGES_2:
+    //7A0 1952
+      outMsg.id = DashMessageID;
+      outMsg.len = 8;
+      outMsg.buf[0] = currentStatus.vvt1Angle;
+      outMsg.buf[1] = currentStatus.fuelPressure;
+      outMsg.buf[2] = currentStatus.oilPressure;
+      outMsg.buf[3] = currentStatus.battery10;
+      outMsg.buf[4] = lowByte(currentStatus.O2);
+      outMsg.buf[5] = highByte(currentStatus.O2);
+      outMsg.buf[6] = currentStatus.fuelLoad;
+      outMsg.buf[7] = currentStatus.ignLoad;
+    break;
+    
+    case CAN_GAUGES_3:
+    //6A0 1696
+      outMsg.id = DashMessageID;
+      outMsg.len = 8;
+      outMsg.buf[0] = currentStatus.boostTarget;
+      outMsg.buf[1] = currentStatus.boostDuty;
+      outMsg.buf[2] = currentStatus.ethanolPct;
+      outMsg.buf[3] = currentStatus.afrTarget;
+      outMsg.buf[4] = currentStatus.fuelLoad;
+      outMsg.buf[5] = currentStatus.baro;
+      outMsg.buf[6] = 0x00;
+      outMsg.buf[7] = 0x00;
     break;
 
     default:

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -914,7 +914,7 @@ struct config2 {
 
   byte canBMWCluster : 1;
   byte canVAGCluster : 1;
-  byte enableCluster1 : 1;
+  byte canGaugeSCluster : 1;
   byte enableCluster2 : 1;
   byte unusedClusterBits : 4;
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -316,6 +316,7 @@ void loop()
       #if defined(NATIVE_CAN_AVAILABLE)
       if (configPage2.canBMWCluster == true) { sendBMWCluster(); }
       if (configPage2.canVAGCluster == true) { sendVAGCluster(); }
+      if (configPage2.canGaugeSCluster == true) { sendGaugeSCluster(); }
       #endif
       #if TPS_READ_FREQUENCY == 30
         readTPS();

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -620,7 +620,7 @@ void doUpdates()
     //CAN broadcast introduced
     configPage2.canBMWCluster = 0;
     configPage2.canVAGCluster = 0;
-    
+    configPage2.canGaugeSCluster = 0;
 
     configPage15.boostDCWhenDisabled = 0;
     configPage15.boostControlEnable = EN_BOOST_CONTROL_BARO;


### PR DESCRIPTION
 Add rebroadcasting interface for the Gauge.S which I helped design. This allows Speeduino to rebroadcast various data to this OLED dsplay panel in order for a user to see what is happening live as well as log this data to the SD card inside Gauge.S

[Gauge.S Github](https://github.com/handmade0octopus/gauge.s-sorek.uk)

Signed-off-by: sbtoonz <sbtoonz@gmail.com>