### PR TITLE
Additonal schedule initialization unit tests

### DIFF
--- a/speeduino/scheduledIO.h
+++ b/speeduino/scheduledIO.h
@@ -269,4 +269,6 @@ void tachoOutputOff(void);
 
 void nullCallback(void);
 
+typedef void (*voidVoidCallback)(void);
+
 #endif

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -4,6 +4,7 @@
 #include "init.h"
 #include "schedule_calcs.h"
 #include "scheduledIO.h"
+#include "..\test_utils.h"
 
 extern uint16_t req_fuel_uS;
 
@@ -621,15 +622,15 @@ void test_fuel_schedule_8_cylinder_4stroke(void)
 
 void testFuelScheduleInit()
 {
-    RUN_TEST(test_fuel_schedule_1_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_1_cylinder_2stroke);
-    RUN_TEST(test_fuel_schedule_2_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_2_cylinder_2stroke);
-    RUN_TEST(test_fuel_schedule_3_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_3_cylinder_2stroke);
-    RUN_TEST(test_fuel_schedule_4_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_4_cylinder_2stroke);
-    RUN_TEST(test_fuel_schedule_5_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_6_cylinder_4stroke);
-    RUN_TEST(test_fuel_schedule_8_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_1_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_1_cylinder_2stroke);
+    RUN_TEST_P(test_fuel_schedule_2_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_2_cylinder_2stroke);
+    RUN_TEST_P(test_fuel_schedule_3_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_3_cylinder_2stroke);
+    RUN_TEST_P(test_fuel_schedule_4_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_4_cylinder_2stroke);
+    RUN_TEST_P(test_fuel_schedule_5_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_6_cylinder_4stroke);
+    RUN_TEST_P(test_fuel_schedule_8_cylinder_4stroke);
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -56,9 +56,10 @@ static void __attribute__((noinline)) assert_fuel_schedules(uint16_t crankAngle,
 #endif 
 }
 
-static void cylinder1_stroke4_seq_no_stage(void)
+static void cylinder1_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, false, false, false, false, false, false, false};
@@ -66,9 +67,10 @@ static void cylinder1_stroke4_seq_no_stage(void)
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 }
 
-static void cylinder1_stroke4_semiseq_no_stage(void)
+static void cylinder1_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, false, false, false, false, false, false, false};
@@ -76,9 +78,10 @@ static void cylinder1_stroke4_semiseq_no_stage(void)
   assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 }
 
-static void cylinder1_stroke4_seq_with_stage(void)
+static void cylinder1_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
@@ -86,9 +89,10 @@ static void cylinder1_stroke4_seq_with_stage(void)
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder1_stroke4_semiseq_with_stage(void)
+static void cylinder1_stroke4_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
@@ -101,54 +105,57 @@ static void run_1_cylinder_4stroke_tests(void)
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel; 
   configPage2.divider = 1;
 
-  RUN_TEST_P(cylinder1_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder1_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder1_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder1_stroke4_semiseq_with_stage);
+  RUN_TEST_P(cylinder1_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder1_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder1_stroke4_seq_staged);
+  RUN_TEST_P(cylinder1_stroke4_semiseq_staged);
 }
 
-static void cylinder1_stroke2_seq_no_stage(void)
+static void cylinder1_stroke2_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
   const bool enabled[] = {true, false, false, false, false, false, false, false};
   const uint16_t angle[] = {0,0,0,0,0,0,0,0};
   assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);  
-  }
+}
 
-static void cylinder1_stroke2_semiseq_no_stage(void)
+static void cylinder1_stroke2_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, false, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
   assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder1_stroke2_seq_with_stage(void)
+static void cylinder1_stroke2_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
   assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder1_stroke2_semiseq_with_stage(void)
-  {
+static void cylinder1_stroke2_semiseq_staged(void)
+{
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-	const bool enabled[] = {true, true, false, false, false, false, false, false};
-	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);  
+  const bool enabled[] = {true, true, false, false, false, false, false, false};
+  const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);  
 }
 
 static void run_1_cylinder_2stroke_tests(void)
@@ -156,49 +163,52 @@ static void run_1_cylinder_2stroke_tests(void)
   configPage2.nCylinders = 1;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  RUN_TEST_P(cylinder1_stroke2_seq_no_stage);
-  RUN_TEST_P(cylinder1_stroke2_semiseq_no_stage);
-  RUN_TEST_P(cylinder1_stroke2_seq_with_stage);
-  RUN_TEST_P(cylinder1_stroke2_semiseq_with_stage);
+  RUN_TEST_P(cylinder1_stroke2_seq_nostage);
+  RUN_TEST_P(cylinder1_stroke2_semiseq_nostage);
+  RUN_TEST_P(cylinder1_stroke2_seq_staged);
+  RUN_TEST_P(cylinder1_stroke2_semiseq_staged);
 }
 
-static void cylinder2_stroke4_seq_no_stage(void)
+static void cylinder2_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke4_semiseq_no_stage(void)
+static void cylinder2_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke4_seq_with_stage(void)
+static void cylinder2_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, true, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke4_semiseq_with_stage(void)
+static void cylinder2_stroke4_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, true, false, false, false, false};
@@ -211,50 +221,53 @@ static void run_2_cylinder_4stroke_tests(void)
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  RUN_TEST_P(cylinder2_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder2_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder2_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder2_stroke4_semiseq_with_stage);
+  RUN_TEST_P(cylinder2_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder2_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder2_stroke4_seq_staged);
+  RUN_TEST_P(cylinder2_stroke4_semiseq_staged);
 }
 
 
-static void cylinder2_stroke2_seq_no_stage(void)
+static void cylinder2_stroke2_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke2_semiseq_no_stage(void)
+static void cylinder2_stroke2_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, false, false, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke2_seq_with_stage(void)
+static void cylinder2_stroke2_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, true, false, false, false, false};
 	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder2_stroke2_semiseq_with_stage(void)
+static void cylinder2_stroke2_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, true, false, false, false, false};
@@ -267,39 +280,41 @@ static void run_2_cylinder_2stroke_tests(void)
   configPage2.nCylinders = 2;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  RUN_TEST_P(cylinder2_stroke2_seq_no_stage);
-  RUN_TEST_P(cylinder2_stroke2_semiseq_no_stage);
-  RUN_TEST_P(cylinder2_stroke2_seq_with_stage);
-  RUN_TEST_P(cylinder2_stroke2_semiseq_with_stage);
+  RUN_TEST_P(cylinder2_stroke2_seq_nostage);
+  RUN_TEST_P(cylinder2_stroke2_semiseq_nostage);
+  RUN_TEST_P(cylinder2_stroke2_seq_staged);
+  RUN_TEST_P(cylinder2_stroke2_semiseq_staged);
 }
 
-static void cylinder3_stroke4_seq_no_stage(void)
+static void cylinder3_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, false, false, false, false, false};
 	const uint16_t angle[] = {0,240,480,0,0,0,0,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
+}
 
-static void cylinder3_stroke4_semiseq_no_stage(void)
+static void cylinder3_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 	const bool enabled[] = {true, true, true, false, false, false, false, false};
 	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
   assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle);
-  }
+}
 
-static void cylinder3_stroke4_seq_with_stage(void)
+static void cylinder3_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage2.injTiming = true;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS>=6
@@ -311,9 +326,9 @@ static void cylinder3_stroke4_seq_with_stage(void)
 	const uint16_t angle[] = {0,240,480,0,0,0,0,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #endif
-  }
+}
 
-static void cylinder3_stroke4_semiseq_with_stage(void)
+static void cylinder3_stroke4_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -334,17 +349,16 @@ static void run_3_cylinder_4stroke_tests(void)
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  RUN_TEST_P(cylinder3_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder3_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder3_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder3_stroke4_semiseq_with_stage);
+  RUN_TEST_P(cylinder3_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder3_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder3_stroke4_seq_staged);
+  RUN_TEST_P(cylinder3_stroke4_semiseq_staged);
 }
 
