### PR TITLE
Correct the get3DTableValue() return type.

### DIFF
--- a/speeduino/table3d.h
+++ b/speeduino/table3d.h
@@ -92,7 +92,7 @@ TABLE3D_GENERATOR(TABLE3D_GEN_TYPE)
 
 // Generate get3DTableValue() functions
 #define TABLE3D_GEN_GET_TABLE_VALUE(size, xDom, yDom) \
-    static inline int get3DTableValue(TABLE3D_TYPENAME_BASE(size, xDom, yDom) *pTable, table3d_axis_t y, table3d_axis_t x) \
+    static inline table3d_value_t get3DTableValue(TABLE3D_TYPENAME_BASE(size, xDom, yDom) *pTable, table3d_axis_t y, table3d_axis_t x) \
     { \
       return get3DTableValue( &pTable->get_value_cache, \
                               TABLE3D_TYPENAME_BASE(size, xDom, yDom)::value_t::row_size, \


### PR DESCRIPTION
The core interpolation function returns `table3d_value_t` (currently `uint8_t`), so the table specific wrappers should also: they were silently promoting the return to int (`int16_t` on Mega2560).