### PR TITLE
Jeep2000 fix

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1785,13 +1785,9 @@ void triggerSetup_Jeep2000()
 
 void triggerPri_Jeep2000()
 {
-
   if(toothCurrentCount == 13) { currentStatus.hasSync = false; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
   else
   {
-    uint16_t tempTriggerToothAngle;
-    long tempCurGap;
-
     curTime = micros();
     curGap = curTime - toothLastToothTime;
     if ( curGap >= triggerFilterTime )
@@ -1810,11 +1806,8 @@ void triggerPri_Jeep2000()
         toothCurrentCount++; //Increment the tooth counter
         triggerToothAngle = toothAngles[(toothCurrentCount-1)] - toothAngles[(toothCurrentCount-2)]; //Calculate the last tooth gap in degrees
       }
-      
-      tempTriggerToothAngle = toothAngles[(toothCurrentCount)] - toothAngles[(toothCurrentCount-1)]; // gap to the next tooth
 
-      tempCurGap = curGap * (tempTriggerToothAngle/triggerToothAngle);
-      setFilter(tempCurGap); //Recalc the new filter value
+      setFilter(curGap); //Recalc the new filter value
 
       validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
@@ -1825,10 +1818,7 @@ void triggerPri_Jeep2000()
 }
 void triggerSec_Jeep2000()
 {
-  if(toothCurrentCount > 11) // The cam signal should only happen after primary tooth 12 (or 13, at startup). So this is a cheap way to filter cam signal noise 
-  {
-    toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
-  }
+  toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
   return;
 }
 

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1839,7 +1839,7 @@ int getCrankAngle_Jeep2000()
     interrupts();
 
     int crankAngle;
-    if (toothCurrentCount == 0) { crankAngle = 114 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the cam tooth goes high, but the timings were taken on the previous crank tooth, so it's 114
+    if (toothCurrentCount == 0) { crankAngle = 114 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. Since  the tooth timings were taken on the previous crank tooth, the previous crank tooth angle is used here, not cam angle.
     else { crankAngle = toothAngles[(tempToothCurrentCount - 1)] + configPage4.triggerAngle;} //Perform a lookup of the fixed toothAngles array to find what the angle of the last tooth passed was.
 
     //Estimate the number of degrees travelled since the last tooth}

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1839,7 +1839,7 @@ int getCrankAngle_Jeep2000()
     interrupts();
 
     int crankAngle;
-    if (toothCurrentCount == 0) { crankAngle = 146 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the crank tooth goes high.
+    if (toothCurrentCount == 0) { crankAngle = 118 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the crank tooth goes high, but the timing was taken on the previous crank tooth, so it's 118
     else { crankAngle = toothAngles[(tempToothCurrentCount - 1)] + configPage4.triggerAngle;} //Perform a lookup of the fixed toothAngles array to find what the angle of the last tooth passed was.
 
     //Estimate the number of degrees travelled since the last tooth}

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1839,7 +1839,7 @@ int getCrankAngle_Jeep2000()
     interrupts();
 
     int crankAngle;
-    if (toothCurrentCount == 0) { crankAngle = 118 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the crank tooth goes high, but the timing was taken on the previous crank tooth, so it's 118
+    if (toothCurrentCount == 0) { crankAngle = 114 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the cam tooth goes high, but the timings were taken on the previous crank tooth, so it's 114
     else { crankAngle = toothAngles[(tempToothCurrentCount - 1)] + configPage4.triggerAngle;} //Perform a lookup of the fixed toothAngles array to find what the angle of the last tooth passed was.
 
     //Estimate the number of degrees travelled since the last tooth}

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1785,9 +1785,13 @@ void triggerSetup_Jeep2000()
 
 void triggerPri_Jeep2000()
 {
+
   if(toothCurrentCount == 13) { currentStatus.hasSync = false; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
   else
   {
+    uint16_t tempTriggerToothAngle;
+    long tempCurGap;
+
     curTime = micros();
     curGap = curTime - toothLastToothTime;
     if ( curGap >= triggerFilterTime )
@@ -1806,8 +1810,11 @@ void triggerPri_Jeep2000()
         toothCurrentCount++; //Increment the tooth counter
         triggerToothAngle = toothAngles[(toothCurrentCount-1)] - toothAngles[(toothCurrentCount-2)]; //Calculate the last tooth gap in degrees
       }
+      
+      tempTriggerToothAngle = toothAngles[(toothCurrentCount)] - toothAngles[(toothCurrentCount-1)]; // gap to the next tooth
 
-      setFilter(curGap); //Recalc the new filter value
+      tempCurGap = curGap * (tempTriggerToothAngle/triggerToothAngle);
+      setFilter(tempCurGap); //Recalc the new filter value
 
       validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
@@ -1818,7 +1825,10 @@ void triggerPri_Jeep2000()
 }
 void triggerSec_Jeep2000()
 {
-  toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
+  if(toothCurrentCount > 11) // The cam signal should only happen after primary tooth 12 (or 13, at startup). So this is a cheap way to filter cam signal noise 
+  {
+    toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
+  }
   return;
 }
 


### PR DESCRIPTION
This replaces #896 which included an 'LTS' style fix plus some improvements which wouldn't be in an LTS release. 
(also I'd made the PR out of my master branch, which made things tricky!)
This PR is now ONLY a fix for #897 
the fix is: getCrankAngle_Jeep2000() sets crankangle = 146 + triggerAngle when toothCurrentCount = 0, because toothCurrentCount was set to 0 on seeing the Cam tooth, and the cam tooth angle is 146.
However, the tooth timings that are subsequently used in calculations are from the previous crank tooth, which was at 114. Therefore 114 is the correct crankangle to work with.
