### PR TITLE
Stuck ego fix

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -609,7 +609,7 @@ byte correctionAFRClosedLoop()
   {
     AFRValue = currentStatus.egoCorrection; //Need to record this here, just to make sure the correction stays 'on' even if the nextCycle count isn't ready
     
-    if(ignitionCount >= AFRnextCycle)
+    if((ignitionCount >= AFRnextCycle) || (ignitionCount < (AFRnextCycle - configPage6.egoCount)))
     {
       AFRnextCycle = ignitionCount + configPage6.egoCount; //Set the target ignition event for the next calculation
         


### PR DESCRIPTION

Ego control gets stuck at 100% when ignitionCount wraps during an DFCO event because the test "if (ignitionCount < AFRnextCycle).." continues to fail until ignitionCount catches up with AFRnextCycle again -  long time.
This fix also checks for ignitionCount < (AFRnextCycle - configPage6.egoCount)