-static void cylinder3_stroke2_seq_no_stage(void)
+static void cylinder3_stroke2_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -354,7 +368,7 @@ static void cylinder3_stroke2_seq_no_stage(void)
   assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder3_stroke2_semiseq_no_stage(void)
+static void cylinder3_stroke2_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -364,7 +378,7 @@ static void cylinder3_stroke2_semiseq_no_stage(void)
   assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder3_stroke2_seq_with_stage(void)
+static void cylinder3_stroke2_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -380,7 +394,7 @@ static void cylinder3_stroke2_seq_with_stage(void)
 #endif
   }
 
-static void cylinder3_stroke2_semiseq_with_stage(void)
+static void cylinder3_stroke2_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -405,13 +419,13 @@ static void run_3_cylinder_2stroke_tests(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
  
-  RUN_TEST_P(cylinder3_stroke2_seq_no_stage);
-  RUN_TEST_P(cylinder3_stroke2_semiseq_no_stage);
-  RUN_TEST_P(cylinder3_stroke2_seq_with_stage);
-  RUN_TEST_P(cylinder3_stroke2_semiseq_with_stage);
+  RUN_TEST_P(cylinder3_stroke2_seq_nostage);
+  RUN_TEST_P(cylinder3_stroke2_semiseq_nostage);
+  RUN_TEST_P(cylinder3_stroke2_seq_staged);
+  RUN_TEST_P(cylinder3_stroke2_semiseq_staged);
 }
 
-static void cylinder4_stroke4_seq_no_stage(void)
+static void cylinder4_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -421,7 +435,7 @@ static void cylinder4_stroke4_seq_no_stage(void)
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder4_stroke4_semiseq_no_stage(void)
+static void cylinder4_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -431,7 +445,7 @@ static void cylinder4_stroke4_semiseq_no_stage(void)
   assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
   }
 
-static void cylinder4_stroke4_seq_with_stage(void)
+static void cylinder4_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -451,7 +465,7 @@ static void cylinder4_stroke4_seq_with_stage(void)
 #endif
   }
 
-static void cylinder4_stroke4_semiseq_with_stage(void)  
+static void cylinder4_stroke4_semiseq_staged(void)  
 {
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
@@ -470,13 +484,13 @@ void run_4_cylinder_4stroke_tests(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 2;
 
-  RUN_TEST_P(cylinder4_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder4_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder4_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder4_stroke4_semiseq_with_stage);  
+  RUN_TEST_P(cylinder4_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder4_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder4_stroke4_seq_staged);
+  RUN_TEST_P(cylinder4_stroke4_semiseq_staged);  
 }
 
-static void cylinder4_stroke2_seq_no_stage(void)
+static void cylinder4_stroke2_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -486,7 +500,7 @@ static void cylinder4_stroke2_seq_no_stage(void)
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder4_stroke2_semiseq_no_stage(void)
+static void cylinder4_stroke2_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -496,7 +510,7 @@ static void cylinder4_stroke2_semiseq_no_stage(void)
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
   }
 
-static void cylinder4_stroke2_seq_with_stage(void)
+static void cylinder4_stroke2_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -516,7 +530,7 @@ static void cylinder4_stroke2_seq_with_stage(void)
 #endif
   }
 
-static void cylinder4_stroke2_semiseq_with_stage(void)
+static void cylinder4_stroke2_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
@@ -535,13 +549,13 @@ void run_4_cylinder_2stroke_tests(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 2;
 
-  RUN_TEST_P(cylinder4_stroke2_seq_no_stage);
-  RUN_TEST_P(cylinder4_stroke2_semiseq_no_stage);
-  RUN_TEST_P(cylinder4_stroke2_seq_with_stage);
-  RUN_TEST_P(cylinder4_stroke2_semiseq_with_stage);  
+  RUN_TEST_P(cylinder4_stroke2_seq_nostage);
+  RUN_TEST_P(cylinder4_stroke2_semiseq_nostage);
+  RUN_TEST_P(cylinder4_stroke2_seq_staged);
+  RUN_TEST_P(cylinder4_stroke2_semiseq_staged);  
 }
 
-static void cylinder5_stroke4_seq_no_stage(void)
+static void cylinder5_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -558,7 +572,7 @@ static void cylinder5_stroke4_seq_no_stage(void)
   }
 
 
-static void cylinder5_stroke4_semiseq_no_stage(void)
+static void cylinder5_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -568,7 +582,7 @@ static void cylinder5_stroke4_semiseq_no_stage(void)
   assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
   }
 
-static void cylinder5_stroke4_seq_with_stage(void)
+static void cylinder5_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -584,7 +598,7 @@ static void cylinder5_stroke4_seq_with_stage(void)
 #endif
   }
 
-static void cylinder5_stroke4_semiseq_with_stage(void) 
+static void cylinder5_stroke4_semiseq_staged(void) 
 {
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
@@ -609,13 +623,13 @@ void run_5_cylinder_4stroke_tests(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 5;
 
-  RUN_TEST_P(cylinder5_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder5_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder5_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder5_stroke4_semiseq_with_stage); 
+  RUN_TEST_P(cylinder5_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder5_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder5_stroke4_seq_staged);
+  RUN_TEST_P(cylinder5_stroke4_semiseq_staged); 
 }
 
-static void cylinder6_stroke4_seq_no_stage(void)
+static void cylinder6_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -631,7 +645,7 @@ static void cylinder6_stroke4_seq_no_stage(void)
 #endif
   }
 
-static void cylinder6_stroke4_semiseq_no_stage(void)
+static void cylinder6_stroke4_semiseq_nostage(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -641,7 +655,7 @@ static void cylinder6_stroke4_semiseq_no_stage(void)
   assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
   }
 
-static void cylinder6_stroke4_seq_with_stage(void)
+static void cylinder6_stroke4_seq_staged(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -658,7 +672,7 @@ static void cylinder6_stroke4_seq_with_stage(void)
   }
 
 
-static void cylinder6_stroke4_semiseq_with_stage(void)
+static void cylinder6_stroke4_semiseq_staged(void)
 {
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = true;
@@ -683,13 +697,13 @@ void run_6_cylinder_4stroke_tests(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 6;
 
-  RUN_TEST_P(cylinder6_stroke4_seq_no_stage);
-  RUN_TEST_P(cylinder6_stroke4_semiseq_no_stage);
-  RUN_TEST_P(cylinder6_stroke4_seq_with_stage);
-  RUN_TEST_P(cylinder6_stroke4_semiseq_with_stage); 
+  RUN_TEST_P(cylinder6_stroke4_seq_nostage);
+  RUN_TEST_P(cylinder6_stroke4_semiseq_nostage);
+  RUN_TEST_P(cylinder6_stroke4_seq_staged);
+  RUN_TEST_P(cylinder6_stroke4_semiseq_staged); 
 }
 
-static void cylinder8_stroke4_seq_no_stage(void)
+static void cylinder8_stroke4_seq_nostage(void)
 {
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
@@ -716,7 +730,7 @@ void run_8_cylinder_4stroke_tests(void)
 
   // Staging not supported on 8 cylinders
 
-  RUN_TEST_P(cylinder8_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder8_stroke4_seq_nostage);
 }
 
 static constexpr uint16_t zeroAngles[] = {0,0,0,0,0,0,0,0};
@@ -823,6 +837,55 @@ static void run_no_inj_timing_tests(void)
   RUN_TEST_P(cylinder_8_NoinjTiming_paired);
 }
 
