### PR TITLE
Fix extra unaccounted fuel squirts at low RPM on Teensy 4.1

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -459,6 +459,15 @@ void initialiseAll(void)
     ignition7EndAngle = 0;
     ignition8EndAngle = 0;
 
+    fuelSchedule1.scheduleFlags = 0;
+    fuelSchedule2.scheduleFlags = 0;
+    fuelSchedule3.scheduleFlags = 0;
+    fuelSchedule4.scheduleFlags = 0;
+
+    fuelSchedule5.scheduleFlags = 0;
+    fuelSchedule6.scheduleFlags = 0;
+    fuelSchedule7.scheduleFlags = 0;
+    fuelSchedule8.scheduleFlags = 0;
     if(configPage2.strokes == FOUR_STROKE) { CRANK_ANGLE_MAX_INJ = 720 / currentStatus.nSquirts; }
     else { CRANK_ANGLE_MAX_INJ = 360 / currentStatus.nSquirts; }
 

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -159,6 +159,10 @@ inline void refreshIgnitionSchedule1(unsigned long timeToEnd) __attribute__((alw
  */
 enum ScheduleStatus {OFF, PENDING, STAGED, RUNNING}; //The statuses that a schedule can have
 
+//Define bit positions within engine variable
+#define BIT_SCHEDULE_NEXT        0    // Enable flag for planned next schedule (when current schedule is RUNNING)
+#define BIT_SCHEDULE_DECODER     1    // Decoder had set the scheduler timer
+#define BIT_SCHEDULE_REPEATED    2    // Ignition had already repeated
 /** Ignition schedule.
  */
 struct Schedule {
@@ -190,6 +194,7 @@ struct FuelSchedule {
   COMPARE_TYPE nextStartCompare;
   COMPARE_TYPE nextEndCompare;
   volatile bool hasNextSchedule = false;
+  volatile byte scheduleFlags;
 };
 
 //volatile Schedule *timer3Aqueue[4];


### PR DESCRIPTION
Channels 3 and 4 (in a 4x cyl application) have extra unaccounted squirts from cranking to under 1100 RPM
This PR fixes that and has been checked with logic analyzer and in real running car - my daily driver.