### PR TITLE
Disable automatic retransmission on STM32 CAN

### DIFF
--- a/speeduino/src/STM32_CAN/STM32_CAN.h
+++ b/speeduino/src/STM32_CAN/STM32_CAN.h
@@ -109,8 +109,8 @@ class STM32_CAN {
   public:
     // Default buffer sizes are set to 16. But this can be changed by using constructor in main code.
     STM32_CAN(CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
-    // Begin. By default the automatic retransmission is enabled. If it causes problems, use begin(false) to disable it.
-    void begin(bool retransmission = true);
+    // Begin. By default the automatic retransmission is disabled in Speeduino, because it has been observed to cause sync issues.
+    void begin(bool retransmission = false);
     void setBaudRate(uint32_t baud);
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);


### PR DESCRIPTION
I noticed that I have accidentally left the automatic retransmission enabled on the new STM32 CAN library. It has been observed to possibly cause some sync loss issues, so it's better to to be disabled.