### PR TITLE
Scale AFR gauge warnings by stoichiometric ratio

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -4981,7 +4981,7 @@ cmdVSSratio6 =      "E\x99\x06"
     dwellGauge        = dwell,         "Ign Dwell",          "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
     boostTargetGauge  = boostTarget,   "Target Boost",       "kPa",     0,   {maphigh},      0,    20,  {mapwarn},  {mapdang}, 0, 0
     boostDutyGauge    = boostDuty,     "Boost Duty Cycle",   "%",       0,   100,     -1,    -1,  101,  110, 1, 1
-    afrTargetGauge    = afrTarget,     "Target AFR",         "",        7,    25,     12,    13,   15,   16, 2, 2
+    afrTargetGauge    = afrTarget,     "Target AFR",         "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
     lambdaTargetGauge = lambdaTarget,  "Target Lambda",      "",        0.5, 1.5,   0.82,  0.89, 1.02, 1.09, 3, 3
     IdleTargetGauge   = CLIdleTarget,  "Idle Target RPM",    "RPM",     0,  2000,    300,   600, 1500, 1700, 0, 0
     idleLoadGauge     = idleLoad,      "IAC Load",          { bitStringValue( idleUnits , iacAlgorithm  ) }, 0,   {(iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6) ? 100: iacStepHome},      0,    0,  2000,  2000, 0, 0
@@ -5009,8 +5009,8 @@ cmdVSSratio6 =      "E\x99\x06"
     tpsADCGauge       = tpsADC,        "TPS ADC",            "",        0,   255,     -1,    -1,  256,  256, 0, 0
     throttleGauge     = throttle,      "Throttle Position",  "%TPS",    0,   100,     -1,     1,   90,  100, 1, 1
 
-    afrGauge          = afr,           "Air:Fuel Ratio",     "",        7,    25,     12,    13,   15,   16, 2, 2
-    afrGauge2         = afr2,          "Air:Fuel Ratio 2",   "",        7,    25,     12,    13,   15,   16, 2, 2
+    afrGauge          = afr,           "Air:Fuel Ratio",     "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
+    afrGauge2         = afr2,          "Air:Fuel Ratio 2",   "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
     lambdaGauge       = lambda,        "Lambda",             "",        0.5,  1.5,    0.5,   0.7,    2,  1.1, 2, 2
     TPSdotGauge       = TPSdot,        "TPS DOT",            "%/s",   -1000, 1000,  -2560, -2560, 2560, 2560, 0, 0
     MAPdotGauge       = MAPdot,        "MAP DOT",            "kPa/s", -1000, 1000,  -2560, -2560, 2560, 2560, 0, 0


### PR DESCRIPTION
Link AFR gauge warning levels to the stoichiometric ratio.