### PR TITLE
TS Engine constants menu

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2414,7 +2414,13 @@ menuDialog = main
         field = "Channel 3 angle", oddfire3,                { engineType == 1 && nCylinders >= 3 }
         field = "Channel 4 angle", oddfire4,                { engineType == 1 && nCylinders >= 4 }
 
+    dialog = engine_constants_southeast, "Fueling calculation"
+        field = "Multiply VE value by MAP ratio", multiplyMAP
+        field = "Multiply by ratio of AFR to Target AFR", includeAFR,         { egoType == 2 && !incorporateAFR  || (incorporateAFR==includeAFR) }
+        field = "Multiply by ratio of stoich AFR/target AFR (incorporate AFR)", incorporateAFR,  { !includeAFR || (incorporateAFR==includeAFR) }
+
     dialog = engine_constants_east, ""
+        panel = engine_constants_southeast, South
         panel = engine_constants_northeast, North
         field = ""
 
@@ -2596,17 +2602,8 @@ menuDialog = main
         panel = decelEnleanment
         panel = accelEnrichments_south, South
 
-    dialog = veTableDialog_north, ""
+    dialog = veTableDialog, ""
         panel = veTable1Tbl
-
-    dialog = veTableDialog_south, ""
-        field = "Multiply VE value by MAP ratio", multiplyMAP
-        field = "Multiply by ratio of AFR to Target AFR", includeAFR,         { egoType == 2 && !incorporateAFR  || (incorporateAFR==includeAFR) }
-        field = "Multiply by ratio of stoich AFR/target AFR (incorporate AFR)", incorporateAFR,  { !includeAFR || (incorporateAFR==includeAFR) }
-
-    dialog = veTableDialog, "VE Table"
-        panel = veTableDialog_north, North
-        panel = veTableDialog_south, South
 
     dialog = fuelTable2Dialog_switch, "Switch Conditions", xAxis 
         field = "Use secondary table when:",     fuel2SwitchVariable


### PR DESCRIPTION
Moved the fueling calculation options from VE Table to the engine constants menu.
The option takes a lot of space in the VE table so I moved them to another menu. 
![TS-menu](https://github.com/noisymime/speeduino/assets/62360429/d50b7f68-f8b3-4371-af2f-c08a967a82ef)
