### PR TITLE
Fix parse error in the msdroid debuglogs

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -2088,7 +2088,7 @@ menuDialog = main
   airConIdleUpRPMAdder = "Increase the idle RPM target (as used by Idle Advance and Closed-Loop Idle) by this amount when the A/C request is active."
   airConPwmFanMinDuty = "If you are using a PWM cooling fan, the fan duty will be clamped to this value or higher (based on the coolant temp./duty cycle table) when the A/C compressor is engaged."
 
-  vssPulsesPerKm    = "The number of pulses on the VSS signal per KM/Mile when "pulses per KM/Mile" -mode is used.\nIn "CAN/Serial/Analog" -mode the Aux input value is divided by this number to get correct VSS. 0 = No dividing/disabled."
+  vssPulsesPerKm    = "The number of pulses on the VSS signal per KM/Mile when (pulses per KM/Mile) -mode is used.\nIn (CAN/Serial/Analog) -mode the Aux input value is divided by this number to get correct VSS. 0 = No dividing/disabled."
   vssAuxCh          = "Use the Auxilary Input Channel Configuration -menus to read VSS from desired source (CAN/Serial/Analog) and then select that Aux in channel here"
   vssSmoothing      = "A smoothing factor to help reduce noise in the VSS signal. Typical values are between 0 and 50"
 


### PR DESCRIPTION
This fix parse problem in the msdroid debuglogs

Also, using quotes inside other quotes should be prohibited as it will make msdroid give parse error while loading ini file, instead parentheses should be used

The error that this fix (  PARSE PROBLEM: ParseProblem [mFileName=firmware.ini, mLineNo=2091, mSeverity=WARNING, mField=vssPulsesPerKm, mErrorMessage=Incorrect number of arguments for setting context help "vssPulsesPerKm", excepted 2 but got 11, mLine=vssPulsesPerKm    = "The number of pulses on the VSS signal per KM/Mile when "pulses per KM/Mile" -mode is used.\nIn "CAN/Serial/Analog" -mode the Aux input value is divided by this number to get correct VSS. 0 = No dividing/disabled."]   )