### PR TITLE
IAC IAT PWM Curve addition 

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1554,9 +1554,10 @@ page = 15
       airConIdleUpRPMAdder          = scalar,  U08,   96,  "Added Target RPM", 10.0, 0.0, 0.0,    250.0,    0
       airConPwmFanMinDuty           = scalar,  U08,   97,  "%",      0.5,        0.0,     0.0,    100.0,    1
 
-      rollingProtRPMDelta           = array,   S08,   98,    [4], "RPM",     10.0,    0,   -1000,   0,    0           
-      rollingProtCutPercent         = array,   U08,   102,   [4],    "%",    1.0,    0,   0,    100,      0
-      Unused15_106_255              = array,   U08,   106,   [150],   "%", 1.0,   0.0,     0.0,      255,    0
+      rollingProtRPMDelta           = array,   S08,   98, [4], "RPM",     10.0,    0,   -1000,   0,    0           
+      rollingProtCutPercent         = array,   U08,   102, [4],    "%",    1.0,    0,   0,    100,      0
+      iacOLPWMIATVal                = array,   U08,   106,  [10],   "Duty %",   1.0,    0,    0,      100,    0
+      Unused15_116_255               = array,   U08,   115,   [140],   "%", 1.0,   0.0,     0.0,      255,    0
 
 ;-------------------------------------------------------------------------------
 
@@ -2052,7 +2053,7 @@ menuDialog = main
         subMenu = std_separator
         subMenu = idleSettings,         "Idle Control"
         subMenu = iacClosedLoop_curve,  "Idle - RPM targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 || iacAlgorithm == 7 || idleAdvEnabled >= 1 }
-        subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6}
+        subMenu = iacPWMSettings,       "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6}
         subMenu = iacPwmCrank_curve,    "Idle - PWM Cranking Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6}
         subMenu = iacStep_curve,        "Idle - Stepper Motor", 7, { iacAlgorithm == 4 || iacAlgorithm == 7 }
         subMenu = iacStepCrank_curve,   "Idle - Stepper Motor Cranking", 7, { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
@@ -3124,6 +3125,9 @@ menuDialog = main
         panel = idle_advance_curve,         { idleAdvEnabled >= 1 }
         panel = iacClosedLoop_curve,        { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 || iacAlgorithm == 7|| idleAdvEnabled >= 1 }
         
+    dialog = iacPWMSettings, "IAC PWM Settings"
+        panel = iacPwm_curve
+        panel = iacPwmIAT_curve
 
     dialog = rotary_ignition,               "Rotary Ignition",  4
         field = "Ignition Configuration",   rotaryType
@@ -4727,7 +4731,7 @@ cmdVSSratio6 =      "E\x99\x06"
 
 ; Curves for idle control
         ; Standard duty table for PWM valves
-        curve = iacPwm_curve, "IAC PWM Duty"
+        curve = iacPwm_curve, "IAC CLT PWM Duty"
             columnLabel = "Coolant Temperature", "Valve"
         #if CELSIUS
             xAxis = -40, 215, 6
@@ -4737,6 +4741,18 @@ cmdVSSratio6 =      "E\x99\x06"
             yAxis = 0, 100, 4
             xBins = iacBins, coolant
             yBins = iacOLPWMVal
+
+        ; Supplemental IAT duty table for PWM valves
+        curve = iacPwmIAT_curve, "IAC IAT PWM Duty"
+            columnLabel = "IAT Temperature", "Valve"
+            #if CELSIUS
+            xAxis = 0, 125, 5
+            #else
+            xAxis = 32, 257, 5
+            #endif
+            yAxis = 0, 100, 4
+            xBins = airDenBins, iat
+            yBins = iacOLPWMIATVal
 
         ; Cranking duty table for PWM valves
         curve = iacPwmCrank_curve, "IAC PWM Cranking Duty"

--- a/speeduino/config_pages.h
+++ b/speeduino/config_pages.h
@@ -594,7 +594,7 @@ struct config6 {
 
   byte iacCLValues[10]; //Closed loop target RPM value
   byte iacOLStepVal[10]; //Open loop step values for stepper motors
-  byte iacOLPWMVal[10]; //Open loop duty values for PMWM valves
+  byte iacOLPWMVal[10]; //Open loop duty values for PWM valves
   byte iacBins[10]; //Temperature Bins for the above 3 curves
   byte iacCrankSteps[4]; //Steps to use when cranking (Stepper motor)
   byte iacCrankDuty[4]; //Duty cycle to use on PWM valves when cranking
@@ -993,8 +993,10 @@ struct config15 {
   int8_t rollingProtRPMDelta[4]; // Signed RPM value representing how much below the RPM limit. Divided by 10
   byte rollingProtCutPercent[4];
   
-  //Bytes 106-255
-  byte Unused15_106_255[150];
+  //Bytes 106-114
+  byte iacOLPWMIATVal [10]; //Open loop IAT duty values for PWM valves
+  //Bytes 116-255
+  byte Unused15_98_255[140];
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
Feature Request: IAT vs IACV correction table https://github.com/noisymime/speeduino/issues/750

I decided to add a curve for IAT IAC corrections. I was going to do a 3d table, but that takes up too much space. 120 bytes vs 40 bytes. This PR only uses 9 additional bytes for IAT IAC Duty cycle table. the IAT bins is shared with airDenBins