### PR TITLE
Sync mode changes: fuel shouldn't impact ignition

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -3438,7 +3438,6 @@ void changeHalfToFullSync(void)
   if( (configPage2.injLayout == INJ_SEQUENTIAL) && (CRANK_ANGLE_MAX_INJ != 720) )
   {
     CRANK_ANGLE_MAX_INJ = 720;
-    maxIgnOutputs = configPage2.nCylinders;
     req_fuel_uS *= 2;
     
     inj1StartFunction = openInjector1;
@@ -3534,7 +3533,6 @@ void changeFullToHalfSync(void)
   if(configPage2.injLayout == INJ_SEQUENTIAL)
   {
     CRANK_ANGLE_MAX_INJ = 360;
-    maxIgnOutputs = configPage2.nCylinders / 2;
     req_fuel_uS /= 2;
     switch (configPage2.nCylinders)
     {


### PR DESCRIPTION
With sequential injection & wasted spark `changeFullToHalfSync()` & `changeFullToHalfSync()` incorrectly change the number of ignition channels.