### PR TITLE
Remove duplicates from speeduino.ini "SettingContextHelp"

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2091,6 +2091,8 @@ menuDialog = main
   idleUpPolarity    = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
   CTPSPolarity      = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
   idleUpAdder       = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
+  idleUpOutputEnabled = "Enable an output that is toggled by the idle up input pin. An example use is driving an AC fan relay."
+  idleUpOutputInv   = "No = When the idle up pin is high the output is active (grounding), when the idle up pin is low the output is inactive. Yes = When the idle up pin is high the output is inactive, when the idle up pin is low the output is active (grounding)."
   idleAdvEnabled    = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
   idleAdvAlgorithm  = "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
   idleAdvDelay      = "The number of seconds after sync is achieved before the idle advance control begins"
@@ -2108,24 +2110,12 @@ menuDialog = main
   taeThresh         = "The minimum speed that TPS must change at to trigger AE. Typical values are 40-100%/s"
   taeMinChange      = "The minimum absolute change in TPS in order to engage AE. Typical values are 0-3%"
   maeMinChange      = "The minimum absolute change in MAP in order to engage AE. Typical values are 0-5%"
+  decelAmount       = "Reduces fuel compared to VE table during deceleration. 100% means no reduction in fuel amount and 0% means all fuel is cut during decel (Do not confuse this with DFCO). Recommended to use values between 100 and 70%. Default: 100%. Works with both TPS and MAP based AE."
   dfcoRPM           = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
   dfcoHyster        = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
   dfcoTPSThresh     = "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
   dfcoDelay         = "Delay for activate DFCO."
   dfcoMinCLT        = "Minimum temperature to enable DFCO."
-
-  launchPin         = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
-  launchHiLo        = "Whether the signal is High or Low when the clutch pedal is engaged. For a ground switching input (Most clutch switches), this should be LOW"
-  lnchPullRes       = "Whether the internal pullup resistor is enabled or left floating. For a ground switching input (Most clutch switches), select Pullup. For a 0v-5v input, select Floating"
-  ignBypassPin      = "The ARDUINO pin that the ignition bypass is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
-  ignBypassEnable   = "If turned on, a ground signal will be output during cranking on the specified pin. This is used to bypass the Speeduino ignition control during cranking."
-  ignCranklock      = "On certain low resolution ignition patterns, the cranking timing can be locked to occur when a pulse is received."
-
-  multiplyMAP       = "If enabled, the MAP reading is included directly into the pulsewidth calculation by multiplying the VE lookup value by the MAP:Baro ratio. This results in a flatter VE table that can be easier to tune in some instances. VE table must be retuned when this value is changed."
-  legacyMAP         = "Use the legacy method of reading the MAP sensor that was used prior to the 201905 firmware. This should ONLY be enabled if you are upgrading from a firmware earlier than this"
-  includeAFR        = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed. "
-  incorporateAFR    = "When enabled, the AFR stoich/AFR target -ratio is incorporated directly in the pulsewidth calculation. When enabled, AFR target table affects pulsewidth even with EGO disabled. VE table must be retuned when this value is changed."
-  useExtBaro        = "By Default, Speeduino will measure barometric pressure upon startup. Optionally however, a 2nd pressure sensor can be used to perform live barometric readings whilst the system is on."
 
   flexEnabled       = "Turns on readings from the Flex sensor and enables the below adjustments"
   flexFreqLow       = "The frequency of the sensor at 0% ethanol (50Hz for standard GM/Continental sensor)"
@@ -2160,8 +2150,6 @@ menuDialog = main
   fuel2InputPolarity = "Whether the 2nd fuel table should be active when input is high or low. This should be LOW for a typical ground switching input"
   fuel2InputPullup  = "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
 
-  enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
-
   cltAdvValues    = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
 
   wueRates        = "Final enrichment value must be 100%."
@@ -2169,45 +2157,6 @@ menuDialog = main
   fpPrime         = "Duration to power fuel pump on to ensure fuel line pressure."
   primingDelay    = "Delay to priming after fuel pump is on, used to wait fuel line get pressurised correctly."
 
