### PR TITLE
Optimize PW function

### DIFF
--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -15,7 +15,7 @@
 
 void setup(void);
 void loop(void);
-uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen);
+uint16_t PW(const int& REQ_FUEL, const byte& VE, const long& MAP, const uint16_t& corrections, const int& injOpen);
 byte getVE1(void);
 byte getAdvance1(void);
 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1312,6 +1312,9 @@ void loop(void)
  * @param injOpen Injector opening time. The time the injector take to open minus the time it takes to close (Both in uS)
  * @return uint16_t The injector pulse width in uS
  */
+#ifndef UNIT_TEST
+inline
+#endif
 uint16_t PW(const int& REQ_FUEL, const byte& VE, const long& MAP, const uint16_t& corrections, const int& injOpen)
 {
   //Standard float version of the calculation

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1312,7 +1312,7 @@ void loop(void)
  * @param injOpen Injector opening time. The time the injector take to open minus the time it takes to close (Both in uS)
  * @return uint16_t The injector pulse width in uS
  */
-uint16_t PW(int REQ_FUEL, byte VE, long MAP, uint16_t corrections, int injOpen)
+uint16_t PW(const int& REQ_FUEL, const byte& VE, const long& MAP, const uint16_t& corrections, const int& injOpen)
 {
   //Standard float version of the calculation
   //return (REQ_FUEL * (float)(VE/100.0) * (float)(MAP/100.0) * (float)(TPS/100.0) * (float)(corrections/100.0) + injOpen);


### PR DESCRIPTION
A few optimizations for the PW function. Details are in commit messages.

The calculations are unchanged, they are just structured differently.

All tests pass. Bench-tested and getting the same PW values before and after. 208 bytes flash reduction and 1-2 loops/sec increase.