+static void cylinder_2_oddfire(void)
+{
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 2;
+  configPage2.divider = 2;
+
+  initialiseAll(); //Run the main initialise function
+
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,13,0,0,0,0,0,0};
+  Serial.println(configPage2.engineType);
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+}
+
+static void run_oddfire_tests()
+{
+  configPage2.strokes = FOUR_STROKE;
+  configPage2.engineType = ODD_FIRE;
+  configPage2.injTiming = true;
+  configPage2.reqFuel = reqFuel;
+  configPage10.stagingEnabled = false;
+  configPage2.oddfire2 = 13;
+  configPage2.oddfire3 = 111;
+  configPage2.oddfire4 = 217;
+
+  // Oddfire only affects 2 cylinder configurations
+  configPage2.nCylinders = 1;
+  configPage2.divider = 1;
+  RUN_TEST_P(cylinder1_stroke4_seq_nostage);
+
+  RUN_TEST_P(cylinder_2_oddfire);
+
+  configPage2.nCylinders = 3;
+  configPage2.divider = 1;
+  RUN_TEST_P(cylinder3_stroke4_seq_nostage);
+  configPage2.nCylinders = 4;
+  configPage2.divider = 2;
+  RUN_TEST_P(cylinder4_stroke4_seq_nostage);
+  configPage2.nCylinders = 5;
+  configPage2.divider = 5;
+  RUN_TEST_P(cylinder5_stroke4_seq_nostage);
+  configPage2.nCylinders = 6;
+  configPage2.divider = 6;
+  RUN_TEST_P(cylinder6_stroke4_seq_nostage);
+  configPage2.nCylinders = 8;
+  configPage2.divider = 8;
+  RUN_TEST_P(cylinder8_stroke4_seq_nostage);
+}
+
 void testFuelScheduleInit()
 {
   run_1_cylinder_4stroke_tests();
@@ -838,4 +901,6 @@ void testFuelScheduleInit()
   run_8_cylinder_4stroke_tests();
 
   run_no_inj_timing_tests();
+
+  run_oddfire_tests();
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -719,6 +719,109 @@ void run_8_cylinder_4stroke_tests(void)
   RUN_TEST_P(cylinder8_stroke4_seq_no_stage);
 }
 
+static constexpr uint16_t zeroAngles[] = {0,0,0,0,0,0,0,0};
+
+static void cylinder_1_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 1;
+  configPage2.divider = 1;
+
+  initialiseAll(); //Run the main initialise function
+
+  const bool enabled[] = {true, false, false, false, false, false, false, false};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);  
+}
+
+static void cylinder_2_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 2;
+  configPage2.divider = 2;
+
+  initialiseAll(); //Run the main initialise function
+
+  const bool enabled[] = {true, true, false, false, false, false, false, false};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void cylinder_3_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 3;
+  configPage2.divider = 3;
+
+  initialiseAll(); //Run the main initialise function
+
+  const bool enabled[] = {true, true, true, false, false, false, false, false};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void cylinder_4_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 4;
+  configPage2.divider = 4;
+
+  initialiseAll(); //Run the main initialise function
+
+  const bool enabled[] = {true, true, false, false, false, false, false, false};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void cylinder_5_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 5;
+  configPage2.divider = 5;
+
+  initialiseAll(); //Run the main initialise function
+
+#if INJ_CHANNELS>=5  
+  const bool enabled[] = {true, true, true, true, true, false, false, false};
+#else
+  const bool enabled[] = {true, true, true, true, false, false, false, false};
+#endif
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void cylinder_6_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 6;
+  configPage2.divider = 6;
+
+  initialiseAll(); //Run the main initialise function
+
+  const bool enabled[] = {true, true, true, false, false, false, false, false};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void cylinder_8_NoinjTiming_paired(void) {
+  configPage2.injLayout = INJ_PAIRED;
+  configPage2.nCylinders = 8;
+  configPage2.divider = 8;
+
+  initialiseAll(); //Run the main initialise function
+
+#if INJ_CHANNELS>=8  
+  const bool enabled[] = {true, true, true, true, true, true, true, true};
+#else
+  const bool enabled[] = {true, true, true, true, false, false, false, false};
+#endif
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, zeroAngles);   
+}
+
+static void run_no_inj_timing_tests(void)
+{
+  configPage2.strokes = FOUR_STROKE;
+  configPage2.engineType = EVEN_FIRE;
+  configPage2.injTiming = false;
+  configPage2.reqFuel = reqFuel;
+  configPage10.stagingEnabled = false;
+
+  RUN_TEST_P(cylinder_1_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_2_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_3_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_4_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_5_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_6_NoinjTiming_paired);
+  RUN_TEST_P(cylinder_8_NoinjTiming_paired);
+}
 
 void testFuelScheduleInit()
 {
@@ -733,4 +836,6 @@ void testFuelScheduleInit()
   run_5_cylinder_4stroke_tests();
   run_6_cylinder_4stroke_tests();
   run_8_cylinder_4stroke_tests();
+
+  run_no_inj_timing_tests();
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -4,19 +4,20 @@
 #include "init.h"
 #include "schedule_calcs.h"
 #include "scheduledIO.h"
+#include "utilities.h"
 #include "..\test_utils.h"
 
 extern uint16_t req_fuel_uS;
 
 static constexpr uint16_t reqFuel = 86; // ms * 10
 
-static void assert_fuel_channel(bool enabled, uint16_t angle, uint8_t cmdBit, int channelInjDegrees, void (*startFunction)(void), void (*endFunction)(void))
+static void __attribute__((noinline)) assert_fuel_channel(bool enabled, uint16_t angle, uint8_t cmdBit, int channelInjDegrees, voidVoidCallback startFunction, voidVoidCallback endFunction)
 {
   char msg[32];
 
-  sprintf_P(msg, PSTR("channel%" PRIu8 "1InjDegrees.isEnabled"), cmdBit+1);
+  sprintf_P(msg, PSTR("channel%" PRIu8 "InjDegrees.isEnabled"), cmdBit+1);
   TEST_ASSERT_EQUAL_MESSAGE(enabled, BIT_CHECK(channelInjEnabled, cmdBit), msg);
-  sprintf_P(msg, PSTR("channe%" PRIu8 "1InjDegrees"), cmdBit+1);
+  sprintf_P(msg, PSTR("channe%" PRIu8 "InjDegrees"), cmdBit+1);
   TEST_ASSERT_EQUAL_MESSAGE(angle, channelInjDegrees, msg);
   sprintf_P(msg, PSTR("inj%" PRIu8 "StartFunction"), cmdBit+1);
   TEST_ASSERT_TRUE_MESSAGE(!enabled || (startFunction!=nullCallback), msg);
@@ -24,7 +25,7 @@ static void assert_fuel_channel(bool enabled, uint16_t angle, uint8_t cmdBit, in
   TEST_ASSERT_TRUE_MESSAGE(!enabled || (endFunction!=nullCallback), msg);
 }
 
-static void assert_fuel_schedules(uint16_t crankAngle, uint16_t reqFuel, const bool enabled[], const uint16_t angle[])
+static void __attribute__((noinline)) assert_fuel_schedules(uint16_t crankAngle, uint16_t reqFuel, const bool enabled[], const uint16_t angle[])
 {
   char msg[32];
 
@@ -55,100 +56,157 @@ static void assert_fuel_schedules(uint16_t crankAngle, uint16_t reqFuel, const b
 #endif 
 }
 
-void test_fuel_schedule_1_cylinder_4stroke(void)
+static void cylinder1_stroke4_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, false, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+}
+
+static void cylinder1_stroke4_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, false, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+}
+
+static void cylinder1_stroke4_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder1_stroke4_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+}
+
+static void run_1_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
-  configPage2.injTiming = true;
-  configPage2.reqFuel = reqFuel;
-  configPage2.divider = 1;
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, false, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, false, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-  }
-}
-
-void test_fuel_schedule_1_cylinder_2stroke(void)
-{
-  configPage2.nCylinders = 1;
-  configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
   configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel; 
   configPage2.divider = 1;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, false, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, false, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
-  }
+  RUN_TEST_P(cylinder1_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder1_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder1_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder1_stroke4_semiseq_with_stage);
 }
 
+static void cylinder1_stroke2_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+  const bool enabled[] = {true, false, false, false, false, false, false, false};
+  const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);  
+  }
 
