### PR TITLE
Fix decel enleanment in AE Add -mode

### DIFF
--- a/speeduino/corrections.ino
+++ b/speeduino/corrections.ino
@@ -84,9 +84,9 @@ uint16_t correctionsFuel(void)
   if (result != 100) { sumCorrections = div100(sumCorrections * result); }
 
   currentStatus.AEamount = correctionAccel();
-  if (configPage2.aeApplyMode == AE_MODE_MULTIPLIER)
+  if ( (configPage2.aeApplyMode == AE_MODE_MULTIPLIER) || BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC) ) // multiply by the AE amount in case of multiplier AE mode or Decel
   {
-  if (currentStatus.AEamount != 100) { sumCorrections = div100(sumCorrections * currentStatus.AEamount);}
+    if (currentStatus.AEamount != 100) { sumCorrections = div100(sumCorrections * currentStatus.AEamount);}
   }
 
   result = correctionFloodClear();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1361,11 +1361,16 @@ uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
   {
     //If intermediate is not 0, we need to add the opening time (0 typically indicates that one of the full fuel cuts is active)
     intermediate += injOpen; //Add the injector opening time
-    //AE Adds % of req_fuel
-    if ( configPage2.aeApplyMode == AE_MODE_ADDER )
+    //AE calculation only when ACC is active.
+    if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC) )
     {
-      intermediate += ( ((unsigned long)REQ_FUEL) * (currentStatus.AEamount - 100) ) / 100;
+      //AE Adds % of req_fuel
+      if ( configPage2.aeApplyMode == AE_MODE_ADDER )
+        {
+          intermediate += ( ((unsigned long)REQ_FUEL) * (currentStatus.AEamount - 100) ) / 100;
+        }
     }
+
     if ( intermediate > 65535)
     {
       intermediate = 65535;  //Make sure this won't overflow when we convert to uInt. This means the maximum pulsewidth possible is 65.535mS


### PR DESCRIPTION
This PR fixes the decel enleanment problems in AE Add -mode. Also seems that this will gain ~5 loops per sec on mega in AE Add -mode, because it's not calculating the AE amount on every loop.