### PR TITLE
Reorganize gauge selection into categories

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -4956,91 +4956,107 @@ cmdVSSratio6 =      "E\x99\x06"
    ; vd    = Decimal places in displayed value
    ; ld    = Label decimal places for display of Lo and Hi, above.
 
-    gaugeCategory = "Main"
+    gaugeCategory = "1 Main"
+    ;Name               Var            Title                  Units      Lo    Hi     LoD    LoW   HiW   HiD vd ld
+    tachometer        = rpm,           "Engine Speed",        "RPM",     0,  {rpmhigh},    300,   600, {rpmwarn}, {rpmdang}, 0, 0
+
+    vssGauge          = vss,           "Vehicle Speed (kph)", "km/h",    0,    250,     5,    10,  180,  200, 0, 0
+    vssGaugeMPH       = vssMPH,        "Vehicle Speed (mph)", "mph",     0,    250,     5,    10,  180,  200, 0, 0
+
+    tpsADCGauge       = tpsADC,        "TPS ADC",             "",        0,    255,    -1,    -1,  256,  256, 0, 0
+    throttleGauge     = throttle,      "Throttle Position",   "%TPS",    0,    100,    -1,     1,   90,  100, 1, 1
+    TPSdotGauge       = TPSdot,        "TPS DOT",             "%/s", -1000,   1000, -2560, -2560, 2560, 2560, 0, 0
+
+    batteryVoltage    = batteryVoltage,"Battery Voltage",     "volts",   0,     25,     8,     9,   15,   16, 2, 2
+
+    #if CELSIUS
+    cltGauge          = coolant,       "Coolant Temp",        "TEMP",  -40,    120,   -15,     0,   95,  105, 0, 0
+    iatGauge          = iat,           "Inlet Air Temp",      "TEMP",  -40,    120,   -15,     0,   95,  100, 0, 0
+    #else   
+    cltGauge          = coolant,       "Coolant Temp",        "TEMP",  -40,    248,     0,    30,  200,  220, 0, 0
+    iatGauge          = iat,           "Inlet Air Temp",      "TEMP",  -40,    248,     0,    30,  200,  210, 0, 0
+    #endif 
+     
+    veGauge           = veCurr,        "VE (Current)",        "%",       0,    120,    -1,    -1,  999,  999, 0, 0
+    ve1Gauge          = VE1,           "VE1 (Fuel Table 1)",  "%",       0,    120,    -1,    -1,  999,  999, 0, 0
+    ve2Gauge          = VE2,           "VE2 (Fuel Table 2)",  "%",       0,    120,    -1,    -1,  999,  999, 0, 0
+    mapMultiplyGauge  = map_multiply_amt, "MAP Multiply",     "%",       0,    200,   130,   140,  140,  150, 0, 0
+ 
+    gaugeCategory = "2 Pressure"
+    ;Name                  Var              Title                     Units          Lo         Hi    LoD    LoW        HiW        HiD vd ld
+    fuelPressureGauge    = fuelPressure,    "Fuel Pressure (PSI)",    "PSI",        -15,       100,     0,    20,       200,       245, 0, 0
+    oilPressureGauge     = oilPressure,     "Oil Pressure (PSI)",     "PSI",        -15,       100,     0,    20,       200,       245, 0, 0
+    fuelPressureBarGauge = fuelPressure_bar,"Fuel Pressure (BAR)",    "BAR",       -1.0,       7.0,   0.5,   1.4,      14.0,      17.0, 1, 1
+    oilPressureBarGauge  = oilPressure_bar, "Oil Pressure (BAR)",     "BAR",       -1.0,       7.0,   0.5,   1.4,      14.0,      17.0, 1, 1
+    fuelPressurekPaGauge = fuelPressure_kpa,"Fuel Pressure (kPa)",    "kPa",       -100,       700,    50,   140,      1400,      1700, 0, 0
+    oilPressurekPaGauge  = oilPressure_kpa, "Oil Pressure (kPa)",     "kPa",       -100,       700,    50,   140,      1400,      1700, 0, 0
+    boostDutyGauge       = boostDuty,       "Boost Duty Cycle",       "%",            0,       100,    -1,    -1,       101,       110, 1, 1
+    boostTargetGauge     = boostTarget,     "Target Boost",           "kPa",          0, {maphigh},     0,    20, {mapwarn}, {mapdang}, 0, 0
+    baroGauge            = baro,            "Baro Pressure",          "kPa",          0, {maphigh},     0,    20, {mapwarn}, {mapdang}, 0, 0
+    emapGauge            = emap,            "Exhaust MAP",            "kPa",          0, {maphigh},     0,    20, {mapwarn}, {mapdang}, 0, 0
+    mapGauge             = map,             "Engine MAP",             "kPa",          0, {maphigh},     0,    20, {mapwarn}, {mapdang}, 0, 0
+    mapGauge_psi         = map_psi,         "Engine MAP (PSI)",       "PSI",        -15,       100,     0,    20,       200,       245, 0, 0
+    mapGauge_bar         = map_bar,         "Engine MAP (BAR)",       "Bar",         -1,         3,    -1,    -1,         5,         5, 2, 2
+    mapGauge_vacBoost    = map_vacboost,    "Engine MAP (in-Hg/PSI)", "in-Hg/PSI",  -30,        30,   -30,   -30,        30,        30, 1, 1
+    MAPdotGauge          = MAPdot,          "Engine MAP DOT",         "kPa/s",    -1000,      1000, -2560, -2560,      2560,      2560, 0, 0
+  
+    gaugeCategory = "3 Fuel"
     ;Name               Var            Title                 Units     Lo     Hi     LoD    LoW   HiW   HiD vd ld
