### PR TITLE
important change in speeduino.ini for bluetooth to work with msdroid

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -245,6 +245,9 @@
     burnCommand         = "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i"
 #else
     burnCommand         = "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i"
+    ;fix for frequent bluetooth connection drop when using msdroid
+    messageEnvelopeFormat = msEnvelope_1.0 ;New and testing only
+    tableCrcCommand     = "k\$tsCanId%2i%2o%2c" ;TS can only use this command in new mode
 #endif
 
 
@@ -263,8 +266,6 @@
     interWriteDelay = 10 ;Ignored when tsWriteBlocks is on
     pageActivationDelay = 10
     restrictSquirtRelationship = false ;This requires TS 3.1 or above
-    messageEnvelopeFormat = msEnvelope_1.0 ;New and testing only
-    tableCrcCommand     = "k\$tsCanId%2i%2o%2c" ;TS can only use this command in new mode
     readSdCompressed = false
 
     ;New for TS 3.0.08ish upwards, define lists of standard I/O options
@@ -2065,13 +2066,13 @@ menuDialog = main
   fanSP             = "The trigger temperature for the fan. Fan will be enabled above this temp"
 
   airConEnable      = "Whether we are doing A/C control"
-  airConCompPol     = "Normal should be used in most cases - where a logic HIGH output turns on the output power transistor, which is the ON state. Inverted makes logic LOW the ON state, in the rare case that turning off the transistor turns the compressor on, or you are using some sort of depletion mode FET".
+  airConCompPol     = "Normal should be used in most cases - where a logic HIGH output turns on the output power transistor, which is the ON state. Inverted makes logic LOW the ON state, in the rare case that turning off the transistor turns the compressor on, or you are using some sort of depletion mode FET."
   airConReqPol      = "Normal should be used in most cases - where the A/C button provides a ground when pressed. Inverted removes the internal pullup resistor, and makes +5V the ON signal instead of ground."
   airConTurnsFanOn  = "Whether the cooling fan turns on when the A/C compressor is running."
   airConCompPin     = "The Arduino pin that the A/C request compressor signal is output on. This is NOT necesarrily the same as the connector pin on any particlar board."
   airConReqPin      = "The Arduino pin that the A/C request control signal is input on. This is NOT necesarrily the same as the connector pin on any particlar board."
   airConFanPin      = "The Arduino pin that the A/C fan control signal is output on (if enabled). This is only needed if you have a stand-alone A/C fan, separate to the cooling fan (which can be enabled to come on with the A/C compressor). This is NOT necesarrily the same as the connector pin on any particlar board."
-  airConFanPol      = "Normal should be used in most cases - where a logic HIGH output turns on the output power transistor, which is the ON state. Inverted makes logic LOW the ON state, in the rare case that turning off the transistor turns the fan on, or you are using some sort of depletion mode FET".
+  airConFanPol      = "Normal should be used in most cases - where a logic HIGH output turns on the output power transistor, which is the ON state. Inverted makes logic LOW the ON state, in the rare case that turning off the transistor turns the fan on, or you are using some sort of depletion mode FET."
   airConFanEnabled  = "Enable/disable stand-alone A/C fan. This would be a separate fan that only comes on when the A/C compressor is engaged, and should not be needed if the main cooling fan comes on with the A/C."
   airConTPSCut      = "The TPS position at which the air compressor will be locked out and turn off. When TPS falls below this level (minus a 5% hysteresis), the A/C compressor will kick back in after the delay period (TPS Cut Time), provided the A/C request signal is still present."
   airConMinRPM      = "The minimum RPM at which we will allow the A/C compressor to run (this setting is in 10 RPM steps)."
@@ -5635,15 +5636,17 @@ loggerDef = compositeLogger2, "Composite Logger 2nd Cam", composite
 
 
 [ReferenceTables]
+;fix for frequent bluetooth connection drop when using msdroid
+#if COMMS_COMPAT
+    tableBlockingFactor   = 64
+#else
     tableWriteCommand     = "t\$tsCanId%2i%2o%2c%v"; "t%2i%2o%2c%v";      "t\x01\xFC\x00\x01\xFC"    "t\%2i%2o%2c%v"
   #if mcu_stm32
     tableBlockingFactor   = 64
   #else
     tableBlockingFactor   = 256
   #endif
-  #if COMMS_COMPAT
-    tableBlockingFactor   = 64
-  #endif
+ #endif
   
     referenceTable = std_ms2gentherm, "Calibrate Thermistor Tables."
       topicHelp = "http://wiki.speeduino.com/en/configuration/Sensor_Calibration"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -45,6 +45,10 @@
     settingOption = COMMS_COMPAT, "Compatibility Mode"
     settingOption = DEFAULT, "Normal"
 
+    settingGroup = COMMS_BLT_DROP_FIX, "Fix Bluetooth Dropping"
+    settingOption = COMMS_BLT_FIX, "Enable(!ACTIVATE ONLY WHEN USING MSDROID!)"
+    settingOption = DEFAULT, "Disable"
+
 [PcVariables]
    ; valid types: boolean, double, int, list
    ;
@@ -245,9 +249,6 @@
     burnCommand         = "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i"
 #else
     burnCommand         = "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i"
-    ;fix for frequent bluetooth connection drop when using msdroid
-    messageEnvelopeFormat = msEnvelope_1.0 ;New and testing only
-    tableCrcCommand     = "k\$tsCanId%2i%2o%2c" ;TS can only use this command in new mode
 #endif
 
 
@@ -266,6 +267,12 @@
     interWriteDelay = 10 ;Ignored when tsWriteBlocks is on
     pageActivationDelay = 10
     restrictSquirtRelationship = false ;This requires TS 3.1 or above
+    #if COMMS_BLT_FIX
+    ;fix for frequent bluetooth connection drop when using msdroid
+    #else
+    messageEnvelopeFormat = msEnvelope_1.0 ;New and testing only
+    tableCrcCommand     = "k\$tsCanId%2i%2o%2c" ;TS can only use this command in new mode
+    #endif
     readSdCompressed = false
 
     ;New for TS 3.0.08ish upwards, define lists of standard I/O options
@@ -5636,18 +5643,16 @@ loggerDef = compositeLogger2, "Composite Logger 2nd Cam", composite
 
 
 [ReferenceTables]
-;fix for frequent bluetooth connection drop when using msdroid
-#if COMMS_COMPAT
-    tableBlockingFactor   = 64
-#else
     tableWriteCommand     = "t\$tsCanId%2i%2o%2c%v"; "t%2i%2o%2c%v";      "t\x01\xFC\x00\x01\xFC"    "t\%2i%2o%2c%v"
   #if mcu_stm32
     tableBlockingFactor   = 64
   #else
     tableBlockingFactor   = 256
   #endif
- #endif
-  
+  #if COMMS_COMPAT
+    tableBlockingFactor   = 64
+  #endif
+
     referenceTable = std_ms2gentherm, "Calibrate Thermistor Tables."
       topicHelp = "http://wiki.speeduino.com/en/configuration/Sensor_Calibration"
       tableIdentifier = 000, "Coolant Temperature Sensor", 001, "Air Temperature Sensor"


### PR DESCRIPTION
*Fix air conditioner info character out of the quotation marks making msdroid not loading the ini file

*Adds a option for using legacy communication for msdroid this reduce the dropping in bluetooth connection (with a warning to activate only when using msdroid)
