### PR TITLE
Use full range of O2 sensor / scale O2 calibration all the way to ADC 1023-5V

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -641,11 +641,11 @@ void processSerialCommand(void)
         for(uint16_t x = 0; x < calibrationLength; x++)
         {
           uint16_t totalOffset = valueOffset + x;
-          //Only apply every 32nd value
-          if( (x % 32) == 0 )
+          //Only apply every 33nd value
+          if( (totalOffset % 33) == 0 )
           {
-            ((uint8_t*)pnt_TargetTable_values)[(totalOffset/32)] = serialPayload[x+7]; //O2 table stores 8 bit values
-            pnt_TargetTable_bins[(totalOffset/32)] = (totalOffset);
+            ((uint8_t*)pnt_TargetTable_values)[(totalOffset/33)] = serialPayload[x+7]; //O2 table stores 8 bit values
+            pnt_TargetTable_bins[(totalOffset/33)] = (totalOffset);
 
           }
 


### PR DESCRIPTION
The O2 calibration was only done to ADC 992 leaving 3% of the input range unused.

For the below calibration of 0v-10afr and 5v-20afr, 19,7 to 20,0 would not be utilized. Max AFR readable would be 19,7.

This is similar to #959 but for O2 calibration the values were already mapped correctly.

Bench-tested on mega.

ADC old | AFR old | ADC new | AFR new
-- | -- | -- | --
0 | 100 | 0 | 100
32 | 103 | 33 | 103
64 | 106 | 66 | 106
96 | 109 | 99 | 110
128 | 113 | 132 | 113
160 | 116 | 165 | 116
192 | 119 | 198 | 119
224 | 122 | 231 | 123
256 | 125 | 264 | 126
288 | 128 | 297 | 129
320 | 131 | 330 | 132
352 | 134 | 363 | 135
384 | 138 | 396 | 139
416 | 141 | 429 | 142
448 | 144 | 462 | 145
480 | 147 | 495 | 148
512 | 150 | 528 | 152
544 | 153 | 561 | 155
576 | 156 | 594 | 158
608 | 159 | 627 | 161
640 | 163 | 660 | 164
672 | 166 | 693 | 168
704 | 169 | 726 | 171
736 | 172 | 759 | 174
768 | 175 | 792 | 177
800 | 178 | 825 | 181
832 | 181 | 858 | 184
864 | 184 | 891 | 187
896 | 188 | 924 | 190
928 | 191 | 957 | 193
960 | 194 | 990 | 197
992 | 197 | 1023 | 200