### PR TITLE
Add Lambda options for EGO correction and Nitrous leanest AFR

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1113,8 +1113,10 @@ page = 10
 #endif
       n2o_maxMAP          = scalar, U08,      77,      "kPa",      2.0,   0.0,  0.0,  511.0,      0
       n2o_minTPS          = scalar, U08,      78,      "%TPS",     0.5,   0.0,  0.0,  100.0,      1
-      n2o_maxAFR          = scalar, U08,      79,      "AFR",      0.1,   0.0,  0.0,  25.5,       1
-      
+
+      n2o_maxAFR          = scalar, U08,         79,    "AFR",     0.1          , 0, 0,  25.5          , 1
+      n2o_maxLambda       = scalar, U08, lastOffset, "Lambda",    {0.1 / stoich}, 0, 0, {25.5 / stoich}, 3
+
       n2o_stage1_pin      = bits ,  U08,      80, [0:5],           $IO_Pins_no_def
       n2o_pin_polarity    = bits ,  U08,      80, [6:6],           "HIGH", "LOW"
       n2o_unused          = bits ,  U08,      80, [7:7],           "No", "Yes"
@@ -3102,6 +3104,7 @@ menuDialog = main
         field = "Minimum TPS",                  n2o_minTPS,     { n2o_enable > 0 }
         field = "Maximum MAP",                  n2o_maxMAP,     { n2o_enable > 0 }
         field = "Leanest AFR",                  n2o_maxAFR,     { n2o_enable > 0 }
+        field = "Leanest Lambda",               n2o_maxLambda,  { n2o_enable > 0 }
 
     dialog = NitrousControl,                "Nitrous"
         topicHelp = "https://wiki.speeduino.com/en/configuration/Nitrous_Control"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -644,8 +644,12 @@ page = 6
       vvtCLAlterFuelTiming    = bits,   U08,       6, [6:6],      "No", "Yes"
       boostCutEnabled         = bits,   U08,       6, [7:7],      "Off", "On"
       egoLimit                = scalar, U08,       7,             "",         1,      0,    0,    16,         0
-      ego_min                 = scalar, U08,       8,             "AFR",      0.1,    0.0,  7,    25,         1
-      ego_max                 = scalar, U08,       9,             "AFR",      0.1,    0.0,  7,    25,         1
+      
+      ego_min_afr    = scalar, U08,          8,    "AFR",  0.1          , 0,  7          ,  25          , 1
+      ego_min_lambda = scalar, U08, lastOffset, "Lambda", {0.1 / stoich}, 0, {7 / stoich}, {25 / stoich}, 3
+      ego_max_afr    = scalar, U08,          9,    "AFR",  0.1          , 0,  7          ,  25          , 1
+      ego_max_lambda = scalar, U08, lastOffset, "Lambda", {0.1 / stoich}, 0, {7 / stoich}, {25 / stoich}, 3
+
       ego_sdelay  = scalar, U08,      10,             "sec",      1,      0,    0,    120,        0
       egoRPM      = scalar, U08,      11,             "rpm",      100,    0.0,  100,  25500,      0
       egoTPSMax   = scalar, U08,      12,             "%",        0.5,      0,    0,  100.0,      1
@@ -2720,8 +2724,11 @@ menuDialog = main
       field = "Algorithm",                  egoAlgorithm,       { egoType }
       field = "Ignition Events per Step",   egoCount,           { egoType && (egoAlgorithm < 3) }
       field = "Controller Auth +/-",        egoLimit,           { egoType && (egoAlgorithm < 3) }
-      field = "Only correct above:",        ego_min,            { egoType && (egoAlgorithm < 3) }
-      field = "and correct below:",         ego_max,            { egoType && (egoAlgorithm < 3) }
+
+      field = "Only correct above ",        ego_min_afr,        { egoType && (egoAlgorithm < 3) }
+      field = "and correct below ",         ego_max_afr,        { egoType && (egoAlgorithm < 3) }
+      field = "Only correct above ",        ego_min_lambda,     { egoType && (egoAlgorithm < 3) }
+      field = "and correct below ",         ego_max_lambda,     { egoType && (egoAlgorithm < 3) }
 
       field = "Active Above Coolant",       egoTemp,            { egoType && (egoAlgorithm < 3) }
       field = "Active Above RPM",           egoRPM,             { egoType && (egoAlgorithm < 3) }


### PR DESCRIPTION
These options could only be set with AFR. Now they can be set with Lambda as well. The fields point to the same data, so updating one updates the other.