-void test_fuel_schedule_2_cylinder_4stroke(void)
+static void cylinder1_stroke2_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, false, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder1_stroke2_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder1_stroke2_semiseq_with_stage(void)
+  {
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+    assert_fuel_schedules(360U, reqFuel * 100U, enabled, angle);  
+}
+
+static void run_1_cylinder_2stroke_tests(void)
+{
+  configPage2.nCylinders = 1;
+  configPage2.strokes = TWO_STROKE;
+  configPage2.engineType = EVEN_FIRE;
+  configPage2.injTiming = true;
+  configPage2.reqFuel = reqFuel;
+  configPage2.divider = 1;
+
+  RUN_TEST_P(cylinder1_stroke2_seq_no_stage);
+  RUN_TEST_P(cylinder1_stroke2_semiseq_no_stage);
+  RUN_TEST_P(cylinder1_stroke2_seq_with_stage);
+  RUN_TEST_P(cylinder1_stroke2_semiseq_with_stage);
+}
+
+static void cylinder2_stroke4_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder2_stroke4_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
+  }
+
+static void cylinder2_stroke4_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder2_stroke4_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
+}
+
+static void run_2_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
@@ -157,44 +215,54 @@ void test_fuel_schedule_2_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
-  }
+  RUN_TEST_P(cylinder2_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder2_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder2_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder2_stroke4_semiseq_with_stage);
 }
 
-void test_fuel_schedule_2_cylinder_2stroke(void)
+
+static void cylinder2_stroke2_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder2_stroke2_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder2_stroke2_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder2_stroke2_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+}
+
+static void run_2_cylinder_2stroke_tests(void)
 {
   configPage2.nCylinders = 2;
   configPage2.strokes = TWO_STROKE;
@@ -203,44 +271,65 @@ void test_fuel_schedule_2_cylinder_2stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
+  RUN_TEST_P(cylinder2_stroke2_seq_no_stage);
+  RUN_TEST_P(cylinder2_stroke2_semiseq_no_stage);
+  RUN_TEST_P(cylinder2_stroke2_seq_with_stage);
+  RUN_TEST_P(cylinder2_stroke2_semiseq_with_stage);
 }
 
-void test_fuel_schedule_3_cylinder_4stroke(void)
+static void cylinder3_stroke4_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,240,480,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder3_stroke4_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle);
+  }
+
+static void cylinder3_stroke4_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS>=6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	const uint16_t angle[] = {0,240,480,0,240,480,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,240,480,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#endif
+  }
+
+static void cylinder3_stroke4_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS>=6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	const uint16_t angle[] = {0,80,160,0,80,160,0,0};
+  assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle); 
+#endif
+}
+
+static void run_3_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
@@ -249,55 +338,65 @@ void test_fuel_schedule_3_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,240,480,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-    assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS>=6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,240,480,0,240,480,0,0};
-#else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,240,480,0,0,0,0,0};
-#endif
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS>=6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,80,160,0,80,160,0,0};
-#else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-#endif
-    assert_fuel_schedules(240U, reqFuel * 50U, enabled, angle);
-  }
+  RUN_TEST_P(cylinder3_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder3_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder3_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder3_stroke4_semiseq_with_stage);
 }
 
+static void cylinder3_stroke2_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+  }
 
-void test_fuel_schedule_3_cylinder_2stroke(void)
+static void cylinder3_stroke2_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+  }
+
+static void cylinder3_stroke2_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS>=6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	const uint16_t angle[] = {0,80,160,0,80,160,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+#endif
+  }
+
+static void cylinder3_stroke2_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS>=6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	const uint16_t angle[] = {0,80,160,0,80,160,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,80,160,0,0,0,0,0};
+  assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
+#endif
+}
+
+static void run_3_cylinder_2stroke_tests(void)
 {
   configPage2.nCylinders = 3;
   configPage2.strokes = TWO_STROKE;
@@ -305,56 +404,64 @@ void test_fuel_schedule_3_cylinder_2stroke(void)
   configPage2.injTiming = true;
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 1;
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-    assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-    assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS>=6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,80,160,0,80,160,0,0};
-#else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-#endif
-    assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS>=6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,80,160,0,80,160,0,0};
-#else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,80,160,0,0,0,0,0};
-#endif
-    assert_fuel_schedules(120U, reqFuel * 100U, enabled, angle);
-  }
+ 
+  RUN_TEST_P(cylinder3_stroke2_seq_no_stage);
+  RUN_TEST_P(cylinder3_stroke2_semiseq_no_stage);
+  RUN_TEST_P(cylinder3_stroke2_seq_with_stage);
+  RUN_TEST_P(cylinder3_stroke2_semiseq_with_stage);
 }
 
+static void cylinder4_stroke4_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+  }
 
-void test_fuel_schedule_4_cylinder_4stroke(void)
+static void cylinder4_stroke4_semiseq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
+  }
+
+static void cylinder4_stroke4_seq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS>=8
+	const bool enabled[] = {true, true, true, true, true, true, true, true;
+	static const uint16_t angles[] PROGMEM = e[] = {0,180,360,540,0,180,36;
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#elif INJ_CHANNELS >= 5
+	const bool enabled[] = {true, true, true, true, true, false, false, false};
+	const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#endif
+  }
+
+static void cylinder4_stroke4_semiseq_with_stage(void)  
+{
+  configPage2.injLayout = INJ_PAIRED;
+  configPage10.stagingEnabled = true;
+  initialiseAll(); //Run the main initialise function
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
+}
+
+void run_4_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
@@ -363,52 +470,63 @@ void test_fuel_schedule_4_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 2;
 
+  RUN_TEST_P(cylinder4_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder4_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder4_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder4_stroke4_semiseq_with_stage);  
+}
+
+static void cylinder4_stroke2_seq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,360,540,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
   }
 
+static void cylinder4_stroke2_semiseq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
+	const bool enabled[] = {true, true, false, false, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
   }
 
+static void cylinder4_stroke2_seq_with_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
 #if INJ_CHANNELS>=8
-    const bool enabled[] = {true, true, true, true, true, true, true, true};
-    const uint16_t angle[] = {0,180,360,540,0,180,360,540};
+	const bool enabled[] = {true, true, true, true, true, true, true, true;
+	const uint16_t angle[] = {0,180,0,0,0,180,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
 #elif INJ_CHANNELS >= 5
-    const bool enabled[] = {true, true, true, true, true, false, false, false};
-    const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+	const bool enabled[] = {true, true, true, true, true, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
 #else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
 #endif
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
   }
 
+static void cylinder4_stroke2_semiseq_with_stage(void)
+{
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(360U, reqFuel * 50U, enabled, angle);
-  }
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,180,0,180,0,0,0,0};
+  assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
 }
 
-void test_fuel_schedule_4_cylinder_2stroke(void)
+void run_4_cylinder_2stroke_tests(void)
 {
   configPage2.nCylinders = 4;
   configPage2.strokes = TWO_STROKE;
@@ -417,53 +535,72 @@ void test_fuel_schedule_4_cylinder_2stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 2;
 
+  RUN_TEST_P(cylinder4_stroke2_seq_no_stage);
+  RUN_TEST_P(cylinder4_stroke2_semiseq_no_stage);
+  RUN_TEST_P(cylinder4_stroke2_seq_with_stage);
+  RUN_TEST_P(cylinder4_stroke2_semiseq_with_stage);  
+}
+
+static void cylinder5_stroke4_seq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+#if INJ_CHANNELS >= 5
+	const bool enabled[] = {true, true, true, true, true, false, false, false};
+	const uint16_t angle[] = {0,144,288,432,576,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+#endif
   }
 
+
+static void cylinder5_stroke4_semiseq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, false, false, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
   }
 
+static void cylinder5_stroke4_seq_with_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS>=8
-    const bool enabled[] = {true, true, true, true, true, true, true, true};
-    const uint16_t angle[] = {0,180,0,0,0,180,0,0};
-#elif INJ_CHANNELS >= 5
-    const bool enabled[] = {true, true, true, true, true, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+#if INJ_CHANNELS >= 6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	const uint16_t angle[] = {0,144,288,432,576,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #endif
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
   }
 
+static void cylinder5_stroke4_semiseq_with_stage(void) 
+{
   configPage2.injLayout = INJ_PAIRED;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,180,0,180,0,0,0,0};
