### PR TITLE
MAP Limits for EGO

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1005,8 +1005,8 @@ page = 9
       
       unused10_110         = scalar, U08,     110,        "",       1, 0, 0, 255, 0 
       unused10_111         = scalar, U08,     111,        "",       1, 0, 0, 255, 0
-      unused10_112         = scalar, U08,     112,        "",       1, 0, 0, 255, 0
-      unused10_113         = scalar, U08,     113,        "",       1, 0, 0, 255, 0
+      egoMAPMax = scalar, U08, 112, "kPa", 2.0, 0.0, 2.0, 511.0, 0
+      egoMAPMin = scalar, U08, 113, "kPa", 2.0, 0.0, 2.0, 511.0, 0
 
       speeduino_tsCanId     = bits,   U08,    114,     [0:3],  $tsCanId_list
       true_address           = bits,   U16,     115,     [0:10], $CAN_ADDRESS_HEX
@@ -1835,6 +1835,9 @@ page = 15
     defaultValue = rollingProtRPMDelta,      -300 -200  -100  -50
     defaultValue = rollingProtCutPercent,    50   65    80    95
 
+    defaultValue = egoMAPMax, 100
+    defaultValue = egoMAPMin, 26
+
 #if LAMBDA
       defaultValue = wueAFR, -0.136 -0.102 -0.082 -0.068 -0.054 -0.041 -0.027 -0.014 -0.007 0.000
 #else
@@ -2393,6 +2396,9 @@ menuDialog = main
   boostDCWhenDisabled         = "When the closedloop boost controller is disabled by 'enable trigger', this is the Duty cycle set on the boost selenoid. Ususally this is 99% because it keeps the waste gate firmly closed until the threshold and builds boost as fast as possible (no wastegate leak)"
   boostControlEnableThreshold = "When the 'Boost control enable trigger' is set to 'fixed', this value is used as threshold. Usually the value is set just below the wastgate pressure of the used turbo setup. For example 130kpa for a 0.3 bar wastegate actuator. Below this value the ECU has no control over the boost anyway."
 
+  egoMAPMax = "Only Correct below this MAP Value"
+  egoMAPMin = "Only Correct above this MAP Value"
+
 [UserDefined]
 
 ; Enhanced TunerStudio dialogs can be defined here
@@ -2701,6 +2707,8 @@ menuDialog = main
       field = "Active Above Coolant",       egoTemp,            { egoType && (egoAlgorithm < 3) }
       field = "Active Above RPM",           egoRPM,             { egoType && (egoAlgorithm < 3) }
       field = "Active Below TPS",           egoTPSMax,          { egoType && (egoAlgorithm < 3) }
+      field = "Active Below MAP",           egoMAPMax,          { egoType && (egoAlgorithm < 3) }
+      field = "Active Above MAP",           egoMAPMin,          { egoType && (egoAlgorithm < 3) }
       field = "EGO delay after start",      ego_sdelay,         { (egoAlgorithm < 3) }
       field = "PID Proportional Gain",      egoKP,              { egoType && (egoAlgorithm == 2) }
       field = "PID Integral",               egoKI,              { egoType && (egoAlgorithm == 2) }

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -631,7 +631,7 @@ byte correctionAFRClosedLoop(void)
       AFRnextCycle = ignitionCount + configPage6.egoCount; //Set the target ignition event for the next calculation
         
       //Check all other requirements for closed loop adjustments
-      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS <= configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) && ( currentStatus.MAP <= (configPage9.egoMAPMax * 2) ) && ( currentStatus.MAP >= (configPage9.egoMAPMin * 2) ) )
+      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS <= configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) && ( currentStatus.MAP <= (configPage9.egoMAPMax * 2U) ) && ( currentStatus.MAP >= (configPage9.egoMAPMin * 2U) ) )
       {
 
         //Check which algorithm is used, simple or PID

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -631,7 +631,7 @@ byte correctionAFRClosedLoop(void)
       AFRnextCycle = ignitionCount + configPage6.egoCount; //Set the target ignition event for the next calculation
         
       //Check all other requirements for closed loop adjustments
-      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS <= configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) )
+      if( (currentStatus.coolant > (int)(configPage6.egoTemp - CALIBRATION_TEMPERATURE_OFFSET)) && (currentStatus.RPM > (unsigned int)(configPage6.egoRPM * 100)) && (currentStatus.TPS <= configPage6.egoTPSMax) && (currentStatus.O2 < configPage6.ego_max) && (currentStatus.O2 > configPage6.ego_min) && (currentStatus.runSecs > configPage6.ego_sdelay) &&  (BIT_CHECK(currentStatus.status1, BIT_STATUS1_DFCO) == 0) && ( currentStatus.MAP <= (configPage9.egoMAPMax * 2) ) && ( currentStatus.MAP >= (configPage9.egoMAPMin * 2) ) )
       {
 
         //Check which algorithm is used, simple or PID

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1098,8 +1098,8 @@ struct config9 {
 
   byte unused10_110;
   byte unused10_111;
-  byte unused10_112;
-  byte unused10_113;
+  byte egoMAPMax; //needs to be multiplied by 2 to get the proper value
+  byte egoMAPMin; //needs to be multiplied by 2 to get the proper value
   byte speeduino_tsCanId:4;         //speeduino TS canid (0-14)
   uint16_t true_address;            //speeduino 11bit can address
   uint16_t realtime_base_address;   //speeduino 11 bit realtime base address

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -728,6 +728,9 @@ void doUpdates(void)
   {
     //202311-dev
 
+    //EGO MAP Limits
+    configPage9.egoMAPMax = 50,
+    configPage9.egoMAPMin = 13,
 
     writeAllConfig();
     storeEEPROMVersion(23);

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -729,8 +729,8 @@ void doUpdates(void)
     //202311-dev
 
     //EGO MAP Limits
-    configPage9.egoMAPMax = 50,
-    configPage9.egoMAPMin = 13,
+    configPage9.egoMAPMax = 150, // 150 will be 300 kpa
+    configPage9.egoMAPMin = 5,  // 5 will be 10 kpa
 
     writeAllConfig();
     storeEEPROMVersion(23);

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -729,8 +729,8 @@ void doUpdates(void)
     //202311-dev
 
     //EGO MAP Limits
-    configPage9.egoMAPMax = 150, // 150 will be 300 kpa
-    configPage9.egoMAPMin = 5,  // 5 will be 10 kpa
+    configPage9.egoMAPMax = 255, // 255 will be 510 kpa
+    configPage9.egoMAPMin = 0,  // 0 will be 0 kpa
 
     writeAllConfig();
     storeEEPROMVersion(23);


### PR DESCRIPTION
This will add two new settings for the EGO. The Active Below MAP that will only allow for the ego to run when the current map is below that option. And the Active Above MAP that will only allow for the ego to run when the current map is above that option. These new settings will allow to use the EGO under boost more safely. This will close the issue  #1104 