### PR TITLE
Replace 8 channelXInjEnabled variables with 1

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -557,14 +557,7 @@ extern byte triggerInterrupt2;
 extern byte triggerInterrupt3;
 
 //These need to be here as they are used in both speeduino.ino and scheduler.ino
-extern bool channel1InjEnabled;
-extern bool channel2InjEnabled;
-extern bool channel3InjEnabled;
-extern bool channel4InjEnabled;
-extern bool channel5InjEnabled;
-extern bool channel6InjEnabled;
-extern bool channel7InjEnabled;
-extern bool channel8InjEnabled;
+extern byte channelInjEnabled;
 
 extern int ignition1EndAngle;
 extern int ignition2EndAngle;

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -105,14 +105,7 @@ volatile PORT_TYPE *triggerSec_pin_port;
 volatile PINMASK_TYPE triggerSec_pin_mask;
 
 /// These need to be here as they are used in both speeduino.ino and scheduler.ino
-bool channel1InjEnabled = true;
-bool channel2InjEnabled = false;
-bool channel3InjEnabled = false;
-bool channel4InjEnabled = false;
-bool channel5InjEnabled = false;
-bool channel6InjEnabled = false;
-bool channel7InjEnabled = false;
-bool channel8InjEnabled = false;
+byte channelInjEnabled = 0;
 
 int ignition1EndAngle = 0;
 int ignition2EndAngle = 0;

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -441,14 +441,9 @@ void initialiseAll(void)
     CRANK_ANGLE_MAX = 720;
     CRANK_ANGLE_MAX_IGN = 360;
     CRANK_ANGLE_MAX_INJ = 360;
-    channel1InjEnabled = true;
-    channel2InjEnabled = false;
-    channel3InjEnabled = false;
-    channel4InjEnabled = false;
-    channel5InjEnabled = false;
-    channel6InjEnabled = false;
-    channel7InjEnabled = false;
-    channel8InjEnabled = false;
+
+    channelInjEnabled = 0; // Disable all injectors
+    BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
 
     ignition1EndAngle = 0;
     ignition2EndAngle = 0;
@@ -478,12 +473,12 @@ void initialiseAll(void)
           req_fuel_uS = req_fuel_uS * 2;
         }
 
-        channel1InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
 
         //Check if injector staging is enabled
         if(configPage10.stagingEnabled == true)
         {
-          channel3InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
           channel3InjDegrees = channel1InjDegrees;
         }
         break;
@@ -514,14 +509,14 @@ void initialiseAll(void)
           channel2InjDegrees = 0; 
         }
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
 
         //Check if injector staging is enabled
         if(configPage10.stagingEnabled == true)
         {
-          channel3InjEnabled = true;
-          channel4InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
 
           channel3InjDegrees = channel1InjDegrees;
           channel4InjDegrees = channel2InjDegrees;
@@ -593,9 +588,9 @@ void initialiseAll(void)
           channel3InjDegrees = 240;
         }
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
-        channel3InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
         break;
     case 4:
         channel1IgnDegrees = 0;
@@ -655,8 +650,8 @@ void initialiseAll(void)
           channel3InjDegrees = 360;
           channel4InjDegrees = 540;
 
-          channel3InjEnabled = true;
-          channel4InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
 
           CRANK_ANGLE_MAX_INJ = 720;
           currentStatus.nSquirts = 1;
@@ -665,26 +660,26 @@ void initialiseAll(void)
         else
         {
           //Should never happen, but default values
-          channel3InjEnabled = false;
-          channel4InjEnabled = false;
-          channel5InjEnabled = false;
-          channel6InjEnabled = false;
-          channel7InjEnabled = false;
-          channel8InjEnabled = false;
+          BIT_CLEAR(channelInjEnabled, INJ3_CMD_BIT);
+          BIT_CLEAR(channelInjEnabled, INJ4_CMD_BIT);
+          BIT_CLEAR(channelInjEnabled, INJ5_CMD_BIT);
+          BIT_CLEAR(channelInjEnabled, INJ6_CMD_BIT);
+          BIT_CLEAR(channelInjEnabled, INJ7_CMD_BIT);
+          BIT_CLEAR(channelInjEnabled, INJ8_CMD_BIT);
         }
 
         //Check if injector staging is enabled
         if(configPage10.stagingEnabled == true)
         {
-          channel3InjEnabled = true;
-          channel4InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
 
           channel3InjDegrees = channel1InjDegrees;
           channel4InjDegrees = channel2InjDegrees;
         }
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
         break;
     case 5:
         channel1IgnDegrees = 0;