-    accelEnrichGauge  = accelEnrich,   "Accel Enrich",       "%",      50,   150,     -1,    -1,  999,  999, 0, 0
     injOpenGauge      = inj_open,      "Injector Open Time", "mSec",  0.0,   3.0,    0.0,   0.0,  3.0,  3.0, 3, 3
     dutyCycleGauge    = dutyCycle,     "Duty Cycle",         "%",       0,   100,     -1,    -1,   70,   80, 1, 1
     stgDutyCycleGauge = stgDutyCycle,  "Staging Duty Cycle", "%",       0,   100,     -1,    -1,   70,   80, 1, 1
-    egoCorrGauge      = egoCorrection, "EGO Correction",     "%",      50,   150,     90,    99,  101,  110, 0, 0
-
-    gammaEnrichGauge  = gammaEnrich,   "Gamma Enrichment",   "%",      50,   250,     -1,    -1,  151,  151, 0, 0
+    WMIdutyCycleGauge = wmiPW,         "WMI Duty Cycle",     "%",       0,   100,     -1,    -1,  101,  110, 1, 1
     pulseWidthGauge   = pulseWidth,    "Pulse Width",        "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
     pulseWidthGauge2  = pulseWidth2,   "Pulse Width 2",      "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
     pulseWidthGauge3  = pulseWidth3,   "Pulse Width 3",      "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
     pulseWidthGauge4  = pulseWidth4,   "Pulse Width 4",      "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
