### PR TITLE
Jeep 2000 noise filtering

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1849,7 +1849,11 @@ int getCrankAngle_Jeep2000()
     interrupts();
 
     int crankAngle;
+<<<<<<< HEAD
     if (toothCurrentCount == 0) { crankAngle = 114 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the cam tooth goes high, but the timings were taken on the previous crank tooth, so it's 114
+=======
+    if (toothCurrentCount == 0) { crankAngle = 146 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the crank tooth goes high.
+>>>>>>> parent of b3d6f95d (Fix Jeep2000 decoder)
     else { crankAngle = toothAngles[(tempToothCurrentCount - 1)] + configPage4.triggerAngle;} //Perform a lookup of the fixed toothAngles array to find what the angle of the last tooth passed was.
 
     //Estimate the number of degrees travelled since the last tooth}

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1813,7 +1813,12 @@ void triggerPri_Jeep2000()
       
       tempTriggerToothAngle = toothAngles[(toothCurrentCount)] - toothAngles[(toothCurrentCount-1)]; // gap to the next tooth
 
-      tempCurGap = curGap * (tempTriggerToothAngle/triggerToothAngle);
+      /* scale up curGap to be what the duration would be for the next tooth gap, if the crank speed doesn't change. 
+      i.e. given next tooth gap might be longer or shorter than current, predict what curgap will be to the next tooth, 
+      so on the next primary trigger, a  trigger filter can be set for it. */
+      
+      tempCurGap = curGap * (tempTriggerToothAngle/triggerToothAngle); 
+      
       setFilter(tempCurGap); //Recalc the new filter value
 
       validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1849,11 +1849,8 @@ int getCrankAngle_Jeep2000()
     interrupts();
 
     int crankAngle;
-<<<<<<< HEAD
-    if (toothCurrentCount == 0) { crankAngle = 114 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the cam tooth goes high, but the timings were taken on the previous crank tooth, so it's 114
-=======
+
     if (toothCurrentCount == 0) { crankAngle = 146 + configPage4.triggerAngle; } //This is the special case to handle when the 'last tooth' seen was the cam tooth. 146 is the angle at which the crank tooth goes high.
->>>>>>> parent of b3d6f95d (Fix Jeep2000 decoder)
     else { crankAngle = toothAngles[(tempToothCurrentCount - 1)] + configPage4.triggerAngle;} //Perform a lookup of the fixed toothAngles array to find what the angle of the last tooth passed was.
 
     //Estimate the number of degrees travelled since the last tooth}


### PR DESCRIPTION
The current Jeep 2000 decoder has no code for noise filtering on cam trigger, and the crank trigger filtering can't be used because of the variable gap between teeth.
This contains two changes to address that. 
*  only accept cam tooth triggers when crank tooth is > 11 (i.e. 12 or 13) because a cam tooth at any other time must be noise. 
* setfilter() for the next crank tooth based on scaling the curGap by ratio of current tooth angle and  next tooth angle - thereby increasing the filter time allowance if the next gap is bigger and reducing it if the next gap is smaller. 