-  fanInv          = ""
-  fanHyster       = "The number of degrees of hysteresis to be used in controlling the fan. Recommended values are between 2 and 5"
-
-  aeTime          = "The duration of the acceleration enrichment"
-  aseTaperTime    = "Transition time to disable ASE"
-  iacChannels     = "The number of output channels used for PWM valves. Select 1 for 2-wire valves or 2 for 3-wire valves."
-  iacStepTime     = "Duration of each stepping pulse. Values that are too low can cause the motor to behave erratically or not at all. See the manual for suggested step times"
-  iacCoolTime     = "Cool time between each step. Set to zero if you don't want any cooling at all"
-  iacStepHome     = "Homing steps to perform on startup. Must be greater than the fully open steps value"
-  iacMaxSteps     = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
-  iacStepHyster   = "The minimum number of steps to move in any one go."
-  iacAlgorithm    = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
-  iacPWMdir       = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
-  iacCLminValue    = "When using closed loop idle control, this is the minimum duty cycle that the PID loop will allow. Combined with the maximum value, this specifies the working range of your idle valve"
-  iacCLmaxValue    = "When using closed loop idle control, this is the maximum duty cycle that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
-  iacFastTemp     = "Below this temperature, the idle output will be high (On). Above this temperature, it will turn off."
-  idleUpPolarity  = "Normal polarity is a ground switch where an earthed signal activates the Idle Up. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the Idle Up."
-  idleUpOutputEnabled = "Enable an output that is toggled by the idle up input pin. An example use is driving an AC fan relay."
-  idleUpOutputInv = "No = When the idle up pin is high the output is active (grounding), when the idle up pin is low the output is inactive. Yes = When the idle up pin is high the output is inactive, when the idle up pin is low the output is active (grounding)."
-  CTPSPolarity    = "Normal polarity is a ground switch where an earthed signal activates the closed throttle position. The internal pullup will be enabled with Normal polarity. \n Inverted may be used if a 5v signal is used to enable the closed throttle position."
-  idleUpAdder     = "The amount (In either Duty Cycle % or Steps (Depending on the idle control method in use), that the idle control will increase by when Idle Up is active"
-  idleAdvEnabled  = "Added setting adds curve values to current spark table values when user defined idle is active. \n Switched setting overrides spark table values and uses curve values for idle ignition timing."
-  idleAdvAlgorithm= "Use Throttle position sensor (TPS) or closed throttle position sensor (CTPS) to detect idle state."
-  idleAdvDelay    = "The number of seconds after sync is achieved before the idle advance control begins"
-  idleTaperTime   = "Soft time transition from crank to running PWM targets"
-
-  oddfire2        = "The ATDC angle of channel 2 for oddfire engines. This is relative to the TDC angle of channel 1"
-  oddfire3        = "The ATDC angle of channel 3 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 2)"
-  oddfire4        = "The ATDC angle of channel 4 for oddfire engines. This is relative to the TDC angle of channel 1 (NOT channel 3)"
-
-  aeColdPct       = "Acceleration enrichment adjustment for cold engine. Cold adjustment % is tapered between start and end temperatures.\n100% = no adjustment."
-  aeColdTaperMin  = "AE cold adjustment taper start temperature. When coolant is below this value, full cold adjustment is applied."
-  aeColdTaperMax  = "AE cold adjustment taper end temperature. When coolant is above this value, no cold adjustment is applied."
-  decelAmount     = "Reduces fuel compared to VE table during deceleration. 100% means no reduction in fuel amount and 0% means all fuel is cut during decel (Do not confuse this with DFCO). Recommended to use values between 100 and 70%. Default: 100%. Works with both TPS and MAP based AE."
-  dfcoRPM         = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
-  dfcoHyster      = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
-  dfcoTPSThresh   = "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
-  dfcoDelay       = "Delay for activate DFCO."
-  dfcoMinCLT      = "Minimum temperature to enable DFCO."
   crankingEnrichTaper = "Taper time from cranking enrichment to ASE or run (after engine has started)."
 
   launchPin       = "The ARDUINO pin that the clutch switch is connected to. This is NOT the pin on the connector, but the pin it relates to on the arduino"
