### PR TITLE
fix-eng-protect-min-tooltip

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2125,7 +2125,7 @@ menuDialog = main
   hardCutType       = "How the cuts should be performed for rev/launch limits. Full cut will stop all fuel/ignition events, Rolling cut will step through all ignition outputs, only cutting a limited number per revolution"
   SoftLimitMode     = "Fixed: the soft limiter will retard the ignition advance to the specified value.\nRelative: current timing advance will be retarted by the specified amount"
   hardRevLim        = "A fixed hard rev limit is a single point that the fuel or ignition (or both) will be cut completely to reduce increasing RPMs"
-  engineProtectMaxRPM = "The RPM point that engine protections will engage from. Below this RPM value, engine protections will NOT be active"
+  engineProtectMaxRPM = "The RPM point above which engine protections will engage. At this RPM and below, engine protections will NOT be active"
 
   ; AFR Protection Help
   afrProtectMAP     = "Minimum manifold air pressure the AFR lean protection will activate"


### PR DESCRIPTION
The original tool tip says that engine protections won't be active below min rpm. the code implementation is actually that they won't be active until above the min rpm.