### PR TITLE
Update decoders.ino

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -482,13 +482,13 @@ void triggerPri_missingTooth()
       if( (configPage2.perToothIgn == true) && (!BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK)) ) 
       {
         int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
-        crankAngle = ignitionLimits(crankAngle);
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) )
         {
           crankAngle += 360;
+          crankAngle = ignitionLimits(crankAngle);
           checkPerToothTiming(crankAngle, (configPage4.triggerTeeth + toothCurrentCount)); 
         }
-        else{ checkPerToothTiming(crankAngle, toothCurrentCount); }
+        else{ crankAngle = ignitionLimits(crankAngle); checkPerToothTiming(crankAngle, toothCurrentCount); }
       }
    }
 }


### PR DESCRIPTION
Fix an issue where the current logic cause erroneous crankAngles for ignition by tooth whether the trigger angle is negative or positive.

Moving the ignitionLimits() to inside the if statement after the 360 deg addition to first revolution check as well as inside the else statement before calling checkPerToothTiming() fixes the issue.