### PR TITLE
Include CPP files in MISRA script

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ platform=atmelavr
 board=megaatmega2560
 framework=arduino
 build_unflags = -Os
-build_flags = -O3 -ffast-math -fshort-enums -funroll-loops -Wall -Wextra -std=c99
+build_flags = -DUSE_LIBDIVIDE -O3 -ffast-math -fshort-enums -funroll-loops -Wall -Wextra -std=c99
 lib_deps = EEPROM, Time
 ;test_build_project_src = true
 test_build_src = yes
@@ -25,7 +25,7 @@ platform=atmelavr
 board=ATmega2561
 framework=arduino
 build_unflags = -Os
-build_flags = -O3 -ffast-math -Wall -Wextra -std=c99
+build_flags = -DUSE_LIBDIVIDE -O3 -ffast-math -Wall -Wextra -std=c99
 lib_deps = EEPROM, Time
 test_build_src = yes
 
@@ -66,7 +66,7 @@ framework = arduino
 board = black_f407ve
 lib_deps = stm32duino/STM32duino RTC, greiman/SdFat
 board_build.core = stm32
-build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_CAN_MODULE_ENABLED
+build_flags = -DUSE_LIBDIVIDE -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_CAN_MODULE_ENABLED
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -78,7 +78,7 @@ framework = arduino
 board = blackpill_f401cc
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
-build_flags = -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
+build_flags = -DUSE_LIBDIVIDE -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -90,7 +90,7 @@ framework = arduino
 board = blackpill_f411ce
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
-build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS
+build_flags = -DUSE_LIBDIVIDE -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -102,7 +102,7 @@ framework = arduino
 board = blackpill_f411ce
 lib_deps = stm32duino/STM32duino RTC
 board_build.core = stm32
-build_flags = -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
+build_flags = -DUSE_LIBDIVIDE -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
@@ -113,8 +113,8 @@ framework = arduino
 ; framework-arduinoststm32
 board = bluepill_f103c8_128k
 lib_deps = EEPROM, stm32duino/STM32duino RTC
-;build_flags = -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map
-build_flags = -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
+;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map
+build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
 
 ;SAMD21
 [env:samd21]
@@ -122,8 +122,8 @@ platform = atmelsam
 framework = arduino
 board = zeroUSB
 ;lib_deps = cmaglie/FlashStorage @ ^1.0.0
-;build_flags = -fpermissive -std=gnu++11 -DUSE_SPI_EEPROM
-build_flags = -fpermissive -std=gnu++11
+;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -DUSE_SPI_EEPROM
+build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11
 upload_protocol = sam-ba
 
 ;SAME51
@@ -132,8 +132,8 @@ platform = atmelsam
 framework = arduino
 board = adafruit_feather_m4_can
 ;lib_deps = cmaglie/FlashStorage @ ^1.0.0
-;build_flags = -fpermissive -std=gnu++11 -DUSE_SPI_EEPROM
-build_flags = -fpermissive -std=gnu++11
+;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -DUSE_SPI_EEPROM
+build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11
 upload_protocol = sam-ba
 
 
@@ -143,7 +143,7 @@ upload_protocol = sam-ba
 ;framework = arduino
 ;board = disco_f407vg
 ;lib_deps = EEPROM
-;build_flags = -fpermissive -std=gnu++11 -DUSE_STM32GENERIC -DMENU_USB_SERIAL
+;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -DUSE_STM32GENERIC -DMENU_USB_SERIAL
 
 [env:custom_monitor_speedrate]
 monitor_speed = 115200
@@ -162,8 +162,8 @@ default_envs = megaatmega2560
 
 [env:native]
 platform = native
-build_flags = -std=gnu++11
+build_flags = -DUSE_LIBDIVIDE -std=gnu++11
 debug_build_flags = -std=gnu++11 -O0 -g3
-test_ignore = test_misc, test_decoders, test_schedules, test_fuel
+test_ignore = test_misc2, test_misc, test_decoders, test_schedules, test_fuel
 debug_test = test_table3d_native
 build_type = debug

--- a/speeduino/int16_byte.h
+++ b/speeduino/int16_byte.h
@@ -5,8 +5,12 @@
 
 #pragma once
 
+
 #include <stdint.h>
+
+#ifdef USE_LIBDIVIDE
 #include "src/libdivide/libdivide.h"
+#endif
 
 /** @brief Byte type. This is not defined in any C or C++ standard header. */
 typedef uint8_t byte;
@@ -30,20 +34,32 @@ public:
      * \c divider could be computed from \c factor, but including it as a parameter
      * allows callers to create \c factor instances at compile time.
      */
-    constexpr int16_byte(uint8_t factor, const libdivide::libdivide_s16_t &divider) 
-        : _factor(factor), _divider(divider)
+    constexpr int16_byte(uint8_t factor
+#ifdef USE_LIBDIVIDE
+    , const libdivide::libdivide_s16_t &divider
+#endif
+        )
+        : _factor(factor)
+#ifdef USE_LIBDIVIDE
+        , _divider(divider)
+#endif
     {
     }
 
     /** @brief Convert to a \c byte */
+#ifdef USE_LIBDIVIDE
     inline byte to_byte(int16_t value) const { return _factor==1 ? value : _factor==2 ? value>>1 : (byte)libdivide::libdivide_s16_do(value, &_divider); }
-
+#else
+    inline byte to_byte(int16_t value) const { return (byte)(value/_factor); }
+#endif
     /** @brief Convert from a \c byte */
     inline int16_t from_byte( byte in ) const { return (int16_t)in * _factor;  }
 
 private:
     uint8_t _factor;
+#ifdef USE_LIBDIVIDE
     libdivide::libdivide_s16_t _divider;
+#endif
 };
 
 /** @} */

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -1,8 +1,6 @@
 #ifndef MATH_H
 #define MATH_H
 
-#define USE_LIBDIVIDE
-
 int fastMap1023toX(int, int);
 unsigned long percentage(uint8_t, unsigned long);
 unsigned long halfPercentage(uint8_t, unsigned long);

--- a/speeduino/table3d_axis_io.h
+++ b/speeduino/table3d_axis_io.h
@@ -11,7 +11,9 @@
 
 #include "int16_byte.h"
 #include "table3d_axes.h"
+#ifdef USE_LIBDIVIDE
 #include "src/libdivide/constant_fast_div.h"
+#endif
 
 /** @brief table axis I/O support 
  * 
@@ -59,9 +61,15 @@ public:
     static inline int16_t from_byte(axis_domain domain, byte in ) { return get_converter(domain)->from_byte(in); }    
 
 private:
+#ifdef USE_LIBDIVIDE
     static constexpr int16_byte converter_100 = { 100, { S16_MAGIC(100), S16_MORE(100) } };
     static constexpr int16_byte converter_2 = { 2, { S16_MAGIC(2), S16_MORE(2) } };
     static constexpr int16_byte converter_1 = { 1, { S16_MAGIC(1), S16_MORE(1) } };
+#else
+    static constexpr int16_byte converter_100 = { 100 };
+    static constexpr int16_byte converter_2 = { 2 };
+    static constexpr int16_byte converter_1 = { 1 };
+#endif
 };
 
 /** @} */


### PR DESCRIPTION
Include *.cpp as well as *.ino in the MISRA checks.

This PR:

1. Excludes `libdivide` headers from cppcheck via use of `#ifdef USE_LIBDIVIDE`
2. The cppcheck MISRA add on does not respect `#ifdef USE_LIBDIVIDE`, so the script now renames the `libdivide` folder before and after the scan.

Fixes #924