### PR TITLE
Fix Miata 99-05 new ignition mode conditional

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -2186,18 +2186,16 @@ void triggerPri_Miata9905()
 
       //EXPERIMENTAL!
       //New ignition mode is ONLY available on 9905 when the trigger angle is set to the stock value of 0.
-      if( (configPage2.perToothIgn == true) || (configPage4.triggerAngle == 0) )
+      if(    (configPage2.perToothIgn == true) 
+          && (configPage4.triggerAngle == 0) 
+          && (currentStatus.advance > 0) )
       {
-        if (currentStatus.advance > 0)
-        {
-          int16_t crankAngle = ignitionLimits( toothAngles[(toothCurrentCount-1)] );
+        int16_t crankAngle = ignitionLimits( toothAngles[(toothCurrentCount-1)] );
 
-          //Handle non-sequential tooth counts 
-          if( (configPage4.sparkMode != IGN_MODE_SEQUENTIAL) && (toothCurrentCount > configPage2.nCylinders) ) { checkPerToothTiming(crankAngle, (toothCurrentCount-configPage2.nCylinders) ); }
-          else { checkPerToothTiming(crankAngle, toothCurrentCount); }
-        }
+        //Handle non-sequential tooth counts 
+        if( (configPage4.sparkMode != IGN_MODE_SEQUENTIAL) && (toothCurrentCount > configPage2.nCylinders) ) { checkPerToothTiming(crankAngle, (toothCurrentCount-configPage2.nCylinders) ); }
+        else { checkPerToothTiming(crankAngle, toothCurrentCount); }
       }
-
     } //Has sync
 
     toothLastMinusOneToothTime = toothLastToothTime;


### PR DESCRIPTION
In triggerPri_Miata9905(), the check for new ignition mode will pass when trigger angle is zero and new ignition mode is off: the logical or (||) needs to be replaced with logical and (&&).

This PR also hoists the inner nested if statement condition into the check.

Fixes #917 