### PR TITLE
Stepper enable invert option

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1061,7 +1061,7 @@ page = 9
 
       boostByGearEnabled  = bits,   U08,   153, [4:5],      "Off", "Multiplied %", "Constant limit", "INVALID"
 
-      blankfield          = bits,   U08,   153, [6:6], "",""
+      iacStepperEnInv     = bits,   U08,   153, [6:6], "Active Low","Active High"
       iacStepperPower     = bits,   U08,   153, [7:7], "When Active", "Always"
       
       iacMaxSteps         = scalar, U08,     154,     "Steps",     3,    0,  0,  {iacStepHome-3},    0
@@ -2127,6 +2127,7 @@ menuDialog = main
   iacMaxSteps       = "Maximum number of steps the IAC can be moved away from the home position. Should always be less than Homing steps."
   iacStepHyster     = "The minimum number of steps to move in any one go."
   iacStepperInv     = "Invert the step pulse polarity"
+  iacStepperEnInv   = "Invert the stepper enable control signal"
   iacStepperPower   = "Power the stepper motor only when performing a step (Default) or constantly. If unsure, choose Only When Active."
   iacAlgorithm      = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
   iacPWMdir         = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
@@ -2827,13 +2828,14 @@ menuDialog = main
       panel = airConIdleUp
 
     dialog = stepper_idle, "Stepper Idle"
-      field = "Step time (ms)",       iacStepTime,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Cool time (ms)",       iacCoolTime,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Home steps",           iacStepHome,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Minimum Steps",        iacStepHyster,            { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Don't exceed",         iacMaxSteps,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Stepper Inverted",     iacStepperInv,            { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
-      field = "Stepper Power",        iacStepperPower,          { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Step time (ms)",          iacStepTime,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Cool time (ms)",          iacCoolTime,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Home steps",              iacStepHome,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Minimum Steps",           iacStepHyster,            { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Don't exceed",            iacMaxSteps,              { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Stepper Inverted",        iacStepperInv,            { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Stepper Enable Inverted", iacStepperEnInv,          { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
+      field = "Stepper Power",           iacStepperPower,          { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
 
     dialog = pwm_idle, "PWM Idle"
       field = "Number of outputs",    iacChannels,              { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1117,7 +1117,7 @@ struct config9 {
   byte iacCoolTime : 3; // how long to wait for the stepper to cool between steps
 
   byte boostByGearEnabled : 2;
-  byte blankField : 1;
+  byte iacStepperEnInv : 1; //Whether or not the stepper enable signal is inverted or not
   byte iacStepperPower : 1; //Whether or not to power the stepper motor when not in use
 
   byte iacMaxSteps; // Step limit beyond which the stepper won't be driven. Should always be less than homing steps. Stored div 3 as per home steps.

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -363,7 +363,13 @@ static inline byte checkForStepping(void)
         if(configPage9.iacStepperPower == STEPPER_POWER_WHEN_ACTIVE) 
         { 
           //Disable the DRV8825, but only if we're at the final step in this cycle. 
-          if(idleStepper.targetIdleStep == idleStepper.curIdleStep) { digitalWrite(pinStepperEnable, HIGH); } 
+          if(idleStepper.targetIdleStep == idleStepper.curIdleStep)
+	    if(configPage9.iacStepperEnInv) { 
+              digitalWrite(pinStepperEnable, LOW);
+            } else {
+              digitalWrite(pinStepperEnable, HIGH);
+            }
+	  }
         }
       }
     }
@@ -398,7 +404,11 @@ static inline void doStep(void)
       idleStepper.curIdleStep++;
     }
 
-    digitalWrite(pinStepperEnable, LOW); //Enable the DRV8825
+    if(configPage9.iacStepperEnInv) {
+      (pinStepperEnable, HIGH); 
+    } else {
+      (pinStepperEnable, LOW); //Enable the DRV8825
+    }
     digitalWrite(pinStepperStep, HIGH);
     idleStepper.stepStartTime = micros_safe();
     idleStepper.stepperStatus = STEPPING;
@@ -418,7 +428,11 @@ static inline byte isStepperHomed(void)
   if( completedHomeSteps < (configPage6.iacStepHome * 3) ) //Home steps are divided by 3 from TS
   {
     digitalWrite(pinStepperDir, idleStepper.lessAirDirection); //homing the stepper closes off the air bleed
-    digitalWrite(pinStepperEnable, LOW); //Enable the DRV8825
+    if(configPage9.iacStepperEnInv) {
+      digitalWrite(pinStepperEnable, HIGH);
+    } else {
+      digitalWrite(pinStepperEnable, LOW); //Enable the DRV8825
+    }
     digitalWrite(pinStepperStep, HIGH);
     idleStepper.stepStartTime = micros_safe();
     idleStepper.stepperStatus = STEPPING;


### PR DESCRIPTION
I built a custom speeduino board with MP6500 ic for the stepper driver, which uses a high level to enable the driver instead of a low signal like the drv8825. These changes add an option in tunerstudio to fully integrate this driver. 