### PR TITLE
Remove half/full sync sequential decision from decoders

### DIFF
--- a/speeduino/cancomms.ino
+++ b/speeduino/cancomms.ino
@@ -20,6 +20,7 @@ sendcancommand is called when a command is to be sent either to serial3
 #include "maths.h"
 #include "errors.h"
 #include "utilities.h"
+#include "comms.h"
 
 uint8_t currentsecondserialCommand;
 uint8_t currentCanPage = 1;//Not the same as the speeduino config page numbers
@@ -203,7 +204,7 @@ void sendcanValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portTy
           }
     #endif
 
-  currentStatus.spark ^= (-currentStatus.hasSync ^ currentStatus.spark) & (1U << BIT_SPARK_SYNC); //Set the sync bit of the Spark variable to match the hasSync variable
+  currentStatus.spark ^= (-syncStatusForComms() ^ currentStatus.spark) & (1U << BIT_SPARK_SYNC); //Set the sync bit of the Spark
 
 #if defined(CANSerial_AVAILABLE)
   byte fullStatus[NEW_CAN_PACKET_SIZE];    // this must be set to the maximum number of data fullstatus must read in

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -919,7 +919,7 @@ void generateLiveValues(uint16_t offset, uint16_t packetLength)
 bool syncStatusForComms(void) {
   bool hasFullSync = false;
 
-  if ( BIT_CHECK(decoderState, BIT_DECODER_IS_SEQUENTIAL) && ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) ) {
+  if ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) {
     if      ( decoderSync == DS_4STROKE_CYCLE ) { hasFullSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
     else if ( decoderSync == DS_REVOLUTION    ) { hasFullSync = false; BIT_SET  (currentStatus.status3, BIT_STATUS3_HALFSYNC); } 
     else                                        { hasFullSync = false; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -919,7 +919,7 @@ void generateLiveValues(uint16_t offset, uint16_t packetLength)
 bool syncStatusForComms(void) {
   bool hasFullSync = false;
 
-  if ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) {
+  if ( BIT_CHECK(decoderState, BIT_DECODER_IS_SEQUENTIAL) && ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) ) {
     if      ( decoderSync == DS_4STROKE_CYCLE ) { hasFullSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
     else if ( decoderSync == DS_REVOLUTION    ) { hasFullSync = false; BIT_SET  (currentStatus.status3, BIT_STATUS3_HALFSYNC); } 
     else                                        { hasFullSync = false; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -79,6 +79,7 @@ void sendSerialReturnCode(byte returnCode);
 void sendSerialPayload(void* payload, uint16_t payloadLength);
 
 void generateLiveValues(uint16_t offset, uint16_t packetLength);
+bool syncStatusForComms(void);
 void flushRXbuffer(void);
 void sendToothLog(uint8_t startOffset);
 void sendCompositeLog(uint8_t startOffset);

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -18,6 +18,7 @@ A full copy of the license may be found in the projects root directory
 #include "pages.h"
 #include "page_crc.h"
 #include "logger.h"
+#include "comms.h"
 #include "table3d_axis_io.h"
 #ifdef RTC_ENABLED
   #include "rtc_common.h"
@@ -626,7 +627,7 @@ void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum)
     requestCount++;
   }
 
-  currentStatus.spark ^= (-currentStatus.hasSync ^ currentStatus.spark) & (1U << BIT_SPARK_SYNC); //Set the sync bit of the Spark variable to match the hasSync variable
+  currentStatus.spark ^= (-syncStatusForComms() ^ currentStatus.spark) & (1U << BIT_SPARK_SYNC); //Set the sync bit of the Spark variable
 
   for(byte x=0; x<packetLength; x++)
   {

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -44,6 +44,14 @@
 #define BIT_DECODER_VALID_TRIGGER       5 //Is set true when the last trigger (Primary or secondary) was valid (ie passed filters)
 #define BIT_DECODER_TOOTH_ANG_CORRECT   6 //Whether or not the triggerToothAngle variable is currently accurate. Some patterns have times when the triggerToothAngle variable cannot be accurately set.
 
+// Decoder Synced Resolution
+#define DSR_NO_SYNC       0 // No sync
+#define DSR_CYLINDER      1 // Per cylinder, normally basic distributor / degrees varies depending on cylinder count, 144 for 5 cylinder (720/5) (not in use)
+#define DSR_REVOLUTION    2 // Per crankshaft revolution / 360 degrees
+#define DSR_4STROKE_CYCLE 3 // Per 4-stroke cycle / 720 degrees
+#define DSR_WANKEL_CYCLE  4 // Per wankel cycle / 1080 degrees (not in use)
+extern volatile byte decoderSyncedResolution;
+
 //220 bytes free
 extern volatile uint8_t decoderState;
 

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -45,12 +45,14 @@
 #define BIT_DECODER_TOOTH_ANG_CORRECT   6 //Whether or not the triggerToothAngle variable is currently accurate. Some patterns have times when the triggerToothAngle variable cannot be accurately set.
 
 // Decoder Synced Resolution
-#define DS_NO_SYNC       0 // No sync
-//#define DS_CYLINDER      1 // Per cylinder, normally basic distributor / degrees varies depending on cylinder count, 144 for 5 cylinder (720/5) (not in use)
-#define DS_REVOLUTION    2 // Per crankshaft revolution / 360 degrees
-#define DS_4STROKE_CYCLE 3 // Per 4-stroke cycle / 720 degrees
-//#define DS_WANKEL_CYCLE  4 // Per wankel cycle / 1080 degrees (not in use)
-extern volatile byte decoderSync;
+enum decoderSync_t : byte {
+  DS_NO_SYNC        = 0, // No sync
+  //DS_CYLINDER     = 1, // Per cylinder, normally basic distributor / degrees varies depending on cylinder count, 144 for 5 cylinder (720/5) (not in use)
+  DS_REVOLUTION     = 2, // Per crankshaft revolution / 360 degrees
+  DS_4STROKE_CYCLE  = 3, // Per 4-stroke cycle / 720 degrees
+  //DS_WANKEL_CYCLE = 4, // Per wankel cycle / 1080 degrees (not in use)
+};
+extern volatile decoderSync_t decoderSync;
 
 //220 bytes free
 extern volatile uint8_t decoderState;

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -45,12 +45,12 @@
 #define BIT_DECODER_TOOTH_ANG_CORRECT   6 //Whether or not the triggerToothAngle variable is currently accurate. Some patterns have times when the triggerToothAngle variable cannot be accurately set.
 
 // Decoder Synced Resolution
-#define DSR_NO_SYNC       0 // No sync
-#define DSR_CYLINDER      1 // Per cylinder, normally basic distributor / degrees varies depending on cylinder count, 144 for 5 cylinder (720/5) (not in use)
-#define DSR_REVOLUTION    2 // Per crankshaft revolution / 360 degrees
-#define DSR_4STROKE_CYCLE 3 // Per 4-stroke cycle / 720 degrees
-#define DSR_WANKEL_CYCLE  4 // Per wankel cycle / 1080 degrees (not in use)
-extern volatile byte decoderSyncedResolution;
+#define DS_NO_SYNC       0 // No sync
+//#define DS_CYLINDER      1 // Per cylinder, normally basic distributor / degrees varies depending on cylinder count, 144 for 5 cylinder (720/5) (not in use)
+#define DS_REVOLUTION    2 // Per crankshaft revolution / 360 degrees
+#define DS_4STROKE_CYCLE 3 // Per 4-stroke cycle / 720 degrees
+//#define DS_WANKEL_CYCLE  4 // Per wankel cycle / 1080 degrees (not in use)
+extern volatile byte decoderSync;
 
 //220 bytes free
 extern volatile uint8_t decoderState;

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -221,7 +221,7 @@ static inline uint16_t stdGetRPM(uint16_t degreesOver)
 {
   uint16_t tempRPM = 0;
 
-  if( decoderSyncedResolution > 0 )
+  if( decoderSyncedResolution > DSR_NO_SYNC )
   {
     if( (currentStatus.RPM < currentStatus.crankRPM) && (currentStatus.startRevolutions == 0) ) { tempRPM = 0; } //Prevents crazy RPM spike when there has been less than 1 full revolution
     else if( (toothOneTime == 0) || (toothOneMinusOneTime == 0) ) { tempRPM = 0; }
@@ -263,7 +263,7 @@ For a missing tooth wheel, this is the number if the tooth had NOT been missing 
 static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
 {
   uint16_t tempRPM = 0;
-  if( (currentStatus.startRevolutions >= configPage4.StgCycles) && (decoderSyncedResolution > 0) )
+  if( (currentStatus.startRevolutions >= configPage4.StgCycles) && (decoderSyncedResolution > DSR_NO_SYNC) )
   {
     if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) && (toothLastToothTime > toothLastMinusOneToothTime) )
     {

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -263,7 +263,7 @@ For a missing tooth wheel, this is the number if the tooth had NOT been missing 
 static inline int crankingGetRPM(byte totalTeeth, uint16_t degreesOver)
 {
   uint16_t tempRPM = 0;
-  if( (currentStatus.startRevolutions >= configPage4.StgCycles) && ((currentStatus.hasSync == true) || BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC)) )
+  if( (currentStatus.startRevolutions >= configPage4.StgCycles) && (decoderSyncedResolution > 0) )
   {
     if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) && (toothLastToothTime > toothLastMinusOneToothTime) )
     {
@@ -387,7 +387,7 @@ void triggerPri_missingTooth(void)
      toothCurrentCount++; //Increment the tooth counter
      BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-     //if(toothCurrentCount > checkSyncToothCount || currentStatus.hasSync == false)
+     //if(toothCurrentCount > checkSyncToothCount || decoderSyncedResolution == DSR_NO_SYNC)
       if( (toothLastToothTime > 0) && (toothLastMinusOneToothTime > 0) )
       {
         bool isMissingTooth = false;
@@ -419,7 +419,7 @@ void triggerPri_missingTooth(void)
                 currentStatus.syncLossCounter++;
             }
             //This is to handle a special case on startup where sync can be obtained and the system immediately thinks the revs have jumped:
-            //else if (currentStatus.hasSync == false && toothCurrentCount < checkSyncToothCount ) { triggerFilterTime = 0; }
+            //else if (decoderSyncedResolution == DSR_NO_SYNC && toothCurrentCount < checkSyncToothCount ) { triggerFilterTime = 0; }
             else
             {
                 if(decoderSyncedResolution > DSR_NO_SYNC)
@@ -719,7 +719,7 @@ void triggerPri_DualWheel(void)
       toothLastMinusOneToothTime = toothLastToothTime;
       toothLastToothTime = curTime;
 
-      if ( currentStatus.hasSync == true )
+      if ( decoderSyncedResolution == DSR_4STROKE_CYCLE )
       {
         if ( (toothCurrentCount == 1) || (toothCurrentCount > configPage4.triggerTeeth) )
         {
@@ -759,14 +759,14 @@ void triggerSec_DualWheel(void)
     toothLastSecToothTime = curTime2;
     triggerSecFilterTime = curGap2 >> 2; //Set filter at 25% of the current speed
 
-    if( (currentStatus.hasSync == false) || (currentStatus.startRevolutions <= configPage4.StgCycles) )
+    if( (decoderSyncedResolution == DSR_NO_SYNC) || (currentStatus.startRevolutions <= configPage4.StgCycles) )
     {
       toothLastToothTime = micros();
       toothLastMinusOneToothTime = micros() - (6000000 / configPage4.triggerTeeth); //Fixes RPM at 10rpm until a full revolution has taken place
       toothCurrentCount = configPage4.triggerTeeth;
       triggerFilterTime = 0; //Need to turn the filter off here otherwise the first primary tooth after achieving sync is ignored
 
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     }
     else 
     {
@@ -787,7 +787,7 @@ void triggerSec_DualWheel(void)
 uint16_t getRPM_DualWheel(void)
 {
   uint16_t tempRPM = 0;
-  if( currentStatus.hasSync == true )
+  if( decoderSyncedResolution == DSR_4STROKE_CYCLE )
   {
     if( currentStatus.RPM < currentStatus.crankRPM )
     {
@@ -934,15 +934,15 @@ void triggerPri_BasicDistributor(void)
   curGap = curTime - toothLastToothTime;
   if ( (curGap >= triggerFilterTime) )
   {
-    if(currentStatus.hasSync == true) { setFilter(curGap); } //Recalc the new filter value
+    if(decoderSyncedResolution == DSR_REVOLUTION) { setFilter(curGap); } //Recalc the new filter value
     else { triggerFilterTime = 0; } //If we don't yet have sync, ensure that the filter won't prevent future valid pulses from being ignored. 
     
-    if( (toothCurrentCount == triggerActualTeeth) || (currentStatus.hasSync == false) ) //Check if we're back to the beginning of a revolution
+    if( (toothCurrentCount == triggerActualTeeth) || (decoderSyncedResolution == DSR_NO_SYNC) ) //Check if we're back to the beginning of a revolution
     {
       toothCurrentCount = 1; //Reset the counter
       toothOneMinusOneTime = toothOneTime;
       toothOneTime = curTime;
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_REVOLUTION;
       currentStatus.startRevolutions++; //Counter
     }
     else
@@ -952,10 +952,10 @@ void triggerPri_BasicDistributor(void)
       {
         //This means toothCurrentCount is greater than triggerActualTeeth, which is bad.
         //If we have sync here then there's a problem. Throw a sync loss
-        if( currentStatus.hasSync == true ) 
+        if( decoderSyncedResolution == DSR_REVOLUTION ) 
         { 
           currentStatus.syncLossCounter++;
-          currentStatus.hasSync = false;
+          decoderSyncedResolution = DSR_NO_SYNC;
         }
       }
       
@@ -1089,7 +1089,7 @@ void triggerPri_GM7X(void)
         if ( curGap < targetGap ) //If the gap between this tooth and the last one is less than half of the previous gap, then we are very likely at the magical 3rd tooth
         {
           toothCurrentCount = 3;
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_REVOLUTION;
           BIT_CLEAR(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT); //The tooth angle is double at this point
           currentStatus.startRevolutions++; //Counter
         }
@@ -1269,7 +1269,7 @@ void triggerPri_4G63(void)
        currentStatus.startRevolutions++; //Counter
     }
 
-    if (currentStatus.hasSync == true)
+    if (decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
       if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && configPage4.ignCranklock && (currentStatus.startRevolutions >= configPage4.StgCycles))
       {
@@ -1428,7 +1428,7 @@ void triggerPri_4G63(void)
         { 
           //Crank is low, cam is high and the crank pulse STARTED when the cam was high. 
           if(configPage2.nCylinders == 4) { toothCurrentCount = 5; } //Means we're at 5* BTDC on a 4G63 4 cylinder
-          else if(configPage2.nCylinders == 6) { toothCurrentCount = 2; currentStatus.hasSync = true; } //Means we're at 45* ATDC on 6G72 6 cylinder
+          else if(configPage2.nCylinders == 6) { toothCurrentCount = 2; decoderSyncedResolution = DSR_4STROKE_CYCLE; } //Means we're at 45* ATDC on 6G72 6 cylinder
         } 
       }
     }
@@ -1440,7 +1440,7 @@ void triggerSec_4G63(void)
   //byte crankState = READ_PRI_TRIGGER();
   //First filter is a duration based one to ensure the pulse was of sufficient length (time)
   //if(READ_SEC_TRIGGER()) { secondaryLastToothTime1 = micros(); return; }
-  if(currentStatus.hasSync == true)
+  if(decoderSyncedResolution == DSR_4STROKE_CYCLE)
   {
   //1166 is the time taken to cross 70 degrees at 10k rpm
   //if ( (micros() - secondaryLastToothTime1) < triggerSecFilterTime_duration ) { return; }
@@ -1463,8 +1463,8 @@ void triggerSec_4G63(void)
     //75%:
     //triggerSecFilterTime = (curGap2 * 6) >> 3;
 
-    //if( (currentStatus.RPM < currentStatus.crankRPM) || (currentStatus.hasSync == false) )
-    if( (currentStatus.hasSync == false) )
+    //if( (currentStatus.RPM < currentStatus.crankRPM) || (decoderSyncedResolution == DSR_NO_SYNC) )
+    if( (decoderSyncedResolution == DSR_NO_SYNC) )
     {
 
       triggerFilterTime = 1500; //If this is removed, can have trouble getting sync again after the engine is turned off (but ECU not reset).
@@ -1473,11 +1473,11 @@ void triggerSec_4G63(void)
       {
         if(configPage2.nCylinders == 4)
         { 
-          if(toothCurrentCount == 8) { currentStatus.hasSync = true; } //Is 8 for sequential, was 4
+          if(toothCurrentCount == 8) { decoderSyncedResolution = DSR_4STROKE_CYCLE; } //Is 8 for sequential, was 4
         }
         else if(configPage2.nCylinders == 6) 
         { 
-          if(toothCurrentCount == 7) { currentStatus.hasSync = true; }
+          if(toothCurrentCount == 7) { decoderSyncedResolution = DSR_4STROKE_CYCLE; }
         }
 
       }
@@ -1485,7 +1485,7 @@ void triggerSec_4G63(void)
       {
         if(configPage2.nCylinders == 4)
         { 
-          if(toothCurrentCount == 5) { currentStatus.hasSync = true; } //Is 5 for sequential, was 1
+          if(toothCurrentCount == 5) { decoderSyncedResolution = DSR_4STROKE_CYCLE; } //Is 5 for sequential, was 1
         }
         //Cannot gain sync for 6 cylinder here. 
       }
@@ -1494,7 +1494,7 @@ void triggerSec_4G63(void)
     //if ( (micros() - secondaryLastToothTime1) < triggerSecFilterTime_duration && configPage2.useResync )
     if ( (currentStatus.RPM < currentStatus.crankRPM) || (configPage4.useResync == 1) )
     {
-      if( (currentStatus.hasSync == true) && (configPage2.nCylinders == 4) )
+      if( (decoderSyncedResolution == DSR_4STROKE_CYCLE) && (configPage2.nCylinders == 4) )
       {
         triggerSecFilterTime_duration = (micros() - secondaryLastToothTime1) >> 1;
         if(READ_PRI_TRIGGER() == true)
@@ -1503,7 +1503,7 @@ void triggerSec_4G63(void)
           if(toothCurrentCount != 8) 
           { 
             // This should never be true, except when there's noise
-            currentStatus.hasSync = false; 
+            decoderSyncedResolution = DSR_NO_SYNC; 
             currentStatus.syncLossCounter++;
           } 
           else { toothCurrentCount = 8; } //Why? Just why?
@@ -1519,7 +1519,7 @@ uint16_t getRPM_4G63(void)
   uint16_t tempRPM = 0;
   //During cranking, RPM is calculated 4 times per revolution, once for each rising/falling of the crank signal.
   //Because these signals aren't even (Alternating 110 and 70 degrees), this needs a special function
-  if(currentStatus.hasSync == true)
+  if(decoderSyncedResolution == DSR_4STROKE_CYCLE)
   {
     if( (currentStatus.RPM < currentStatus.crankRPM)  )
     {
@@ -1554,7 +1554,7 @@ uint16_t getRPM_4G63(void)
 int getCrankAngle_4G63(void)
 {
     int crankAngle = 0;
-    if(currentStatus.hasSync == true)
+    if(decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
       //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
       unsigned long tempToothLastToothTime;
@@ -1668,7 +1668,7 @@ void triggerSetup_24X(void)
 
 void triggerPri_24X(void)
 {
-  if(toothCurrentCount == 25) { currentStatus.hasSync = false; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
+  if(toothCurrentCount == 25) { decoderSyncedResolution = DSR_NO_SYNC; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
   else
   {
     curTime = micros();
@@ -1680,7 +1680,7 @@ void triggerPri_24X(void)
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
        revolutionOne = !revolutionOne; //Sequential revolution flip
-       currentStatus.hasSync = true;
+       decoderSyncedResolution = DSR_4STROKE_CYCLE;
        currentStatus.startRevolutions++; //Counter
        triggerToothAngle = 15; //Always 15 degrees for tooth #15
     }
@@ -1780,7 +1780,7 @@ void triggerSetup_Jeep2000(void)
 
 void triggerPri_Jeep2000(void)
 {
-  if(toothCurrentCount == 13) { currentStatus.hasSync = false; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
+  if(toothCurrentCount == 13) { decoderSyncedResolution = DSR_NO_SYNC; } //Indicates sync has not been achieved (Still waiting for 1 revolution of the crank to take place)
   else
   {
     curTime = micros();
@@ -1792,7 +1792,7 @@ void triggerPri_Jeep2000(void)
          toothCurrentCount = 1; //Reset the counter
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
-         currentStatus.hasSync = true;
+         decoderSyncedResolution = DSR_REVOLUTION;
          currentStatus.startRevolutions++; //Counter
          triggerToothAngle = 60; //There are groups of 4 pulses (Each 20 degrees apart), with each group being 60 degrees apart. Hence #1 is always 60
       }
@@ -1882,7 +1882,7 @@ void triggerPri_Audi135(void)
    {
      toothSystemCount++;
 
-     if ( currentStatus.hasSync == false ) { toothLastToothTime = curTime; }
+     if ( decoderSyncedResolution == DSR_NO_SYNC ) { toothLastToothTime = curTime; }
      else
      {
        if ( toothSystemCount >= 3 )
@@ -1921,10 +1921,10 @@ void triggerSec_Audi135(void)
   toothLastSecToothTime = curTime2;
   */
 
-  if( currentStatus.hasSync == false )
+  if( decoderSyncedResolution == DSR_NO_SYNC )
   {
     toothCurrentCount = 0;
-    currentStatus.hasSync = true;
+    decoderSyncedResolution = DSR_4STROKE_CYCLE;
     toothSystemCount = 3; //Need to set this to 3 so that the next primary tooth is counted
   }
   else if (configPage4.useResync == 1) { toothCurrentCount = 0; toothSystemCount = 3; }
@@ -1998,11 +1998,11 @@ void triggerPri_HondaD17(void)
    BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
    //
-   if( (toothCurrentCount == 13) && (currentStatus.hasSync == true) )
+   if( (toothCurrentCount == 13) && (decoderSyncedResolution == DSR_REVOLUTION) )
    {
      toothCurrentCount = 0;
    }
-   else if( (toothCurrentCount == 1) && (currentStatus.hasSync == true) )
+   else if( (toothCurrentCount == 1) && (decoderSyncedResolution == DSR_REVOLUTION) )
    {
      toothOneMinusOneTime = toothOneTime;
      toothOneTime = curTime;
@@ -2018,7 +2018,7 @@ void triggerPri_HondaD17(void)
      if ( curGap < targetGap) //If the gap between this tooth and the last one is less than half of the previous gap, then we are very likely at the magical 13th tooth
      {
        toothCurrentCount = 0;
-       currentStatus.hasSync = true;
+       decoderSyncedResolution = DSR_REVOLUTION;
      }
      else
      {
@@ -2133,22 +2133,22 @@ void triggerPri_Miata9905(void)
        toothCurrentCount = 1; //Reset the counter
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
-       //currentStatus.hasSync = true;
+       //decoderSyncedResolution = DSR_4STROKE_CYCLE;
        currentStatus.startRevolutions++; //Counter
     }
     else
     {
-      if( (currentStatus.hasSync == false) || (configPage4.useResync == true) )
+      if( (decoderSyncedResolution == DSR_NO_SYNC) || (configPage4.useResync == true) )
       {
         if(secondaryToothCount == 2)
         {
           toothCurrentCount = 6;
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
       }
     }
 
-    if (currentStatus.hasSync == true)
+    if (decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
 
       //Whilst this is an uneven tooth pattern, if the specific angle between the last 2 teeth is specified, 1st deriv prediction can be used
@@ -2212,7 +2212,7 @@ void triggerSec_Miata9905(void)
   curTime2 = micros();
   curGap2 = curTime2 - toothLastSecToothTime;
 
-  if(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) || (currentStatus.hasSync == false) )
+  if(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) || (decoderSyncedResolution == DSR_NO_SYNC) )
   {
     triggerFilterTime = 1500; //If this is removed, can have trouble getting sync again after the engine is turned off (but ECU not reset).
   }
@@ -2238,7 +2238,7 @@ uint16_t getRPM_Miata9905(void)
   //During cranking, RPM is calculated 4 times per revolution, once for each tooth on the crank signal.
   //Because these signals aren't even (Alternating 110 and 70 degrees), this needs a special function
   uint16_t tempRPM = 0;
-  if( (currentStatus.RPM < currentStatus.crankRPM) && (currentStatus.hasSync == true) )
+  if( (currentStatus.RPM < currentStatus.crankRPM) && (decoderSyncedResolution == DSR_4STROKE_CYCLE) )
   {
     if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { tempRPM = 0; }
     else
@@ -2268,7 +2268,7 @@ uint16_t getRPM_Miata9905(void)
 int getCrankAngle_Miata9905(void)
 {
     int crankAngle = 0;
-    //if(currentStatus.hasSync == true)
+    //if(decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
       //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
       unsigned long tempToothLastToothTime;
@@ -2387,11 +2387,11 @@ void triggerPri_MazdaAU(void)
        toothCurrentCount = 1; //Reset the counter
        toothOneMinusOneTime = toothOneTime;
        toothOneTime = curTime;
-       currentStatus.hasSync = true;
+       decoderSyncedResolution = DSR_4STROKE_CYCLE;
        currentStatus.startRevolutions++; //Counter
     }
 
-    if (currentStatus.hasSync == true)
+    if (decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
       // Locked cranking timing is available, fixed at 12* BTDC
       if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && configPage4.ignCranklock )
@@ -2418,15 +2418,15 @@ void triggerSec_MazdaAU(void)
   //if ( curGap2 < triggerSecFilterTime ) { return; }
   toothLastSecToothTime = curTime2;
 
-  //if(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) || currentStatus.hasSync == false)
-  if(currentStatus.hasSync == false)
+  //if(BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) || decoderSyncedResolution == DSR_NO_SYNC)
+  if(decoderSyncedResolution == DSR_NO_SYNC)
   {
     //we find sync by looking for the 2 teeth that are close together. The next crank tooth after that is the one we're looking for.
     //For the sake of this decoder, the lone cam tooth will be designated #1
     if(secondaryToothCount == 2)
     {
       toothCurrentCount = 1;
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     }
     else
     {
@@ -2446,7 +2446,7 @@ uint16_t getRPM_MazdaAU(void)
 {
   uint16_t tempRPM = 0;
 
-  if (currentStatus.hasSync == true)
+  if (decoderSyncedResolution == DSR_4STROKE_CYCLE)
   {
     //During cranking, RPM is calculated 4 times per revolution, once for each tooth on the crank signal.
     //Because these signals aren't even (Alternating 108 and 72 degrees), this needs a special function
@@ -2468,7 +2468,7 @@ uint16_t getRPM_MazdaAU(void)
 int getCrankAngle_MazdaAU(void)
 {
     int crankAngle = 0;
-    if(currentStatus.hasSync == true)
+    if(decoderSyncedResolution == DSR_4STROKE_CYCLE)
     {
       //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
       unsigned long tempToothLastToothTime;
@@ -2530,7 +2530,7 @@ void triggerSec_non360(void)
 uint16_t getRPM_non360(void)
 {
   uint16_t tempRPM = 0;
-  if( (currentStatus.hasSync == true) && (toothCurrentCount != 0) )
+  if( (decoderSyncedResolution == DSR_4STROKE_CYCLE) && (toothCurrentCount != 0) )
   {
     if(currentStatus.RPM < currentStatus.crankRPM) { tempRPM = crankingGetRPM(configPage4.triggerTeeth, 360); }
     else { tempRPM = stdGetRPM(360); }
@@ -2603,7 +2603,7 @@ void triggerPri_Nissan360(void)
    toothLastMinusOneToothTime = toothLastToothTime;
    toothLastToothTime = curTime;
 
-   if ( currentStatus.hasSync == true )
+   if ( decoderSyncedResolution == DSR_4STROKE_CYCLE )
    {
      if ( toothCurrentCount == 361 ) //2 complete crank revolutions
      {
@@ -2656,7 +2656,7 @@ void triggerSec_Nissan360(void)
     //If we reach here, we are at the end of a secondary window
     byte secondaryDuration = toothCurrentCount - secondaryToothCount; //How many primary teeth have passed during the duration of this secondary window
 
-    if(currentStatus.hasSync == false)
+    if(decoderSyncedResolution == DSR_NO_SYNC)
     {
       if(configPage2.nCylinders == 4)
       {
@@ -2665,24 +2665,24 @@ void triggerSec_Nissan360(void)
         if( (secondaryDuration >= 15) && (secondaryDuration <= 17) ) //Duration of window = 16 primary teeth
         {
           toothCurrentCount = 16; //End of first window (The longest) occurs 16 teeth after TDC
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
         else if( (secondaryDuration >= 11) && (secondaryDuration <= 13) ) //Duration of window = 12 primary teeth
         {
           toothCurrentCount = 102; //End of second window is after 90+12 primary teeth
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
         else if( (secondaryDuration >= 7) && (secondaryDuration <= 9) ) //Duration of window = 8 primary teeth
         {
           toothCurrentCount = 188; //End of third window is after 90+90+8 primary teeth
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
         else if( (secondaryDuration >= 3) && (secondaryDuration <= 5) ) //Duration of window = 4 primary teeth
         {
           toothCurrentCount = 274; //End of fourth window is after 90+90+90+4 primary teeth
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
-        else { currentStatus.hasSync = false; currentStatus.syncLossCounter++; } //This should really never happen
+        else { decoderSyncedResolution = DSR_NO_SYNC; currentStatus.syncLossCounter++; } //This should really never happen
       }
       else if(configPage2.nCylinders == 6)
       {
@@ -2690,7 +2690,7 @@ void triggerSec_Nissan360(void)
         if( (secondaryDuration >= 3) && (secondaryDuration <= 5) ) //Duration of window = 4 primary teeth
         {
           toothCurrentCount = 124; //End of smallest window is after 60+60+4 primary teeth
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
       }
       else if(configPage2.nCylinders == 8)
@@ -2700,10 +2700,10 @@ void triggerSec_Nissan360(void)
         if( (secondaryDuration >= 6) && (secondaryDuration <= 8) ) //Duration of window = 16 primary teeth
         {
           toothCurrentCount = 56; //End of the shortest of the individual windows. Occurs at 102 crank degrees. 
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_4STROKE_CYCLE;
         }
       }
-      else { currentStatus.hasSync = false; } //This should really never happen (Only 4, 6 and 8 cylinder engines for this pattern)
+      else { decoderSyncedResolution = DSR_NO_SYNC; } //This should really never happen (Only 4, 6 and 8 cylinder engines for this pattern)
     }
     else
     {
@@ -2733,7 +2733,7 @@ uint16_t getRPM_Nissan360(void)
 {
   //Can't use stdGetRPM as there is no separate cranking RPM calc (stdGetRPM returns 0 if cranking)
   uint16_t tempRPM;
-  if( (currentStatus.hasSync == true) && (toothLastToothTime != 0) && (toothLastMinusOneToothTime != 0) )
+  if( (decoderSyncedResolution == DSR_4STROKE_CYCLE) && (toothLastToothTime != 0) && (toothLastMinusOneToothTime != 0) )
   {
     if(currentStatus.startRevolutions < 2)
     {
@@ -2849,7 +2849,7 @@ void triggerPri_Subaru67(void)
    toothLastMinusOneToothTime = toothLastToothTime;
    toothLastToothTime = curTime;
 
-   if ( (currentStatus.hasSync == false) || (configPage4.useResync == true) )
+   if ( (decoderSyncedResolution == DSR_NO_SYNC) || (configPage4.useResync == true) )
    {
      if(toothCurrentCount > 12) { toothCurrentCount = toothCurrentCount % 12; } //Because toothCurrentCount is not being reset when hitting tooth 1, we manually loop it here. 
 
@@ -2867,7 +2867,7 @@ void triggerPri_Subaru67(void)
 
         case 2:
           toothCurrentCount = 8;
-          //currentStatus.hasSync = true;
+          //decoderSyncedResolution = DSR_4STROKE_CYCLE;
           secondaryToothCount = 0;
           break;
 
@@ -2875,14 +2875,14 @@ void triggerPri_Subaru67(void)
           //toothCurrentCount = 2;
           if( toothCurrentCount == 2)
           {
-            currentStatus.hasSync = true;
+            decoderSyncedResolution = DSR_4STROKE_CYCLE;
           }
           secondaryToothCount = 0;
           break;
 
         default:
           //Almost certainly due to noise or cranking stop/start
-          currentStatus.hasSync = false;
+          decoderSyncedResolution = DSR_NO_SYNC;
           BIT_CLEAR(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT);
           currentStatus.syncLossCounter++;
           secondaryToothCount = 0;
@@ -2892,7 +2892,7 @@ void triggerPri_Subaru67(void)
    }
 
    //Check sync again
-   if ( currentStatus.hasSync == true )
+   if ( decoderSyncedResolution == DSR_4STROKE_CYCLE )
    {
       //Locked timing during cranking. This is fixed at 10* BTDC.
       if ( BIT_CHECK(currentStatus.engine, BIT_ENGINE_CRANK) && configPage4.ignCranklock)
@@ -2986,7 +2986,7 @@ uint16_t getRPM_Subaru67(void)
 int getCrankAngle_Subaru67(void)
 {
   int crankAngle = 0;
-  if( currentStatus.hasSync == true )
+  if( decoderSyncedResolution == DSR_4STROKE_CYCLE )
   {
     //This is the current angle ATDC the engine is at. This is the last known position based on what tooth was last 'seen'. It is only accurate to the resolution of the trigger wheel (Eg 36-1 is 10 degrees)
     unsigned long tempToothLastToothTime;
@@ -3100,14 +3100,14 @@ void triggerPri_Daihatsu(void)
     toothSystemCount++;
     BIT_SET(decoderState, BIT_DECODER_VALID_TRIGGER); //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-    if (currentStatus.hasSync == true)
+    if (decoderSyncedResolution == DSR_REVOLUTION)
     {
       if( (toothCurrentCount == triggerActualTeeth) ) //Check if we're back to the beginning of a revolution
       {
          toothCurrentCount = 1; //Reset the counter
          toothOneMinusOneTime = toothOneTime;
          toothOneTime = curTime;
-         currentStatus.hasSync = true;
+         decoderSyncedResolution = DSR_REVOLUTION;
          currentStatus.startRevolutions++; //Counter
 
          //Need to set a special filter time for the next tooth
@@ -3148,7 +3148,7 @@ void triggerPri_Daihatsu(void)
         {
           //Means we're on the extra tooth here
           toothCurrentCount = 2; //Reset the counter
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_REVOLUTION;
           triggerFilterTime = targetTime; //Lazy, but it works
         }
       }
@@ -3166,7 +3166,7 @@ uint16_t getRPM_Daihatsu(void)
   if( (currentStatus.RPM < currentStatus.crankRPM) && false) //Disable special cranking processing for now
   {
     //Can't use standard cranking RPM function due to extra tooth
-    if( currentStatus.hasSync == true )
+    if( decoderSyncedResolution == DSR_REVOLUTION )
     {
       if(toothCurrentCount == 2) { tempRPM = currentStatus.RPM; }
       else if (toothCurrentCount == 3) { tempRPM = currentStatus.RPM; }
@@ -3254,7 +3254,7 @@ void triggerPri_Harley(void)
           triggerToothAngle = 0;// Has to be equal to Angle Routine
           toothOneMinusOneTime = toothOneTime;
           toothOneTime = curTime;
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_REVOLUTION;
         }
         else
         {
@@ -3269,8 +3269,8 @@ void triggerPri_Harley(void)
     }
     else
     {
-      if (currentStatus.hasSync == true) { currentStatus.syncLossCounter++; }
-      currentStatus.hasSync = false;
+      if (decoderSyncedResolution == DSR_REVOLUTION) { currentStatus.syncLossCounter++; }
+      decoderSyncedResolution = DSR_NO_SYNC;
       toothCurrentCount = 0;
     } //Primary trigger high
   } //Trigger filter
@@ -3287,7 +3287,7 @@ void triggerSec_Harley(void)
 uint16_t getRPM_Harley(void)
 {
   uint16_t tempRPM = 0;
-  if (currentStatus.hasSync == true)
+  if (decoderSyncedResolution == DSR_REVOLUTION)
   {
     if ( currentStatus.RPM < (unsigned int)(configPage4.crankRPM * 100) )
     {
@@ -3411,7 +3411,7 @@ void triggerPri_ThirtySixMinus222(void)
            else if(configPage2.nCylinders == 6) { toothCurrentCount = 12; } //H6 - NOT TESTED!
            
            toothSystemCount = 0;
-           currentStatus.hasSync = true;
+           decoderSyncedResolution = DSR_REVOLUTION;
          }
          else
          {
@@ -3443,13 +3443,13 @@ void triggerPri_ThirtySixMinus222(void)
           { 
             //H4
             toothCurrentCount = 35; 
-            currentStatus.hasSync = true;
+            decoderSyncedResolution = DSR_REVOLUTION;
           } 
           else if(configPage2.nCylinders == 6) 
           { 
             //H6 - THIS NEEDS TESTING
             toothCurrentCount = 34; 
-            currentStatus.hasSync = true;
+            decoderSyncedResolution = DSR_REVOLUTION;
           } 
           
        }
@@ -3589,13 +3589,13 @@ void triggerPri_ThirtySixMinus21(void)
        {
            //we are at the tooth after the single gap
            toothCurrentCount = 20; //it's either 19 or 20, need to clarify engine direction!
-           currentStatus.hasSync = true;
+           decoderSyncedResolution = DSR_REVOLUTION;
         }
         else 
         {
           //we are at the tooth after the double gap
           toothCurrentCount = 1; 
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_REVOLUTION;
         }
  
          BIT_CLEAR(decoderState, BIT_DECODER_TOOTH_ANG_CORRECT); //The tooth angle is double at this point
@@ -3726,7 +3726,7 @@ void triggerPri_420a(void)
 
     if( (toothLastToothTime == 0) || (toothLastMinusOneToothTime == 0) ) { curGap = 0; }
 
-    if( (toothCurrentCount > 16) && (currentStatus.hasSync == true) )
+    if( (toothCurrentCount > 16) && (decoderSyncedResolution == DSR_4STROKE_CYCLE) )
     {
       //Means a complete rotation has occurred.
       toothCurrentCount = 1;
@@ -3761,11 +3761,11 @@ void triggerSec_420a(void)
   if(READ_PRI_TRIGGER() == true)
   {
     //Secondary signal is falling and primary signal is HIGH
-    if( currentStatus.hasSync == false )
+    if( decoderSyncedResolution == DSR_NO_SYNC )
     {
       //If we don't have sync, then assume the signal is good
       toothCurrentCount = 13;
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     }
     else
     {
@@ -3781,11 +3781,11 @@ void triggerSec_420a(void)
   else
   {
     //Secondary signal is falling and primary signal is LOW
-    if( currentStatus.hasSync == false )
+    if( decoderSyncedResolution == DSR_NO_SYNC )
     {
       //If we don't have sync, then assume the signal is good
       toothCurrentCount = 5;
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     }
     else
     {
@@ -3880,7 +3880,7 @@ void triggerPri_Webber(void)
     toothLastMinusOneToothTime = toothLastToothTime;
     toothLastToothTime = curTime;
 
-    if ( currentStatus.hasSync == true )
+    if ( decoderSyncedResolution == DSR_4STROKE_CYCLE )
     {
       if ( (toothCurrentCount == 1) || (toothCurrentCount > configPage4.triggerTeeth) )
       {
@@ -3898,7 +3898,7 @@ void triggerPri_Webber(void)
       if ( (secondaryToothCount == 1) && (checkSyncToothCount == 4) )
       {
         toothCurrentCount = 2;
-        currentStatus.hasSync = true;
+        decoderSyncedResolution = DSR_4STROKE_CYCLE;
         revolutionOne = 0; //Sequential revolution reset
       }
     }
@@ -3928,13 +3928,13 @@ void triggerSec_Webber(void)
 
     if ( (secondaryToothCount == 2) && (checkSyncToothCount == 3) )
     {
-      if(currentStatus.hasSync == false)
+      if(decoderSyncedResolution == DSR_NO_SYNC)
       {
         toothLastToothTime = micros();
         toothLastMinusOneToothTime = micros() - 1500000; //Fixes RPM at 10rpm until a full revolution has taken place
         toothCurrentCount = configPage4.triggerTeeth-1;
 
-        currentStatus.hasSync = true;
+        decoderSyncedResolution = DSR_4STROKE_CYCLE;
       }
       else
       {
@@ -3945,14 +3945,14 @@ void triggerSec_Webber(void)
       triggerSecFilterTime = curGap << 2; //4 crank teeth
       secondaryToothCount = 1; //Next tooth should be first
     } //Running, on first CAM pulse restart crank teeth count, on second the counter should be 3
-    else if ( (currentStatus.hasSync == false) && (toothCurrentCount >= 3) && (secondaryToothCount == 0) )
+    else if ( (decoderSyncedResolution == DSR_NO_SYNC) && (toothCurrentCount >= 3) && (secondaryToothCount == 0) )
     {
       toothLastToothTime = micros();
       toothLastMinusOneToothTime = micros() - 1500000; //Fixes RPM at 10rpm until a full revolution has taken place
       toothCurrentCount = 1;
       revolutionOne = 1; //Sequential revolution reset
 
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     } //First start, between gaps on CAM pulses have 2 teeth, sync on first CAM pulse if seen 3 teeth or more
     else
     {
@@ -4154,13 +4154,13 @@ void triggerSec_DRZ400(void)
   {
     toothLastSecToothTime = curTime2;
 
-    if(currentStatus.hasSync == false)
+    if(decoderSyncedResolution == DSR_NO_SYNC)
     {
       toothLastToothTime = micros();
       toothLastMinusOneToothTime = micros() - (6000000 / configPage4.triggerTeeth); //Fixes RPM at 10rpm until a full revolution has taken place
       toothCurrentCount = configPage4.triggerTeeth;
       currentStatus.syncLossCounter++;
-      currentStatus.hasSync = true;
+      decoderSyncedResolution = DSR_4STROKE_CYCLE;
     }
     else 
     {
@@ -4255,7 +4255,7 @@ void triggerPri_NGC(void)
     if ( toothLastToothTime > 0 && toothLastMinusOneToothTime > 0 ) { //Make sure we haven't enough tooth information to calculate missing tooth length
 
       //Only check for missing tooth if we expect this one to be it or if we haven't found one yet
-      if (toothCurrentCount == 17 || toothCurrentCount == 35 || ( currentStatus.hasSync == false && BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC) == false) ) {
+      if (toothCurrentCount == 17 || toothCurrentCount == 35 || decoderSyncedResolution == DSR_NO_SYNC) {
         //If the time between the current tooth and the last is greater than 2x the time between the last tooth and the tooth before that, we make the assertion that we must be at the first tooth after the gap
         if (curGap > ( (toothLastToothTime - toothLastMinusOneToothTime) * 2 ) )
         {
@@ -4271,7 +4271,7 @@ void triggerPri_NGC(void)
             toothOneMinusOneTime = toothOneTime;
             toothOneTime = curTime;
 
-            if (currentStatus.hasSync == true) { currentStatus.startRevolutions++; }
+            if (decoderSyncedResolution > DSR_NO_SYNC) { currentStatus.startRevolutions++; }
             else { currentStatus.startRevolutions = 0; }
           }
           else {
@@ -4279,9 +4279,6 @@ void triggerPri_NGC(void)
             toothCurrentCount = 19;
           }
 
-          //If Sequential fuel or ignition is in use, further checks are needed before determining sync
-          if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) || (configPage2.injLayout == INJ_SEQUENTIAL) )
-          {
             // Verify the tooth counters are valid and use this to determine current revolution
             if (
               ( configPage2.nCylinders == 4 && ( (toothCurrentCount == 1 && (secondaryToothCount == 1 || secondaryToothCount == 2) ) || (toothCurrentCount == 19 && secondaryToothCount == 4) ) ) ||
@@ -4289,8 +4286,7 @@ void triggerPri_NGC(void)
               ( configPage2.nCylinders == 8 && ( (toothCurrentCount == 1 && (toothSystemCount == 1    || toothSystemCount == 2) )    || (toothCurrentCount == 19 && (toothSystemCount == 3 || toothSystemCount == 4) ) ) ) )
             {
               revolutionOne = false;
-              currentStatus.hasSync = true;
-              BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); //the engine is fully synced so clear the Half Sync bit
+              decoderSyncedResolution = DSR_4STROKE_CYCLE;
             }
             else if (
               ( configPage2.nCylinders == 4 && ( (toothCurrentCount == 1 && secondaryToothCount == 5)                          || (toothCurrentCount == 19 && secondaryToothCount == 7) ) ) ||
@@ -4298,24 +4294,18 @@ void triggerPri_NGC(void)
               ( configPage2.nCylinders == 8 && ( (toothCurrentCount == 1 && (toothSystemCount == 5 || toothSystemCount == 6) ) || (toothCurrentCount == 19 && (toothSystemCount == 7 || toothSystemCount == 8) ) ) ) )
             {
               revolutionOne = true;
-              currentStatus.hasSync = true;
-              BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); //the engine is fully synced so clear the Half Sync bit
+              decoderSyncedResolution = DSR_4STROKE_CYCLE;
             }
-            // If tooth counters are not valid, set half sync bit
-            else {
-              if (currentStatus.hasSync == true) { currentStatus.syncLossCounter++; }
-              currentStatus.hasSync = false;
-              BIT_SET(currentStatus.status3, BIT_STATUS3_HALFSYNC); //If there is primary trigger but no secondary we only have half sync.
+            else { // If tooth counters are not valid, we don't have cam sync
+              if (decoderSyncedResolution == DSR_4STROKE_CYCLE) { currentStatus.syncLossCounter++; }
+              decoderSyncedResolution = DSR_REVOLUTION;
             }
-          }
-          else { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); } //If nothing is using sequential, we have sync and also clear half sync bit
 
         }
         else {
           // If we have found a missing tooth and don't get the next one at the correct tooth we end up here -> Resync
-          if (currentStatus.hasSync == true) { currentStatus.syncLossCounter++; }
-          currentStatus.hasSync = false;
-          BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
+          if (decoderSyncedResolution > DSR_NO_SYNC) { currentStatus.syncLossCounter++; }
+          decoderSyncedResolution = DSR_NO_SYNC;
         }
       }
 
@@ -4611,7 +4601,7 @@ void triggerPri_Vmax(void)
             triggerToothAngle = 70;// Has to be equal to Angle Routine, and describe the delta between two teeth.
             toothOneMinusOneTime = toothOneTime;
             toothOneTime = curTime;
-            currentStatus.hasSync = true;
+            decoderSyncedResolution = DSR_REVOLUTION;
             setFilter((curGap/1.75));//Angle to this tooth is 70, next is in 40, compensating.
             currentStatus.startRevolutions++; //Counter
           }
@@ -4665,7 +4655,7 @@ void triggerPri_Vmax(void)
     curGap3 = curTime - curGap2;
     if (curGap3 > (lastGap * 2)){// Small lobe is 5 degrees, big lobe is 45 degrees. So this should be the wide lobe.
         if (toothCurrentCount == 0 || toothCurrentCount == 6){//Wide should be seen with toothCurrentCount = 0, when there is no sync yet, or toothCurrentCount = 6 when we have done a full revolution. 
-          currentStatus.hasSync = true;
+          decoderSyncedResolution = DSR_REVOLUTION;
         }
         else{//Wide lobe seen where it shouldn't, adding a sync error.
           currentStatus.syncLossCounter++;
@@ -4699,7 +4689,7 @@ void triggerSec_Vmax(void)
 uint16_t getRPM_Vmax(void)
 {
   uint16_t tempRPM = 0;
-  if (currentStatus.hasSync == true)
+  if (decoderSyncedResolution == DSR_REVOLUTION)
   {
     if ( currentStatus.RPM < (unsigned int)(configPage4.crankRPM * 100) )
     {

--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -81,7 +81,7 @@ volatile unsigned long triggerFilterTime; // The shortest time (in uS) that puls
 volatile unsigned long triggerSecFilterTime; // The shortest time (in uS) that pulses will be accepted (Used for debounce filtering) for the secondary input
 
 volatile uint8_t decoderState = 0;
-volatile byte decoderSync; // When sync is achieved, this is set to how accurate the sync is. 0 = no sync, 360 = every rotation, 720 = every 4-stroke cycle. // TODO: What to set for per ignition event accuracy? // TODO: Maybe make this an enum?
+volatile decoderSync_t decoderSync; // If sync is achieved and the resolution of that sync
 
 unsigned int triggerSecFilterTime_duration; // The shortest valid time (in uS) pulse DURATION
 volatile uint16_t triggerToothAngle; //The number of crank degrees that elapse per tooth

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -642,7 +642,7 @@ extern volatile byte LOOP_TIMER;
 * unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
 */
 struct statuses {
-  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino). Legacy, remove when possible. Replaced by decoderSyncedResolution
+  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino). Legacy, remove when possible. Replaced by decoderSync
     This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
   uint16_t RPM;   ///< RPM - Current Revs per minute
   byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -216,7 +216,7 @@
 #define BIT_STATUS3_NITROUS       1
 #define BIT_STATUS3_FUEL2_ACTIVE  2
 #define BIT_STATUS3_VSS_REFRESH   3
-#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary.
+#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary. Only used for comms/external devices. Firmware use replaced by decoderSyncedResolution
 #define BIT_STATUS3_NSQUIRTS1     5
 #define BIT_STATUS3_NSQUIRTS2     6
 #define BIT_STATUS3_NSQUIRTS3     7
@@ -642,7 +642,7 @@ extern volatile byte LOOP_TIMER;
 * unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
 */
 struct statuses {
-  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino).
+  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino). Legacy, remove when possible. Replaced by decoderSyncedResolution
     This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
   uint16_t RPM;   ///< RPM - Current Revs per minute
   byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -216,7 +216,7 @@
 #define BIT_STATUS3_NITROUS       1
 #define BIT_STATUS3_FUEL2_ACTIVE  2
 #define BIT_STATUS3_VSS_REFRESH   3
-#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary. Only used for comms/external devices. Firmware use replaced by decoderSyncedResolution
+#define BIT_STATUS3_HALFSYNC      4 //shows if there is only sync from primary trigger, but not from secondary. Only used for comms/external devices. Firmware use replaced by decoderSync
 #define BIT_STATUS3_NSQUIRTS1     5
 #define BIT_STATUS3_NSQUIRTS2     6
 #define BIT_STATUS3_NSQUIRTS3     7

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -642,8 +642,6 @@ extern volatile byte LOOP_TIMER;
 * unit based values in similar variable(s) without ADC part in name (see sensors.ino for reading of sensors).
 */
 struct statuses {
-  volatile bool hasSync; /**< Flag for crank/cam position being known by decoders (See decoders.ino). Legacy, remove when possible. Replaced by decoderSync
-    This is used for sanity checking e.g. before logging tooth history or reading some sensors and computing readings. */
   uint16_t RPM;   ///< RPM - Current Revs per minute
   byte RPMdiv100; ///< RPM value scaled (divided by 100) to fit a byte (0-255, e.g. 12000 => 120)
   long longRPM;   ///< RPM as long int (gets assigned to / maintained in statuses.RPM as well)

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -150,9 +150,9 @@ volatile uint16_t ignitionCount; /**< The count of ignition events that have tak
   byte secondaryTriggerEdge;
   byte tertiaryTriggerEdge;
 #endif
-int CRANK_ANGLE_MAX = 720;
-int CRANK_ANGLE_MAX_IGN = 360;
-int CRANK_ANGLE_MAX_INJ = 360; ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
+int CRANK_ANGLE_MAX;
+int CRANK_ANGLE_MAX_IGN;
+int CRANK_ANGLE_MAX_INJ; ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;
 volatile byte HWTest_INJ = 0; /**< Each bit in this variable represents one of the injector channels and it's HW test status */

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -393,7 +393,7 @@ void initialiseAll(void)
     //The interrupt numbering is a bit odd - See here for reference: arduino.cc/en/Reference/AttachInterrupt
     //These assignments are based on the Arduino Mega AND VARY BETWEEN BOARDS. Please confirm the board you are using and update accordingly.
     currentStatus.RPM = 0;
-    decoderSyncedResolution = DSR_NO_SYNC;
+    decoderSync = DS_NO_SYNC;
     currentStatus.runSecs = 0;
     currentStatus.secl = 0;
     //currentStatus.seclx10 = 0;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -393,8 +393,7 @@ void initialiseAll(void)
     //The interrupt numbering is a bit odd - See here for reference: arduino.cc/en/Reference/AttachInterrupt
     //These assignments are based on the Arduino Mega AND VARY BETWEEN BOARDS. Please confirm the board you are using and update accordingly.
     currentStatus.RPM = 0;
-    currentStatus.hasSync = false;
-    BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
+    decoderSyncedResolution = DSR_NO_SYNC;
     currentStatus.runSecs = 0;
     currentStatus.secl = 0;
     //currentStatus.seclx10 = 0;

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -215,7 +215,7 @@ static inline void readMAP(void)
     case 1:
       //Average of a cycle
 
-      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSyncedResolution > DSR_NO_SYNC) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSync > DS_NO_SYNC) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
       {
         if( (MAPcurRev == currentStatus.startRevolutions) || ( (MAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
         {
@@ -338,7 +338,7 @@ static inline void readMAP(void)
 
     case 3:
       //Average of an ignition event
-      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSyncedResolution > DSR_NO_SYNC) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSync > DS_NO_SYNC) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
       {
         if( (MAPcurRev == ignitionCount) ) //Watch for a change in the ignition counter to determine whether we're still on the same event
         {

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -215,7 +215,7 @@ static inline void readMAP(void)
     case 1:
       //Average of a cycle
 
-      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && ((currentStatus.hasSync == true) || BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC)) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSyncedResolution > DSR_NO_SYNC) && (currentStatus.startRevolutions > 1) ) //If the engine isn't running and RPM below switch point, fall back to instantaneous reads
       {
         if( (MAPcurRev == currentStatus.startRevolutions) || ( (MAPcurRev+1) == currentStatus.startRevolutions) ) //2 revolutions are looked at for 4 stroke. 2 stroke not currently catered for.
         {
@@ -338,7 +338,7 @@ static inline void readMAP(void)
 
     case 3:
       //Average of an ignition event
-      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && ((currentStatus.hasSync == true) || BIT_CHECK(currentStatus.status3, BIT_STATUS3_HALFSYNC)) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
+      if ( (currentStatus.RPMdiv100 > configPage2.mapSwitchPoint) && (decoderSyncedResolution > DSR_NO_SYNC) && (currentStatus.startRevolutions > 1) && (! currentStatus.engineProtectStatus) ) //If the engine isn't running, fall back to instantaneous reads
       {
         if( (MAPcurRev == ignitionCount) ) //Watch for a change in the ignition counter to determine whether we're still on the same event
         {

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -207,7 +207,7 @@ void loop(void)
       toothLastToothTime = 0;
       toothLastSecToothTime = 0;
       //toothLastMinusOneToothTime = 0;
-      decoderSyncedResolution = DSR_NO_SYNC;
+      decoderSync = DS_NO_SYNC;
       currentStatus.runSecs = 0; //Reset the counter for number of seconds running.
       currentStatus.startRevolutions = 0;
       toothSystemCount = 0;
@@ -241,11 +241,11 @@ void loop(void)
 
     // Update legacy variables for comms
     if ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) {
-      if      ( decoderSyncedResolution == DSR_4STROKE_CYCLE ) { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
-      else if ( decoderSyncedResolution == DSR_REVOLUTION    ) { currentStatus.hasSync = false; BIT_SET  (currentStatus.status3, BIT_STATUS3_HALFSYNC); } 
+      if      ( decoderSync == DS_4STROKE_CYCLE ) { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
+      else if ( decoderSync == DS_REVOLUTION    ) { currentStatus.hasSync = false; BIT_SET  (currentStatus.status3, BIT_STATUS3_HALFSYNC); } 
       else                                                     { currentStatus.hasSync = false; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
     }
-    else if (decoderSyncedResolution > DSR_NO_SYNC) {
+    else if (decoderSync > DS_NO_SYNC) {
       currentStatus.hasSync = true; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
     }
     else {
@@ -473,7 +473,7 @@ void loop(void)
 
     //Always check for sync
     //Main loop runs within this clause
-    if (decoderSyncedResolution > DSR_NO_SYNC && (currentStatus.RPM > 0))
+    if (decoderSync > DS_NO_SYNC && (currentStatus.RPM > 0))
     {
         if(currentStatus.startRevolutions >= configPage4.StgCycles)  { ignitionOn = true; fuelOn = true; } //Enable the fuel and ignition, assuming staging revolutions are complete
         //Check whether running or cranking
@@ -668,7 +668,7 @@ void loop(void)
           //injector2StartAngle = calculateInjector2StartAngle(PWdivTimerPerDegree);
           injector2StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel2InjDegrees);
 
-          if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+          if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
           {
             if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
 
@@ -694,7 +694,7 @@ void loop(void)
           }
           else
           {
-            if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
+            if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
           }
           break;
         //5 cylinders
@@ -715,7 +715,7 @@ void loop(void)
           injector3StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel3InjDegrees);
           
           #if INJ_CHANNELS >= 6
-            if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+            if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
             {
             if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
 
@@ -735,7 +735,7 @@ void loop(void)
             }
             else
             {
-              if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
+              if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
             }
           #endif
           break;
@@ -752,7 +752,7 @@ void loop(void)
           injector4StartAngle = calculateInjectorStartAngle(PWdivTimerPerDegree, channel4InjDegrees);
 
           #if INJ_CHANNELS >= 8
-            if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+            if((configPage2.injLayout == INJ_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
             {
               if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
 
@@ -775,7 +775,7 @@ void loop(void)
             }
             else
             {
-              if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
+              if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_INJ != 360) ) { changeFullToHalfSync(); }
             }
 
           #endif
@@ -1573,7 +1573,7 @@ void calculateIgnitionAngles(int dwellAngle)
       calculateIgnitionAngle2(dwellAngle);
 
       #if IGN_CHANNELS >= 4
-      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
       {
         if( CRANK_ANGLE_MAX_IGN != 720 ) { changeHalfToFullSync(); }
 
@@ -1591,7 +1591,7 @@ void calculateIgnitionAngles(int dwellAngle)
       }
       else
       {
-        if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
+        if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
       }
       #endif
       break;
@@ -1610,7 +1610,7 @@ void calculateIgnitionAngles(int dwellAngle)
       calculateIgnitionAngle3(dwellAngle);
 
       #if IGN_CHANNELS >= 6
-      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
       {
         if( CRANK_ANGLE_MAX_IGN != 720 ) { changeHalfToFullSync(); }
 
@@ -1620,7 +1620,7 @@ void calculateIgnitionAngles(int dwellAngle)
       }
       else
       {
-        if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
+        if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
       }
       #endif
       break;
@@ -1632,7 +1632,7 @@ void calculateIgnitionAngles(int dwellAngle)
       calculateIgnitionAngle4(dwellAngle);
 
       #if IGN_CHANNELS >= 8
-      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSyncedResolution == DSR_4STROKE_CYCLE)
+      if((configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && decoderSync == DS_4STROKE_CYCLE)
       {
         if( CRANK_ANGLE_MAX_IGN != 720 ) { changeHalfToFullSync(); }
 
@@ -1643,7 +1643,7 @@ void calculateIgnitionAngles(int dwellAngle)
       }
       else
       {
-        if( decoderSyncedResolution == DSR_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
+        if( decoderSync == DS_REVOLUTION && (CRANK_ANGLE_MAX_IGN != 360) ) { changeFullToHalfSync(); }
       }
       #endif
       break;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -239,19 +239,6 @@ void loop(void)
       if(configPage4.ignBypassEnabled > 0) { digitalWrite(pinIgnBypass, LOW); } //Reset the ignition bypass ready for next crank attempt
     }
 
-    // Update legacy variables for comms
-    if ( configPage4.sparkMode == IGN_MODE_SEQUENTIAL || configPage2.injLayout == INJ_SEQUENTIAL ) {
-      if      ( decoderSync == DS_4STROKE_CYCLE ) { currentStatus.hasSync = true;  BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
-      else if ( decoderSync == DS_REVOLUTION    ) { currentStatus.hasSync = false; BIT_SET  (currentStatus.status3, BIT_STATUS3_HALFSYNC); } 
-      else                                                     { currentStatus.hasSync = false; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC); }
-    }
-    else if (decoderSync > DS_NO_SYNC) {
-      currentStatus.hasSync = true; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
-    }
-    else {
-      currentStatus.hasSync = false; BIT_CLEAR(currentStatus.status3, BIT_STATUS3_HALFSYNC);
-    }
-
     //***Perform sensor reads***
     //-----------------------------------------------------------------------------------------------------
     readMAP();  


### PR DESCRIPTION
This change replaces hasSync and BIT_STATUS3_HALFSYNC for all purposes except communications. Instead the decoders sets the decoderSync variable to the current decoded resolution. This way the decoders does not have to care about the sequential or not operation of Speeduino.

Firmware size, memory used and performance are unaffected. Bench-tested on mega with a few decoders.