### PR TITLE
Fix eeprom initialization and div by 0 on new board

### DIFF
--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -298,7 +298,8 @@ void initialiseAll(void)
     if((configPage2.pinMapping == 255) || (configPage2.pinMapping == 0)) //255 = EEPROM value in a blank AVR; 0 = EEPROM value in new FRAM
     {
       //First time running on this board
-      resetConfigPages(); 
+      resetConfigPages();
+      configPage4.triggerTeeth = 4; //Avoiddiv by 0 when start decoders
       setPinMapping(3); //Force board to v0.4
     }
     else { setPinMapping(configPage2.pinMapping); }

--- a/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.cpp
+++ b/speeduino/src/SPIAsEEPROM/SPIAsEEPROM.cpp
@@ -268,7 +268,7 @@ byte SPI_EEPROM_Class::read(uint16_t addressEEPROM){
 int8_t SPI_EEPROM_Class::begin(SPIClass &_spi, uint8_t pinSPIFlash_CS=6){
     pinMode(pinSPIFlash_CS, OUTPUT);
     bool flashavailable;
-    flashavailable = winbondSPIFlash.begin(_W25Q16,_spi, pinSPIFlash_CS);
+    flashavailable = winbondSPIFlash.begin(winbondFlashClass::partNumber::autoDetect, _spi, pinSPIFlash_CS);
     return FLASH_EEPROM_BaseClass::initialize(flashavailable);
 }    
 


### PR DESCRIPTION
Currently the supported flash is locked to W25Q16 and this PR enables it to use any windbond flash from W25Q80, W25Q16, W25Q32, W25Q64 and W25Q128.

When start the board from an empty eeprom all pages are set to 0 and that causes a divide by 0 on missing tooth decoder initialization, now a valid value is set to avoid infinite loop due to exception.

@noisymime This is a critical problem right now, please pull it