### PR TITLE
Lower max on IAT and CLT gauges for celsius

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5001,13 +5001,13 @@ cmdVSSratio6 =      "E\x99\x06"
     MAPdotGauge       = MAPdot,        "MAP DOT",            "kPa/s",   0,    1000,    -1,    -1, 2560, 2560, 0, 0
 
     #if CELSIUS
-    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   110,    -15,     0,   95,  105, 0, 0
-    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   110,    -15,     0,   95,  100, 0, 0
-    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   110,    -15,     0,   95,  100, 0, 0
+    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   120,    -15,     0,   95,  105, 0, 0
+    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   120,    -15,     0,   95,  100, 0, 0
+    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   120,    -15,     0,   95,  100, 0, 0
     #else
-    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   215,      0,    30,  200,  220, 0, 0
-    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   215,      0,    30,  200,  210, 0, 0
-    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   215,      0,    30,  200,  210, 0, 0
+    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   248,      0,    30,  200,  220, 0, 0
+    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   248,      0,    30,  200,  210, 0, 0
+    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   248,      0,    30,  200,  210, 0, 0
     #endif
     flexGauge         = flex,          "Flex sensor",        "%",       0,   100,     -1,    -1,  999,  999, 0, 0
 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5001,9 +5001,9 @@ cmdVSSratio6 =      "E\x99\x06"
     MAPdotGauge       = MAPdot,        "MAP DOT",            "kPa/s",   0,    1000,    -1,    -1, 2560, 2560, 0, 0
 
     #if CELSIUS
-    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   215,    -15,     0,   95,  105, 0, 0
-    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   215,    -15,     0,   95,  100, 0, 0
-    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   215,    -15,     0,   95,  100, 0, 0
+    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   110,    -15,     0,   95,  105, 0, 0
+    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   110,    -15,     0,   95,  100, 0, 0
+    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   110,    -15,     0,   95,  100, 0, 0
     #else
     cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   215,      0,    30,  200,  220, 0, 0
     iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   215,      0,    30,  200,  210, 0, 0


### PR DESCRIPTION
Lowers the maximum for Celsius on the IAT and CLT gauges in TunerStudio to a more reasonable value.