-    assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
-  }
+#if INJ_CHANNELS >= 5
+	const bool enabled[] = {true, true, true, true, true, false, false, false};
+	const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+#endif
 }
 
-
-void test_fuel_schedule_5_cylinder_4stroke(void)
+void run_5_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 5;
   configPage2.strokes = FOUR_STROKE;
@@ -472,63 +609,72 @@ void test_fuel_schedule_5_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 5;
 
+  RUN_TEST_P(cylinder5_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder5_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder5_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder5_stroke4_semiseq_with_stage); 
+}
+
+static void cylinder6_stroke4_seq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 5
-    const bool enabled[] = {true, true, true, true, true, false, false, false};
-    const uint16_t angle[] = {0,144,288,432,576,0,0,0};
-    uint16_t expectedFuel = reqFuel * 100U;
+#if INJ_CHANNELS >= 6
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	static const uint16_t angles[] PROGMEM = = {0,120,240,360,480,600,0,;
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    uint16_t expectedFuel = reqFuel * 50U;
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #endif
-    assert_fuel_schedules(720U, expectedFuel, enabled, angle);
   }
 
+static void cylinder6_stroke4_semiseq_no_stage(void)
+{
   configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,72,144,216,288,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
   }
 
+static void cylinder6_stroke4_seq_with_stage(void)
+{
   configPage2.injLayout = INJ_SEQUENTIAL;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,144,288,432,576,0,0,0};
-    uint16_t expectedFuel = reqFuel * 100U;
+#if INJ_CHANNELS >= 8
+	const bool enabled[] = {true, true, true, true, true, true, false, false};
+	static const uint16_t angles[] PROGMEM = = {0,120,240,360,480,600,0,;
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    uint16_t expectedFuel = reqFuel * 50U;
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #endif
-    assert_fuel_schedules(720U, expectedFuel, enabled, angle);
   }
 
-  configPage2.injLayout = INJ_PAIRED;
+
+static void cylinder6_stroke4_semiseq_with_stage(void)
+{
+  configPage2.injLayout = INJ_SEMISEQUENTIAL;
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 5
-    const bool enabled[] = {true, true, true, true, true, false, false, false};
-    const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+#if INJ_CHANNELS >= 8
+	const bool enabled[] = {true, true, true, true, true, true, true, true;
+	static const uint16_t angles[] PROGMEM = = {0,120,240,0,0,120,240,;
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+	const bool enabled[] = {true, true, true, false, false, false, false, false};
+	const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #endif
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-  }
 }
 
-void test_fuel_schedule_6_cylinder_4stroke(void)
+void run_6_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 6;
   configPage2.strokes = FOUR_STROKE;
@@ -537,62 +683,29 @@ void test_fuel_schedule_6_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 6;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 6
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,120,240,360,480,600,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-#else
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-#endif
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-  }
-
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 8
-    const bool enabled[] = {true, true, true, true, true, true, false, false};
-    const uint16_t angle[] = {0,120,240,360,480,600,0,0};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-#else
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-#endif
-  }
-
-  configPage2.injLayout = INJ_SEMISEQUENTIAL;
-  configPage10.stagingEnabled = true;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 8
-    const bool enabled[] = {true, true, true, true, true, true, true, true};
-    const uint16_t angle[] = {0,120,240,0,0,120,240,0};
-#else
-    const bool enabled[] = {true, true, true, false, false, false, false, false};
-    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
-#endif
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-  }
+  RUN_TEST_P(cylinder6_stroke4_seq_no_stage);
+  RUN_TEST_P(cylinder6_stroke4_semiseq_no_stage);
+  RUN_TEST_P(cylinder6_stroke4_seq_with_stage);
+  RUN_TEST_P(cylinder6_stroke4_semiseq_with_stage); 
 }
 
+static void cylinder8_stroke4_seq_no_stage(void)
+{
+  configPage2.injLayout = INJ_SEQUENTIAL;
+  configPage10.stagingEnabled = false;
+  initialiseAll(); //Run the main initialise function
+#if INJ_CHANNELS >= 8
+	const bool enabled[] = {true, true, true, true, true, true, true, true;
+	static const uint16_t angles[] PROGMEM = e[] = {0,90,180,270,360,450,5;
+  assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
+#else
+	const bool enabled[] = {true, true, true, true, false, false, false, false};
+	const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
+#endif
+  }
 
-void test_fuel_schedule_8_cylinder_4stroke(void)
+void run_8_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 8;
   configPage2.strokes = FOUR_STROKE;
@@ -601,36 +714,23 @@ void test_fuel_schedule_8_cylinder_4stroke(void)
   configPage2.reqFuel = reqFuel;
   configPage2.divider = 8;
 
-  configPage2.injLayout = INJ_SEQUENTIAL;
-  configPage10.stagingEnabled = false;
-  initialiseAll(); //Run the main initialise function
-  {
-#if INJ_CHANNELS >= 8
-    const bool enabled[] = {true, true, true, true, true, true, true, true};
-    const uint16_t angle[] = {0,90,180,270,360,450,540,630};
-    assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
-#else
-    const bool enabled[] = {true, true, true, true, false, false, false, false};
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
-#endif
-  }
-
   // Staging not supported on 8 cylinders
+
+  RUN_TEST_P(cylinder8_stroke4_seq_no_stage);
 }
 
 
 void testFuelScheduleInit()
 {
-    RUN_TEST_P(test_fuel_schedule_1_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_1_cylinder_2stroke);
-    RUN_TEST_P(test_fuel_schedule_2_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_2_cylinder_2stroke);
-    RUN_TEST_P(test_fuel_schedule_3_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_3_cylinder_2stroke);
-    RUN_TEST_P(test_fuel_schedule_4_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_4_cylinder_2stroke);
-    RUN_TEST_P(test_fuel_schedule_5_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_6_cylinder_4stroke);
-    RUN_TEST_P(test_fuel_schedule_8_cylinder_4stroke);
+  run_1_cylinder_4stroke_tests();
+  run_1_cylinder_2stroke_tests();
+  run_2_cylinder_4stroke_tests();
+  run_2_cylinder_2stroke_tests();
+  run_3_cylinder_4stroke_tests();
+  run_3_cylinder_2stroke_tests();
+  run_4_cylinder_4stroke_tests();
+  run_4_cylinder_2stroke_tests();
+  run_5_cylinder_4stroke_tests();
+  run_6_cylinder_4stroke_tests();
+  run_8_cylinder_4stroke_tests();
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -437,8 +437,8 @@ static void cylinder4_stroke4_seq_with_stage(void)
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS>=8
-	const bool enabled[] = {true, true, true, true, true, true, true, true;
-	static const uint16_t angles[] PROGMEM = e[] = {0,180,360,540,0,180,36;
+	const bool enabled[] = {true, true, true, true, true, true, true, true};
+	const uint16_t angle[] = {0,180,360,540,0,180,36};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #elif INJ_CHANNELS >= 5
 	const bool enabled[] = {true, true, true, true, true, false, false, false};
@@ -502,7 +502,7 @@ static void cylinder4_stroke2_seq_with_stage(void)
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS>=8
-	const bool enabled[] = {true, true, true, true, true, true, true, true;
+	const bool enabled[] = {true, true, true, true, true, true, true, true};
 	const uint16_t angle[] = {0,180,0,0,0,180,0,0};
   assert_fuel_schedules(180U, reqFuel * 100U, enabled, angle);
 #elif INJ_CHANNELS >= 5
@@ -622,7 +622,7 @@ static void cylinder6_stroke4_seq_no_stage(void)
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS >= 6
 	const bool enabled[] = {true, true, true, true, true, true, false, false};
-	static const uint16_t angles[] PROGMEM = = {0,120,240,360,480,600,0,;
+	const uint16_t angle[] = {0,120,240,360,480,600,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
 	const bool enabled[] = {true, true, true, false, false, false, false, false};
@@ -648,7 +648,7 @@ static void cylinder6_stroke4_seq_with_stage(void)
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS >= 8
 	const bool enabled[] = {true, true, true, true, true, true, false, false};
-	static const uint16_t angles[] PROGMEM = = {0,120,240,360,480,600,0,;
+	const uint16_t angle[] = {0,120,240,360,480,600,0,0};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
 	const bool enabled[] = {true, true, true, false, false, false, false, false};
@@ -664,8 +664,8 @@ static void cylinder6_stroke4_semiseq_with_stage(void)
   configPage10.stagingEnabled = true;
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS >= 8
-	const bool enabled[] = {true, true, true, true, true, true, true, true;
-	static const uint16_t angles[] PROGMEM = = {0,120,240,0,0,120,240,;
+	const bool enabled[] = {true, true, true, true, true, true, true, true};
+	const uint16_t angle[] = {0,120,240,0,0,120,240,0};
   assert_fuel_schedules(720U, reqFuel * 50U, enabled, angle);
 #else
 	const bool enabled[] = {true, true, true, false, false, false, false, false};
@@ -695,8 +695,8 @@ static void cylinder8_stroke4_seq_no_stage(void)
   configPage10.stagingEnabled = false;
   initialiseAll(); //Run the main initialise function
 #if INJ_CHANNELS >= 8
-	const bool enabled[] = {true, true, true, true, true, true, true, true;
-	static const uint16_t angles[] PROGMEM = e[] = {0,90,180,270,360,450,5;
+	const bool enabled[] = {true, true, true, true, true, true, true, true};
+	const uint16_t angle[] = {0,90,180,270,360,450,5};
   assert_fuel_schedules(720U, reqFuel * 100U, enabled, angle);
 #else
 	const bool enabled[] = {true, true, true, true, false, false, false, false};

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -17,7 +17,7 @@ static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channel
   TEST_ASSERT_TRUE_MESSAGE(channel>=maxIgnOutputs || (endFunction!=nullCallback), msg);
 }
 
-static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutputs, uint16_t angle[])
+static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutputs, const uint16_t angle[])
 {
   char msg[48];
 
@@ -53,14 +53,14 @@ static void test_ignition_schedule_1_cylinder(void)
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,0,0,0,0,0,0,0};
+    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
     assert_ignition_schedules(720U, 1U, angle);
   }
 
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,0,0,0,0,0,0,0};
+    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
     assert_ignition_schedules(360U, 1U, angle);
   }  
 }
@@ -74,14 +74,14 @@ static void test_ignition_schedule_2_cylinder(void)
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,180,0,0,0,0,0,0};
+    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
     assert_ignition_schedules(720U, 2U, angle);
   }
 
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,180,0,0,0,0,0,0};
+    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
     assert_ignition_schedules(360U, 2U, angle);
   }  
 }
