### PR TITLE
Bug fix: reset control can be enabled but pin can be set to zero

### DIFF
--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2866,8 +2866,10 @@ void setPinMapping(byte boardID)
      because the control pin will go low as soon as the pinMode is set to OUTPUT. */
   if ( (configPage4.resetControlConfig != 0) && (configPage4.resetControlPin < BOARD_MAX_IO_PINS) )
   {
+    if (configPage4.resetControlPin!=0U) {
+      pinResetControl = pinTranslate(configPage4.resetControlPin);
+    }
     resetControl = configPage4.resetControlConfig;
-    pinResetControl = pinTranslate(configPage4.resetControlPin);
     setResetControlPinState();
     pinMode(pinResetControl, OUTPUT);
   }

--- a/speeduino/utilities.cpp
+++ b/speeduino/utilities.cpp
@@ -114,6 +114,9 @@ void setResetControlPinState(void)
       digitalWrite(pinResetControl, HIGH);
       BIT_CLEAR(currentStatus.status3, BIT_STATUS3_RESET_PREVENT);
       break;
+    default:
+      // Do nothing - keep MISRA happy
+      break;
   }
 }
 

--- a/test/test_init/main.cpp
+++ b/test/test_init/main.cpp
@@ -1,5 +1,27 @@
 #include <Arduino.h>
 #include <unity.h>
+#include "storage.h"
+#include "globals.h"
+
+// Since it's almost impossible for the tests to clean up
+// after themselves, we need to reset the global context
+// prior to each test running.
+//
+// Since each test is (usually) testing the results of
+// initialiseAll(), the flow is:
+// 1. prepareForInitialise()
+// 2. Set any config page values.
+// 3. initialiseAll()
+// 4. ASSERT on the results.
+void prepareForInitialiseAll(uint8_t boardId) {
+  resetConfigPages();
+  // This is required to prevent initialiseAll() also
+  // calling resetConfigPages & thus blatting any
+  // configuration made in step 2.
+  configPage2.pinMapping = boardId;
+  initialisationComplete = false;
+}
+
 
 void testInitialisation(void);
 void testFuelScheduleInit(void);
@@ -17,9 +39,9 @@ void setup()
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
-    testInitialisation();
     testFuelScheduleInit();
     testIgnitionScheduleInit();
+    testInitialisation();
 
     UNITY_END(); // stop unit testing
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -6,8 +6,10 @@
 #include "scheduledIO.h"
 #include "utilities.h"
 #include "../test_utils.h"
+#include "storage.h"
 
 extern uint16_t req_fuel_uS;
+void prepareForInitialiseAll(uint8_t boardId);
 
 static constexpr uint16_t reqFuel = 86; // ms * 10
 
@@ -102,6 +104,7 @@ static void cylinder1_stroke4_semiseq_staged(void)
 
 static void run_1_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -160,6 +163,7 @@ static void cylinder1_stroke2_semiseq_staged(void)
 
 static void run_1_cylinder_2stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 1;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -218,6 +222,7 @@ static void cylinder2_stroke4_semiseq_staged(void)
 
 static void run_2_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -277,6 +282,7 @@ static void cylinder2_stroke2_semiseq_staged(void)
 
 static void run_2_cylinder_2stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 2;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -345,6 +351,7 @@ static void cylinder3_stroke4_semiseq_staged(void)
 
 static void run_3_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -409,6 +416,7 @@ static void cylinder3_stroke2_semiseq_staged(void)
 
 static void run_3_cylinder_2stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 3;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -478,6 +486,7 @@ static void cylinder4_stroke4_semiseq_staged(void)
 
 void run_4_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -543,6 +552,7 @@ static void cylinder4_stroke2_semiseq_staged(void)
 
 void run_4_cylinder_2stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 4;
   configPage2.strokes = TWO_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -617,6 +627,7 @@ static void cylinder5_stroke4_semiseq_staged(void)
 
 void run_5_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 5;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -689,6 +700,7 @@ static void cylinder6_stroke4_semiseq_staged(void)
 
 void run_6_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 6;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -720,6 +732,7 @@ static void cylinder8_stroke4_seq_nostage(void)
 
 void run_8_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 8;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
