### PR TITLE
Fix for semi-seq inj after #478

### DIFF
--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -612,7 +612,11 @@ void doUpdates()
 
     //Option added to select injector pairing on 4 cylinder engines
     if( configPage4.inj4cylPairing > INJ_PAIR_14_23 ) { configPage4.inj4cylPairing = 0; } //Check valid value
-    if( configPage2.nCylinders == 4 ) { configPage4.inj4cylPairing = INJ_PAIR_14_23; } //Force setting to use the default mode from previous FW versions. This is to prevent issues on any setups that have been wired accordingly
+    if( configPage2.nCylinders == 4 )
+    {
+      if ( configPage2.injLayout == INJ_SEQUENTIAL ) { configPage4.inj4cylPairing = INJ_PAIR_13_24; } //Since #478 engine will always start in semi, make the sequence right for the majority of inlie 4 engines
+      else { configPage4.inj4cylPairing = INJ_PAIR_14_23; } //Force setting to use the default mode from previous FW versions. This is to prevent issues on any setups that have been wired accordingly
+    }
 
     configPage9.hardRevMode = 1; //Set hard rev limiter to Fixed mode
     configPage6.tachoMode = 0;


### PR DESCRIPTION
After #478 engines will start in semi-sequential mode until a CAM sync is detected on missing tooth patterns, it was defined to run on older semi pattern but it is wrong to most inline 4 engines, this fix it.

Older patter injects cylinders 1 and 4 together, but on sequential they are order of injection instead of cylinder number, this will make half the injections wrong, new mode inject first and third cylinder, which are the majority of inline 4 sequences.