### PR TITLE
Volatile decoder variables

### DIFF
--- a/speeduino/crankMaths.ino
+++ b/speeduino/crankMaths.ino
@@ -41,9 +41,10 @@ unsigned long angleToTime(int16_t angle, byte method)
         {
           noInterrupts();
           unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          uint16_t tempTriggerToothAngle = triggerToothAngle; // triggerToothAngle is set by interrupts
           interrupts();
           
-          returnTime = ( (toothTime * angle) / triggerToothAngle );
+          returnTime = ( (toothTime * angle) / tempTriggerToothAngle );
         }
         else { returnTime = angleToTime(angle, CRANKMATH_METHOD_INTERVAL_REV); } //Safety check. This can occur if the last tooth seen was outside the normal pattern etc
     }
@@ -76,9 +77,10 @@ uint16_t timeToAngle(unsigned long time, byte method)
         {
           noInterrupts();
           unsigned long toothTime = (toothLastToothTime - toothLastMinusOneToothTime);
+          uint16_t tempTriggerToothAngle = triggerToothAngle; // triggerToothAngle is set by interrupts
           interrupts();
 
-          returnAngle = ( (unsigned long)(time * triggerToothAngle) / toothTime );
+          returnAngle = ( (unsigned long)(time * tempTriggerToothAngle) / toothTime );
         }
         else { returnAngle = timeToAngle(time, CRANKMATH_METHOD_INTERVAL_REV); } //Safety check. This can occur if the last tooth seen was outside the normal pattern etc
     }

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -233,7 +233,7 @@ extern volatile unsigned int secondaryToothCount; //Used for identifying the cur
 extern volatile unsigned long secondaryLastToothTime; //The time (micros()) that the last tooth was registered (Cam input)
 extern volatile unsigned long secondaryLastToothTime1; //The time (micros()) that the last tooth was registered (Cam input)
 
-extern volatile uint16_t triggerActualTeeth;
+extern uint16_t triggerActualTeeth;
 extern volatile unsigned long triggerFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering)
 extern volatile unsigned long triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
 extern volatile bool validTrigger; //Is set true when the last trigger (Primary or secondary) was valid (ie passed filters)

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -76,7 +76,7 @@ volatile unsigned int secondaryToothCount; //Used for identifying the current se
 volatile unsigned long secondaryLastToothTime = 0; //The time (micros()) that the last tooth was registered (Cam input)
 volatile unsigned long secondaryLastToothTime1 = 0; //The time (micros()) that the last tooth was registered (Cam input)
 
-volatile uint16_t triggerActualTeeth;
+uint16_t triggerActualTeeth;
 volatile unsigned long triggerFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering)
 volatile unsigned long triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
 volatile bool validTrigger; //Is set true when the last trigger (Primary or secondary) was valid (ie passed filters)


### PR DESCRIPTION
triggerToothAngle is modified by interrupts, hence it needs to be read when interrupts are disabled.

triggerActualTeeth is only set in decoder setup routines, hence is not set in an interrupt and does not need to be volatile.

Firmware size decrease by 68 bytes. Loops/sec is unchanged.