### PR TITLE
Save 600+ bytes RAM (step 5 of 9) - De-duplicate setSchedule functions

### DIFF
--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -385,17 +385,6 @@ static __attribute__((noinline)) int crankingGetRPM(byte totalTeeth, bool isCamT
 
   return currentStatus.RPM;
 }
-#define MIN_CYCLES_FOR_ENDCOMPARE 6
-
-inline void adjustCrankAngle(IgnitionSchedule &schedule, int endAngle, int crankAngle) {
-  if( (schedule.Status == RUNNING) ) { 
-    SET_COMPARE(schedule.compare, schedule.counter + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (endAngle - crankAngle) ) ) ) ); 
-  }
-  else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { 
-    schedule.endCompare = schedule.counter + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (endAngle - crankAngle) ) ) ); 
-    schedule.endScheduleSetByDecoder = true; 
-  }
-}
 
 /**
 On decoders that are enabled for per tooth based timing adjustments, this function performs the timer compare changes on the schedules themselves

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -385,6 +385,17 @@ static __attribute__((noinline)) int crankingGetRPM(byte totalTeeth, bool isCamT
 
   return currentStatus.RPM;
 }
+#define MIN_CYCLES_FOR_ENDCOMPARE 6
+
+inline void adjustCrankAngle(IgnitionSchedule &schedule, int endAngle, int crankAngle) {
+  if( (schedule.Status == RUNNING) ) { 
+    SET_COMPARE(schedule.compare, schedule.counter + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (endAngle - crankAngle) ) ) ) ); 
+  }
+  else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { 
+    schedule.endCompare = schedule.counter + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (endAngle - crankAngle) ) ) ); 
+    schedule.endScheduleSetByDecoder = true; 
+  }
+}
 
 /**
 On decoders that are enabled for per tooth based timing adjustments, this function performs the timer compare changes on the schedules themselves
@@ -392,57 +403,48 @@ For each ignition channel, a check is made whether we're at the relevant tooth a
 Only if both these conditions are met will the schedule be updated with the latest timing information.
 If it's the correct tooth, but the schedule is not yet started, calculate and an end compare value (This situation occurs when both the start and end of the ignition pulse happen after the end tooth, but before the next tooth)
 */
-#define MIN_CYCLES_FOR_ENDCOMPARE 6
 static inline void checkPerToothTiming(int16_t crankAngle, uint16_t currentTooth)
 {
   if ( (fixedCrankingOverride == 0) && (currentStatus.RPM > 0) )
   {
     if ( (currentTooth == ignition1EndTooth) )
     {
-      if( (ignitionSchedule1.Status == RUNNING) ) { SET_COMPARE(IGN1_COMPARE, IGN1_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule1.endCompare = IGN1_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition1EndAngle - crankAngle) ) ) ); ignitionSchedule1.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule1, ignition1EndAngle, crankAngle);
     }
     else if ( (currentTooth == ignition2EndTooth) )
     {
-      if( (ignitionSchedule2.Status == RUNNING) ) { SET_COMPARE(IGN2_COMPARE, IGN2_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule2.endCompare = IGN2_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition2EndAngle - crankAngle) ) ) ); ignitionSchedule2.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule2, ignition2EndAngle, crankAngle);
     }
     else if ( (currentTooth == ignition3EndTooth) )
     {
-      if( (ignitionSchedule3.Status == RUNNING) ) { SET_COMPARE(IGN3_COMPARE, IGN3_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule3.endCompare = IGN3_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition3EndAngle - crankAngle) ) ) ); ignitionSchedule3.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule3, ignition3EndAngle, crankAngle);
     }
     else if ( (currentTooth == ignition4EndTooth) )
     {
-      if( (ignitionSchedule4.Status == RUNNING) ) { SET_COMPARE(IGN4_COMPARE, IGN4_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule4.endCompare = IGN4_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition4EndAngle - crankAngle) ) ) ); ignitionSchedule4.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule4, ignition4EndAngle, crankAngle);
     }
 #if IGN_CHANNELS >= 5
     else if ( (currentTooth == ignition5EndTooth) )
     {
-      if( (ignitionSchedule5.Status == RUNNING) ) { SET_COMPARE(IGN5_COMPARE, IGN5_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule5.endCompare = IGN5_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition5EndAngle - crankAngle) ) ) ); ignitionSchedule5.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule5, ignition5EndAngle, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 6
     else if ( (currentTooth == ignition6EndTooth) )
     {
-      if( (ignitionSchedule6.Status == RUNNING) ) { SET_COMPARE(IGN6_COMPARE, IGN6_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule6.endCompare = IGN6_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition6EndAngle - crankAngle) ) ) ); ignitionSchedule6.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule6, ignition6EndAngle, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 7
     else if ( (currentTooth == ignition7EndTooth) )
     {
-      if( (ignitionSchedule7.Status == RUNNING) ) { SET_COMPARE(IGN7_COMPARE, IGN7_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule7.endCompare = IGN7_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition7EndAngle - crankAngle) ) ) ); ignitionSchedule7.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule7, ignition7EndAngle, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 8
     else if ( (currentTooth == ignition8EndTooth) )
     {
-      if( (ignitionSchedule8.Status == RUNNING) ) { SET_COMPARE(IGN8_COMPARE, IGN8_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ) ); }
-      else if(currentStatus.startRevolutions > MIN_CYCLES_FOR_ENDCOMPARE) { ignitionSchedule8.endCompare = IGN8_COUNTER + uS_TO_TIMER_COMPARE( angleToTimeMicroSecPerDegree( ignitionLimits( (ignition8EndAngle - crankAngle) ) ) ); ignitionSchedule8.endScheduleSetByDecoder = true; }
+      adjustCrankAngle(ignitionSchedule8, ignition8EndAngle, crankAngle);
     }
 #endif
   }

--- a/speeduino/scheduler.cpp
+++ b/speeduino/scheduler.cpp
@@ -64,59 +64,53 @@ IgnitionSchedule ignitionSchedule7(IGN7_COUNTER, IGN7_COMPARE, IGN7_TIMER_DISABL
 IgnitionSchedule ignitionSchedule8(IGN8_COUNTER, IGN8_COMPARE, IGN8_TIMER_DISABLE, IGN8_TIMER_ENABLE);
 #endif
 
+static void reset(FuelSchedule &schedule) 
+{
+    schedule.Status = OFF;
+    schedule.pTimerEnable();
+}
+
+static void reset(IgnitionSchedule &schedule) 
+{
+    schedule.Status = OFF;
+    schedule.pTimerEnable();
+}
+
 void initialiseSchedulers()
 {
-    fuelSchedule1.Status = OFF;
-    fuelSchedule2.Status = OFF;
-    fuelSchedule3.Status = OFF;
-    fuelSchedule4.Status = OFF;
+    reset(fuelSchedule1);
+    reset(fuelSchedule2);
+    reset(fuelSchedule3);
+    reset(fuelSchedule4);
 #if INJ_CHANNELS >= 5
-    fuelSchedule5.Status = OFF;
+    reset(fuelSchedule5);
 #endif
 #if INJ_CHANNELS >= 6
-    fuelSchedule6.Status = OFF;
+    reset(fuelSchedule6);
 #endif
 #if INJ_CHANNELS >= 7
-    fuelSchedule7.Status = OFF;
+    reset(fuelSchedule7);
 #endif
 #if INJ_CHANNELS >= 8
-    fuelSchedule8.Status = OFF;
+    reset(fuelSchedule8);
 #endif
 
-    ignitionSchedule1.Status = OFF;
-    IGN1_TIMER_ENABLE();
-    ignitionSchedule2.Status = OFF;
-    IGN2_TIMER_ENABLE();
-    ignitionSchedule3.Status = OFF;
-    IGN3_TIMER_ENABLE();
-    ignitionSchedule4.Status = OFF;
-    IGN4_TIMER_ENABLE();
+    reset(ignitionSchedule1);
+    reset(ignitionSchedule2);
+    reset(ignitionSchedule3);
+    reset(ignitionSchedule4);
+    reset(ignitionSchedule5);
 #if (IGN_CHANNELS >= 5)
-    ignitionSchedule5.Status = OFF;
-    IGN5_TIMER_ENABLE();
+    reset(ignitionSchedule5);
 #endif
 #if IGN_CHANNELS >= 6
-    ignitionSchedule6.Status = OFF;
-    IGN6_TIMER_ENABLE();
+    reset(ignitionSchedule6);
 #endif
 #if IGN_CHANNELS >= 7
-    ignitionSchedule7.Status = OFF;
-    IGN7_TIMER_ENABLE();
+    reset(ignitionSchedule7);
 #endif
 #if IGN_CHANNELS >= 8
-    ignitionSchedule8.Status = OFF;
-    IGN8_TIMER_ENABLE();
-#endif
-
-    FUEL1_TIMER_ENABLE();
-    FUEL2_TIMER_ENABLE();
-    FUEL3_TIMER_ENABLE();
-    FUEL4_TIMER_ENABLE();
-#if (INJ_CHANNELS >= 5)
-    FUEL5_TIMER_ENABLE();
-    FUEL6_TIMER_ENABLE();
-    FUEL7_TIMER_ENABLE();
-    FUEL8_TIMER_ENABLE();
+    reset(ignitionSchedule8);
 #endif
 
   fuelSchedule1.pStartFunction = nullCallback;

--- a/speeduino/scheduler.cpp
+++ b/speeduino/scheduler.cpp
@@ -219,7 +219,7 @@ timeout: The number of uS in the future that the startCallback should be trigger
 duration: The number of uS after startCallback is called before endCallback is called
 endCallback: This function is called once the duration time has been reached
 */
-inline __attribute__((always_inline)) void setFuelSchedule(FuelSchedule &schedule, unsigned long timeout, unsigned long duration) //Uses timer 3 compare B
+void setFuelSchedule(FuelSchedule &schedule, unsigned long timeout, unsigned long duration) //Uses timer 3 compare B
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -247,54 +247,6 @@ inline __attribute__((always_inline)) void setFuelSchedule(FuelSchedule &schedul
     }
   }
 }
