### PR TITLE
make it possible to disable legacy comms

### DIFF
--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -7,8 +7,66 @@
  * 
  */
 
-#ifndef NEW_COMMS_H
-#define NEW_COMMS_H
+#ifndef COMMS_H
+#define COMMS_H
+
+/** \enum SerialStatus
+ * @brief The current state of serial communication
+ * */
+enum SerialStatus {
+  /** No serial comms is in progress */
+  SERIAL_INACTIVE, 
+  /** A partial write is in progress. */
+  SERIAL_TRANSMIT_INPROGRESS, 
+  /** A partial write is in progress (legacy send). */
+  SERIAL_TRANSMIT_INPROGRESS_LEGACY, 
+  /** We are part way through transmitting the tooth log */
+  SERIAL_TRANSMIT_TOOTH_INPROGRESS, 
+  /** We are part way through transmitting the tooth log (legacy send) */
+  SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY, 
+  /** We are part way through transmitting the composite log */
+  SERIAL_TRANSMIT_COMPOSITE_INPROGRESS,
+  /** We are part way through transmitting the composite log (legacy send) */
+  SERIAL_TRANSMIT_COMPOSITE_INPROGRESS_LEGACY,
+  /** Whether or not a serial request has only been partially received.
+   * This occurs when a the length has been received in the serial buffer,
+   * but not all of the payload or CRC has yet been received. 
+   * 
+   * Expectation is that ::serialReceive is called  until the status reverts 
+   * to SERIAL_INACTIVE
+  */
+  SERIAL_RECEIVE_INPROGRESS,
+  /** We are part way through processing a legacy serial commang: call ::serialReceive */
+  SERIAL_COMMAND_INPROGRESS_LEGACY,
+};
+/** @brief Current status of serial comms. */
+extern SerialStatus serialStatusFlag;
+
+/**
+ * @brief Is a serial write in progress?
+ * 
+ * Expectation is that ::serialTransmit is called until this
+ * returns false
+ */
+inline bool serialTransmitInProgress(void) {
+    return serialStatusFlag==SERIAL_TRANSMIT_INPROGRESS
+    || serialStatusFlag==SERIAL_TRANSMIT_INPROGRESS_LEGACY
+    || serialStatusFlag==SERIAL_TRANSMIT_TOOTH_INPROGRESS
+    || serialStatusFlag==SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY
+    || serialStatusFlag==SERIAL_TRANSMIT_COMPOSITE_INPROGRESS
+    || serialStatusFlag==SERIAL_TRANSMIT_COMPOSITE_INPROGRESS_LEGACY;
+}
+
+/**
+ * @brief Is a non-blocking serial receive operation in progress?
+ * 
+ * Expectation is the ::serialReceive is called until this
+ * returns false.
+ */
+inline bool serialRecieveInProgress(void) {
+  return serialStatusFlag==SERIAL_RECEIVE_INPROGRESS
+  || serialStatusFlag==SERIAL_COMMAND_INPROGRESS_LEGACY;
+}
 
 /**
  * @brief The serial receive pump. Should be called whenever the serial port
@@ -19,5 +77,10 @@ void serialReceive(void);
 /** @brief The serial transmit pump. Should be called when ::serialStatusFlag indicates a transmit
  * operation is in progress */
 void serialTransmit(void);
+
+extern bool firstCommsRequest; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
+extern byte logItemsTransmitted;
+
+void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum);
 
 #endif // COMMS_H

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -6,7 +6,11 @@ A full copy of the license may be found in the projects root directory
 /** @file
  * Process Incoming and outgoing serial communications.
  */
+
+#ifndef DISABLE_LEGACY_COMMS
+
 #include "globals.h"
+#include "comms.h"
 #include "comms_legacy.h"
 #include "cancomms.h"
 #include "storage.h"
@@ -24,16 +28,12 @@ A full copy of the license may be found in the projects root directory
 #endif
 
 static byte currentPage = 1;//Not the same as the speeduino config page numbers
-bool firstCommsRequest = true; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
 static byte currentCommand; /**< The serial command that is currently being processed. This is only useful when cmdPending=True */
 static bool chunkPending = false; /**< Whether or not the current chunk write is complete or not */
 static uint16_t chunkComplete = 0; /**< The number of bytes in a chunk write that have been written so far */
 static uint16_t chunkSize = 0; /**< The complete size of the requested chunk write */
 static int valueOffset; /**< The memory offset within a given page for a value to be read from or written to. Note that we cannot use 'offset' as a variable name, it is a reserved word for several teensy libraries */
-byte logItemsTransmitted;
 byte inProgressLength;
