### PR TITLE
Add initialisation for function pointers.

### DIFF
--- a/speeduino/decoders.ino
+++ b/speeduino/decoders.ino
@@ -40,12 +40,16 @@ A full copy of the license may be found in the projects root directory
 #include "crankMaths.h"
 #include "timers.h"
 
-void (*triggerHandler)(void); ///Pointer for the trigger function (Gets pointed to the relevant decoder)
-void (*triggerSecondaryHandler)(void); ///Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
-void (*triggerTertiaryHandler)(void); ///Pointer for the tertiary trigger function (Gets pointed to the relevant decoder)
-uint16_t (*getRPM)(void); ///Pointer to the getRPM function (Gets pointed to the relevant decoder)
-int (*getCrankAngle)(void); ///Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
-void (*triggerSetEndTeeth)(void); ///Pointer to the triggerSetEndTeeth function of each decoder
+void nullTriggerHandler (void){return;} //initialisation function for triggerhandlers, does exactly nothing
+uint16_t nullGetRPM(void){return 0;} //initialisation function for getRpm, returns safe value of 0
+int nullGetCrankAngle(void){return 0;} //initialisation function for getCrankAngle, returns safe value of 0
+
+void (*triggerHandler)(void) = nullTriggerHandler; ///Pointer for the trigger function (Gets pointed to the relevant decoder)
+void (*triggerSecondaryHandler)(void) = nullTriggerHandler; ///Pointer for the secondary trigger function (Gets pointed to the relevant decoder)
+void (*triggerTertiaryHandler)(void) = nullTriggerHandler; ///Pointer for the tertiary trigger function (Gets pointed to the relevant decoder)
+uint16_t (*getRPM)(void) = nullGetRPM; ///Pointer to the getRPM function (Gets pointed to the relevant decoder)
+int (*getCrankAngle)(void) = nullGetCrankAngle; ///Pointer to the getCrank Angle function (Gets pointed to the relevant decoder)
+void (*triggerSetEndTeeth)(void) = triggerSetEndTeeth_missingTooth; ///Pointer to the triggerSetEndTeeth function of each decoder
 
 static void triggerRoverMEMSCommon(void);
 


### PR DESCRIPTION
This is just a safety change.
Provides safe initial functions for decoder related function pointers. Prevents possibly hard to track board reset issues in case some future decoder accidentally leaves any of the functions uninitialised. Or when those pointers accidentally are used before proper values are assigned.

Flash usage 18bytes for atmega2560
Ram usage unaffected.