@@ -736,7 +731,7 @@ void initialiseAll(void)
           channel4InjDegrees = 432;
           channel5InjDegrees = 576;
 
-          channel5InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ5_CMD_BIT);
 
           CRANK_ANGLE_MAX_INJ = 720;
           currentStatus.nSquirts = 1;
@@ -744,10 +739,10 @@ void initialiseAll(void)
         }
     #endif
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
-        channel3InjEnabled = true;
-        channel4InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
         break;
     case 6:
         channel1IgnDegrees = 0;
@@ -797,9 +792,9 @@ void initialiseAll(void)
           channel5InjDegrees = 480;
           channel6InjDegrees = 600;
 
-          channel4InjEnabled = true;
-          channel5InjEnabled = true;
-          channel6InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ5_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ6_CMD_BIT);
 
           CRANK_ANGLE_MAX_INJ = 720;
           currentStatus.nSquirts = 1;
@@ -807,9 +802,9 @@ void initialiseAll(void)
         }
     #endif
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
-        channel3InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
         break;
     case 8:
         channel1IgnDegrees = 0;
@@ -875,10 +870,10 @@ void initialiseAll(void)
           channel7InjDegrees = 540;
           channel8InjDegrees = 630;
 
-          channel5InjEnabled = true;
-          channel6InjEnabled = true;
-          channel7InjEnabled = true;
-          channel8InjEnabled = true;
+          BIT_SET(channelInjEnabled, INJ5_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ6_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ7_CMD_BIT);
+          BIT_SET(channelInjEnabled, INJ8_CMD_BIT);
 
           CRANK_ANGLE_MAX_INJ = 720;
           currentStatus.nSquirts = 1;
@@ -886,10 +881,10 @@ void initialiseAll(void)
         }
     #endif
 
-        channel1InjEnabled = true;
-        channel2InjEnabled = true;
-        channel3InjEnabled = true;
-        channel4InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ1_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
         break;
     default: //Handle this better!!!
         channel1InjDegrees = 0;
@@ -3466,21 +3461,21 @@ void changeHalfToFullSync(void)
     switch (configPage2.nCylinders)
     {
       case 4:
-        channel3InjEnabled = true;
-        channel4InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ3_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
         break;
             
       case 6:
-        channel4InjEnabled = true;
-        channel5InjEnabled = true;
-        channel6InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ4_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ5_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ6_CMD_BIT);
         break;
 
       case 8:
-        channel5InjEnabled = true;
-        channel6InjEnabled = true;
-        channel7InjEnabled = true;
-        channel8InjEnabled = true;
+        BIT_SET(channelInjEnabled, INJ5_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ6_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ7_CMD_BIT);
+        BIT_SET(channelInjEnabled, INJ8_CMD_BIT);
         break;
 
       default:
@@ -3558,8 +3553,8 @@ void changeFullToHalfSync(void)
           inj2StartFunction = openInjector2and3;
           inj2EndFunction = closeInjector2and3;
         }
-        channel3InjEnabled = false;
-        channel4InjEnabled = false;
+        BIT_CLEAR(channelInjEnabled, INJ3_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ4_CMD_BIT);
         break;
             
       case 6:
@@ -3569,9 +3564,9 @@ void changeFullToHalfSync(void)
         inj2EndFunction = closeInjector2and5;
         inj3StartFunction = openInjector3and6;
         inj3EndFunction = closeInjector3and6;
-        channel4InjEnabled = false;
-        channel5InjEnabled = false;
-        channel6InjEnabled = false;
+        BIT_CLEAR(channelInjEnabled, INJ4_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ5_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ6_CMD_BIT);
         break;
 
       case 8:
@@ -3583,10 +3578,10 @@ void changeFullToHalfSync(void)
         inj3EndFunction = closeInjector3and7;
         inj4StartFunction = openInjector4and8;
         inj4EndFunction = closeInjector4and8;
-        channel5InjEnabled = false;
-        channel6InjEnabled = false;
-        channel7InjEnabled = false;
-        channel8InjEnabled = false;
+        BIT_CLEAR(channelInjEnabled, INJ5_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ6_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ7_CMD_BIT);
+        BIT_CLEAR(channelInjEnabled, INJ8_CMD_BIT);
         break;
     }
   }

--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -801,27 +801,27 @@ extern void beginInjectorPriming(void)
   if( (primingValue > 0) && (currentStatus.TPS < configPage4.floodClear) )
   {
     primingValue = primingValue * 100 * 5; //to achieve long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-    if ( channel1InjEnabled == true ) { setFuelSchedule1(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ1_CMD_BIT) == true ) { setFuelSchedule1(100, primingValue); }
 #if (INJ_CHANNELS >= 2)
-    if ( channel2InjEnabled == true ) { setFuelSchedule2(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ2_CMD_BIT) == true ) { setFuelSchedule2(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 3)
-    if ( channel3InjEnabled == true ) { setFuelSchedule3(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ3_CMD_BIT) == true ) { setFuelSchedule3(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 4)
-    if ( channel4InjEnabled == true ) { setFuelSchedule4(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ4_CMD_BIT) == true ) { setFuelSchedule4(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 5)
-    if ( channel5InjEnabled == true ) { setFuelSchedule5(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ5_CMD_BIT) == true ) { setFuelSchedule5(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 6)
-    if ( channel6InjEnabled == true ) { setFuelSchedule6(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ6_CMD_BIT) == true ) { setFuelSchedule6(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 7)
-    if ( channel7InjEnabled == true) { setFuelSchedule7(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ7_CMD_BIT) == true) { setFuelSchedule7(100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 8)
-    if ( channel8InjEnabled == true ) { setFuelSchedule8(100, primingValue); }
+    if ( BIT_CHECK(channelInjEnabled, INJ8_CMD_BIT) == true ) { setFuelSchedule8(100, primingValue); }
 #endif
   }
 }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -912,7 +912,7 @@ void loop(void)
         |------------------------------------------------------------------------------------------
         */
 #if INJ_CHANNELS >= 2
-        if( (channel2InjEnabled) && (currentStatus.PW2 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ2_CMD_BIT) == true) && (currentStatus.PW2 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel2InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -930,7 +930,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 3
-        if( (channel3InjEnabled) && (currentStatus.PW3 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ3_CMD_BIT) == true) && (currentStatus.PW3 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel3InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -948,7 +948,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 4
-        if( (channel4InjEnabled) && (currentStatus.PW4 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ4_CMD_BIT) == true) && (currentStatus.PW4 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel4InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -966,7 +966,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 5
-        if( (channel5InjEnabled) && (currentStatus.PW5 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ5_CMD_BIT) == true) && (currentStatus.PW5 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel5InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -992,7 +992,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 6
-        if( (channel6InjEnabled) && (currentStatus.PW6 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ6_CMD_BIT) == true) && (currentStatus.PW6 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel6InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -1010,7 +1010,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 7
-        if( (channel7InjEnabled) && (currentStatus.PW7 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ7_CMD_BIT) == true) && (currentStatus.PW7 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel7InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }
@@ -1028,7 +1028,7 @@ void loop(void)
 #endif
 
 #if INJ_CHANNELS >= 8
-        if( (channel8InjEnabled) && (currentStatus.PW8 >= inj_opentime_uS) )
+        if( (BIT_CHECK(channelInjEnabled, INJ8_CMD_BIT) == true) && (currentStatus.PW8 >= inj_opentime_uS) )
         {
           tempCrankAngle = crankAngle - channel8InjDegrees;
           if( tempCrankAngle < 0) { tempCrankAngle += CRANK_ANGLE_MAX_INJ; }


### PR DESCRIPTION
Saves 8 bytes of memory (I'm a bit surprised, I expected only 7). 24 bytes increase in firmware size. Loops/s seem unaffected.