-SerialStatus serialStatusFlag;
-
 
 static bool isMap(void) {
     // Detecting if the current page is a table/map
@@ -998,7 +998,6 @@ void sendPageASCII(void)
   }
 }
 
-
 /** Processes an incoming stream of calibration data (for CLT, IAT or O2) from TunerStudio.
  * Result is store in EEPROM and memory.
  * 
@@ -1166,3 +1165,5 @@ void testComm(void)
   Serial.write(1);
   return;
 }
+
+#endif // DISABLE_LEGACY_COMMS

--- a/speeduino/comms_legacy.h
+++ b/speeduino/comms_legacy.h
@@ -7,73 +7,14 @@
  * 
  */
 
-#ifndef COMMS_H
-#define COMMS_H
+#ifndef LEGACY_COMMS_H
+#define LEGACY_COMMS_H
 
-/** \enum SerialStatus
- * @brief The current state of serial communication
- * */
-enum SerialStatus {
-  /** No serial comms is in progress */
-  SERIAL_INACTIVE, 
-  /** A partial write is in progress. */
-  SERIAL_TRANSMIT_INPROGRESS, 
-  /** A partial write is in progress (legacy send). */
-  SERIAL_TRANSMIT_INPROGRESS_LEGACY, 
-  /** We are part way through transmitting the tooth log */
-  SERIAL_TRANSMIT_TOOTH_INPROGRESS, 
-  /** We are part way through transmitting the tooth log (legacy send) */
-  SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY, 
-  /** We are part way through transmitting the composite log */
-  SERIAL_TRANSMIT_COMPOSITE_INPROGRESS,
-  /** We are part way through transmitting the composite log (legacy send) */
-  SERIAL_TRANSMIT_COMPOSITE_INPROGRESS_LEGACY,
-  /** Whether or not a serial request has only been partially received.
-   * This occurs when a the length has been received in the serial buffer,
-   * but not all of the payload or CRC has yet been received. 
-   * 
-   * Expectation is that ::serialReceive is called  until the status reverts 
-   * to SERIAL_INACTIVE
-  */
-  SERIAL_RECEIVE_INPROGRESS,
-  /** We are part way through processing a legacy serial commang: call ::serialReceive */
-  SERIAL_COMMAND_INPROGRESS_LEGACY,
-};
-/** @brief Current status of serial comms. */
-extern SerialStatus serialStatusFlag;
+#ifndef DISABLE_LEGACY_COMMS
 
-/**
- * @brief Is a serial write in progress?
- * 
- * Expectation is that ::serialTransmit is called until this
- * returns false
- */
-inline bool serialTransmitInProgress(void) {
-    return serialStatusFlag==SERIAL_TRANSMIT_INPROGRESS
-    || serialStatusFlag==SERIAL_TRANSMIT_INPROGRESS_LEGACY
-    || serialStatusFlag==SERIAL_TRANSMIT_TOOTH_INPROGRESS
-    || serialStatusFlag==SERIAL_TRANSMIT_TOOTH_INPROGRESS_LEGACY
-    || serialStatusFlag==SERIAL_TRANSMIT_COMPOSITE_INPROGRESS
-    || serialStatusFlag==SERIAL_TRANSMIT_COMPOSITE_INPROGRESS_LEGACY;
-}
-
-/**
- * @brief Is a non-blocking serial receive operation in progress?
- * 
- * Expectation is the ::serialReceive is called until this
- * returns false.
- */
-inline bool serialRecieveInProgress(void) {
-  return serialStatusFlag==SERIAL_RECEIVE_INPROGRESS
-  || serialStatusFlag==SERIAL_COMMAND_INPROGRESS_LEGACY;
-}
-
-extern bool firstCommsRequest; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
-extern byte logItemsTransmitted;
 extern byte inProgressLength;
 
 void legacySerialCommand(void);//This is the heart of the Command Line Interpreter.  All that needed to be done was to make it human readable.
-void sendValues(uint16_t offset, uint16_t packetLength, byte cmd, byte portNum);
 void sendValuesLegacy(void);
 void sendPage(void);
 void sendPageASCII(void);
@@ -82,4 +23,6 @@ void testComm(void);
 void sendToothLog_legacy(byte startOffset);
 void sendCompositeLog_legacy(byte startOffset);
 
-#endif // COMMS_H
+#endif // DISABLE_LEGACY_COMMS
+
+#endif // LEGACY_COMMS_H


### PR DESCRIPTION
not enabled anywhere yet, but can be tested by adding -DDISABLE_LEGACY_COMMS to compiler flags