@@ -95,14 +95,14 @@ static void test_ignition_schedule_3_cylinder(void)
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,240,480,0,0,0,0,0};
+    const uint16_t angle[] = {0,240,480,0,0,0,0,0};
     assert_ignition_schedules(720U, 3U, angle);
   }
 
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,120,240,0,0,0,0,0};
+    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
     assert_ignition_schedules(360U, 3U, angle);
   }  
 }
@@ -116,14 +116,14 @@ static void test_ignition_schedule_4_cylinder(void)
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,180,360,540,0,0,0,0};
+    const uint16_t angle[] = {0,180,360,540,0,0,0,0};
     assert_ignition_schedules(720U, 4U, angle);
   }
 
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,180,0,0,0,0,0,0};
+    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
     assert_ignition_schedules(360U, 2U, angle);
   }  
 }
@@ -137,14 +137,14 @@ static void test_ignition_schedule_5_cylinder(void)
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,144,288,432,576,0,0,0};
+    const uint16_t angle[] = {0,144,288,432,576,0,0,0};
     assert_ignition_schedules(720U, 5U, angle);
   }
 
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,72,144,216,288,0,0,0};
+    const uint16_t angle[] = {0,72,144,216,288,0,0,0};
     assert_ignition_schedules(360U, 5U, angle);
   }  
 }
@@ -159,10 +159,10 @@ static void test_ignition_schedule_6_cylinder(void)
   initialiseAll(); //Run the main initialise function
   {
 #if IGN_CHANNELS >= 6
-    uint16_t angle[] = {0,120,240,360,480,540,0,0};
+    const uint16_t angle[] = {0,120,240,360,480,540,0,0};
     assert_ignition_schedules(720U, 6U, angle);
 #else
-    uint16_t angle[] = {0,120,240,0,0,0,0,0};
+    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
     assert_ignition_schedules(360U, 3U, angle);
 #endif
   }
@@ -170,7 +170,7 @@ static void test_ignition_schedule_6_cylinder(void)
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,120,240,0,0,0,0,0};
+    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
     assert_ignition_schedules(360U, 3U, angle);
   }  
 }
@@ -185,10 +185,10 @@ static void test_ignition_schedule_8_cylinder(void)
   initialiseAll(); //Run the main initialise function
   {
 #if IGN_CHANNELS >= 8
-    uint16_t angle[] = {0,90,180,270,360,450,540,630};
+    const uint16_t angle[] = {0,90,180,270,360,450,540,630};
     assert_ignition_schedules(720U, 8U, angle);
 #else
-    uint16_t angle[] = {0,90,180,270,0,0,0,0};
+    const uint16_t angle[] = {0,90,180,270,0,0,0,0};
     assert_ignition_schedules(360U, 4U, angle);
 #endif
   }
@@ -196,7 +196,7 @@ static void test_ignition_schedule_8_cylinder(void)
   configPage4.sparkMode = IGN_MODE_WASTED;
   initialiseAll(); //Run the main initialise function
   {
-    uint16_t angle[] = {0,90,180,270,0,0,0,0};
+    const uint16_t angle[] = {0,90,180,270,0,0,0,0};
     assert_ignition_schedules(360U, 4U, angle);
   }  
 }

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -4,6 +4,7 @@
 #include "init.h"
 #include "schedule_calcs.h"
 #include "scheduledIO.h"
+#include "..\test_utils.h"
 
 static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channelInjDegrees, void (*startFunction)(void), void (*endFunction)(void))
 {
@@ -203,11 +204,11 @@ static void test_ignition_schedule_8_cylinder(void)
 
 void testIgnitionScheduleInit()
 {
-    RUN_TEST(test_ignition_schedule_1_cylinder);
-    RUN_TEST(test_ignition_schedule_2_cylinder);
-    RUN_TEST(test_ignition_schedule_3_cylinder);
-    RUN_TEST(test_ignition_schedule_4_cylinder);
-    RUN_TEST(test_ignition_schedule_5_cylinder);
-    RUN_TEST(test_ignition_schedule_6_cylinder);
-    RUN_TEST(test_ignition_schedule_8_cylinder);
+    RUN_TEST_P(test_ignition_schedule_1_cylinder);
+    RUN_TEST_P(test_ignition_schedule_2_cylinder);
+    RUN_TEST_P(test_ignition_schedule_3_cylinder);
+    RUN_TEST_P(test_ignition_schedule_4_cylinder);
+    RUN_TEST_P(test_ignition_schedule_5_cylinder);
+    RUN_TEST_P(test_ignition_schedule_6_cylinder);
+    RUN_TEST_P(test_ignition_schedule_8_cylinder);
 }

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -45,71 +45,111 @@ static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutp
 #endif 
 }
 
-static void cylinder1_stroke4_seq(void)
+static void cylinder1_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,0,0,0,0,0,0,0};
   assert_ignition_schedules(720U, 1U, angle);
 }
 
-static void cylinder1_stroke4_wasted(void)
+static void cylinder1_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,0,0,0,0,0,0,0};
   assert_ignition_schedules(360U, 1U, angle);
 }  
 
+static void cylinder1_stroke4_seq_odd(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = ODD_FIRE;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_ignition_schedules(720U, 1U, angle);
+}
+
 static void run_1_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder1_stroke4_seq);
-  RUN_TEST_P(cylinder1_stroke4_wasted);
+  RUN_TEST_P(cylinder1_stroke4_seq_even);
+  RUN_TEST_P(cylinder1_stroke4_wasted_even);
+  RUN_TEST_P(cylinder1_stroke4_seq_odd);
 }
 
