### PR TITLE
Fix problem of using an uninitialised variable when initialising the stepper after power on

### DIFF
--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -69,7 +69,7 @@ uint8_t idleTaper;
 byte idleUpOutputHIGH = HIGH; // Used to invert the idle Up Output 
 byte idleUpOutputLOW = LOW;   // Used to invert the idle Up Output 
 
-void initialiseIdle();
+void initialiseIdle(bool forcehoming);
 void initialiseIdleUpOutput();
 void disableIdle();
 void idleInterrupt();

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -32,7 +32,7 @@ static inline void enableIdle()
   }
 }
 
-void initialiseIdle()
+void initialiseIdle(bool forcehoming)
 {
   //By default, turn off the PWM interrupt (It gets turned on below if needed)
   IDLE_TIMER_DISABLE();
@@ -154,7 +154,7 @@ void initialiseIdle()
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 
-      if( completedHomeSteps < (configPage6.iacStepHome * 3) )
+      if (forcehoming)
       {
         //Change between modes running make engine stall
         completedHomeSteps = 0;
@@ -185,7 +185,7 @@ void initialiseIdle()
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 
-      if( completedHomeSteps < (configPage6.iacStepHome * 3) )
+      if (forcehoming)
       {
         //Change between modes running make engine stall
         completedHomeSteps = 0;
@@ -229,7 +229,7 @@ void initialiseIdle()
       iacStepTime_uS = configPage6.iacStepTime * 1000;
       iacCoolTime_uS = configPage9.iacCoolTime * 1000;
 
-      if( completedHomeSteps < (configPage6.iacStepHome * 3) )
+      if (forcehoming)
       {
         //Change between modes running make engine stall
         completedHomeSteps = 0;
@@ -393,7 +393,7 @@ static inline byte isStepperHomed()
 
 void idleControl()
 {
-  if( idleInitComplete != configPage6.iacAlgorithm) { initialiseIdle(); }
+  if( idleInitComplete != configPage6.iacAlgorithm) { initialiseIdle(false); }
   if( (currentStatus.RPM > 0) || (configPage6.iacPWMrun == true) ) { enableIdle(); }
 
   //Check whether the idleUp is active

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -342,7 +342,7 @@ void initialiseAll()
     //Perform all initialisations
     initialiseSchedulers();
     //initialiseDisplay();
-    initialiseIdle();
+    initialiseIdle(true);
     initialiseFan();
     initialiseAuxPWM();
     initialiseCorrections();

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -593,7 +593,7 @@ void readBat()
     //Redo the stepper homing
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) )
     {
-      initialiseIdle();
+      initialiseIdle(true);
     }
   }
 


### PR DESCRIPTION
This fixes a bug I found after upgrading from May 2020 to July 2022. I use open loop stepper mode currently. The symptom was that the stepper motor behaviour was basically random. Some starts would result in really low idle RPM (stepper closed off) and others somewhat high RPM (stepper apparently wide open). Altering the curve did not fix it and in any case there should be no reason why the curve should be different between upgrades. 

I discovered that about 8 months ago a change was made to stop the stepper from being re-homed when the idle mode is changed (e.g. from stepper open loop to stepper open+closed). This is because depending on the engine setup it may cause a stall. That is not a real world problem since in normal running it isn't something that will happen, but there's no problem retaining the feature as far as I can tell.
There are multiple issues being fixed here although they all relate to the same underlying cause; 
- going from USB power only to ignition power could result in the stepper being in a random position, making the engine idle point different each time it is started under those conditions.
- initial power on with key will not always re-home the stepper and leaves a random position. Again this results in random idle speed.

This change just alters the method by which the decision is made for re-homing to make it deterministic. It also removes the accessing of the uninitialised variable from the condition, the original purpose of the code being to initialise that variable (compeltedHomeSteps) and others.

Note there is a very slight difference in behaviour in the situation where homing is not completed but the stepper mode is changed. In this scenario, homing will continue until completed whereas previously it would be restarted. The end result should be the same.

I recommend this fix is added to the LTS branch.