-
-void setFuelSchedule1(unsigned long timeout, unsigned long duration) //Uses timer 3 compare A
-{
-  setFuelSchedule(fuelSchedule1, timeout, duration);
-}
-
-void setFuelSchedule2(unsigned long timeout, unsigned long duration) //Uses timer 3 compare B
-{
-  setFuelSchedule(fuelSchedule2, timeout, duration);
-}
-
-void setFuelSchedule3(unsigned long timeout, unsigned long duration) //Uses timer 3 compare C
-{
-  setFuelSchedule(fuelSchedule3, timeout, duration);
-}
-
-void setFuelSchedule4(unsigned long timeout, unsigned long duration) //Uses timer 4 compare B
-{
-  setFuelSchedule(fuelSchedule4, timeout, duration);
-}
-
-#if INJ_CHANNELS >= 5
-void setFuelSchedule5(unsigned long timeout, unsigned long duration) //Uses timer 4 compare C
-{
-  setFuelSchedule(fuelSchedule5, timeout, duration);
-}
-#endif
-
-#if INJ_CHANNELS >= 6
-void setFuelSchedule6(unsigned long timeout, unsigned long duration) //Uses timer 4 compare A
-{
-  setFuelSchedule(fuelSchedule6, timeout, duration);
-}
-#endif
-
-#if INJ_CHANNELS >= 7
-void setFuelSchedule7(unsigned long timeout, unsigned long duration) //Uses timer 5 compare C
-{
-  setFuelSchedule(fuelSchedule7, timeout, duration);
-}
-#endif
-
-#if INJ_CHANNELS >= 8
-void setFuelSchedule8(unsigned long timeout, unsigned long duration) //Uses timer 5 compare B
-{
-  setFuelSchedule(fuelSchedule8, timeout, duration);
-}
-#endif
 
 //Ignition schedulers use Timer 5
 void setIgnitionSchedule1(unsigned long timeout, unsigned long duration)
