### PR TITLE
Suppress MISRA 5.8 & 8.6

### DIFF
--- a/misra/suppressions.txt
+++ b/misra/suppressions.txt
@@ -30,3 +30,8 @@ misra-c2012-20.1
 misra-c2012-20.5
 misra-c2012-20.10
 misra-c2012-21.12
+# As of cppcheck 2.9, these checks produce too many false positives
+# They do not account for class scope. 
+# E.g. class1::method1==class2::method1
+misra-c2012-5.8
+misra-c2012-8.6


### PR DESCRIPTION
As of cppcheck 2.9, these checks produce too many false positives: They assume "C" code and use the bare identifier name, so C++ code (which is most of the code base) trips them up:

1. C++ scoping, such as class members. E.g. `class1::method1(void)` is considered equivalent to `class2::method1(void)`
2. Function overloading. E.g. `foo(int8_t)`  is considered equivalent to `foo(int16_t)`
