### PR TITLE
Rename engineProtectMaxRPM to 'min'

### DIFF
--- a/speeduino/engineProtection.ino
+++ b/speeduino/engineProtection.ino
@@ -7,7 +7,7 @@ byte checkEngineProtect()
   byte protectActive = 0;
   if(checkRevLimit() || checkBoostLimit() || checkOilPressureLimit() || checkAFRLimit() )
   {
-    if( currentStatus.RPMdiv100 > configPage4.engineProtectMaxRPM ) { protectActive = 1; }
+    if( currentStatus.RPMdiv100 > configPage4.engineProtectMinRPM ) { protectActive = 1; }
   }
 
   return protectActive;
@@ -207,4 +207,3 @@ byte checkAFRLimit()
 
   return checkAFRLimitActive;
 }
-

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1011,7 +1011,7 @@ struct config4 {
   byte idleAdvBins[6];
   byte idleAdvValues[6];
 
-  byte engineProtectMaxRPM;
+  byte engineProtectMinRPM;
 
   int16_t vvt2CL0DutyAng;
   byte vvt2PWMdir : 1;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -829,7 +829,7 @@ void loop()
       //Check for any of the engine protections or rev limiters being turned on
       if(checkEngineProtect() || currentStatus.launchingHard || currentStatus.flatShiftingHard)
       {
-        if( (currentStatus.RPMdiv100 > configPage4.engineProtectMaxRPM) || currentStatus.launchingHard || currentStatus.flatShiftingHard) //Ugly, but the launch/flat shift check needs to be here as well to prevent these limiters not happening when under the the Engine Protection min rpm
+        if( (currentStatus.RPMdiv100 > configPage4.engineProtectMinRPM) || currentStatus.launchingHard || currentStatus.flatShiftingHard) //Ugly, but the launch/flat shift check needs to be here as well to prevent these limiters not happening when under the the Engine Protection min rpm
         {
           if( (configPage2.hardCutType == HARD_CUT_FULL) || (configPage6.engineProtectType == PROTECT_CUT_FUEL) ) 
           { 


### PR DESCRIPTION
Rename engineProtectMaxRPM to engineProtectMinRPM.  This agrees with Tunerstudio's GUI and also with the way the value is used.