### PR TITLE
Fix Injector open time gauge and adds injection open time to the data log

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -5001,7 +5001,7 @@ cmdVSSratio6 =      "E\x99\x06"
     gaugeCategory = "Main"
     ;Name               Var            Title                 Units     Lo     Hi     LoD    LoW   HiW   HiD vd ld
     accelEnrichGauge  = accelEnrich,   "Accel Enrich",       "%",      50,   150,     -1,    -1,  999,  999, 0, 0
-    injOpenGauge      = inj_open,      "Injector Open Time", "mSec",  0.0,   3.0,    0.0,   0.0,  3.0,  3.0, 3, 3
+    injOpenGauge      = inj_open,      "Injector Open Time", "mSec",  0.0,   5.0,    0.2,   0.4,  3.0,  3.5, 3, 3
     dutyCycleGauge    = dutyCycle,     "Duty Cycle",         "%",       0,   100,     -1,    -1,   70,   80, 1, 1
     stgDutyCycleGauge = stgDutyCycle,  "Staging Duty Cycle", "%",       0,   100,     -1,    -1,   70,   80, 1, 1
     egoCorrGauge      = egoCorrection, "EGO Correction",     "%",      50,   150,     90,    99,  101,  110, 0, 0
@@ -5017,7 +5017,7 @@ cmdVSSratio6 =      "E\x99\x06"
     ve2Gauge          = VE2,           "VE2 (Fuel Table 2)", "%",       0,   120,     -1,    -1,  999,  999, 0, 0
     warmupEnrichGauge = warmupEnrich,  "Warmup Enrichment",  "%",     100,   200,    130,   140,  140,  150, 0, 0
     aseEnrichGauge    = ase_enrich,    "Afterstart Enrichment","%",     0,   200,    130,   140,  140,  150, 0, 0
-    batCorrectGauge   = bat_correction,"Voltage Correction", "%",       0,   200,    130,   140,  140,  150, 0, 0
+    batCorrectGauge   = bat_correction,"Voltage Correction", "%",       0,   200,    70,   80,  140,  160, 0, 0
     iatCorrectGauge   = airCorrection, "IAT Correction",     "%",       0,   200,    130,   140,  140,  150, 0, 0
     baroCorrectGauge  = baroCorrection,"Baro Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
     flexEnrich        = flexFuelCor,   "Flex Correction",    "%",       0,   200,    130,   140,  140,  150, 0, 0
@@ -5583,6 +5583,8 @@ cmdVSSratio6 =      "E\x99\x06"
   entry = engineProtectAFR,  "Engine Prot. AFR",          int,      "onOff", { engineProtectType && afrProtectEnabled && (egoType == 2) }
   entry = engineProtectCoolant,  "Engine Prot. CLT",      int,      "onOff", { engineProtectType }
 
+  entry = inj_open,  "Injector Open Time",         int,    "%.3f"
+  
 [LoggerDefinition]
     ; valid logger types: composite, tooth, trigger, csv
 

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -100,7 +100,7 @@ uint16_t correctionsFuel(void)
   if (configPage2.battVCorMode == BATTV_COR_MODE_OPENTIME)
   {
     inj_opentime_uS = configPage2.injOpen * currentStatus.batCorrection; // Apply voltage correction to injector open time.
-    currentStatus.batCorrection = 100; // This is to ensure that the correction is not applied twice. There is no battery correction fator as we have instead changed the open time
+    //currentStatus.batCorrection = 100; // This is to ensure that the correction is not applied twice. There is no battery correction fator as we have instead changed the open time "commented this line for the open time gauge to work on tunerstudio because it uses this value for calculating the open time gauge. also this line may not be needed because when using open time in the setting battery correction mode it will not sum the battery correction in the correction"
   }
   if (configPage2.battVCorMode == BATTV_COR_MODE_WHOLE)
   {


### PR DESCRIPTION
*Fix the injector open time gauge in tunerstudio to reflect the current open time adjusted to the open time curve.

*Fix injector open time gauge scale

*Adds the injector open time to the data log

The new look of the injector open time gauge
![Screenshot_3](https://github.com/noisymime/speeduino/assets/143891251/fd0f61c5-0cb7-4bd6-9d7f-b5e43bcdf73d)