@@ -580,27 +532,27 @@ extern void beginInjectorPriming(void)
   if( (primingValue > 0) && (currentStatus.TPS < configPage4.floodClear) )
   {
     primingValue = primingValue * 100 * 5; //to achieve long enough priming pulses, the values in tuner studio are divided by 0.5 instead of 0.1, so multiplier of 5 is required.
-    if ( maxInjOutputs >= 1 ) { setFuelSchedule1(100, primingValue); }
+    if ( maxInjOutputs >= 1 ) { setFuelSchedule(fuelSchedule1, 100, primingValue); }
 #if (INJ_CHANNELS >= 2)
-    if ( maxInjOutputs >= 2 ) { setFuelSchedule2(100, primingValue); }
+    if ( maxInjOutputs >= 2 ) { setFuelSchedule(fuelSchedule2, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 3)
-    if ( maxInjOutputs >= 3 ) { setFuelSchedule3(100, primingValue); }
+    if ( maxInjOutputs >= 3 ) { setFuelSchedule(fuelSchedule3, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 4)
-    if ( maxInjOutputs >= 4 ) { setFuelSchedule4(100, primingValue); }
+    if ( maxInjOutputs >= 4 ) { setFuelSchedule(fuelSchedule4, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 5)
-    if ( maxInjOutputs >= 5 ) { setFuelSchedule5(100, primingValue); }
+    if ( maxInjOutputs >= 5 ) { setFuelSchedule(fuelSchedule5, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 6)
-    if ( maxInjOutputs >= 6 ) { setFuelSchedule6(100, primingValue); }
+    if ( maxInjOutputs >= 6 ) { setFuelSchedule(fuelSchedule6, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 7)
-    if ( maxInjOutputs >= 7 ) { setFuelSchedule7(100, primingValue); }
+    if ( maxInjOutputs >= 7) { setFuelSchedule(fuelSchedule7, 100, primingValue); }
 #endif
 #if (INJ_CHANNELS >= 8)
-    if ( maxInjOutputs >= 8 ) { setFuelSchedule8(100, primingValue); }
+    if ( maxInjOutputs >= 8 ) { setFuelSchedule(fuelSchedule8, 100, primingValue); }
 #endif
   }
 }

--- a/speeduino/scheduler.cpp
+++ b/speeduino/scheduler.cpp
@@ -249,7 +249,7 @@ void setFuelSchedule(FuelSchedule &schedule, unsigned long timeout, unsigned lon
 }
 
 //Ignition schedulers use Timer 5
-inline __attribute__((always_inline)) void setIgnitionSchedule(IgnitionSchedule &schedule, unsigned long timeout, unsigned long duration)
+void setIgnitionSchedule(IgnitionSchedule &schedule, unsigned long timeout, unsigned long duration)
 {
   //Check whether timeout exceeds the maximum future time. This can potentially occur on sequential setups when below ~115rpm
   if(timeout < MAX_TIMER_PERIOD)
@@ -282,12 +282,6 @@ inline __attribute__((always_inline)) void setIgnitionSchedule(IgnitionSchedule 
   }
 }
 
-//Ignition schedulers use Timer 5
-void setIgnitionSchedule1(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule1, timeout, duration);
-}
-
 void refreshIgnitionSchedule1(unsigned long timeToEnd)
 {
   if( (ignitionSchedule1.Status == RUNNING) && (timeToEnd < ignitionSchedule1.duration) )
@@ -300,47 +294,6 @@ void refreshIgnitionSchedule1(unsigned long timeToEnd)
     interrupts();
   }
 }
-
-void setIgnitionSchedule2(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule2, timeout, duration);
-}
-
-void setIgnitionSchedule3(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule3, timeout, duration);
-}
-
-void setIgnitionSchedule4(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule4, timeout, duration);
-}
-
-void setIgnitionSchedule5(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule5, timeout, duration);
-}
-
-#if IGN_CHANNELS >= 6
-void setIgnitionSchedule6(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule6, timeout, duration);
-}
-#endif
-
-#if IGN_CHANNELS >= 7
-void setIgnitionSchedule7(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule7, timeout, duration);
-}
-#endif
-
-#if IGN_CHANNELS >= 8
-void setIgnitionSchedule8(unsigned long timeout, unsigned long duration)
-{
-  setIgnitionSchedule(ignitionSchedule8, timeout, duration);
-}
-#endif
 
 /** Perform the injector priming pulses.
  * Set these to run at an arbitrary time in the future (100us).

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -53,21 +53,6 @@ See page 136 of the processors datasheet: http://www.atmel.com/Images/doc2549.pd
 void initialiseSchedulers(void);
 void beginInjectorPriming(void);
 
-void setIgnitionSchedule1(unsigned long timeout, unsigned long duration);
-void setIgnitionSchedule2(unsigned long timeout, unsigned long duration);
-void setIgnitionSchedule3(unsigned long timeout, unsigned long duration);
-void setIgnitionSchedule4(unsigned long timeout, unsigned long duration);
-void setIgnitionSchedule5(unsigned long timeout, unsigned long duration);
-#if IGN_CHANNELS >= 6
-void setIgnitionSchedule6(unsigned long timeout, unsigned long duration);
-#endif
-#if IGN_CHANNELS >= 7
-void setIgnitionSchedule7(unsigned long timeout, unsigned long duration);
-#endif
-#if IGN_CHANNELS >= 8
-void setIgnitionSchedule8(unsigned long timeout, unsigned long duration);
-#endif
-
 void disablePendingFuelSchedule(byte channel);
 void disablePendingIgnSchedule(byte channel);
 
@@ -162,6 +147,7 @@ struct IgnitionSchedule {
   void (&pTimerEnable)();     // Reference to the timer enable function  
 };
 
+void setIgnitionSchedule(IgnitionSchedule &schedule, unsigned long timeout, unsigned long duration);
 
 /** Fuel injection schedule.
 * Fuel schedules don't use the callback pointers, or the startTime/endScheduleSetByDecoder variables.

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -53,23 +53,6 @@ See page 136 of the processors datasheet: http://www.atmel.com/Images/doc2549.pd
 void initialiseSchedulers(void);
 void beginInjectorPriming(void);
 
-void setFuelSchedule1(unsigned long timeout, unsigned long duration);
-void setFuelSchedule2(unsigned long timeout, unsigned long duration);
-void setFuelSchedule3(unsigned long timeout, unsigned long duration);
-void setFuelSchedule4(unsigned long timeout, unsigned long duration);
-#if INJ_CHANNELS >= 5
-void setFuelSchedule5(unsigned long timeout, unsigned long duration);
-#endif
-#if INJ_CHANNELS >= 6
-void setFuelSchedule6(unsigned long timeout, unsigned long duration);
-#endif
-#if INJ_CHANNELS >= 7
-void setFuelSchedule7(unsigned long timeout, unsigned long duration);
-#endif
-#if INJ_CHANNELS >= 8
-void setFuelSchedule8(unsigned long timeout, unsigned long duration);
-#endif
-
 void setIgnitionSchedule1(unsigned long timeout, unsigned long duration);
 void setIgnitionSchedule2(unsigned long timeout, unsigned long duration);
 void setIgnitionSchedule3(unsigned long timeout, unsigned long duration);
@@ -216,6 +199,8 @@ struct FuelSchedule {
   void (&pTimerDisable)();    // Reference to the timer disable function
   void (&pTimerEnable)();     // Reference to the timer enable function  
 };
+
+void setFuelSchedule(FuelSchedule &schedule, unsigned long timeout, unsigned long duration);
 
 extern FuelSchedule fuelSchedule1;
 extern FuelSchedule fuelSchedule2;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -1047,7 +1047,7 @@ void loop(void)
         uint32_t timeOut = calculateIgnitionTimeout(ignitionSchedule1, ignition1StartAngle, channel1IgnDegrees, crankAngle);
         if ( (timeOut > 0U) && (BIT_CHECK(ignitionChannelsOn, IGN1_CMD_BIT)) )
         {
-          setIgnitionSchedule1(timeOut,
+          setIgnitionSchedule(ignitionSchedule1, timeOut,
                     currentStatus.dwell + fixedCrankingOverride);
         }
 #endif
@@ -1079,7 +1079,7 @@ void loop(void)
 
             if ( (ignition2StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN2_CMD_BIT)) )
             {
-              setIgnitionSchedule2(ignition2StartTime,
+              setIgnitionSchedule(ignitionSchedule2, ignition2StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1092,7 +1092,7 @@ void loop(void)
 
             if ( (ignition3StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN3_CMD_BIT)) )
             {
-              setIgnitionSchedule3(ignition3StartTime,
+              setIgnitionSchedule(ignitionSchedule3, ignition3StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1105,7 +1105,7 @@ void loop(void)
 
             if ( (ignition4StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN4_CMD_BIT)) )
             {
-              setIgnitionSchedule4(ignition4StartTime,
+              setIgnitionSchedule(ignitionSchedule4, ignition4StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1118,7 +1118,7 @@ void loop(void)
 
             if ( (ignition5StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN5_CMD_BIT)) )
             {
-              setIgnitionSchedule5(ignition5StartTime,
+              setIgnitionSchedule(ignitionSchedule5, ignition5StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1131,7 +1131,7 @@ void loop(void)
 
             if ( (ignition6StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN6_CMD_BIT)) )
             {
-              setIgnitionSchedule6(ignition6StartTime,
+              setIgnitionSchedule(ignitionSchedule6, ignition6StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1144,7 +1144,7 @@ void loop(void)
 
             if ( (ignition7StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN7_CMD_BIT)) )
             {
-              setIgnitionSchedule7(ignition7StartTime,
+              setIgnitionSchedule(ignitionSchedule7, ignition7StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }
@@ -1157,7 +1157,7 @@ void loop(void)
 
             if ( (ignition8StartTime > 0) && (BIT_CHECK(ignitionChannelsOn, IGN8_CMD_BIT)) )
             {
-              setIgnitionSchedule8(ignition8StartTime,
+              setIgnitionSchedule(ignitionSchedule8, ignition8StartTime,
                         currentStatus.dwell + fixedCrankingOverride);
             }
         }

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -889,10 +889,10 @@ void loop(void)
         uint32_t timeOut = calculateInjectorTimeout(fuelSchedule1, channel1InjDegrees, injector1StartAngle, crankAngle);
         if (timeOut>0U)
         {
-          setFuelSchedule1(
-                    timeOut,
-                    (unsigned long)currentStatus.PW1
-                    );
+            setFuelSchedule(fuelSchedule1, 
+                      timeOut,
+                      (unsigned long)currentStatus.PW1
+                      );
         }
       }
 #endif
@@ -913,7 +913,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule2, channel2InjDegrees, injector2StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule2(
+            setFuelSchedule(fuelSchedule2, 
                       timeOut,
                       (unsigned long)currentStatus.PW2
                       );
@@ -927,7 +927,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule3, channel3InjDegrees, injector3StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule3(
+            setFuelSchedule(fuelSchedule3, 
                       timeOut,
                       (unsigned long)currentStatus.PW3
                       );
@@ -941,7 +941,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule4, channel4InjDegrees, injector4StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule4(
+            setFuelSchedule(fuelSchedule4, 
                       timeOut,
                       (unsigned long)currentStatus.PW4
                       );
@@ -955,7 +955,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule5, channel5InjDegrees, injector5StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule5(
+            setFuelSchedule(fuelSchedule5, 
                       timeOut,
                       (unsigned long)currentStatus.PW5
                       );
@@ -969,7 +969,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule6, channel6InjDegrees, injector6StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule6(
+            setFuelSchedule(fuelSchedule6, 
                       timeOut,
                       (unsigned long)currentStatus.PW6
                       );
@@ -983,7 +983,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule7, channel7InjDegrees, injector7StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule7(
+            setFuelSchedule(fuelSchedule7, 
                       timeOut,
                       (unsigned long)currentStatus.PW7
                       );
@@ -997,7 +997,7 @@ void loop(void)
           uint32_t timeOut = calculateInjectorTimeout(fuelSchedule8, channel8InjDegrees, injector8StartAngle, crankAngle);
           if ( timeOut>0U )
           {
-            setFuelSchedule8(
+            setFuelSchedule(fuelSchedule8, 
                       timeOut,
                       (unsigned long)currentStatus.PW8
                       );

--- a/test/test_schedule_calcs/test_adjust_crank_angle.cpp
+++ b/test/test_schedule_calcs/test_adjust_crank_angle.cpp
@@ -1,0 +1,81 @@
+#include <Arduino.h>
+#include <unity.h>
+#include "schedule_calcs.h"
+
+static void nullIgnCallback(void) {};
+
+void test_adjust_crank_angle_pending_below_minrevolutions()
+{
+    auto counter = decltype(+IGN4_COUNTER){0};
+    auto compare = decltype(+IGN4_COMPARE){0};
+    IgnitionSchedule schedule(counter, compare, nullIgnCallback, nullIgnCallback);
+
+    schedule.Status = PENDING;
+    currentStatus.startRevolutions = 0;
+
+    schedule.compare = 101;
+    schedule.counter = 100;
+
+    // Should do nothing.
+    adjustCrankAngle(schedule, 359, 180);
+
+    TEST_ASSERT_EQUAL(101, schedule.compare);
+    TEST_ASSERT_EQUAL(100, schedule.counter);
+    TEST_ASSERT_FALSE(schedule.endScheduleSetByDecoder);
+}
+
+
+void test_adjust_crank_angle_pending_above_minrevolutions()
+{
+    auto counter = decltype(+IGN4_COUNTER){0};
+    auto compare = decltype(+IGN4_COMPARE){0};
+    IgnitionSchedule schedule(counter, compare, nullIgnCallback, nullIgnCallback);
+    
+    schedule.Status = PENDING;
+    currentStatus.startRevolutions = 2000;
+    // timePerDegreex16 = 666;
+
+    schedule.compare = 101;
+    schedule.counter = 100;
+    schedule.endCompare = 100;
+    constexpr uint16_t newCrankAngle = 180;
+    constexpr uint16_t chargeAngle = 359;
+
+    adjustCrankAngle(schedule, chargeAngle, newCrankAngle);
+
+    TEST_ASSERT_EQUAL(101, schedule.compare);
+    TEST_ASSERT_EQUAL(100, schedule.counter);
+    TEST_ASSERT_EQUAL(schedule.counter+uS_TO_TIMER_COMPARE(angleToTimeMicroSecPerDegree(chargeAngle-newCrankAngle)), schedule.endCompare);
+    TEST_ASSERT_TRUE(schedule.endScheduleSetByDecoder);
+}
+
+void test_adjust_crank_angle_running()
+{
+    auto counter = decltype(+IGN4_COUNTER){0};
+    auto compare = decltype(+IGN4_COMPARE){0};
+    IgnitionSchedule schedule(counter, compare, nullIgnCallback, nullIgnCallback);
+    
+    schedule.Status = RUNNING;
+    currentStatus.startRevolutions = 2000;
+    // timePerDegreex16 = 666;
+
+    schedule.compare = 101;
+    schedule.counter = 100;
+    schedule.endCompare = 100;
+    constexpr uint16_t newCrankAngle = 180;
+    constexpr uint16_t chargeAngle = 359;
+
+    adjustCrankAngle(schedule, chargeAngle, newCrankAngle);
+
+    TEST_ASSERT_EQUAL(schedule.counter+uS_TO_TIMER_COMPARE(angleToTimeMicroSecPerDegree(chargeAngle-newCrankAngle)), schedule.compare);
+    TEST_ASSERT_EQUAL(100, schedule.counter);
+    TEST_ASSERT_EQUAL(100, schedule.endCompare);
+    TEST_ASSERT_FALSE(schedule.endScheduleSetByDecoder);
+}
+
+void test_adjust_crank_angle()
+{
+    RUN_TEST(test_adjust_crank_angle_pending_below_minrevolutions);
+    RUN_TEST(test_adjust_crank_angle_pending_above_minrevolutions);
+    RUN_TEST(test_adjust_crank_angle_running);
+}

--- a/test/test_schedule_calcs/test_schedule_calcs.cpp
+++ b/test/test_schedule_calcs/test_schedule_calcs.cpp
@@ -4,6 +4,7 @@
 
 extern void test_calc_ign_timeout();
 extern void test_calc_inj_timeout();
+extern void test_adjust_crank_angle();
 
 void setup()
 {
@@ -14,6 +15,7 @@ void setup()
 
   test_calc_ign_timeout();
   test_calc_inj_timeout();
+  test_adjust_crank_angle();
   
   UNITY_END(); // stop unit testing
 

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -76,7 +76,7 @@ void test_accuracy_duration_ign1(void)
     initialiseSchedulers();
     ignitionSchedule1.pStartCallback = startCallback;
     ignitionSchedule1.pEndCallback = endCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     while( (ignitionSchedule1.Status == PENDING) || (ignitionSchedule1.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
 }
@@ -86,7 +86,7 @@ void test_accuracy_duration_ign2(void)
     initialiseSchedulers();
     ignitionSchedule2.pStartCallback = startCallback;
     ignitionSchedule2.pEndCallback = endCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     while( (ignitionSchedule2.Status == PENDING) || (ignitionSchedule2.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -96,7 +96,7 @@ void test_accuracy_duration_ign3(void)
     initialiseSchedulers();
     ignitionSchedule3.pStartCallback = startCallback;
     ignitionSchedule3.pEndCallback = endCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     while( (ignitionSchedule3.Status == PENDING) || (ignitionSchedule3.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -106,7 +106,7 @@ void test_accuracy_duration_ign4(void)
     initialiseSchedulers();
     ignitionSchedule4.pStartCallback = startCallback;
     ignitionSchedule4.pEndCallback = endCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     while( (ignitionSchedule4.Status == PENDING) || (ignitionSchedule4.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -117,7 +117,7 @@ void test_accuracy_duration_ign5(void)
     initialiseSchedulers();
     ignitionSchedule5.pStartCallback = startCallback;
     ignitionSchedule5.pEndCallback = endCallback;
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     while( (ignitionSchedule5.Status == PENDING) || (ignitionSchedule5.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 #endif
@@ -129,7 +129,7 @@ void test_accuracy_duration_ign6(void)
     initialiseSchedulers();
     ignitionSchedule6.pStartCallback = startCallback;
     ignitionSchedule6.pEndCallback = endCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     while( (ignitionSchedule6.Status == PENDING) || (ignitionSchedule6.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -141,7 +141,7 @@ void test_accuracy_duration_ign7(void)
     initialiseSchedulers();
     ignitionSchedule7.pStartCallback = startCallback;
     ignitionSchedule7.pEndCallback = endCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     while( (ignitionSchedule7.Status == PENDING) || (ignitionSchedule7.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -153,7 +153,7 @@ void test_accuracy_duration_ign8(void)
     initialiseSchedulers();
     ignitionSchedule8.pStartCallback = startCallback;
     ignitionSchedule8.pEndCallback = endCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     while( (ignitionSchedule8.Status == PENDING) || (ignitionSchedule8.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -15,7 +15,7 @@ static void endCallback(void) { end_time = micros(); }
 void test_accuracy_duration_inj1(void)
 {
     initialiseSchedulers();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule1.Status == RUNNING) /*Wait*/ ;
