### PR TITLE
Remove unused temp sensor calibration option

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5582,13 +5582,12 @@ cmdVSSratio6 =      "E\x99\x06"
 #endif
     referenceTable = std_ms2gentherm, "Calibrate Thermistor Tables."
       topicHelp = "https://wiki.speeduino.com/en/configuration/Sensor_Calibration"
-      tableIdentifier = 000, "Coolant Temperature Sensor", 001, "Air Temperature Sensor", 003, "Custom#1 Temperature Sensor"
+      tableIdentifier = 000, "Coolant Temperature Sensor", 001, "Air Temperature Sensor"
       ; tableLimits (optional) = intentifier, min, max, defaultVal 
       ; will set the default value if value is outside the min and max limits.
       tableLimits = 000, -40, 350, 180 ;Coolant
       tableLimits = 001, -40, 350, 70  ;IAT
       ;Table 002 is AFR
-      tableLimits = 003, -40, 400, 70 ; Not currently used
       
       adcCount            = 32  ; length of the table
       bytesPerAdc         = 2     ; using shorts


### PR DESCRIPTION
The "Custom#1 Temperature Sensor" calibration option gives the false impression that there is a third temperature sensor available to configure. Trying to calibrate this sensor gives errors.