### PR TITLE
Add parameters to require power cycle

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1446,6 +1446,11 @@ page = 15
 [ConstantsExtensions]
     requiresPowerCycle = nCylinders
     requiresPowerCycle = pinLayout
+    requiresPowerCycle = injLayout
+    requiresPowerCycle = inj4CylPairing
+    requiresPowerCycle = twoStroke
+    requiresPowerCycle = engineType
+    requiresPowerCycle = alternate
     requiresPowerCycle = fanPin
     requiresPowerCycle = reqFuel
     requiresPowerCycle = numTeeth


### PR DESCRIPTION
These parameters are used during initialization to set various things, but are missing from the requiresPowerCycle -list in the speeduino.ini. The missing prompt to require power cycle has lead to confusing situations for users, so I'm adding these to the requiresPowerCycle -list, as they should be.