@@ -26,7 +26,7 @@ void test_accuracy_duration_inj1(void)
 void test_accuracy_duration_inj2(void)
 {
     initialiseSchedulers();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule2.Status == RUNNING) /*Wait*/ ;
@@ -37,7 +37,7 @@ void test_accuracy_duration_inj2(void)
 void test_accuracy_duration_inj3(void)
 {
     initialiseSchedulers();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule3.Status == RUNNING) /*Wait*/ ;
@@ -48,7 +48,7 @@ void test_accuracy_duration_inj3(void)
 void test_accuracy_duration_inj4(void)
 {
     initialiseSchedulers();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule4.Status == RUNNING) /*Wait*/ ;
@@ -60,7 +60,7 @@ void test_accuracy_duration_inj4(void)
 void test_accuracy_duration_inj5(void)
 {
     initialiseSchedulers();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule5.Status == RUNNING) /*Wait*/ ;
@@ -73,7 +73,7 @@ void test_accuracy_duration_inj5(void)
 void test_accuracy_duration_inj6(void)
 {
     initialiseSchedulers();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule6.Status == RUNNING) /*Wait*/ ;
@@ -86,7 +86,7 @@ void test_accuracy_duration_inj6(void)
 void test_accuracy_duration_inj7(void)
 {
     initialiseSchedulers();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule7.Status == RUNNING) /*Wait*/ ;