@@ -813,6 +826,7 @@ static void cylinder_8_NoinjTiming_paired(void) {
 
 static void run_no_inj_timing_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;
   configPage2.injTiming = false;
@@ -843,6 +857,7 @@ static void cylinder_2_oddfire(void)
 
 static void run_oddfire_tests()
 {
+  prepareForInitialiseAll(3U);
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = ODD_FIRE;
   configPage2.injTiming = true;
@@ -878,6 +893,7 @@ static void run_oddfire_tests()
 
 static void test_partial_sync(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
   configPage2.engineType = EVEN_FIRE;

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -5,6 +5,9 @@
 #include "schedule_calcs.h"
 #include "scheduledIO.h"
 #include "../test_utils.h"
+#include "storage.h"
+
+void prepareForInitialiseAll(uint8_t boardId);
 
 static void assert_ignition_channel(uint16_t angle, uint8_t channel, int channelInjDegrees, voidVoidCallback startFunction, voidVoidCallback endFunction)
 {
@@ -74,6 +77,7 @@ static void cylinder1_stroke4_seq_odd(void)
 
 static void run_1_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 1;
   configPage2.strokes = FOUR_STROKE;
 
@@ -115,6 +119,7 @@ static void cylinder2_stroke4_seq_odd(void)
 
 static void run_2_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 2;
   configPage2.strokes = FOUR_STROKE;
 
@@ -155,6 +160,7 @@ static void cylinder3_stroke4_wasted_odd(void)
 
 static void run_3_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 3;
   configPage2.strokes = FOUR_STROKE;
 
@@ -201,6 +207,7 @@ static void cylinder4_stroke4_seq_odd(void)
 
 static void run_4_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
 
@@ -229,6 +236,7 @@ static void cylinder5_stroke4_wasted_even(void)
 
 static void run_5_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 5;
   configPage2.strokes = FOUR_STROKE;
 
@@ -261,6 +269,7 @@ static void cylinder6_stroke4_wasted_even(void)
 
 static void run_6_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 6;
   configPage2.strokes = FOUR_STROKE;
 
@@ -294,6 +303,7 @@ static void cylinder8_stroke4_wasted_even(void)
 
 static void run_8_cylinder_4stroke_tests(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 8;
   configPage2.strokes = FOUR_STROKE;
 
@@ -303,6 +313,7 @@ static void run_8_cylinder_4stroke_tests(void)
 
 static void test_partial_sync(void)
 {
+  prepareForInitialiseAll(3U);
   configPage2.nCylinders = 4;
   configPage2.strokes = FOUR_STROKE;
   configPage4.sparkMode = IGN_MODE_SEQUENTIAL;

--- a/test/test_init/tests_init.cpp
+++ b/test/test_init/tests_init.cpp
@@ -256,6 +256,46 @@ void test_initialisation_outputs_reset_control_override_board_default(void)
   TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinResetControl));
 }
 
+void test_initialisation_user_pin_override_board_default(void)
+{
+  prepareForInitialiseAll(3);
+  // We do not test all pins, too many & too fragile. So fingers crossed the 
+  // same pattern is used for all.
+  configPage2.tachoPin = 15;
+  initialiseAll(); //Run the main initialise function
+
+  TEST_ASSERT_EQUAL(15, pinTachOut);  
+  TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinTachOut));
+}
+
+// All config user pin fields are <= 6 *bits*. So too small to
+// assign BOARD_MAX_IO_PINS to. So while there is defensive code
+// in place, it cannot be unit tested.
+#if false
+void test_initialisation_user_pin_not_valid_no_override(void)
+{
+  prepareForInitialiseAll(3);
+  configPage2.tachoPin = (uint8_t)BOARD_MAX_IO_PINS;// + (uint8_t)1U;
+  ++configPage2.tachoPin;
+  initialiseAll(); //Run the main initialise function
+
+  TEST_ASSERT_EQUAL(49, pinTachOut);  
+  TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinTachOut));
+}
+#endif
+
+void test_initialisation_input_user_pin_does_not_override_outputpin(void)
+{
+  // A user defineable input pin should not overwrite any output pins.
+  prepareForInitialiseAll(3);
+  configPage6.launchPin = 49; // 49 is the default tacho output
+  initialiseAll(); //Run the main initialise function
+
+  TEST_ASSERT_EQUAL(49, pinTachOut);  
+  TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinTachOut));
+  TEST_ASSERT_EQUAL(49, pinLaunch);  
+}
+
 void testInitialisation()
 {
   RUN_TEST_P(test_initialisation_complete);
@@ -268,4 +308,6 @@ void testInitialisation()
   RUN_TEST_P(test_initialisation_outputs_VVT);
   RUN_TEST_P(test_initialisation_outputs_reset_control_use_board_default);
   RUN_TEST_P(test_initialisation_outputs_reset_control_override_board_default);
+  RUN_TEST_P(test_initialisation_user_pin_override_board_default);
+  RUN_TEST_P(test_initialisation_input_user_pin_does_not_override_outputpin);
 }


### PR DESCRIPTION
Fix for #1141

I added unit tests for this condition:
```
test_initialisation_outputs_reset_control_use_board_default
test_initialisation_outputs_reset_control_override_board_default
```
This had a knock on effect on the other init unit test: hence the slightly wider init unit test changes.

Plus I added a couple of missing init tests:
```
test_initialisation_user_pin_override_board_default
test_initialisation_input_user_pin_does_not_override_outputpin
```