@@ -2224,31 +2173,11 @@ menuDialog = main
 
   multiplyMAP     = "If enabled, the MAP reading is included directly into the pulsewidth calculation by multiplying the VE lookup value by either the MAP:Baro ratio or MAP/100.\n This results in a flatter VE table that can be easier to tune in some instances. The MAP/100 option is generally used for compatibility with fuel tables from other ECUs. MAP:Baro ratio is recommended for new tunes. \n VE table must be retuned when this value is changed."
   legacyMAP       = "Use the legacy method of reading the MAP sensor that was used prior to the 201905 firmware. This should ONLY be enabled if you are upgrading from a firmware earlier than this"
-  includeAFR      = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed. "
+  includeAFR      = "When enabled, the current AFR reading is incorporated directly in the pulsewidth calculation as a percentage of the current target ratio. VE table must be retuned when this value is changed."
+  incorporateAFR  = "When enabled, the AFR stoich/AFR target -ratio is incorporated directly in the pulsewidth calculation. When enabled, AFR target table affects pulsewidth even with EGO disabled. VE table must be retuned when this value is changed."
   useExtBaro      = "By Default, Speeduino will measure barometric pressure upon startup. Optionally however, a 2nd pressure sensor can be used to perform live barometric readings whilst the system is on."
 
-  flexEnabled     = "Turns on readings from the Flex sensor and enables the below adjustments"
-  flexFreqLow     = "The frequency of the sensor at 0% ethanol (50Hz for standard GM/Continental sensor)"
-  flexFreqHigh    = "The frequency of the sensor at 100% ethanol (150Hz for standard GM/Continental sensor)"
-  flexFuelAdj     = "Fuel % to be used for the current ethanol % (Typically 100% @ 0%, 163% @ 100%)"
-  flexAdvAdj      = "Additional advance (in degrees) for the current ethanol % (Typically 0 @ 0%, 10-20 @ 100%)"
-  flexBoostAdj    = "Adjustment, in kPa, to the boost target for the current ethanol %. Negative values are allowed to lower boost at lower ethanol % if necessary."
-
-  n2o_arming_pin  = "Pin that the nitrous arming/engagement switch is on."
-  n2o_pin_polarity= "Whether Nitrous is active (Armed) when the pin is LOW or HIGH. If LOW is selected, the internal pullup will be used."
-
-  flatSArm        = "The RPM switch point that determines whether an engaged clutch is for launch control or flat shift. Below this figure, an engaged clutch is considered to be for launch, above this figure an active clutch input will be considered a flat shift. This should be set at least several hundred RPM above idle"
-  flatSSoftWin    = "The number of RPM below the flat shift point where the softlimit will be applied (aka Soft limit window). Recommended values are 200-1000"
-  flatSRetard     = "The absolute timing (BTDC) that will be used when within the soft limit window"
-  hardCutType     = "How hard cuts should be performed for rev/launch limits. Full cut will stop all ignition events, Rolling cut will step through all ignition outputs, only cutting 1 per revolution"
-
-  fuel2InputPin   = "The Arduino pin that is being used to trigger the second fuel table to be active"
-  fuel2InputPolarity = "Whether the 2nd fuel table should be active when input is high or low. This should be LOW for a typical ground switching input"
-  fuel2InputPullup= "Whether to use the built in PULLUP for the switching input. This should be Yes for a typical ground switching input"
-
   enable_secondarySerial = "This Enables the secondary serial port . Secondary serial is serial3 on mega2560 processor, and Serial2 on STM32 and Teensy processor "
-  
-  cltAdvValues    = "This curve can be used to advance ignition timing when engine is warming up. This can also be used to warm up the catalytic converters in cold start by retarding timing. Or even as safety feature to retard timing when engine is too hot to prevent knock."
 
   ;speeduino_tsCanId = "This is the TsCanId that the Speeduino ECU will respond to. This should match the main controller CAN ID in project properties if it is connected directly to TunerStudio, Otherwise the device ID if connected via CAN passthrough"
   true_address    = "This is the 11bit Can address of the Speeduino ECU "


### PR DESCRIPTION
For some reason the "SettingContextHelp" in speeduino.ini was full of duplicate entries. There was even some old versions left that aren't true anymore. I did remove the duplicates. Especially the wrong ones if there was one. And rearranged few so that same types are closer to each other.