@@ -99,7 +99,7 @@ void test_accuracy_duration_inj7(void)
 void test_accuracy_duration_inj8(void)
 {
     initialiseSchedulers();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
     start_time = micros();
     while(fuelSchedule8.Status == RUNNING) /*Wait*/ ;

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -70,92 +70,61 @@ void test_accuracy_duration_inj8(void)
 }
 #endif
 
-
-void test_accuracy_duration_ign1(void)
+void test_accuracy_duration_ign(IgnitionSchedule &schedule)
 {
     initialiseSchedulers();
-    ignitionSchedule1.pStartCallback = startCallback;
-    ignitionSchedule1.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
-    while( (ignitionSchedule1.Status == PENDING) || (ignitionSchedule1.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    schedule.pStartCallback = startCallback;
+    schedule.pEndCallback = endCallback;
+    setIgnitionSchedule(schedule, TIMEOUT, DURATION);
+    while(schedule.Status != OFF) /*Wait*/ ;
+    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);    
+
+}
+void test_accuracy_duration_ign1(void)
+{
+    test_accuracy_duration_ign(ignitionSchedule1);
 }
 
 void test_accuracy_duration_ign2(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule2.pStartCallback = startCallback;
-    ignitionSchedule2.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
-    while( (ignitionSchedule2.Status == PENDING) || (ignitionSchedule2.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule2);
 }
 
 void test_accuracy_duration_ign3(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule3.pStartCallback = startCallback;
-    ignitionSchedule3.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
-    while( (ignitionSchedule3.Status == PENDING) || (ignitionSchedule3.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule3);
 }
 
 void test_accuracy_duration_ign4(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule4.pStartCallback = startCallback;
-    ignitionSchedule4.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
-    while( (ignitionSchedule4.Status == PENDING) || (ignitionSchedule4.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule4);
 }
 
 void test_accuracy_duration_ign5(void)
 {
 #if IGN_CHANNELS >= 5
-    initialiseSchedulers();
-    ignitionSchedule5.pStartCallback = startCallback;
-    ignitionSchedule5.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
-    while( (ignitionSchedule5.Status == PENDING) || (ignitionSchedule5.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule5);
 #endif
 }
 
 #if INJ_CHANNELS >= 6
 void test_accuracy_duration_ign6(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule6.pStartCallback = startCallback;
-    ignitionSchedule6.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
-    while( (ignitionSchedule6.Status == PENDING) || (ignitionSchedule6.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule6);
 }
 #endif
 
 #if INJ_CHANNELS >= 7
 void test_accuracy_duration_ign7(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule7.pStartCallback = startCallback;
-    ignitionSchedule7.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
-    while( (ignitionSchedule7.Status == PENDING) || (ignitionSchedule7.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule7);
 }
 #endif
 
 #if INJ_CHANNELS >= 8
 void test_accuracy_duration_ign8(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule8.pStartCallback = startCallback;
-    ignitionSchedule8.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
-    while( (ignitionSchedule8.Status == PENDING) || (ignitionSchedule8.Status == RUNNING) ) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_duration_ign(ignitionSchedule8);
 }
 #endif
 

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -12,99 +12,61 @@ static uint32_t start_time, end_time;
 static void startCallback(void) { start_time = micros(); }
 static void endCallback(void) { end_time = micros(); }
 
-void test_accuracy_duration_inj1(void)
+void test_accuracy_duration_inj(FuelSchedule &schedule)
 {
     initialiseSchedulers();
-    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
-    while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule1.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
+    schedule.pStartFunction = startCallback;
+    schedule.pEndFunction = endCallback;
+    setFuelSchedule(schedule, TIMEOUT, DURATION);
+    while(schedule.Status != OFF) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+}
+
+void test_accuracy_duration_inj1(void)
+{
+    test_accuracy_duration_inj(fuelSchedule1);
 }
 
 void test_accuracy_duration_inj2(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
-    while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule2.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule2);
 }
 
 void test_accuracy_duration_inj3(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
-    while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule3.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule3);
 }
 
 void test_accuracy_duration_inj4(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
-    while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule4.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule4);
 }
 
 #if INJ_CHANNELS >= 5
 void test_accuracy_duration_inj5(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
-    while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule5.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule5);
 }
 #endif
 
 #if INJ_CHANNELS >= 6
 void test_accuracy_duration_inj6(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
-    while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule6.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule6);
 }
 #endif
 
 #if INJ_CHANNELS >= 7
 void test_accuracy_duration_inj7(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
-    while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule7.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule7);
 }
 #endif
 
 #if INJ_CHANNELS >= 8
 void test_accuracy_duration_inj8(void)
 {
-    initialiseSchedulers();
-    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
-    while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
-    start_time = micros();
-    while(fuelSchedule8.Status == RUNNING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, DURATION, end_time - start_time);
+    test_accuracy_duration_inj(fuelSchedule8);
 }
 #endif
 

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -13,91 +13,62 @@ static uint32_t start_time, end_time;
 static void startCallback(void) { end_time = micros(); }
 static void endCallback(void) { /*Empty*/ }
 
-void test_accuracy_timeout_inj1(void)
+void test_accuracy_timeout_inj(FuelSchedule &schedule)
 {
     initialiseSchedulers();
+    schedule.pStartFunction = startCallback;
+    schedule.pEndFunction = endCallback;
     start_time = micros();
-    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
-    while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
+    setFuelSchedule(schedule, TIMEOUT, DURATION);
+    while(schedule.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+}
+
+void test_accuracy_timeout_inj1(void)
+{
+    test_accuracy_timeout_inj(fuelSchedule1);
 }
 
 void test_accuracy_timeout_inj2(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
-    while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule2);
 }
 
 void test_accuracy_timeout_inj3(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
-    while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule3);
 }
 
 void test_accuracy_timeout_inj4(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
-    while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule4);
 }
 
 #if INJ_CHANNELS >= 5
 void test_accuracy_timeout_inj5(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
-    while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule5);
 }
 #endif
 
 #if INJ_CHANNELS >= 6
 void test_accuracy_timeout_inj6(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
-    while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule6);
 }
 #endif
 
 #if INJ_CHANNELS >= 7
 void test_accuracy_timeout_inj7(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
-    while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule7);
 }
 #endif
 
 #if INJ_CHANNELS >= 8
 void test_accuracy_timeout_inj8(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
-    while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
-    end_time = micros();
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_inj(fuelSchedule8);
 }
 #endif
 

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -79,7 +79,7 @@ void test_accuracy_timeout_ign1(void)
     start_time = micros();
     ignitionSchedule1.pStartCallback = startCallback;
     ignitionSchedule1.pEndCallback = endCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -90,7 +90,7 @@ void test_accuracy_timeout_ign2(void)
     start_time = micros();
     ignitionSchedule2.pStartCallback = startCallback;
     ignitionSchedule2.pEndCallback = endCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -101,7 +101,7 @@ void test_accuracy_timeout_ign3(void)
     start_time = micros();
     ignitionSchedule3.pStartCallback = startCallback;
     ignitionSchedule3.pEndCallback = endCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -112,7 +112,7 @@ void test_accuracy_timeout_ign4(void)
     start_time = micros();
     ignitionSchedule4.pStartCallback = startCallback;
     ignitionSchedule4.pEndCallback = endCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -124,7 +124,7 @@ void test_accuracy_timeout_ign5(void)
     ignitionSchedule5.pStartCallback = startCallback;
     ignitionSchedule5.pEndCallback = endCallback;
     start_time = micros();
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -137,7 +137,7 @@ void test_accuracy_timeout_ign6(void)
     start_time = micros();
     ignitionSchedule6.pStartCallback = startCallback;
     ignitionSchedule6.pEndCallback = endCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -150,7 +150,7 @@ void test_accuracy_timeout_ign7(void)
     start_time = micros();
     ignitionSchedule7.pStartCallback = startCallback;
     ignitionSchedule7.pEndCallback = endCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }
