### PR TITLE
noise filtering for Jeep2000 decoder cam signal

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -1818,7 +1818,10 @@ void triggerPri_Jeep2000()
 }
 void triggerSec_Jeep2000()
 {
-  toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
+  if(toothCurrentCount > 11) // The cam signal should only happen after primary tooth 12 (or 13, at startup). So this is a cheap way to filter cam signal noise 
+  {
+    toothCurrentCount = 0; //All we need to do is reset the tooth count back to zero, indicating that we're at the beginning of a new revolution
+  }
   return;
 }
 


### PR DESCRIPTION
check that we're at an acceptable crank tooth before acting on cam trigger pulse.