### PR TITLE
Fix STM32duino RTC library version to 1.2.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -71,7 +71,8 @@ platform = ststm32
 framework = arduino
 ;board = genericSTM32F407VET6
 board = black_f407ve
-lib_deps = stm32duino/STM32duino RTC, greiman/SdFat
+; RTC library fixed to 1.2.0, because in newer than that the RTC fails to keep up time. At least up to 1.3.7 version
+lib_deps = stm32duino/STM32duino RTC @ 1.2.0, greiman/SdFat
 board_build.core = stm32
 build_flags = -DUSE_LIBDIVIDE -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL2 -DENABLE_HWSERIAL3 -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_CAN_MODULE_ENABLED -DSERIAL_TX_BUFFER_SIZE=128 -DSERIAL_RX_BUFFER_SIZE=128
 upload_protocol = dfu
@@ -83,7 +84,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f401cc
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = stm32duino/STM32duino RTC @ 1.2.0
 board_build.core = stm32
 build_flags = -DUSE_LIBDIVIDE -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DHAL_DAC_MODULE_DISABLED -DHAL_ETH_MODULE_DISABLED -DHAL_SD_MODULE_DISABLED -DHAL_QSPI_MODULE_DISABLED 
 upload_protocol = dfu
@@ -95,7 +96,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = stm32duino/STM32duino RTC @ 1.2.0
 board_build.core = stm32
 build_flags = -DUSE_LIBDIVIDE -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS
 upload_protocol = dfu
@@ -107,7 +108,7 @@ monitor_speed = 115200
 platform = ststm32
 framework = arduino
 board = blackpill_f411ce
-lib_deps = stm32duino/STM32duino RTC
+lib_deps = stm32duino/STM32duino RTC @ 1.2.0
 board_build.core = stm32
 build_flags = -DUSE_LIBDIVIDE -O3 -std=gnu++11 -UBOARD_MAX_IO_PINS -DUSBCON -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC
 upload_protocol = dfu
@@ -119,7 +120,7 @@ platform = ststm32
 framework = arduino
 ; framework-arduinoststm32
 board = bluepill_f103c8_128k
-lib_deps = EEPROM, stm32duino/STM32duino RTC
+lib_deps = EEPROM, stm32duino/STM32duino RTC @ 1.2.0
 ;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map
 build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
 


### PR DESCRIPTION
Seems that the RTC on STM32 fails to keep up time when powered on VBAT if the RTC library version is higher than 1.2.0. So for now, I did fix the RTC library version to 1.2.0 which seems to be the newest one that works.

I did also report this bug on the library itself, so lets see if this gets fixed at some point: https://github.com/stm32duino/STM32RTC/issues/96