@@ -163,7 +163,7 @@ void test_accuracy_timeout_ign8(void)
     start_time = micros();
     ignitionSchedule8.pStartCallback = startCallback;
     ignitionSchedule8.pEndCallback = endCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
 }

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -72,100 +72,62 @@ void test_accuracy_timeout_inj8(void)
 }
 #endif
 
+void test_accuracy_timeout_ign(IgnitionSchedule &schedule)
+{
+    initialiseSchedulers();
+    schedule.pStartCallback = startCallback;
+    schedule.pEndCallback = endCallback;
+    start_time = micros();
+    setIgnitionSchedule(schedule, TIMEOUT, DURATION);
+    while(schedule.Status == PENDING) /*Wait*/ ;
+    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+}
 
 void test_accuracy_timeout_ign1(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule1.pStartCallback = startCallback;
-    ignitionSchedule1.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
-    while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule1);
 }
 
 void test_accuracy_timeout_ign2(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule2.pStartCallback = startCallback;
-    ignitionSchedule2.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
-    while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule2);
 }
 
 void test_accuracy_timeout_ign3(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule3.pStartCallback = startCallback;
-    ignitionSchedule3.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
-    while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule3);
 }
 
 void test_accuracy_timeout_ign4(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule4.pStartCallback = startCallback;
-    ignitionSchedule4.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
-    while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule4);
 }
 
 #if IGN_CHANNELS >= 5
 void test_accuracy_timeout_ign5(void)
 {
-    initialiseSchedulers();
-    ignitionSchedule5.pStartCallback = startCallback;
-    ignitionSchedule5.pEndCallback = endCallback;
-    start_time = micros();
-    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
-    while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule5);
 }
 #endif
 
 #if IGN_CHANNELS >= 6
 void test_accuracy_timeout_ign6(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule6.pStartCallback = startCallback;
-    ignitionSchedule6.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
-    while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule6);
 }
 #endif
 
 #if IGN_CHANNELS >= 7
 void test_accuracy_timeout_ign7(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule7.pStartCallback = startCallback;
-    ignitionSchedule7.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
-    while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule7);
 }
 #endif
 
 #if IGN_CHANNELS >= 8
 void test_accuracy_timeout_ign8(void)
 {
-    initialiseSchedulers();
-    start_time = micros();
-    ignitionSchedule8.pStartCallback = startCallback;
-    ignitionSchedule8.pEndCallback = endCallback;
-    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
-    while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
-    TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
+    test_accuracy_timeout_ign(ignitionSchedule8);
 }
 #endif
 

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -17,7 +17,7 @@ void test_accuracy_timeout_inj1(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -27,7 +27,7 @@ void test_accuracy_timeout_inj2(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -37,7 +37,7 @@ void test_accuracy_timeout_inj3(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -47,7 +47,7 @@ void test_accuracy_timeout_inj4(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -58,7 +58,7 @@ void test_accuracy_timeout_inj5(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -70,7 +70,7 @@ void test_accuracy_timeout_inj6(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -82,7 +82,7 @@ void test_accuracy_timeout_inj7(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);
@@ -94,7 +94,7 @@ void test_accuracy_timeout_inj8(void)
 {
     initialiseSchedulers();
     start_time = micros();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
     end_time = micros();
     TEST_ASSERT_UINT32_WITHIN(DELTA, TIMEOUT, end_time - start_time);

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -79,7 +79,7 @@ void test_status_off_to_pending_ign1(void)
     initialiseSchedulers();
     ignitionSchedule1.pStartCallback = emptyCallback;
     ignitionSchedule1.pEndCallback = emptyCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule1.Status);
 }
 
@@ -88,7 +88,7 @@ void test_status_off_to_pending_ign2(void)
     initialiseSchedulers();
     ignitionSchedule2.pStartCallback = emptyCallback;
     ignitionSchedule2.pEndCallback = emptyCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule2.Status);
 }
 
@@ -97,7 +97,7 @@ void test_status_off_to_pending_ign3(void)
     initialiseSchedulers();
     ignitionSchedule3.pStartCallback = emptyCallback;
     ignitionSchedule3.pEndCallback = emptyCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule3.Status);
 }
 
@@ -106,7 +106,7 @@ void test_status_off_to_pending_ign4(void)
     initialiseSchedulers();
     ignitionSchedule4.pStartCallback = emptyCallback;
     ignitionSchedule4.pEndCallback = emptyCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule4.Status);
 }
 
@@ -116,7 +116,7 @@ void test_status_off_to_pending_ign5(void)
     initialiseSchedulers();
     ignitionSchedule5.pStartCallback = emptyCallback;
     ignitionSchedule5.pEndCallback = emptyCallback;
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule5.Status);
 }
 #endif
@@ -127,7 +127,7 @@ void test_status_off_to_pending_ign6(void)
     initialiseSchedulers();
     ignitionSchedule6.pStartCallback = emptyCallback;
     ignitionSchedule6.pEndCallback = emptyCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule6.Status);
 }
 #endif
@@ -138,7 +138,7 @@ void test_status_off_to_pending_ign7(void)
     initialiseSchedulers();
     ignitionSchedule7.pStartCallback = emptyCallback;
     ignitionSchedule7.pEndCallback = emptyCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule7.Status);
 }
 #endif
@@ -149,7 +149,7 @@ void test_status_off_to_pending_ign8(void)
     initialiseSchedulers();
     ignitionSchedule8.pStartCallback = emptyCallback;
     ignitionSchedule8.pEndCallback = emptyCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule8.Status);
 }
 #endif

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -12,28 +12,28 @@ static void emptyCallback(void) {  }
 void test_status_off_to_pending_inj1(void)
 {
     initialiseSchedulers();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule1.Status);
 }
 
 void test_status_off_to_pending_inj2(void)
 {
     initialiseSchedulers();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule2.Status);
 }
 
 void test_status_off_to_pending_inj3(void)
 {
     initialiseSchedulers();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule3.Status);
 }
 
 void test_status_off_to_pending_inj4(void)
 {
     initialiseSchedulers();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule4.Status);
 }
 
@@ -41,7 +41,7 @@ void test_status_off_to_pending_inj4(void)
 void test_status_off_to_pending_inj5(void)
 {
     initialiseSchedulers();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule5.Status);
 }
 #endif
@@ -50,7 +50,7 @@ void test_status_off_to_pending_inj5(void)
 void test_status_off_to_pending_inj6(void)
 {
     initialiseSchedulers();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule6.Status);
 }
 #endif
@@ -59,7 +59,7 @@ void test_status_off_to_pending_inj6(void)
 void test_status_off_to_pending_inj7(void)
 {
     initialiseSchedulers();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule7.Status);
 }
 #endif
@@ -68,7 +68,7 @@ void test_status_off_to_pending_inj7(void)
 void test_status_off_to_pending_inj8(void)
 {
     initialiseSchedulers();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule8.Status);
 }
 #endif

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -12,7 +12,7 @@ static void emptyCallback(void) {  }
 void test_status_pending_to_running_inj1(void)
 {
     initialiseSchedulers();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule1.Status);
 }
@@ -20,7 +20,7 @@ void test_status_pending_to_running_inj1(void)
 void test_status_pending_to_running_inj2(void)
 {
     initialiseSchedulers();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule2.Status);
 }
@@ -28,7 +28,7 @@ void test_status_pending_to_running_inj2(void)
 void test_status_pending_to_running_inj3(void)
 {
     initialiseSchedulers();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule3.Status);
 }