-    tachometer        = rpm,           "Engine Speed",       "RPM",     0,  {rpmhigh},    300,   600, {rpmwarn}, {rpmdang}, 0, 0
-    veGauge           = veCurr,        "VE (Current)",         "%",       0,   120,     -1,    -1,  999,  999, 0, 0
-    ve1Gauge          = VE1,           "VE1 (Fuel Table 1)", "%",       0,   120,     -1,    -1,  999,  999, 0, 0
-    ve2Gauge          = VE2,           "VE2 (Fuel Table 2)", "%",       0,   120,     -1,    -1,  999,  999, 0, 0
-    warmupEnrichGauge = warmupEnrich,  "Warmup Enrichment",  "%",     100,   200,    130,   140,  140,  150, 0, 0
-    aseEnrichGauge    = ase_enrich,    "Afterstart Enrichment","%",     0,   200,    130,   140,  140,  150, 0, 0
-    batCorrectGauge   = bat_correction,"Voltage Correction", "%",       0,   200,    130,   140,  140,  150, 0, 0
-    iatCorrectGauge   = airCorrection, "IAT Correction",     "%",       0,   200,    130,   140,  140,  150, 0, 0
-    baroCorrectGauge  = baroCorrection,"Baro Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
-    flexEnrich        = flexFuelCor,   "Flex Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
-    fuelTempCorGauge  = fuelTempCor,   "Fuel Temp Correction", "%",     0,   200,    130,   140,  140,  150, 0, 0
-    advanceGauge      = advance,       "Advance (Current)",     "deg",    50, -10,      0,     0,    35,   45, 0, 0
-    advance1Gauge     = advance1,      "Advance1 (Spark Table 1)",  "deg",50, -10,      0,     0,    35,   45, 0, 0
-    advance2Gauge     = advance2,      "Advance2 (Spark Table 2)",  "deg",50, -10,      0,     0,    35,   45, 0, 0
-    dwellGauge        = dwell,         "Ign Dwell",          "mSec",    0,  35.0,    1.0,   1.2,   20,   25, 3, 3
-    boostTargetGauge  = boostTarget,   "Target Boost",       "kPa",     0,   {maphigh},      0,    20,  {mapwarn},  {mapdang}, 0, 0
-    boostDutyGauge    = boostDuty,     "Boost Duty Cycle",   "%",       0,   100,     -1,    -1,  101,  110, 1, 1
-    afrTargetGauge    = afrTarget,     "Target AFR",         "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
-    lambdaTargetGauge = lambdaTarget,  "Target Lambda",      "",        0.5, 1.5,   0.82,  0.89, 1.02, 1.09, 3, 3
-    IdleTargetGauge   = CLIdleTarget,  "Idle Target RPM",    "RPM",     0,  2000,    300,   600, 1500, 1700, 0, 0
-    idleLoadGauge     = idleLoad,      "IAC Load",          { bitStringValue( idleUnits , iacAlgorithm  ) }, 0,   {(iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6) ? 100: iacStepHome},      0,    0,  2000,  2000, 0, 0
-    FANdutyCycleGauge = fanDuty,       "FAN Duty Cycle",     "%",       0,   100,     -1,    -1,  101,  110, 1, 1
-    vvt1DutyCycleGauge= vvt1Duty,      "VVT Duty Cycle",     "%",       0,  100,     -1,    -1,   101, 110, 1, 1
-    vvt1TargetGauge   = vvt1Target,    "VVT Target Angle",   "deg",     0,  100,     15,    25,    65,  75, 1, 1
-    vvt1AngleGauge    = vvt1Angle,     "VVT Angle",          "deg",   -20,  100,      0,    -5,    70,  90, 1, 1
-    vvt2DutyCycleGauge= vvt2Duty,      "VVT2 Duty Cycle",    "%",       0,  100,     -1,    -1,   101, 110, 1, 1
-    vvt2TargetGauge   = vvt2Target,    "VVT2 Target Angle",  "deg",     0,  100,     15,    25,    65,  75, 1, 1
-    vvt2AngleGauge    = vvt2Angle,     "VVT2 Angle",         "deg",   -20,  100,      0,    -5,    70,  90, 1, 1
-
-    WMIdutyCycleGauge = wmiPW,         "WMI Duty Cycle",     "%",       0,   100,     -1,    -1,  101,  110, 1, 1
-
-    gaugeCategory = "Sensor inputs"
-    mapGauge          = map,           "Engine MAP",              "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
-    mapGauge_psi      = map_psi,       "Engine MAP (PSI)",        "PSI",          -15,    100,    0,      20,  200,  245, 0, 0
-    mapGauge_bar      = map_bar,       "Engine MAP (BAR)",        "Bar",          -1,     3,      -1,     -1,    5,  5,  2, 2
-    mapGauge_vacBoost = map_vacboost,  "Engine MAP (in-Hg/PSI)",  "in-Hg/PSI",    -30,    30,     -30,    -30, 30, 30, 1, 1
-    emapGauge         = emap,          "Exhaust MAP",             "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
-    baroGauge         = baro,          "Baro Pressure",           "kPa",          0,      {maphigh},    0,      20,  {mapwarn},  {mapdang}, 0, 0
-    batteryVoltage    = batteryVoltage,"Battery Voltage",         "volts",        0,    25,      8,     9,   15,   16, 2, 2
-    vssGauge          = vss,           "Vehicle Speed (kph)",     "km/h",         0,    250,     5,    10,   180,   200, 0, 0
-    vssGaugeMPH       = vssMPH,        "Vehicle Speed (mph)",     "mph",          0,    250,     5,    10,   180,   200, 0, 0
-
-    tpsADCGauge       = tpsADC,        "TPS ADC",            "",        0,   255,     -1,    -1,  256,  256, 0, 0
-    throttleGauge     = throttle,      "Throttle Position",  "%TPS",    0,   100,     -1,     1,   90,  100, 1, 1
-
     afrGauge          = afr,           "Air:Fuel Ratio",     "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
     afrGauge2         = afr2,          "Air:Fuel Ratio 2",   "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