-static void cylinder2_stroke4_seq(void)
+static void cylinder2_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_ignition_schedules(720U, 2U, angle);
 }
 
-static void cylinder2_stroke4_wasted(void)
+static void cylinder2_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,180,0,0,0,0,0,0};
   assert_ignition_schedules(360U, 2U, angle);
 }  
 
+static void cylinder2_stroke4_seq_odd(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = ODD_FIRE;
+  configPage2.oddfire2 = 13;
+  configPage2.oddfire3 = 111;
+  configPage2.oddfire4 = 217;
+
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,13,0,0,0,0,0,0};
+  assert_ignition_schedules(720U, 2U, angle);
+}
+
 static void run_2_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder2_stroke4_seq);
-  RUN_TEST_P(cylinder2_stroke4_wasted);
+  RUN_TEST_P(cylinder2_stroke4_seq_even);
+  RUN_TEST_P(cylinder2_stroke4_wasted_even);
+  RUN_TEST_P(cylinder2_stroke4_seq_odd);
 }
 
-static void cylinder3_stroke4_seq(void)
+static void cylinder3_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,240,480,0,0,0,0,0};
   assert_ignition_schedules(720U, 3U, angle);
 }
 
-static void cylinder3_stroke4_wasted(void)
+static void cylinder3_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_ignition_schedules(360U, 3U, angle);
+}  
+
+static void cylinder3_stroke4_wasted_odd(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = ODD_FIRE;
+  configPage2.oddfire2 = 13;
+  configPage2.oddfire3 = 111;
+  configPage2.oddfire4 = 217;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,13,111,0,0,0,0,0};
   assert_ignition_schedules(360U, 3U, angle);
 }  
 
@@ -117,49 +157,66 @@ static void run_3_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder3_stroke4_seq);
-  RUN_TEST_P(cylinder3_stroke4_wasted);
+  RUN_TEST_P(cylinder3_stroke4_seq_even);
+  RUN_TEST_P(cylinder3_stroke4_wasted_even);
+  RUN_TEST_P(cylinder3_stroke4_wasted_odd);
 }
 
-static void cylinder4_stroke4_seq(void)
+static void cylinder4_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,180,360,540,0,0,0,0};
   assert_ignition_schedules(720U, 4U, angle);
 }
 
-static void cylinder4_stroke4_wasted(void)
-  {
-	  configPage4.sparkMode = IGN_MODE_WASTED;
-	  initialiseAll(); //Run the main initialise function
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_ignition_schedules(360U, 2U, angle);
-  }  
+static void cylinder4_stroke4_wasted_even(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_ignition_schedules(360U, 2U, angle);
+}  
+
+static void cylinder4_stroke4_seq_odd(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = ODD_FIRE;
+  configPage2.oddfire2 = 13;
+  configPage2.oddfire3 = 111;
+  configPage2.oddfire4 = 217;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,13,111,217,0,0,0,0};
+  assert_ignition_schedules(360U, 4U, angle);
+}
+
 
 static void run_4_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder4_stroke4_seq);
-  RUN_TEST_P(cylinder4_stroke4_wasted);
+  RUN_TEST_P(cylinder4_stroke4_seq_even);
+  RUN_TEST_P(cylinder4_stroke4_wasted_even);
+  RUN_TEST_P(cylinder4_stroke4_seq_odd);
 }
 
-static void cylinder5_stroke4_seq(void)
+static void cylinder5_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,144,288,432,576,0,0,0};
   assert_ignition_schedules(720U, 5U, angle);
 }
 
-static void cylinder5_stroke4_wasted(void)
+static void cylinder5_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,72,144,216,288,0,0,0};
   assert_ignition_schedules(360U, 5U, angle);
@@ -169,15 +226,15 @@ static void run_5_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 5;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder5_stroke4_seq);
-  RUN_TEST_P(cylinder5_stroke4_wasted);
+  RUN_TEST_P(cylinder5_stroke4_seq_even);
+  RUN_TEST_P(cylinder5_stroke4_wasted_even);
 }
 
-static void cylinder6_stroke4_seq(void)
+static void cylinder6_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
 #if IGN_CHANNELS >= 6
   const uint16_t angle[] = {0,120,240,360,480,540,0,0};
@@ -188,9 +245,10 @@ static void cylinder6_stroke4_seq(void)
 #endif
 }
 
-static void cylinder6_stroke4_wasted(void)
+static void cylinder6_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,120,240,0,0,0,0,0};
   assert_ignition_schedules(360U, 3U, angle);
@@ -200,16 +258,16 @@ static void run_6_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 6;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder6_stroke4_seq);
-  RUN_TEST_P(cylinder6_stroke4_wasted); 
+  RUN_TEST_P(cylinder6_stroke4_seq_even);
+  RUN_TEST_P(cylinder6_stroke4_wasted_even); 
 }
 
 
-static void cylinder8_stroke4_seq(void)
+static void cylinder8_stroke4_seq_even(void)
 {
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
 #if IGN_CHANNELS >= 8
   const uint16_t angle[] = {0,90,180,270,360,450,540,630};
@@ -220,9 +278,10 @@ static void cylinder8_stroke4_seq(void)
 #endif
 }
 
-static void cylinder8_stroke4_wasted(void)
+static void cylinder8_stroke4_wasted_even(void)
 {
   configPage4.sparkMode = IGN_MODE_WASTED;
+  configPage2.engineType = EVEN_FIRE;
   initialiseAll(); //Run the main initialise function
   const uint16_t angle[] = {0,90,180,270,0,0,0,0};
   assert_ignition_schedules(360U, 4U, angle);
@@ -232,10 +291,9 @@ static void run_8_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 8;
   configPage2.strokes = FOUR_STROKE;
-  configPage2.engineType = EVEN_FIRE;
 
-  RUN_TEST_P(cylinder8_stroke4_seq);
-  RUN_TEST_P(cylinder8_stroke4_wasted);
+  RUN_TEST_P(cylinder8_stroke4_seq_even);
+  RUN_TEST_P(cylinder8_stroke4_wasted_even);
 }
 
 void testIgnitionScheduleInit()

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -6,7 +6,7 @@
 #include "scheduledIO.h"
 #include "..\test_utils.h"
 
-static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channelInjDegrees, void (*startFunction)(void), void (*endFunction)(void))
+static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channelInjDegrees, voidVoidCallback startFunction, voidVoidCallback endFunction)
 {
   char msg[32];
 
@@ -45,170 +45,206 @@ static void assert_ignition_schedules(uint16_t crankAngle, uint16_t expectedOutp
 #endif 
 }
 
-static void test_ignition_schedule_1_cylinder(void)
+static void cylinder1_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_ignition_schedules(720U, 1U, angle);
+}
+
+static void cylinder1_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,0,0,0,0,0,0,0};
+  assert_ignition_schedules(360U, 1U, angle);
+}  
+
+static void run_1_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_ignition_schedules(720U, 1U, angle);
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,0,0,0,0,0,0,0};
-    assert_ignition_schedules(360U, 1U, angle);
-  }  
+  RUN_TEST_P(cylinder1_stroke4_seq);
+  RUN_TEST_P(cylinder1_stroke4_wasted);
 }
 
-static void test_ignition_schedule_2_cylinder(void)
+static void cylinder2_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_ignition_schedules(720U, 2U, angle);
+}
+
+static void cylinder2_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+  assert_ignition_schedules(360U, 2U, angle);
+}  
+
+static void run_2_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_ignition_schedules(720U, 2U, angle);
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_ignition_schedules(360U, 2U, angle);
-  }  
+  RUN_TEST_P(cylinder2_stroke4_seq);
+  RUN_TEST_P(cylinder2_stroke4_wasted);
 }
 
-static void test_ignition_schedule_3_cylinder(void)
+static void cylinder3_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,240,480,0,0,0,0,0};
+  assert_ignition_schedules(720U, 3U, angle);
+}
+
+static void cylinder3_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_ignition_schedules(360U, 3U, angle);
+}  
+
+static void run_3_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,240,480,0,0,0,0,0};
-    assert_ignition_schedules(720U, 3U, angle);
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
-    assert_ignition_schedules(360U, 3U, angle);
-  }  
+  RUN_TEST_P(cylinder3_stroke4_seq);
+  RUN_TEST_P(cylinder3_stroke4_wasted);
 }
 
