### PR TITLE
Fix single cylinder staging configuration

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -480,7 +480,7 @@ void initialiseAll(void)
         if(configPage10.stagingEnabled == true)
         {
           BIT_SET(channelInjEnabled, INJ2_CMD_BIT);
-          channel3InjDegrees = channel1InjDegrees;
+          channel2InjDegrees = channel1InjDegrees;
         }
         break;
 


### PR DESCRIPTION
The recent injector staging update had a typo for single cylinder configurations: enabled channel 2, but set the injector angle on channel 3.

Note: I couldn't test this configuration