@@ -36,7 +36,7 @@ void test_status_pending_to_running_inj3(void)
 void test_status_pending_to_running_inj4(void)
 {
     initialiseSchedulers();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule4.Status);
 }
@@ -45,7 +45,7 @@ void test_status_pending_to_running_inj5(void)
 {
 #if INJ_CHANNELS >= 5
     initialiseSchedulers();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule5.Status);
 #endif
@@ -55,7 +55,7 @@ void test_status_pending_to_running_inj6(void)
 {
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule6.Status);
 #endif
@@ -65,7 +65,7 @@ void test_status_pending_to_running_inj7(void)
 {
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule7.Status);
 #endif
@@ -75,7 +75,7 @@ void test_status_pending_to_running_inj8(void)
 {
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, fuelSchedule8.Status);
 #endif

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -87,7 +87,7 @@ void test_status_pending_to_running_ign1(void)
     initialiseSchedulers();
     ignitionSchedule1.pStartCallback = emptyCallback;
     ignitionSchedule1.pEndCallback = emptyCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule1.Status);
 }
@@ -97,7 +97,7 @@ void test_status_pending_to_running_ign2(void)
     initialiseSchedulers();
     ignitionSchedule2.pStartCallback = emptyCallback;
     ignitionSchedule2.pEndCallback = emptyCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule2.Status);
 }
@@ -107,7 +107,7 @@ void test_status_pending_to_running_ign3(void)
     initialiseSchedulers();
     ignitionSchedule3.pStartCallback = emptyCallback;
     ignitionSchedule3.pEndCallback = emptyCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule3.Status);
 }
@@ -117,7 +117,7 @@ void test_status_pending_to_running_ign4(void)
     initialiseSchedulers();
     ignitionSchedule4.pStartCallback = emptyCallback;
     ignitionSchedule4.pEndCallback = emptyCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule4.Status);
 }
@@ -128,7 +128,7 @@ void test_status_pending_to_running_ign5(void)
     initialiseSchedulers();
     ignitionSchedule5.pStartCallback = emptyCallback;
     ignitionSchedule5.pEndCallback = emptyCallback;
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule5.Status);
 #endif
@@ -140,7 +140,7 @@ void test_status_pending_to_running_ign6(void)
     initialiseSchedulers();
     ignitionSchedule6.pStartCallback = emptyCallback;
     ignitionSchedule6.pEndCallback = emptyCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule6.Status);
 #endif
@@ -152,7 +152,7 @@ void test_status_pending_to_running_ign7(void)
     initialiseSchedulers();
     ignitionSchedule7.pStartCallback = emptyCallback;
     ignitionSchedule7.pEndCallback = emptyCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule7.Status);
 #endif