-static void test_ignition_schedule_4_cylinder(void)
+static void cylinder4_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,180,360,540,0,0,0,0};
+  assert_ignition_schedules(720U, 4U, angle);
+}
+
+static void cylinder4_stroke4_wasted(void)
+  {
+	  configPage4.sparkMode = IGN_MODE_WASTED;
+	  initialiseAll(); //Run the main initialise function
+    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
+    assert_ignition_schedules(360U, 2U, angle);
+  }  
+
+static void run_4_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,180,360,540,0,0,0,0};
-    assert_ignition_schedules(720U, 4U, angle);
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,180,0,0,0,0,0,0};
-    assert_ignition_schedules(360U, 2U, angle);
-  }  
+  RUN_TEST_P(cylinder4_stroke4_seq);
+  RUN_TEST_P(cylinder4_stroke4_wasted);
 }
 
-static void test_ignition_schedule_5_cylinder(void)
+static void cylinder5_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,144,288,432,576,0,0,0};
+  assert_ignition_schedules(720U, 5U, angle);
+}
+
+static void cylinder5_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,72,144,216,288,0,0,0};
+  assert_ignition_schedules(360U, 5U, angle);
+}  
+
+static void run_5_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 5;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,144,288,432,576,0,0,0};
-    assert_ignition_schedules(720U, 5U, angle);
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,72,144,216,288,0,0,0};
-    assert_ignition_schedules(360U, 5U, angle);
-  }  
+  RUN_TEST_P(cylinder5_stroke4_seq);
+  RUN_TEST_P(cylinder5_stroke4_wasted);
 }
 
-static void test_ignition_schedule_6_cylinder(void)
+static void cylinder6_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+#if IGN_CHANNELS >= 6
+  const uint16_t angle[] = {0,120,240,360,480,540,0,0};
+  assert_ignition_schedules(720U, 6U, angle);
+#else
+  const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_ignition_schedules(360U, 3U, angle);
+#endif
+}
+
+static void cylinder6_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,120,240,0,0,0,0,0};
+  assert_ignition_schedules(360U, 3U, angle);
+} 
+
+static void run_6_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 6;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-#if IGN_CHANNELS >= 6
-    const uint16_t angle[] = {0,120,240,360,480,540,0,0};
-    assert_ignition_schedules(720U, 6U, angle);
-#else
-    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
-    assert_ignition_schedules(360U, 3U, angle);
-#endif
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,120,240,0,0,0,0,0};
-    assert_ignition_schedules(360U, 3U, angle);
-  }  
+  RUN_TEST_P(cylinder6_stroke4_seq);
+  RUN_TEST_P(cylinder6_stroke4_wasted); 
 }
 
-static void test_ignition_schedule_8_cylinder(void)
+
+static void cylinder8_stroke4_seq(void)
+{
+  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
+  initialiseAll(); //Run the main initialise function
+#if IGN_CHANNELS >= 8
+  const uint16_t angle[] = {0,90,180,270,360,450,540,630};
+  assert_ignition_schedules(720U, 8U, angle);
+#else
+  const uint16_t angle[] = {0,90,180,270,0,0,0,0};
+  assert_ignition_schedules(360U, 4U, angle);
+#endif
+}
+
+static void cylinder8_stroke4_wasted(void)
+{
+  configPage4.sparkMode = IGN_MODE_WASTED;
+  initialiseAll(); //Run the main initialise function
+  const uint16_t angle[] = {0,90,180,270,0,0,0,0};
+  assert_ignition_schedules(360U, 4U, angle);
+}  
+
+static void run_8_cylinder_4stroke_tests(void)
 {
   configPage2.nCylinders = 8;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
 
-  configPage4.sparkMode = IGN_MODE_SEQUENTIAL;
-  initialiseAll(); //Run the main initialise function
-  {
-#if IGN_CHANNELS >= 8
-    const uint16_t angle[] = {0,90,180,270,360,450,540,630};
-    assert_ignition_schedules(720U, 8U, angle);
-#else
-    const uint16_t angle[] = {0,90,180,270,0,0,0,0};
-    assert_ignition_schedules(360U, 4U, angle);
-#endif
-  }
-
-  configPage4.sparkMode = IGN_MODE_WASTED;
-  initialiseAll(); //Run the main initialise function
-  {
-    const uint16_t angle[] = {0,90,180,270,0,0,0,0};
-    assert_ignition_schedules(360U, 4U, angle);
-  }  
+  RUN_TEST_P(cylinder8_stroke4_seq);
+  RUN_TEST_P(cylinder8_stroke4_wasted);
 }
 
 void testIgnitionScheduleInit()
 {
-    RUN_TEST_P(test_ignition_schedule_1_cylinder);
-    RUN_TEST_P(test_ignition_schedule_2_cylinder);
-    RUN_TEST_P(test_ignition_schedule_3_cylinder);
-    RUN_TEST_P(test_ignition_schedule_4_cylinder);
-    RUN_TEST_P(test_ignition_schedule_5_cylinder);
-    RUN_TEST_P(test_ignition_schedule_6_cylinder);
-    RUN_TEST_P(test_ignition_schedule_8_cylinder);
+  run_1_cylinder_4stroke_tests();
+  run_2_cylinder_4stroke_tests();
+  run_3_cylinder_4stroke_tests();
+  run_4_cylinder_4stroke_tests();
+  run_5_cylinder_4stroke_tests();
+  run_6_cylinder_4stroke_tests();
+  run_8_cylinder_4stroke_tests();
 }

--- a/test/test_init/tests_init.cpp
+++ b/test/test_init/tests_init.cpp
@@ -1,6 +1,7 @@
 #include <unity.h>
 #include "globals.h"
 #include "init.h"
+#include "..\test_utils.h"
 
 #define UNKNOWN_PIN 0xFF
 
@@ -220,12 +221,12 @@ void test_initialisation_outputs_VVT(void)
 
 void testInitialisation()
 {
-  RUN_TEST(test_initialisation_complete);
-  RUN_TEST(test_initialisation_ports);
-  RUN_TEST(test_initialisation_outputs_V03);
-  RUN_TEST(test_initialisation_outputs_V04);
-  RUN_TEST(test_initialisation_outputs_MX5_8995);
-  RUN_TEST(test_initialisation_outputs_PWM_idle);
-  RUN_TEST(test_initialisation_outputs_boost);
-  RUN_TEST(test_initialisation_outputs_VVT);
+  RUN_TEST_P(test_initialisation_complete);
+  RUN_TEST_P(test_initialisation_ports);
+  RUN_TEST_P(test_initialisation_outputs_V03);
+  RUN_TEST_P(test_initialisation_outputs_V04);
+  RUN_TEST_P(test_initialisation_outputs_MX5_8995);
+  RUN_TEST_P(test_initialisation_outputs_PWM_idle);
+  RUN_TEST_P(test_initialisation_outputs_boost);
+  RUN_TEST_P(test_initialisation_outputs_VVT);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,0 +1,18 @@
+
+#pragma once
+
+// Unity macro to reduce memory usage (RAM, .bss)
+//
+// Unity supplied RUN_TEST captures the function name
+// using #func directly in the call to UnityDefaultTestRun.
+// This is a raw string that is placed in the data segment,
+// which consumes RAM.
+//
+// So instead, place the function name in flash memory and
+// load it at run time.
+#define RUN_TEST_P(func) \
+  { \
+    char funcName[64]; \
+    strcpy_P(funcName, PSTR(#func)); \
+    UnityDefaultTestRun(func, funcName, __LINE__); \
+  }


### PR DESCRIPTION
1. Add unit tests for configPage2.injTiming = false
2. Add oddfire tests for fuel & ignition schedulers
3. Split tests into more fine grained - improves failure error messages
4. Reduce memory used by the Unity test framework