### PR TITLE
fix check for engine rpm below target

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -783,8 +783,17 @@ int8_t correctionIdleAdvance(int8_t advance)
     else { idleAdvTaper = 0; }
   }
 
-  if ( !idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN) && (currentStatus.RPM < (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)IGN_IDLE_THRESHOLD)) ) { idleAdvActive = true; } //Active only after the engine is 200 RPM below target on first time
-  else if (idleAdvActive && !BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) { idleAdvActive = false; } //Clear flag if engine isn't running anymore
+/* When Idle advance is the only idle speed control mechanism, activate as soon as not cranking. 
+When some other mechanism is also present, wait until the engine is no more than 200 RPM below idle target speed on first time
+*/
+
+  if ((!idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) &&
+   ((configPage6.iacAlgorithm == 0) || (currentStatus.RPM > (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)IGN_IDLE_THRESHOLD))))
+  { 
+    idleAdvActive = true; 
+  } 
+  else 
+    if (idleAdvActive && !BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) { idleAdvActive = false; } //Clear flag if engine isn't running anymore
 
   return ignIdleValue;
 }

--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -783,7 +783,7 @@ int8_t correctionIdleAdvance(int8_t advance)
     else { idleAdvTaper = 0; }
   }
 
-  if ( !idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN) && (currentStatus.RPM > (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)IGN_IDLE_THRESHOLD)) ) { idleAdvActive = true; } //Active only after the engine is 200 RPM below target on first time
+  if ( !idleAdvActive && BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN) && (currentStatus.RPM < (((uint16_t)currentStatus.CLIdleTarget * 10) - (uint16_t)IGN_IDLE_THRESHOLD)) ) { idleAdvActive = true; } //Active only after the engine is 200 RPM below target on first time
   else if (idleAdvActive && !BIT_CHECK(currentStatus.engine, BIT_ENGINE_RUN)) { idleAdvActive = false; } //Clear flag if engine isn't running anymore
 
   return ignIdleValue;


### PR DESCRIPTION
In correctionIdleAdvance(),  idleAdvActive is false until the engine RPM is > (target RPM - 200) , which means that on start up, you have to manually (with your foot!) raise the RPM to the target speed before idle advance control engages.
Which is really annoying if you want to be able to just start the car with the key and have it run. 

so I changed it so it is consistent with the comment "// Active only after the engine is 200 RPM below target on first time"  which works now for me. 