### PR TITLE
Prevent possibility of some ignition output sticking ON after switching from half to full sync.

### DIFF
--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -3653,6 +3653,32 @@ static inline bool isAnyFuelScheduleRunning(void) {
       ;
 }
 
+static inline bool isAnyIgnScheduleRunning(void) {
+  return ignitionSchedule1.Status==RUNNING      
+#if IGN_CHANNELS >= 2 
+      || ignitionSchedule2.Status==RUNNING
+#endif      
+#if IGN_CHANNELS >= 3 
+      || ignitionSchedule3.Status==RUNNING
+#endif      
+#if IGN_CHANNELS >= 4       
+      || ignitionSchedule4.Status==RUNNING
+#endif      
+#if IGN_CHANNELS >= 5      
+      || ignitionSchedule5.Status==RUNNING
+#endif
+#if IGN_CHANNELS >= 6
+      || ignitionSchedule6.Status==RUNNING
+#endif
+#if IGN_CHANNELS >= 7
+      || ignitionSchedule7.Status==RUNNING
+#endif
+#if IGN_CHANNELS >= 8
+      || ignitionSchedule8.Status==RUNNING
+#endif
+      ;
+}
+
 /** Change injectors or/and ignition angles to 720deg.
  * Roll back req_fuel size and set number of outputs equal to cylinder count.
 * */
@@ -3712,7 +3738,7 @@ void changeHalfToFullSync(void)
   interrupts();
 
   //Need to do another check for sparkMode as this function can be called from injection
-  if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (CRANK_ANGLE_MAX_IGN != 720) )
+  if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (CRANK_ANGLE_MAX_IGN != 720) && (!isAnyIgnScheduleRunning()) )
   {
     CRANK_ANGLE_MAX_IGN = 720;
     maxIgnOutputs = configPage2.nCylinders;


### PR DESCRIPTION
Add check for running schedules. So that switching from half to full sync only happens when there is no schedules currently running. This prevents possibility of some outputs sticking open for whole engine cycle immediately after switching.

This is replacement for now closed #1069
With the new style copied from the new implementation of the same thing for the injection schedules.

Please review before pulling because it is not tested, but is purely theoretical, and implemented quickly.

If this is not considered essential, please close with the comment, so that I do not have to maintain it further.
Best regards