### PR TITLE
Expand initialisation tests: test start/end callback assignment

### DIFF
--- a/speeduino/scheduler.ino
+++ b/speeduino/scheduler.ino
@@ -170,6 +170,40 @@ void initialiseSchedulers(void)
     channel6InjDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
     channel7InjDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
     channel8InjDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */    
+
+    inj1StartFunction = nullCallback;
+    inj1EndFunction = nullCallback;
+    inj2StartFunction = nullCallback;
+    inj2EndFunction = nullCallback;
+    inj3StartFunction = nullCallback;
+    inj3EndFunction = nullCallback;
+    inj4StartFunction = nullCallback;
+    inj4EndFunction = nullCallback;
+    inj5StartFunction = nullCallback;
+    inj5EndFunction = nullCallback;
+    inj6StartFunction = nullCallback;
+    inj6EndFunction = nullCallback;
+    inj7StartFunction = nullCallback;
+    inj7EndFunction = nullCallback;
+    inj8StartFunction = nullCallback;
+    inj8EndFunction = nullCallback;
+
+    ign1StartFunction = nullCallback;
+    ign1EndFunction = nullCallback;
+    ign2StartFunction = nullCallback;
+    ign2EndFunction = nullCallback;
+    ign3StartFunction = nullCallback;
+    ign3EndFunction = nullCallback;
+    ign4StartFunction = nullCallback;
+    ign4EndFunction = nullCallback;
+    ign5StartFunction = nullCallback;
+    ign5EndFunction = nullCallback;
+    ign6StartFunction = nullCallback;
+    ign6EndFunction = nullCallback;
+    ign7StartFunction = nullCallback;
+    ign7EndFunction = nullCallback;
+    ign8StartFunction = nullCallback;
+    ign8EndFunction = nullCallback;
 }
 
 /*

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -3,10 +3,25 @@
 #include "globals.h"
 #include "init.h"
 #include "schedule_calcs.h"
+#include "scheduledIO.h"
 
 extern uint16_t req_fuel_uS;
 
 static constexpr uint16_t reqFuel = 86; // ms * 10
+
+static void assert_fuel_channel(bool enabled, uint16_t angle, uint8_t cmdBit, int channelInjDegrees, void (*startFunction)(void), void (*endFunction)(void))
+{
+  char msg[32];
+
+  sprintf_P(msg, PSTR("channel%" PRIu8 "1InjDegrees.isEnabled"), cmdBit+1);
+  TEST_ASSERT_EQUAL_MESSAGE(enabled, BIT_CHECK(channelInjEnabled, cmdBit), msg);
+  sprintf_P(msg, PSTR("channe%" PRIu8 "1InjDegrees"), cmdBit+1);
+  TEST_ASSERT_EQUAL_MESSAGE(angle, channelInjDegrees, msg);
+  sprintf_P(msg, PSTR("inj%" PRIu8 "StartFunction"), cmdBit+1);
+  TEST_ASSERT_TRUE_MESSAGE(!enabled || (startFunction!=nullCallback), msg);
+  sprintf_P(msg, PSTR("inj%" PRIu8 "EndFunction"), cmdBit+1);
+  TEST_ASSERT_TRUE_MESSAGE(!enabled || (endFunction!=nullCallback), msg);
+}
 
 static void assert_fuel_schedules(uint16_t crankAngle, uint16_t reqFuel, const bool enabled[], const uint16_t angle[])
 {
@@ -17,45 +32,25 @@ static void assert_fuel_schedules(uint16_t crankAngle, uint16_t reqFuel, const b
   strcpy_P(msg, PSTR("req_fuel_uS"));
   TEST_ASSERT_EQUAL_UINT16_MESSAGE(reqFuel, req_fuel_uS, msg);
 
-  strcpy_P(msg, PSTR("channel1InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[0], BIT_CHECK(channelInjEnabled, INJ1_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel1InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[0], channel1InjDegrees, msg);
-  strcpy_P(msg, PSTR("channel2InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[1], BIT_CHECK(channelInjEnabled, INJ2_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel2InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[1], channel2InjDegrees, msg);
-  strcpy_P(msg, PSTR("channel3InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[2], BIT_CHECK(channelInjEnabled, INJ3_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel3InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[2], channel3InjDegrees, msg);
-  strcpy_P(msg, PSTR("channel4InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[3], BIT_CHECK(channelInjEnabled, INJ4_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel4InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[3], channel4InjDegrees, msg);
+  assert_fuel_channel(enabled[0], angle[0], INJ1_CMD_BIT, channel1InjDegrees, inj1StartFunction, inj1EndFunction);
+  assert_fuel_channel(enabled[1], angle[1], INJ2_CMD_BIT, channel2InjDegrees, inj2StartFunction, inj2EndFunction);
+  assert_fuel_channel(enabled[2], angle[2], INJ3_CMD_BIT, channel3InjDegrees, inj3StartFunction, inj3EndFunction);
+  assert_fuel_channel(enabled[3], angle[3], INJ4_CMD_BIT, channel4InjDegrees, inj4StartFunction, inj4EndFunction);
+
 #if INJ_CHANNELS>=5
-  strcpy_P(msg, PSTR("channel5InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[4], BIT_CHECK(channelInjEnabled, INJ5_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel5InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[4], channel5InjDegrees, msg);
+  assert_fuel_channel(enabled[4], angle[4], INJ5_CMD_BIT, channel5InjDegrees, inj5StartFunction, inj5EndFunction);
 #endif
+
 #if INJ_CHANNELS>=6
-  strcpy_P(msg, PSTR("channel6InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[5], BIT_CHECK(channelInjEnabled, INJ6_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel6InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[5], channel6InjDegrees, msg);
+  assert_fuel_channel(enabled[5], angle[5], INJ6_CMD_BIT, channel6InjDegrees, inj6StartFunction, inj6EndFunction);
 #endif
+
 #if INJ_CHANNELS>=7
-  strcpy_P(msg, PSTR("channel7InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[6], BIT_CHECK(channelInjEnabled, INJ7_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel7InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[6], channel7InjDegrees, msg);
+  assert_fuel_channel(enabled[6], angle[6], INJ7_CMD_BIT, channel7InjDegrees, inj7StartFunction, inj7EndFunction);
 #endif
+
 #if INJ_CHANNELS>=8
-  strcpy_P(msg, PSTR("channel8InjDegrees.isEnabled"));
-  TEST_ASSERT_EQUAL_MESSAGE(enabled[7], BIT_CHECK(channelInjEnabled, INJ8_CMD_BIT), msg);
-  strcpy_P(msg, PSTR("channel8InjDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[7], channel8InjDegrees, msg);
+  assert_fuel_channel(enabled[7], angle[7], INJ8_CMD_BIT, channel8InjDegrees, inj8StartFunction, inj8EndFunction);
 #endif 
 }
 

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -3,6 +3,19 @@
 #include "globals.h"
 #include "init.h"
 #include "schedule_calcs.h"
+#include "scheduledIO.h"
+
+static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channelInjDegrees, void (*startFunction)(void), void (*endFunction)(void))
+{
+  char msg[32];
+
+  sprintf_P(msg, PSTR("channe%" PRIu8 "1InjDegrees"), channel+1);
+  TEST_ASSERT_EQUAL_MESSAGE(angle, channelInjDegrees, msg);
+  sprintf_P(msg, PSTR("ign%" PRIu8 "StartFunction"), channel+1);
+  TEST_ASSERT_TRUE_MESSAGE(channel>=maxIgnOutputs || (startFunction!=nullCallback), msg);
+  sprintf_P(msg, PSTR("ign%" PRIu8 "EndFunction"), channel+1);
+  TEST_ASSERT_TRUE_MESSAGE(channel>=maxIgnOutputs || (endFunction!=nullCallback), msg);
+}
 
 static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutputs, uint16_t angle[])
 {
@@ -13,29 +26,21 @@ static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutp
   strcpy_P(msg, PSTR("maxIgnOutputs"));
   TEST_ASSERT_EQUAL_UINT16_MESSAGE(expectedOutputs, maxIgnOutputs, msg);
 
-  strcpy_P(msg, PSTR("channel1IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[0], channel1IgnDegrees, msg);
-  strcpy_P(msg, PSTR("channel2IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[1], channel2IgnDegrees, msg);
-  strcpy_P(msg, PSTR("channel3IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[2], channel3IgnDegrees, msg);
-  strcpy_P(msg, PSTR("channel4IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[3], channel4IgnDegrees, msg);
+  assert_ignition_channel(angle[0], 0, channel1IgnDegrees, ign1StartFunction, ign1EndFunction);
+  assert_ignition_channel(angle[1], 1, channel2IgnDegrees, ign2StartFunction, ign2EndFunction);
+  assert_ignition_channel(angle[2], 2, channel3IgnDegrees, ign3StartFunction, ign3EndFunction);
+  assert_ignition_channel(angle[3], 3, channel4IgnDegrees, ign4StartFunction, ign4EndFunction);
 #if IGN_CHANNELS>=5
-  strcpy_P(msg, PSTR("channel5IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[4], channel5IgnDegrees, msg);
+  assert_ignition_channel(angle[4], 4, channel5IgnDegrees, ign5StartFunction, ign5EndFunction);
 #endif
 #if IGN_CHANNELS>=6
-  strcpy_P(msg, PSTR("channel6IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[5], channel6IgnDegrees, msg);
+  assert_ignition_channel(angle[5], 5, channel6IgnDegrees, ign6StartFunction, ign6EndFunction);
 #endif
 #if IGN_CHANNELS>=7
-  strcpy_P(msg, PSTR("channel7IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[6], channel7IgnDegrees, msg);
+  assert_ignition_channel(angle[6], 6, channel7IgnDegrees, ign7StartFunction, ign7EndFunction);
 #endif
 #if IGN_CHANNELS>=8
-  strcpy_P(msg, PSTR("channel8IgnDegrees"));
-  TEST_ASSERT_EQUAL_MESSAGE(angle[7], channel8IgnDegrees, msg);
+  assert_ignition_channel(angle[7], 7, channel8IgnDegrees, ign8StartFunction, ign8EndFunction);
 #endif 
 }
 


### PR DESCRIPTION
Add testing of schedule start & end callbacks to the initialisation code.