### PR TITLE
Added User Development Reserved Area of Page15

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1448,7 +1448,11 @@ page = 15
       airConUnused4                 = bits,    U08,   95,  [6:7], "0", "1", "2", "3"
       airConIdleUpRPMAdder          = scalar,  U08,   96,  "Added Target RPM", 10.0, 0.0, 0.0,    250.0,    0
       airConPwmFanMinDuty           = scalar,  U08,   97,  "%",      0.5,        0.0,     0.0,    100.0,    1
-      Unused15_98_255               = array,   U08,   98,   [158],   "%", 1.0,   0.0,     0.0,      255,    0
+      Unused15_98_175               = array,   U08,   98,   [77],   "%", 1.0,   0.0,     0.0,      255,    0
+      
+      ; These last 80 bytes of memory are a user reserved area of page 15 to allow users to develop their own code and functions in the spirit of always allowing user customisation
+      ; in speeduino. It should never be used by the main branch release as this will break all the user customised features. 80 bytes chosen as the size of one 8bit 8x8 table with axes.
+      UserDevArea_175_255           = array,   U08,   175,   [80],   "", 1.0,   0.0,     0.0,      255,    0
 
 ;-------------------------------------------------------------------------------
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1471,8 +1471,16 @@ struct config15 {
   byte airConIdleUpRPMAdder;
   byte airConPwmFanMinDuty;
   
-  //Bytes 98-255
-  byte Unused15_98_255[158];
+  //Bytes 98-175
+  byte Unused15_98_175[77];
+  
+  /* USER DEVELOPMENT SPACE in page 15
+  *  These last 80 bytes of memory are a user reserved area of page 15 to allow users space to develop their own code and functions in the spirit of 
+  *  always allowing user customisation in speeduino. It should never be used by the main branch release as this will break user customised features 
+  *  developed outside the main branch. 
+  *  80 bytes was chosen as the size of one 8bit 8x8 table with axes.
+  */
+  byte UserDevArea_175_255[80]; 
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
Added User Development Reserved Area in Page 15. To protect a space for user customisation once all the EEPROM is used on the Mega.

These last 80 bytes of memory are proposed to be reserved to allow users space to develop their own code and functions in the spirit of always allowing user customisation in speeduino. This I think is core to the appeal of the speeduino environment for many users.

It should never be used by the main branch release as this will break any user customised features already developed outside the main branch. 

When all the EEPROM is used, more difficult conversations will happen about what features to change/remove/refactor etc. But this should always preseve an area for individual customisation of speeduino.

80 bytes was chosen as the size of one 8bit 8x8 table with axes.