### PR TITLE
Add OLCL mode to initBoard() for teensy

### DIFF
--- a/speeduino/board_teensy35.ino
+++ b/speeduino/board_teensy35.ino
@@ -23,7 +23,7 @@ void initBoard()
     ***********************************************************************************************************
     * Idle
     */
-    if ((configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL))
+    if ((configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL))
     {
         //FlexTimer 2, compare channel 0 is used for idle
         FTM2_MODE |= FTM_MODE_WPDIS; // Write Protection Disable

--- a/speeduino/board_teensy41.ino
+++ b/speeduino/board_teensy41.ino
@@ -35,7 +35,7 @@ void initBoard()
     ***********************************************************************************************************
     * Idle
     */
-    if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) )
+    if( (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_PWM_OLCL))
     {
       PIT_TCTRL0 = 0;
       PIT_TCTRL0 |= PIT_TCTRL_TIE; // enable Timer 1 interrupts


### PR DESCRIPTION
This fixes an issue of the idle valve not operating on Teensy based (Dropbear) boards if PWM OL+CL IAC mode is selected. I didn't test with Teensy 4.1 but I'd imagine the change would be the same.