### PR TITLE
Add lambdaTable and memory map to afrTable

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5706,7 +5706,6 @@ cmdVSSratio6 =      "E\x99\x06"
      wueAnalyzeMap = warmup_analyzer_curve, warmup_afr_curve, afrTable1Tbl, afr, coolant, warmupEnrich, egoCorrection
      lambdaTargetTables = afrTable1Tbl, afrTSCustom
 #endif
-     lambdaTargetTables = afrTable1Tbl, afrTSCustom
      filter = std_DeadLambda ; Auto build
      filter = accelFilter,   "Accel Flag",           engine,         &,    16,        false
      filter = aseFilter,     "ASE Flag",             engine,         &,    4,         false

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -608,11 +608,8 @@ page = 4
 ;Start AFR page
 ;--------------------------------------------------
 page = 5
-#if LAMBDA
-      afrTable    = array,  U08,     0,[16x16], "Lambda",  { 0.1 / stoich },   0.0000,  0.00,    2.00,      3
-#else
-      afrTable    = array,  U08,     0,[16x16],    "AFR",      0.1,       0.0,   7,   25.5,      1
-#endif
+      lambdaTable = array,  U08,              0, [16x16], "Lambda",  { 0.1 / stoich },   0.0000,  0.00,    2.00,      3
+      afrTable    = array,  U08,     lastOffset, [16x16],    "AFR",               0.1,      0.0,     7,    25.5,      1
 
       rpmBinsAFR  = array,  U08,   256,[   16],    "RPM",   100.0,     0.0,   100,   25500,      0
       loadBinsAFR  = array,  U08,   272,[   16],    { bitStringValue(algorithmUnits ,  algorithm) },   fuelLoadRes,      0.0,   0.0,   {fuelLoadMax},      fuelDecimalRes
@@ -1867,7 +1864,8 @@ menuDialog = main
       subMenu = flexFuel,           "Flex Fuel",        2
       subMenu = veTableDialog,      "VE Table",       0
       subMenu = sparkTbl,           "Spark Table",    2
-      subMenu = afrTable1Tbl,       "AFR Table",       5
+      subMenu = afrTable1Tbl,       "AFR Target Table",       5
+      subMenu = lambdaTable1Tbl,    "Lambda Target Table",    5
       subMenu = std_separator
       subMenu = fuelTable2Dialog,   "Second fuel Table", 11
       subMenu = sparkTable2Dialog,  "Second spark Table", 14
@@ -1972,6 +1970,7 @@ menuDialog = main
         subMenu = veTable1Map,    "Fuel Table"
         subMenu = sparkMap,       "Spark Table", 3
         subMenu = afrTable1Map,   "AFR Target Table"
+        subMenu = lambdaTable1Map,"Lambda Target Table"
 
 #if enablehardware_test
    menuDialog = main
@@ -4793,6 +4792,14 @@ cmdVSSratio6 =      "E\x99\x06"
       upDownLabel = "RICHER", "LEANER"
       gridOrient  = 250,   0, 340
 
+    table = lambdaTable1Tbl, lambdaTable1Map, "Lambda Table", 5
+      xBins = rpmBinsAFR, rpm
+      yBins = loadBinsAFR, fuelLoad
+      zBins = lambdaTable
+      gridHeight  = 1.0
+      upDownLabel = "RICHER", "LEANER"
+      gridOrient  = 250,   0, 340
+
       ;#if BOOSTPSI
       ;table = boostTbl,    boostMap,    "Boost targets (PSI)", 8
       ;#else
@@ -5660,15 +5667,18 @@ cmdVSSratio6 =      "E\x99\x06"
   addTool = veTableGenerator, "VE Table Generator", veTable1Tbl
   addTool = afrTableGenerator, "AFR Table Generator", afrTable1Tbl
 
+  ; The AFR Table Generator does not work with the lambda target table
+  ;addTool = afrTableGenerator, "AFR Table Generator", lambdaTable1Tbl
 
 [VeAnalyze]
            ;    tableName,  lambdaTargetTableName, lambdaChannel, egoCorrectionChannel, activeCondition
 #if LAMBDA
-     veAnalyzeMap = veTable1Tbl, afrTable1Tbl, lambda, egoCorrection
+     veAnalyzeMap = veTable1Tbl, lambdaTable1Tbl, lambda, egoCorrection
+     lambdaTargetTables = lambdaTable1Tbl, afrTSCustom
 #else
      veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
-#endif
      lambdaTargetTables = afrTable1Tbl, afrTSCustom
+#endif
          filter = std_xAxisMin ; Auto build with appropriate axis channels
          ;filter = minRPMFilter, "Minimum RPM", rpm,           <       , 500,      , true
          filter = std_xAxisMax ; Auto build with appropriate axis channels
@@ -5690,9 +5700,11 @@ cmdVSSratio6 =      "E\x99\x06"
 [WueAnalyze]
 ; wueCurveName, afrTempCompensationCurve, lambdaTargetTableName, lambdaChannel, coolantTempChannel, wueChannel, egoCorrectionChannel, activeCondition
 #if LAMBDA
-     wueAnalyzeMap = warmup_analyzer_curve, warmup_afr_curve, afrTable1Tbl, lambda, coolant, warmupEnrich, egoCorrection
+     wueAnalyzeMap = warmup_analyzer_curve, warmup_afr_curve, lambdaTable1Tbl, lambda, coolant, warmupEnrich, egoCorrection
+     lambdaTargetTables = lambdaTable1Tbl, afrTSCustom
 #else
      wueAnalyzeMap = warmup_analyzer_curve, warmup_afr_curve, afrTable1Tbl, afr, coolant, warmupEnrich, egoCorrection
+     lambdaTargetTables = afrTable1Tbl, afrTSCustom
 #endif
      lambdaTargetTables = afrTable1Tbl, afrTSCustom
      filter = std_DeadLambda ; Auto build


### PR DESCRIPTION
This fixes the below warning when changing the "Lambda display" option. It also removes the hardcoded and now unneeded 14,7:1 conversion.

> Warning: MSQ Units Mismatch for afrTable! Lambda found in current configuration, AFR found in MSQ, values were converted to Lambda based on Gasoline 14.7:1.

AFR Target and Lambda Target tables can now be viewed simultaneously hence both options are available in the menus. Any changes in either are reflected in the other.

The lastOffset option causes the constant to be mapped to the same raw values as the previous row.