-    lambdaGauge       = lambda,        "Lambda",             "",        0.5,  1.5,    0.5,   0.7,    2,  1.1, 2, 2
-    TPSdotGauge       = TPSdot,        "TPS DOT",            "%/s",   -1000, 1000,  -2560, -2560, 2560, 2560, 0, 0
-    MAPdotGauge       = MAPdot,        "MAP DOT",            "kPa/s", -1000, 1000,  -2560, -2560, 2560, 2560, 0, 0
-
-    #if CELSIUS
-    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   120,    -15,     0,   95,  105, 0, 0
-    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   120,    -15,     0,   95,  100, 0, 0
-    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   120,    -15,     0,   95,  100, 0, 0
-    #else
-    cltGauge          = coolant,       "Coolant Temp",       "TEMP", -40,   248,      0,    30,  200,  220, 0, 0
-    iatGauge          = iat,           "Inlet Air Temp",     "TEMP", -40,   248,      0,    30,  200,  210, 0, 0
-    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP", -40,   248,      0,    30,  200,  210, 0, 0
-    #endif
+    afrTargetGauge    = afrTarget,     "Target AFR",         "",        7,    25,   {12 / 14.7 * stoich}, {13 / 14.7 * stoich}, {15 / 14.7 * stoich}, {16 / 14.7 * stoich}, 2, 2
+    lambdaGauge       = lambda,        "Lambda",             "",        0.5, 1.5,    0.5,   0.7,    2,  1.1, 2, 2
+    lambdaTargetGauge = lambdaTarget,  "Target Lambda",      "",        0.5, 1.5,   0.82,  0.89, 1.02, 1.09, 3, 3
     flexGauge         = flex,          "Flex sensor",        "%",       0,   100,     -1,    -1,  999,  999, 0, 0
+    #if CELSIUS
+    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP",  -40,   120,    -15,     0,   95,  100, 0, 0
+    #else
+    fuelTempGauge     = fuelTemp,      "Fuel Temp",          "TEMP",  -40,   248,      0,    30,  200,  210, 0, 0
+    #endif
 
-    fuelPressureGauge    = fuelPressure,    "Fuel Pressure (PSI)", "PSI",    -15,    100,   0,       20,   200,   245, 0, 0
-    oilPressureGauge     = oilPressure,     "Oil Pressure (PSI)",  "PSI",    -15,    100,   0,       20,   200,   245, 0, 0
-    fuelPressureBarGauge = fuelPressure_bar,"Fuel Pressure (BAR)", "BAR",   -1.0,    7.0,   0.5,    1.4,  14.0,  17.0, 1, 1
-    oilPressureBarGauge  = oilPressure_bar, "Oil Pressure (BAR)",  "BAR",   -1.0,    7.0,   0.5,    1.4,  14.0,  17.0, 1, 1
-    fuelPressurekPaGauge = fuelPressure_kpa,"Fuel Pressure (kPa)", "kPa",   -100,    700,   50,     140,  1400,  1700, 0, 0
-    oilPressurekPaGauge  = oilPressure_kpa, "Oil Pressure (kPa)",  "kPa",   -100,    700,   50,     140,  1400,  1700, 0, 0
+    gaugeCategory = "4 Fuel corrections"
+    ;Name               Var            Title                 Units     Lo     Hi     LoD    LoW   HiW   HiD vd ld
+    accelEnrichGauge  = accelEnrich,   "Accel Enrich",         "%",    50,   150,     -1,    -1,  999,  999, 0, 0
+    egoCorrGauge      = egoCorrection, "EGO Correction",       "%",    50,   150,     90,    99,  101,  110, 0, 0
+    gammaEnrichGauge  = gammaEnrich,   "Gamma Enrichment",     "%",    50,   250,     -1,    -1,  151,  151, 0, 0
+    warmupEnrichGauge = warmupEnrich,  "Warmup Enrichment",    "%",   100,   200,    130,   140,  140,  150, 0, 0
+    aseEnrichGauge    = ase_enrich,    "Afterstart Enrichment","%",     0,   200,    130,   140,  140,  150, 0, 0
+    batCorrectGauge   = bat_correction,"Voltage Correction",   "%",     0,   200,    130,   140,  140,  150, 0, 0
+    iatCorrectGauge   = airCorrection, "IAT Correction",       "%",     0,   200,    130,   140,  140,  150, 0, 0
+    baroCorrectGauge  = baroCorrection,"Baro Correction",      "%",     0,   200,    130,   140,  140,  150, 0, 0
+    flexEnrich        = flexFuelCor,   "Flex Correction",      "%",     0,   200,    130,   140,  140,  150, 0, 0
+    fuelTempCorGauge  = fuelTempCor,   "Fuel Temp Correction", "%",     0,   200,    130,   140,  140,  150, 0, 0
 