@@ -164,7 +164,7 @@ void test_status_pending_to_running_ign8(void)
     initialiseSchedulers();
     ignitionSchedule8.pStartCallback = emptyCallback;
     ignitionSchedule8.pEndCallback = emptyCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(RUNNING, ignitionSchedule8.Status);
 #endif

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -12,7 +12,7 @@ static void emptyCallback(void) {  }
 void test_status_running_to_off_inj1(void)
 {
     initialiseSchedulers();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     while( (fuelSchedule1.Status == PENDING) || (fuelSchedule1.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule1.Status);
 }
@@ -20,7 +20,7 @@ void test_status_running_to_off_inj1(void)
 void test_status_running_to_off_inj2(void)
 {
     initialiseSchedulers();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     while( (fuelSchedule2.Status == PENDING) || (fuelSchedule2.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule2.Status);
 }
@@ -28,7 +28,7 @@ void test_status_running_to_off_inj2(void)
 void test_status_running_to_off_inj3(void)
 {
     initialiseSchedulers();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     while( (fuelSchedule3.Status == PENDING) || (fuelSchedule3.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule3.Status);
 }
@@ -36,7 +36,7 @@ void test_status_running_to_off_inj3(void)
 void test_status_running_to_off_inj4(void)
 {
     initialiseSchedulers();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     while( (fuelSchedule4.Status == PENDING) || (fuelSchedule4.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule4.Status);
 }
@@ -45,7 +45,7 @@ void test_status_running_to_off_inj5(void)
 {
 #if INJ_CHANNELS >= 5
     initialiseSchedulers();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     while( (fuelSchedule5.Status == PENDING) || (fuelSchedule5.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule5.Status);
 #endif
@@ -55,7 +55,7 @@ void test_status_running_to_off_inj6(void)
 {
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     while( (fuelSchedule6.Status == PENDING) || (fuelSchedule6.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule6.Status);
 #endif
@@ -65,7 +65,7 @@ void test_status_running_to_off_inj7(void)
 {
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     while( (fuelSchedule7.Status == PENDING) || (fuelSchedule7.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule7.Status);
 #endif
@@ -75,7 +75,7 @@ void test_status_running_to_off_inj8(void)
 {
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     while( (fuelSchedule8.Status == PENDING) || (fuelSchedule8.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, fuelSchedule8.Status);
 #endif

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -87,7 +87,7 @@ void test_status_running_to_off_ign1(void)
     initialiseSchedulers();
     ignitionSchedule1.pStartCallback = emptyCallback;
     ignitionSchedule1.pEndCallback = emptyCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     while( (ignitionSchedule1.Status == PENDING) || (ignitionSchedule1.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule1.Status);
 }
@@ -97,7 +97,7 @@ void test_status_running_to_off_ign2(void)
     initialiseSchedulers();
     ignitionSchedule2.pStartCallback = emptyCallback;
     ignitionSchedule2.pEndCallback = emptyCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     while( (ignitionSchedule2.Status == PENDING) || (ignitionSchedule2.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule2.Status);
 }
@@ -107,7 +107,7 @@ void test_status_running_to_off_ign3(void)
     initialiseSchedulers();
     ignitionSchedule3.pStartCallback = emptyCallback;
     ignitionSchedule3.pEndCallback = emptyCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     while( (ignitionSchedule3.Status == PENDING) || (ignitionSchedule3.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule3.Status);
 }
@@ -117,7 +117,7 @@ void test_status_running_to_off_ign4(void)
     initialiseSchedulers();
     ignitionSchedule4.pStartCallback = emptyCallback;
     ignitionSchedule4.pEndCallback = emptyCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     while( (ignitionSchedule4.Status == PENDING) || (ignitionSchedule4.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule4.Status);
 }
@@ -128,7 +128,7 @@ void test_status_running_to_off_ign5(void)
     initialiseSchedulers();
     ignitionSchedule5.pStartCallback = emptyCallback;
     ignitionSchedule5.pEndCallback = emptyCallback;
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     while( (ignitionSchedule5.Status == PENDING) || (ignitionSchedule5.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule5.Status);
 #endif
@@ -140,7 +140,7 @@ void test_status_running_to_off_ign6(void)
     initialiseSchedulers();
     ignitionSchedule6.pStartCallback = emptyCallback;
     ignitionSchedule6.pEndCallback = emptyCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     while( (ignitionSchedule6.Status == PENDING) || (ignitionSchedule6.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule6.Status);
 #endif
@@ -152,7 +152,7 @@ void test_status_running_to_off_ign7(void)
     initialiseSchedulers();
     ignitionSchedule7.pStartCallback = emptyCallback;
     ignitionSchedule7.pEndCallback = emptyCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     while( (ignitionSchedule7.Status == PENDING) || (ignitionSchedule7.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule7.Status);
 #endif
@@ -164,7 +164,7 @@ void test_status_running_to_off_ign8(void)
     initialiseSchedulers();
     ignitionSchedule8.pStartCallback = emptyCallback;
     ignitionSchedule8.pEndCallback = emptyCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     while( (ignitionSchedule8.Status == PENDING) || (ignitionSchedule8.Status == RUNNING) ) /*Wait*/ ;
     TEST_ASSERT_EQUAL(OFF, ignitionSchedule8.Status);
 #endif

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -12,9 +12,9 @@ static void emptyCallback(void) {  }
 void test_status_running_to_pending_inj1(void)
 {
     initialiseSchedulers();
-    setFuelSchedule1(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, TIMEOUT, DURATION);
     while(fuelSchedule1.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule1(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule1, 2*TIMEOUT, DURATION);
     while(fuelSchedule1.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule1.Status);
 }
@@ -22,9 +22,9 @@ void test_status_running_to_pending_inj1(void)
 void test_status_running_to_pending_inj2(void)
 {
     initialiseSchedulers();
-    setFuelSchedule2(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, TIMEOUT, DURATION);
     while(fuelSchedule2.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule2(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule2, 2*TIMEOUT, DURATION);
     while(fuelSchedule2.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule2.Status);
 }
@@ -32,9 +32,9 @@ void test_status_running_to_pending_inj2(void)
 void test_status_running_to_pending_inj3(void)
 {
     initialiseSchedulers();
-    setFuelSchedule3(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, TIMEOUT, DURATION);
     while(fuelSchedule3.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule3(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule3, 2*TIMEOUT, DURATION);
     while(fuelSchedule3.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule3.Status);
 }
@@ -42,9 +42,9 @@ void test_status_running_to_pending_inj3(void)
 void test_status_running_to_pending_inj4(void)
 {
     initialiseSchedulers();
-    setFuelSchedule4(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, TIMEOUT, DURATION);
     while(fuelSchedule4.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule4(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule4, 2*TIMEOUT, DURATION);
     while(fuelSchedule4.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule4.Status);
 }
@@ -53,9 +53,9 @@ void test_status_running_to_pending_inj5(void)
 {
 #if INJ_CHANNELS >= 5
     initialiseSchedulers();
-    setFuelSchedule5(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, TIMEOUT, DURATION);
     while(fuelSchedule5.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule5(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule5, 2*TIMEOUT, DURATION);
     while(fuelSchedule5.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule5.Status);
 #endif
@@ -65,9 +65,9 @@ void test_status_running_to_pending_inj6(void)
 {
 #if INJ_CHANNELS >= 6
     initialiseSchedulers();
-    setFuelSchedule6(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, TIMEOUT, DURATION);
     while(fuelSchedule6.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule6(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule6, 2*TIMEOUT, DURATION);
     while(fuelSchedule6.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule6.Status);
 #endif
@@ -77,9 +77,9 @@ void test_status_running_to_pending_inj7(void)
 {
 #if INJ_CHANNELS >= 7
     initialiseSchedulers();
-    setFuelSchedule7(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, TIMEOUT, DURATION);
     while(fuelSchedule7.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule7(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule7, 2*TIMEOUT, DURATION);
     while(fuelSchedule7.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule7.Status);
 #endif
@@ -89,9 +89,9 @@ void test_status_running_to_pending_inj8(void)
 {
 #if INJ_CHANNELS >= 8
     initialiseSchedulers();
-    setFuelSchedule8(TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, TIMEOUT, DURATION);
     while(fuelSchedule8.Status == PENDING) /*Wait*/ ;
-    setFuelSchedule8(2*TIMEOUT, DURATION);
+    setFuelSchedule(fuelSchedule8, 2*TIMEOUT, DURATION);
     while(fuelSchedule8.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, fuelSchedule8.Status);
 #endif

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -103,9 +103,9 @@ void test_status_running_to_pending_ign1(void)
     initialiseSchedulers();
     ignitionSchedule1.pStartCallback = emptyCallback;
     ignitionSchedule1.pEndCallback = emptyCallback;
-    setIgnitionSchedule1(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, TIMEOUT, DURATION);
     while(ignitionSchedule1.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule1(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule1, 2*TIMEOUT, DURATION);
     while(ignitionSchedule1.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule1.Status);
 }
@@ -115,9 +115,9 @@ void test_status_running_to_pending_ign2(void)
     initialiseSchedulers();
     ignitionSchedule2.pStartCallback = emptyCallback;
     ignitionSchedule2.pEndCallback = emptyCallback;
-    setIgnitionSchedule2(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, TIMEOUT, DURATION);
     while(ignitionSchedule2.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule2(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule2, 2*TIMEOUT, DURATION);
     while(ignitionSchedule2.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule2.Status);
 }
@@ -127,9 +127,9 @@ void test_status_running_to_pending_ign3(void)
     initialiseSchedulers();
     ignitionSchedule3.pStartCallback = emptyCallback;
     ignitionSchedule3.pEndCallback = emptyCallback;
-    setIgnitionSchedule3(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, TIMEOUT, DURATION);
     while(ignitionSchedule3.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule3(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule3, 2*TIMEOUT, DURATION);
     while(ignitionSchedule3.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule3.Status);
 }
@@ -139,9 +139,9 @@ void test_status_running_to_pending_ign4(void)
     initialiseSchedulers();
     ignitionSchedule4.pStartCallback = emptyCallback;
     ignitionSchedule4.pEndCallback = emptyCallback;
-    setIgnitionSchedule4(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, TIMEOUT, DURATION);
     while(ignitionSchedule4.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule4(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule4, 2*TIMEOUT, DURATION);
     while(ignitionSchedule4.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule4.Status);
 }
@@ -152,9 +152,9 @@ void test_status_running_to_pending_ign5(void)
     initialiseSchedulers();
     ignitionSchedule5.pStartCallback = emptyCallback;
     ignitionSchedule5.pEndCallback = emptyCallback;
-    setIgnitionSchedule5(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, TIMEOUT, DURATION);
     while(ignitionSchedule5.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule5(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule5, 2*TIMEOUT, DURATION);
     while(ignitionSchedule5.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule5.Status);
 #endif
@@ -166,9 +166,9 @@ void test_status_running_to_pending_ign6(void)
     initialiseSchedulers();
     ignitionSchedule6.pStartCallback = emptyCallback;
     ignitionSchedule6.pEndCallback = emptyCallback;
-    setIgnitionSchedule6(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, TIMEOUT, DURATION);
     while(ignitionSchedule6.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule6(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule6, 2*TIMEOUT, DURATION);
     while(ignitionSchedule6.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule6.Status);
 #endif
@@ -180,9 +180,9 @@ void test_status_running_to_pending_ign7(void)
     initialiseSchedulers();
     ignitionSchedule7.pStartCallback = emptyCallback;
     ignitionSchedule7.pEndCallback = emptyCallback;
-    setIgnitionSchedule7(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, TIMEOUT, DURATION);
     while(ignitionSchedule7.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule7(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule7, 2*TIMEOUT, DURATION);
     while(ignitionSchedule7.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule7.Status);
 #endif
@@ -194,9 +194,9 @@ void test_status_running_to_pending_ign8(void)
     initialiseSchedulers();
     ignitionSchedule8.pStartCallback = emptyCallback;
     ignitionSchedule8.pEndCallback = emptyCallback;
-    setIgnitionSchedule8(TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, TIMEOUT, DURATION);
     while(ignitionSchedule8.Status == PENDING) /*Wait*/ ;
-    setIgnitionSchedule8(2*TIMEOUT, DURATION);
+    setIgnitionSchedule(ignitionSchedule8, 2*TIMEOUT, DURATION);
     while(ignitionSchedule8.Status == RUNNING) /*Wait*/ ;
     TEST_ASSERT_EQUAL(PENDING, ignitionSchedule8.Status);
 #endif


### PR DESCRIPTION
This is the 5th PR in a series of scheduler focused PRs that end up saving >600 bytes RAM (compared to master as of 2023-06-11)

This PR removes the duplicate code in the per-channel setSchedule functions (setFuelSchedule\d|setIgnitionSchedule\d), routing them through a generic function that handles all channels:
```
setIgnitionSchedule
setFuelSchedule
```

The end game is [this branch](https://github.com/adbancroft/speeduino/tree/SCHD_8_scheduler_arrays). Since there are so many changes, I split them into as a series of PRs (each with a specific focus), to make the changes easier to understand, test and get feedback on.

1. #1010 
2. #1039 
3. #1018 
4. #1063 
5. This PR
6. De-duplicate schedule structs
7. Optimize ignition schedule struct
8. Optimize fuel schedule struct
9. Use arrays to store schedulers.