### PR TITLE
Fix for Issue #960

### DIFF
--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -97,7 +97,7 @@ void initialiseADC()
             || (((configPage9.enable_secondarySerial == 0) && ( (configPage9.enable_intcan == 1) && (configPage9.intcan_available == 0) )) && (configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 3)
             || (((configPage9.enable_secondarySerial == 0) && (configPage9.enable_intcan == 0)) && ((configPage9.caninput_sel[currentStatus.current_caninchannel]&3) == 3)))
     {  //if current input channel is enabled as digital local pin check caninput_selxb(bits 2:3) with &12 and caninput_selxa(bits 0:1) with &3
-       byte pinNumber = (configPage9.Auxinpinb[currentStatus.current_caninchannel]&63) + 1;
+       byte pinNumber = (configPage9.Auxinpinb[currentStatus.current_caninchannel]&127);
        if( pinIsUsed(pinNumber) )
        {
          //Do nothing here as the pin is already in use.


### PR DESCRIPTION
Fix for issue #960 . Switching this line of code allows me to use Auxiliary input channel to "monitor" the status of a digital pin while the pin is configured for a feature (launch control pin, WMI, etc)