### PR TITLE
Scale IAT and CLT calibration to ADC 1023 instead of 992

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -697,7 +697,7 @@ void processSerialCommand()
 
             
             ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
-            pnt_TargetTable_bins[x] = (x * 32U);
+            pnt_TargetTable_bins[x] = (x * 33U); // 0*33=0 to 31*33=1023
           }
           //Update the CRC
           calibrationCRC = CRC32.crc32(&serialPayload[7], 64);
@@ -729,7 +729,7 @@ void processSerialCommand()
 
             
             ((uint16_t*)pnt_TargetTable_values)[x] = tempValue; //Both temp tables have 16-bit values
-            pnt_TargetTable_bins[x] = (x * 32U);
+            pnt_TargetTable_bins[x] = (x * 33U); // 0*33=0 to 31*33=1023
           }
           //Update the CRC
           calibrationCRC = CRC32.crc32(&serialPayload[7], 64);


### PR DESCRIPTION
Fixes #957

The calibrations for IAT and CLT are currently scaled for ADC values from 0 to 992. This causes a bigger temperature mismatch the lower the temperature gets. This pull request changes it so the full range of 0 to 1023 is used.

Calibrations values before and after.
ADC old | ADC new | Calibration | Actual temp
-- | -- | -- | --
0 | 0 | 122 | 82
32 | 33 | 202 | 162
64 | 66 | 169 | 129
96 | 99 | 151 | 111
128 | 132 | 140 | 100
160 | 165 | 130 | 90
192 | 198 | 123 | 83
224 | 231 | 117 | 77
256 | 264 | 111 | 71
288 | 297 | 106 | 66
320 | 330 | 102 | 62
352 | 363 | 98 | 58
384 | 396 | 94 | 54
416 | 429 | 90 | 50
448 | 462 | 87 | 47
480 | 495 | 83 | 43
512 | 528 | 80 | 40
544 | 561 | 77 | 37
576 | 594 | 73 | 33
608 | 627 | 70 | 30
640 | 660 | 67 | 27
672 | 693 | 64 | 24
704 | 726 | 60 | 20
736 | 759 | 57 | 17
768 | 792 | 53 | 13
800 | 825 | 49 | 9
832 | 858 | 45 | 5
864 | 891 | 40 | 0
896 | 924 | 34 | -6
928 | 957 | 27 | -13
960 | 990 | 15 | -25
992 | 1023 | 122 | 82

Example of reported temperature before and after (note, this is with a 10k bias resistor).
3-point therm generator temperature | 3-point therm generator resistance | Temp old | Temp new
-- | -- | -- | --
0 | 66700 | -5 | 0
42 | 10000 | 40 | 42
99 | 1510 | 99 | 100
  |   |   |  
Expected temperature | Resistance | Temp old | Temp new
-21 | 218000 | 48 | -22

The discrepancy of 48 is because TunerStudio sets the last value(s) to a fail safe of 82. So 48 is from a scaling from -25 to 82.

This change only modifies the calibration writing code so existing calibrations/tunes are not affected, unless a new calibration is performed.