+    gaugeCategory = "5 Spark"
+    ;Name               Var            Title                        Units  Lo     Hi   LoD   LoW   HiW   HiD vd ld
+    advanceGauge      = advance,       "Advance (Current)",         "deg", 50,   -10,    0,    0,   35,   45, 0, 0
+    advance1Gauge     = advance1,      "Advance1 (Spark Table 1)",  "deg", 50,   -10,    0,    0,   35,   45, 0, 0
+    advance2Gauge     = advance2,      "Advance2 (Spark Table 2)",  "deg", 50,   -10,    0,    0,   35,   45, 0, 0
+    dwellGauge        = dwell,         "Ign Dwell",                "mSec",  0,  35.0,  1.0,  1.2,   20,   25, 3, 3
 
-    gaugeCategory     = "Auxiliary Input Channels"
-    AuxInGauge0       = auxin_gauge0,    { stringValue(AUXin00Alias) },        "",             0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    gaugeCategory = "6 Accessories"
+    ;Name               Var            Title                 Units     Lo     Hi     LoD    LoW   HiW   HiD vd ld
+    idleLoadGauge     = idleLoad,      "IAC Load",          { bitStringValue( idleUnits , iacAlgorithm  ) }, 0,   {(iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6) ? 100: iacStepHome},      0,    0,  2000,  2000, 0, 0
+    IdleTargetGauge   = CLIdleTarget,  "Idle Target RPM",    "RPM",     0,  2000,    300,   600, 1500, 1700, 0, 0
+    FANdutyCycleGauge = fanDuty,       "FAN Duty Cycle",     "%",       0,   100,     -1,    -1,  101,  110, 1, 1
+    vvt1DutyCycleGauge= vvt1Duty,      "VVT Duty Cycle",     "%",       0,   100,     -1,    -1,   101, 110, 1, 1
+    vvt1TargetGauge   = vvt1Target,    "VVT Target Angle",   "deg",     0,   100,     15,    25,    65,  75, 1, 1
+    vvt1AngleGauge    = vvt1Angle,     "VVT Angle",          "deg",   -20,   100,      0,    -5,    70,  90, 1, 1
+    vvt2DutyCycleGauge= vvt2Duty,      "VVT2 Duty Cycle",    "%",       0,   100,     -1,    -1,   101, 110, 1, 1
+    vvt2TargetGauge   = vvt2Target,    "VVT2 Target Angle",  "deg",     0,   100,     15,    25,    65,  75, 1, 1
+    vvt2AngleGauge    = vvt2Angle,     "VVT2 Angle",         "deg",   -20,   100,      0,    -5,    70,  90, 1, 1
+
+    gaugeCategory     = "7 Auxiliary Input Channels"
+    ;Name               Var              Title                                 Units     Lo       Hi  LoD    LoW    HiW      HiD  vd  ld
+    AuxInGauge0       = auxin_gauge0,    { stringValue(AUXin00Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
     AuxInGauge1       = auxin_gauge1,    { stringValue(AUXin01Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
     AuxInGauge2       = auxin_gauge2,    { stringValue(AUXin02Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
     AuxInGauge3       = auxin_gauge3,    { stringValue(AUXin03Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
@@ -5050,22 +5066,22 @@ cmdVSSratio6 =      "E\x99\x06"
     AuxInGauge7       = auxin_gauge7,    { stringValue(AUXin07Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
     AuxInGauge8       = auxin_gauge8,    { stringValue(AUXin08Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
     AuxInGauge9       = auxin_gauge9,    { stringValue(AUXin09Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge10      = auxin_gauge10,    { stringValue(AUXin10Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge11      = auxin_gauge11,    { stringValue(AUXin11Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge12      = auxin_gauge12,    { stringValue(AUXin12Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge13      = auxin_gauge13,    { stringValue(AUXin13Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge14      = auxin_gauge14,    { stringValue(AUXin14Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
-    AuxInGauge15      = auxin_gauge15,    { stringValue(AUXin15Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge10      = auxin_gauge10,   { stringValue(AUXin10Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge11      = auxin_gauge11,   { stringValue(AUXin11Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge12      = auxin_gauge12,   { stringValue(AUXin12Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge13      = auxin_gauge13,   { stringValue(AUXin13Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge14      = auxin_gauge14,   { stringValue(AUXin14Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
+    AuxInGauge15      = auxin_gauge15,   { stringValue(AUXin15Alias) },        "",        0,    1024,  -1,    -1,  1025,    1025,  0,  0
 
-    gaugeCategory = "System Data"
-    clockGauge        = secl,          "Clock",              "Seconds", 0,   255,     10,    10,  245,  245, 0, 0
-    loopGauge         = loopsPerSecond,"Main loop speed",    "Loops/S" , 0,  5000,   750,  900, 100000, 100000, 0, 0
-    loopsPerRevGauge  = loopsPerRev,   "Main loops per revolution", "Loops/rev", 0, 100, 10,  15, 10000, 10000, 2, 0
-    memoryGauge       = freeRAM,       "Free memory",        "bytes" ,   0,  8000,     -1,    1000,8000, 1000, 0, 0
-    reqFuelGauge      = req_fuel,       "Req. Fuel",          "ms",      0,  35.0,    1.0,   1.2,   20,   25, 2, 2
-    mapMultiplyGauge  = map_multiply_amt, "MAP Multiply",     "%",       0,   200,    130,   140,  140,  150, 0, 0
-    nSquirtsGauge     = nSquirts,       "# Squirts",          "",        0,    10,    130,   140,  140,  150, 0, 0
-    syncLossGauge     = syncLossCounter, "# Sync Losses",      "",        0,    255,    -1,   -1,  10,  50, 0, 0
+    gaugeCategory = "8 System Data"
+    ;Name               Var              Title                        Units       Lo     Hi    LoD   LoW     HiW     HiD vd ld
+    clockGauge        = secl,            "Clock",                     "Seconds",   0,   255,    10,   10,    245,    245, 0, 0
+    loopGauge         = loopsPerSecond,  "Main loop speed",           "Loops/S" ,  0,  5000,   750,  900, 100000, 100000, 0, 0
+    loopsPerRevGauge  = loopsPerRev,     "Main loops per revolution", "Loops/rev", 0,   100,    10,   15,  10000,  10000, 2, 0
+    memoryGauge       = freeRAM,         "Free memory",               "bytes" ,    0,  8000,    -1, 1000,   8000,   1000, 0, 0
+    reqFuelGauge      = req_fuel,        "Req. Fuel",                 "ms",        0,  35.0,   1.0,  1.2,     20,     25, 2, 2
+    nSquirtsGauge     = nSquirts,        "# Squirts",                 "",          0,    10,   130,  140,    140,    150, 0, 0
+    syncLossGauge     = syncLossCounter, "# Sync Losses",             "",          0,   255,    -1,   -1,     10,     50, 0, 0
 ;-------------------------------------------------------------------------------
 
 [FrontPage]


### PR DESCRIPTION
The current right-click gauge selection menus have become so big they are automatically divided. It is a nuisance to locate the correct gauge.

This is an attempt to categorize the gauges in a way which makes it easier/faster to find what you are looking for. There are no changes to the actual gauges, they are just put under different menus and the .ini-file spacing has been corrected.

Once this is merged it is probably a good idea to rename some gauges. Like renaming "Target Lambda" to "Lambda Target" so it is sorted next to "Lambda".

![image](https://user-images.githubusercontent.com/26184874/215887452-e848a102-4f87-4231-a138-f271b273b457.png)![image](https://user-images.githubusercontent.com/26184874/215887506-f3be5338-5bb4-42f1-ad5f-a030a102dc22.png)![image](https://user-images.githubusercontent.com/26184874/215887530-a3d94cf0-2d93-46be-8419-aa0b4dcb328b.png)![image](https://user-images.githubusercontent.com/26184874/215887559-cd9bd725-3e1e-4aea-a689-447453bf00b6.png)![image](https://user-images.githubusercontent.com/26184874/215887594-2875e16e-56f5-4dee-8524-4d618de150fe.png)![image](https://user-images.githubusercontent.com/26184874/215887626-e4eba16f-b8bb-46e0-8dc5-d1f96ed5a5fc.png)![image](https://user-images.githubusercontent.com/26184874/215887639-559046ba-eff7-4923-9a97-9aa1bd006433.png)![image](https://user-images.githubusercontent.com/26184874/215887655-629a0613-cc4b-49de-bfa4-e44e84939b6b.png)![image](https://user-images.githubusercontent.com/26184874/215887678-678cbf0b-a018-4a26-833f-06510691af94.png)