### PR TITLE
Unit test all corrections

### DIFF
--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -57,7 +57,16 @@ uint8_t dfcoTaper;
  */
 void initialiseCorrections(void)
 {
-  egoPID.SetMode(AUTOMATIC); //Turn O2 PID on
+  PID_output = 0L;
+  PID_O2 = 0L;
+  PID_AFRTarget = 0L;
+  // Toggling between modes resets the PID internal state
+  // This is required by the unit tests
+  // TODO: modify PID code to provide a method to reset it. 
+  egoPID.SetMode(AUTOMATIC);
+  egoPID.SetMode(MANUAL);
+  egoPID.SetMode(AUTOMATIC);
+
   currentStatus.flexIgnCorrection = 0;
   currentStatus.egoCorrection = 100; //Default value of no adjustment must be set to avoid randomness on first correction cycle after startup
   AFRnextCycle = 0;

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -9,6 +9,7 @@ All functions in the gamma file return
 
 void initialiseCorrections(void);
 uint16_t correctionsFuel(void);
+uint8_t calculateAfrTarget(table3d16RpmLoad &afrLookUpTable, const statuses &current, const config2 &page2, const config6 &page6);
 byte correctionWUE(void); //Warmup enrichment
 uint16_t correctionCranking(void); //Cranking enrichment
 byte correctionASE(void); //After Start Enrichment
@@ -23,7 +24,6 @@ byte correctionBaro(void); //Barometric pressure correction
 byte correctionLaunch(void); //Launch control correction
 byte correctionDFCOfuel(void); //DFCO taper correction
 bool correctionDFCO(void); //Decelleration fuel cutoff
-
 
 int8_t correctionsIgn(int8_t advance);
 int8_t correctionFixedTiming(int8_t advance);

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -276,8 +276,10 @@
 #define EVEN_FIRE           0
 #define ODD_FIRE            1
 
-#define EGO_ALGORITHM_SIMPLE  0
-#define EGO_ALGORITHM_PID     2
+#define EGO_ALGORITHM_SIMPLE   0U
+#define EGO_ALGORITHM_INVALID1 1U
+#define EGO_ALGORITHM_PID      2U
+#define EGO_ALGORITHM_NONE     3U
 
 #define STAGING_MODE_TABLE  0
 #define STAGING_MODE_AUTO   1

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -875,6 +875,13 @@ struct config2 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
+#define IDLEADVANCE_MODE_OFF      0U
+#define IDLEADVANCE_MODE_ADDED    1U
+#define IDLEADVANCE_MODE_SWITCHED 2U
+
+#define IDLEADVANCE_ALGO_TPS      0U
+#define IDLEADVANCE_ALGO_CTPS     1U
+
 /** Page 4 of the config - variables required for ignition and rpm/crank phase /cam phase decoding.
 * See the ini file for further reference.
 */

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -34,173 +34,37 @@ static inline
 #endif
 void construct2dTables(void) {
   //Repoint the 2D table structs to the config pages that were just loaded
-  taeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
-  taeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  taeTable.xSize = 4;
-  taeTable.values = configPage4.taeValues;
-  taeTable.axisX = configPage4.taeBins;
-  maeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
-  maeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  maeTable.xSize = 4;
-  maeTable.values = configPage4.maeRates;
-  maeTable.axisX = configPage4.maeBins;
-  WUETable.valueSize = SIZE_BYTE; //Set this table to use byte values
-  WUETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  WUETable.xSize = 10;
-  WUETable.values = configPage2.wueValues;
-  WUETable.axisX = configPage4.wueBins;
-  ASETable.valueSize = SIZE_BYTE;
-  ASETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  ASETable.xSize = 4;
-  ASETable.values = configPage2.asePct;
-  ASETable.axisX = configPage2.aseBins;
-  ASECountTable.valueSize = SIZE_BYTE;
-  ASECountTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  ASECountTable.xSize = 4;
-  ASECountTable.values = configPage2.aseCount;
-  ASECountTable.axisX = configPage2.aseBins;
-  PrimingPulseTable.valueSize = SIZE_BYTE;
-  PrimingPulseTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  PrimingPulseTable.xSize = 4;
-  PrimingPulseTable.values = configPage2.primePulse;
-  PrimingPulseTable.axisX = configPage2.primeBins;
-  crankingEnrichTable.valueSize = SIZE_BYTE;
-  crankingEnrichTable.axisSize = SIZE_BYTE;
-  crankingEnrichTable.xSize = 4;
-  crankingEnrichTable.values = configPage10.crankingEnrichValues;
-  crankingEnrichTable.axisX = configPage10.crankingEnrichBins;
-
-  dwellVCorrectionTable.valueSize = SIZE_BYTE;
-  dwellVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  dwellVCorrectionTable.xSize = 6;
-  dwellVCorrectionTable.values = configPage4.dwellCorrectionValues;
-  dwellVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
-  injectorVCorrectionTable.valueSize = SIZE_BYTE;
-  injectorVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  injectorVCorrectionTable.xSize = 6;
-  injectorVCorrectionTable.values = configPage6.injVoltageCorrectionValues;
-  injectorVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
-  injectorAngleTable.valueSize = SIZE_INT;
-  injectorAngleTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  injectorAngleTable.xSize = 4;
-  injectorAngleTable.values = configPage2.injAng;
-  injectorAngleTable.axisX = configPage2.injAngRPM;
-  IATDensityCorrectionTable.valueSize = SIZE_BYTE;
-  IATDensityCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  IATDensityCorrectionTable.xSize = 9;
-  IATDensityCorrectionTable.values = configPage6.airDenRates;
-  IATDensityCorrectionTable.axisX = configPage6.airDenBins;
-  baroFuelTable.valueSize = SIZE_BYTE;
-  baroFuelTable.axisSize = SIZE_BYTE;
-  baroFuelTable.xSize = 8;
-  baroFuelTable.values = configPage4.baroFuelValues;
-  baroFuelTable.axisX = configPage4.baroFuelBins;
-  IATRetardTable.valueSize = SIZE_BYTE;
-  IATRetardTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  IATRetardTable.xSize = 6;
-  IATRetardTable.values = configPage4.iatRetValues;
-  IATRetardTable.axisX = configPage4.iatRetBins;
-  CLTAdvanceTable.valueSize = SIZE_BYTE;
-  CLTAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  CLTAdvanceTable.xSize = 6;
-  CLTAdvanceTable.values = (byte*)configPage4.cltAdvValues;
-  CLTAdvanceTable.axisX = configPage4.cltAdvBins;
-  idleTargetTable.valueSize = SIZE_BYTE;
-  idleTargetTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  idleTargetTable.xSize = 10;
-  idleTargetTable.values = configPage6.iacCLValues;
-  idleTargetTable.axisX = configPage6.iacBins;
-  idleAdvanceTable.valueSize = SIZE_BYTE;
-  idleAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  idleAdvanceTable.xSize = 6;
-  idleAdvanceTable.values = (byte*)configPage4.idleAdvValues;
-  idleAdvanceTable.axisX = configPage4.idleAdvBins;
-  rotarySplitTable.valueSize = SIZE_BYTE;
-  rotarySplitTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  rotarySplitTable.xSize = 8;
-  rotarySplitTable.values = configPage10.rotarySplitValues;
-  rotarySplitTable.axisX = configPage10.rotarySplitBins;
-
-  flexFuelTable.valueSize = SIZE_BYTE;
-  flexFuelTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  flexFuelTable.xSize = 6;
-  flexFuelTable.values = configPage10.flexFuelAdj;
-  flexFuelTable.axisX = configPage10.flexFuelBins;
-  flexAdvTable.valueSize = SIZE_BYTE;
-  flexAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  flexAdvTable.xSize = 6;
-  flexAdvTable.values = configPage10.flexAdvAdj;
-  flexAdvTable.axisX = configPage10.flexAdvBins;
-  flexBoostTable.valueSize = SIZE_INT;
-  flexBoostTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins (NOTE THIS IS DIFFERENT TO THE VALUES!!)
-  flexBoostTable.xSize = 6;
-  flexBoostTable.values = configPage10.flexBoostAdj;
-  flexBoostTable.axisX = configPage10.flexBoostBins;
-  fuelTempTable.valueSize = SIZE_BYTE;
-  fuelTempTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  fuelTempTable.xSize = 6;
-  fuelTempTable.values = configPage10.fuelTempValues;
-  fuelTempTable.axisX = configPage10.fuelTempBins;
-
-  knockWindowStartTable.valueSize = SIZE_BYTE;
-  knockWindowStartTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  knockWindowStartTable.xSize = 6;
-  knockWindowStartTable.values = configPage10.knock_window_angle;
-  knockWindowStartTable.axisX = configPage10.knock_window_rpms;
-  knockWindowDurationTable.valueSize = SIZE_BYTE;
-  knockWindowDurationTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  knockWindowDurationTable.xSize = 6;
-  knockWindowDurationTable.values = configPage10.knock_window_dur;
-  knockWindowDurationTable.axisX = configPage10.knock_window_rpms;
-
-  oilPressureProtectTable.valueSize = SIZE_BYTE;
-  oilPressureProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  oilPressureProtectTable.xSize = 4;
-  oilPressureProtectTable.values = configPage10.oilPressureProtMins;
-  oilPressureProtectTable.axisX = configPage10.oilPressureProtRPM;
-
-  coolantProtectTable.valueSize = SIZE_BYTE;
-  coolantProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  coolantProtectTable.xSize = 6;
-  coolantProtectTable.values = configPage9.coolantProtRPM;
-  coolantProtectTable.axisX = configPage9.coolantProtTemp;
-
-
-  fanPWMTable.valueSize = SIZE_BYTE;
-  fanPWMTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  fanPWMTable.xSize = 4;
-  fanPWMTable.values = configPage9.PWMFanDuty;
-  fanPWMTable.axisX = configPage6.fanPWMBins;
-
-  rollingCutTable.valueSize = SIZE_BYTE;
-  rollingCutTable.axisSize = SIZE_SIGNED_BYTE; //X axis is SIGNED for this table. 
-  rollingCutTable.xSize = 4;
-  rollingCutTable.values = configPage15.rollingProtCutPercent;
-  rollingCutTable.axisX = configPage15.rollingProtRPMDelta;
-
-  wmiAdvTable.valueSize = SIZE_BYTE;
-  wmiAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-  wmiAdvTable.xSize = 6;
-  wmiAdvTable.values = configPage10.wmiAdvAdj;
-  wmiAdvTable.axisX = configPage10.wmiAdvBins;
-
-  cltCalibrationTable.valueSize = SIZE_INT;
-  cltCalibrationTable.axisSize = SIZE_INT;
-  cltCalibrationTable.xSize = 32;
-  cltCalibrationTable.values = cltCalibration_values;
-  cltCalibrationTable.axisX = cltCalibration_bins;
-
-  iatCalibrationTable.valueSize = SIZE_INT;
-  iatCalibrationTable.axisSize = SIZE_INT;
-  iatCalibrationTable.xSize = 32;
-  iatCalibrationTable.values = iatCalibration_values;
-  iatCalibrationTable.axisX = iatCalibration_bins;
-
-  o2CalibrationTable.valueSize = SIZE_BYTE;
-  o2CalibrationTable.axisSize = SIZE_INT;
-  o2CalibrationTable.xSize = 32;
-  o2CalibrationTable.values = o2Calibration_values;
-  o2CalibrationTable.axisX = o2Calibration_bins;
+  construct2dTable(taeTable,                  _countof(configPage4.taeValues),                  configPage4.taeValues,                  configPage4.taeBins);
+  construct2dTable(maeTable,                  _countof(configPage4.maeRates),                   configPage4.maeRates,                   configPage4.maeBins);
+  construct2dTable(WUETable,                  _countof(configPage2.wueValues),                  configPage2.wueValues,                  configPage4.wueBins);
+  construct2dTable(ASETable,                  _countof(configPage2.asePct),                     configPage2.asePct,                     configPage2.aseBins);
+  construct2dTable(ASECountTable,             _countof(configPage2.aseCount),                   configPage2.aseCount,                   configPage2.aseBins);
+  construct2dTable(PrimingPulseTable,         _countof(configPage2.primePulse),                 configPage2.primePulse,                 configPage2.primeBins);
+  construct2dTable(crankingEnrichTable,       _countof(configPage10.crankingEnrichValues),      configPage10.crankingEnrichValues,      configPage10.crankingEnrichBins);
+  construct2dTable(dwellVCorrectionTable,     _countof(configPage4.dwellCorrectionValues),      configPage4.dwellCorrectionValues,      configPage6.voltageCorrectionBins);
+  construct2dTable(injectorVCorrectionTable,  _countof(configPage6.injVoltageCorrectionValues), configPage6.injVoltageCorrectionValues, configPage6.voltageCorrectionBins);
+  construct2dTable(IATDensityCorrectionTable, _countof(configPage6.airDenRates),                configPage6.airDenRates,                configPage6.airDenBins);
+  construct2dTable(baroFuelTable,             _countof(configPage4.baroFuelValues),             configPage4.baroFuelValues,             configPage4.baroFuelBins);
+  construct2dTable(IATRetardTable,            _countof(configPage4.iatRetValues),               configPage4.iatRetValues,               configPage4.iatRetBins);
+  construct2dTable(CLTAdvanceTable,           _countof(configPage4.cltAdvValues),               configPage4.cltAdvValues,               configPage4.cltAdvBins);
+  construct2dTable(idleTargetTable,           _countof(configPage6.iacCLValues),                configPage6.iacCLValues,                configPage6.iacBins);
+  construct2dTable(idleAdvanceTable,          _countof(configPage4.idleAdvValues),              configPage4.idleAdvValues,              configPage4.idleAdvBins);
+  construct2dTable(rotarySplitTable,          _countof(configPage10.rotarySplitValues),         configPage10.rotarySplitValues,         configPage10.rotarySplitBins);
+  construct2dTable(flexFuelTable,             _countof(configPage10.flexFuelAdj),               configPage10.flexFuelAdj,               configPage10.flexFuelBins);
+  construct2dTable(flexAdvTable,              _countof(configPage10.flexAdvAdj),                configPage10.flexAdvAdj,                configPage10.flexAdvBins);
+  construct2dTable(fuelTempTable,             _countof(configPage10.fuelTempValues),            configPage10.fuelTempValues,            configPage10.fuelTempBins);
+  construct2dTable(oilPressureProtectTable,   _countof(configPage10.oilPressureProtMins),       configPage10.oilPressureProtMins,       configPage10.oilPressureProtRPM);
+  construct2dTable(coolantProtectTable,       _countof(configPage9.coolantProtRPM),             configPage9.coolantProtRPM,             configPage9.coolantProtTemp);
+  construct2dTable(fanPWMTable,               _countof(configPage9.PWMFanDuty),                 configPage9.PWMFanDuty,                 configPage6.fanPWMBins);
+  construct2dTable(wmiAdvTable,               _countof(configPage10.wmiAdvAdj),                 configPage10.wmiAdvAdj,                 configPage10.wmiAdvBins);
+  construct2dTable(rollingCutTable,           _countof(configPage15.rollingProtCutPercent),     configPage15.rollingProtCutPercent,     configPage15.rollingProtRPMDelta);
+  construct2dTable(injectorAngleTable,        _countof(configPage2.injAng),                     configPage2.injAng,                     configPage2.injAngRPM);
+  construct2dTable(flexBoostTable,            _countof(configPage10.flexBoostAdj),              configPage10.flexBoostAdj,              configPage10.flexBoostBins);
+  construct2dTable(knockWindowStartTable,      _countof(configPage10.knock_window_angle),        configPage10.knock_window_angle, configPage10.knock_window_rpms);
+  construct2dTable(knockWindowDurationTable,   _countof(configPage10.knock_window_dur),          configPage10.knock_window_dur,   configPage10.knock_window_rpms);
+  construct2dTable(cltCalibrationTable,       _countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
+  construct2dTable(iatCalibrationTable,       _countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
+  construct2dTable(o2CalibrationTable,        _countof(o2Calibration_values),  o2Calibration_values,  o2Calibration_bins);
 }
 
 /** Initialise Speeduino for the main loop.

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -29,6 +29,180 @@
   #include "rtc_common.h"
 #endif
 
+#if !defined(UNIT_TEST)
+static inline 
+#endif
+void construct2dTables(void) {
+  //Repoint the 2D table structs to the config pages that were just loaded
+  taeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
+  taeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  taeTable.xSize = 4;
+  taeTable.values = configPage4.taeValues;
+  taeTable.axisX = configPage4.taeBins;
+  maeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
+  maeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  maeTable.xSize = 4;
+  maeTable.values = configPage4.maeRates;
+  maeTable.axisX = configPage4.maeBins;
+  WUETable.valueSize = SIZE_BYTE; //Set this table to use byte values
+  WUETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  WUETable.xSize = 10;
+  WUETable.values = configPage2.wueValues;
+  WUETable.axisX = configPage4.wueBins;
+  ASETable.valueSize = SIZE_BYTE;
+  ASETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  ASETable.xSize = 4;
+  ASETable.values = configPage2.asePct;
+  ASETable.axisX = configPage2.aseBins;
+  ASECountTable.valueSize = SIZE_BYTE;
+  ASECountTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  ASECountTable.xSize = 4;
+  ASECountTable.values = configPage2.aseCount;
+  ASECountTable.axisX = configPage2.aseBins;
+  PrimingPulseTable.valueSize = SIZE_BYTE;
+  PrimingPulseTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  PrimingPulseTable.xSize = 4;
+  PrimingPulseTable.values = configPage2.primePulse;
+  PrimingPulseTable.axisX = configPage2.primeBins;
+  crankingEnrichTable.valueSize = SIZE_BYTE;
+  crankingEnrichTable.axisSize = SIZE_BYTE;
+  crankingEnrichTable.xSize = 4;
+  crankingEnrichTable.values = configPage10.crankingEnrichValues;
+  crankingEnrichTable.axisX = configPage10.crankingEnrichBins;
+
+  dwellVCorrectionTable.valueSize = SIZE_BYTE;
+  dwellVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  dwellVCorrectionTable.xSize = 6;
+  dwellVCorrectionTable.values = configPage4.dwellCorrectionValues;
+  dwellVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
+  injectorVCorrectionTable.valueSize = SIZE_BYTE;
+  injectorVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  injectorVCorrectionTable.xSize = 6;
+  injectorVCorrectionTable.values = configPage6.injVoltageCorrectionValues;
+  injectorVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
+  injectorAngleTable.valueSize = SIZE_INT;
+  injectorAngleTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  injectorAngleTable.xSize = 4;
+  injectorAngleTable.values = configPage2.injAng;
+  injectorAngleTable.axisX = configPage2.injAngRPM;
+  IATDensityCorrectionTable.valueSize = SIZE_BYTE;
+  IATDensityCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  IATDensityCorrectionTable.xSize = 9;
+  IATDensityCorrectionTable.values = configPage6.airDenRates;
+  IATDensityCorrectionTable.axisX = configPage6.airDenBins;
+  baroFuelTable.valueSize = SIZE_BYTE;
+  baroFuelTable.axisSize = SIZE_BYTE;
+  baroFuelTable.xSize = 8;
+  baroFuelTable.values = configPage4.baroFuelValues;
+  baroFuelTable.axisX = configPage4.baroFuelBins;
+  IATRetardTable.valueSize = SIZE_BYTE;
+  IATRetardTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  IATRetardTable.xSize = 6;
+  IATRetardTable.values = configPage4.iatRetValues;
+  IATRetardTable.axisX = configPage4.iatRetBins;
+  CLTAdvanceTable.valueSize = SIZE_BYTE;
+  CLTAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  CLTAdvanceTable.xSize = 6;
+  CLTAdvanceTable.values = (byte*)configPage4.cltAdvValues;
+  CLTAdvanceTable.axisX = configPage4.cltAdvBins;
+  idleTargetTable.valueSize = SIZE_BYTE;
+  idleTargetTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  idleTargetTable.xSize = 10;
+  idleTargetTable.values = configPage6.iacCLValues;
+  idleTargetTable.axisX = configPage6.iacBins;
+  idleAdvanceTable.valueSize = SIZE_BYTE;
+  idleAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  idleAdvanceTable.xSize = 6;
+  idleAdvanceTable.values = (byte*)configPage4.idleAdvValues;
+  idleAdvanceTable.axisX = configPage4.idleAdvBins;
+  rotarySplitTable.valueSize = SIZE_BYTE;
+  rotarySplitTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  rotarySplitTable.xSize = 8;
+  rotarySplitTable.values = configPage10.rotarySplitValues;
+  rotarySplitTable.axisX = configPage10.rotarySplitBins;
+
+  flexFuelTable.valueSize = SIZE_BYTE;
+  flexFuelTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  flexFuelTable.xSize = 6;
+  flexFuelTable.values = configPage10.flexFuelAdj;
+  flexFuelTable.axisX = configPage10.flexFuelBins;
+  flexAdvTable.valueSize = SIZE_BYTE;
+  flexAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  flexAdvTable.xSize = 6;
+  flexAdvTable.values = configPage10.flexAdvAdj;
+  flexAdvTable.axisX = configPage10.flexAdvBins;
+  flexBoostTable.valueSize = SIZE_INT;
+  flexBoostTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins (NOTE THIS IS DIFFERENT TO THE VALUES!!)
+  flexBoostTable.xSize = 6;
+  flexBoostTable.values = configPage10.flexBoostAdj;
+  flexBoostTable.axisX = configPage10.flexBoostBins;
+  fuelTempTable.valueSize = SIZE_BYTE;
+  fuelTempTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  fuelTempTable.xSize = 6;
+  fuelTempTable.values = configPage10.fuelTempValues;
+  fuelTempTable.axisX = configPage10.fuelTempBins;
+
+  knockWindowStartTable.valueSize = SIZE_BYTE;
+  knockWindowStartTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  knockWindowStartTable.xSize = 6;
+  knockWindowStartTable.values = configPage10.knock_window_angle;
+  knockWindowStartTable.axisX = configPage10.knock_window_rpms;
+  knockWindowDurationTable.valueSize = SIZE_BYTE;
+  knockWindowDurationTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  knockWindowDurationTable.xSize = 6;
+  knockWindowDurationTable.values = configPage10.knock_window_dur;
+  knockWindowDurationTable.axisX = configPage10.knock_window_rpms;
+
+  oilPressureProtectTable.valueSize = SIZE_BYTE;
+  oilPressureProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  oilPressureProtectTable.xSize = 4;
+  oilPressureProtectTable.values = configPage10.oilPressureProtMins;
+  oilPressureProtectTable.axisX = configPage10.oilPressureProtRPM;
+
+  coolantProtectTable.valueSize = SIZE_BYTE;
+  coolantProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  coolantProtectTable.xSize = 6;
+  coolantProtectTable.values = configPage9.coolantProtRPM;
+  coolantProtectTable.axisX = configPage9.coolantProtTemp;
+
+
+  fanPWMTable.valueSize = SIZE_BYTE;
+  fanPWMTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  fanPWMTable.xSize = 4;
+  fanPWMTable.values = configPage9.PWMFanDuty;
+  fanPWMTable.axisX = configPage6.fanPWMBins;
+
+  rollingCutTable.valueSize = SIZE_BYTE;
+  rollingCutTable.axisSize = SIZE_SIGNED_BYTE; //X axis is SIGNED for this table. 
+  rollingCutTable.xSize = 4;
+  rollingCutTable.values = configPage15.rollingProtCutPercent;
+  rollingCutTable.axisX = configPage15.rollingProtRPMDelta;
+
+  wmiAdvTable.valueSize = SIZE_BYTE;
+  wmiAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
+  wmiAdvTable.xSize = 6;
+  wmiAdvTable.values = configPage10.wmiAdvAdj;
+  wmiAdvTable.axisX = configPage10.wmiAdvBins;
+
+  cltCalibrationTable.valueSize = SIZE_INT;
+  cltCalibrationTable.axisSize = SIZE_INT;
+  cltCalibrationTable.xSize = 32;
+  cltCalibrationTable.values = cltCalibration_values;
+  cltCalibrationTable.axisX = cltCalibration_bins;
+
+  iatCalibrationTable.valueSize = SIZE_INT;
+  iatCalibrationTable.axisSize = SIZE_INT;
+  iatCalibrationTable.xSize = 32;
+  iatCalibrationTable.values = iatCalibration_values;
+  iatCalibrationTable.axisX = iatCalibration_bins;
+
+  o2CalibrationTable.valueSize = SIZE_BYTE;
+  o2CalibrationTable.axisSize = SIZE_INT;
+  o2CalibrationTable.xSize = 32;
+  o2CalibrationTable.values = o2Calibration_values;
+  o2CalibrationTable.axisX = o2Calibration_bins;
+}
+
 /** Initialise Speeduino for the main loop.
  * Top level init entry point for all initialisations:
  * - Initialise and set sizes of 3D tables
@@ -121,178 +295,10 @@ void initialiseAll(void)
     BIT_SET(currentStatus.status4, BIT_STATUS4_ALLOW_LEGACY_COMMS); //Flag legacy comms as being allowed on startup
 
     //Repoint the 2D table structs to the config pages that were just loaded
-    taeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
-    taeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    taeTable.xSize = 4;
-    taeTable.values = configPage4.taeValues;
-    taeTable.axisX = configPage4.taeBins;
-    maeTable.valueSize = SIZE_BYTE; //Set this table to use byte values
-    maeTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    maeTable.xSize = 4;
-    maeTable.values = configPage4.maeRates;
-    maeTable.axisX = configPage4.maeBins;
-    WUETable.valueSize = SIZE_BYTE; //Set this table to use byte values
-    WUETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    WUETable.xSize = 10;
-    WUETable.values = configPage2.wueValues;
-    WUETable.axisX = configPage4.wueBins;
-    ASETable.valueSize = SIZE_BYTE;
-    ASETable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    ASETable.xSize = 4;
-    ASETable.values = configPage2.asePct;
-    ASETable.axisX = configPage2.aseBins;
-    ASECountTable.valueSize = SIZE_BYTE;
-    ASECountTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    ASECountTable.xSize = 4;
-    ASECountTable.values = configPage2.aseCount;
-    ASECountTable.axisX = configPage2.aseBins;
-    PrimingPulseTable.valueSize = SIZE_BYTE;
-    PrimingPulseTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    PrimingPulseTable.xSize = 4;
-    PrimingPulseTable.values = configPage2.primePulse;
-    PrimingPulseTable.axisX = configPage2.primeBins;
-    crankingEnrichTable.valueSize = SIZE_BYTE;
-    crankingEnrichTable.axisSize = SIZE_BYTE;
-    crankingEnrichTable.xSize = 4;
-    crankingEnrichTable.values = configPage10.crankingEnrichValues;
-    crankingEnrichTable.axisX = configPage10.crankingEnrichBins;
-
-    dwellVCorrectionTable.valueSize = SIZE_BYTE;
-    dwellVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    dwellVCorrectionTable.xSize = 6;
-    dwellVCorrectionTable.values = configPage4.dwellCorrectionValues;
-    dwellVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
-    injectorVCorrectionTable.valueSize = SIZE_BYTE;
-    injectorVCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    injectorVCorrectionTable.xSize = 6;
-    injectorVCorrectionTable.values = configPage6.injVoltageCorrectionValues;
-    injectorVCorrectionTable.axisX = configPage6.voltageCorrectionBins;
-    injectorAngleTable.valueSize = SIZE_INT;
-    injectorAngleTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    injectorAngleTable.xSize = 4;
-    injectorAngleTable.values = configPage2.injAng;
-    injectorAngleTable.axisX = configPage2.injAngRPM;
-    IATDensityCorrectionTable.valueSize = SIZE_BYTE;
-    IATDensityCorrectionTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    IATDensityCorrectionTable.xSize = 9;
-    IATDensityCorrectionTable.values = configPage6.airDenRates;
-    IATDensityCorrectionTable.axisX = configPage6.airDenBins;
-    baroFuelTable.valueSize = SIZE_BYTE;
-    baroFuelTable.axisSize = SIZE_BYTE;
-    baroFuelTable.xSize = 8;
-    baroFuelTable.values = configPage4.baroFuelValues;
-    baroFuelTable.axisX = configPage4.baroFuelBins;
-    IATRetardTable.valueSize = SIZE_BYTE;
-    IATRetardTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    IATRetardTable.xSize = 6;
-    IATRetardTable.values = configPage4.iatRetValues;
-    IATRetardTable.axisX = configPage4.iatRetBins;
-    CLTAdvanceTable.valueSize = SIZE_BYTE;
-    CLTAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    CLTAdvanceTable.xSize = 6;
-    CLTAdvanceTable.values = (byte*)configPage4.cltAdvValues;
-    CLTAdvanceTable.axisX = configPage4.cltAdvBins;
-    idleTargetTable.valueSize = SIZE_BYTE;
-    idleTargetTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    idleTargetTable.xSize = 10;
-    idleTargetTable.values = configPage6.iacCLValues;
-    idleTargetTable.axisX = configPage6.iacBins;
-    idleAdvanceTable.valueSize = SIZE_BYTE;
-    idleAdvanceTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    idleAdvanceTable.xSize = 6;
-    idleAdvanceTable.values = (byte*)configPage4.idleAdvValues;
-    idleAdvanceTable.axisX = configPage4.idleAdvBins;
-    rotarySplitTable.valueSize = SIZE_BYTE;
-    rotarySplitTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    rotarySplitTable.xSize = 8;
-    rotarySplitTable.values = configPage10.rotarySplitValues;
-    rotarySplitTable.axisX = configPage10.rotarySplitBins;
-
-    flexFuelTable.valueSize = SIZE_BYTE;
-    flexFuelTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    flexFuelTable.xSize = 6;
-    flexFuelTable.values = configPage10.flexFuelAdj;
-    flexFuelTable.axisX = configPage10.flexFuelBins;
-    flexAdvTable.valueSize = SIZE_BYTE;
-    flexAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    flexAdvTable.xSize = 6;
-    flexAdvTable.values = configPage10.flexAdvAdj;
-    flexAdvTable.axisX = configPage10.flexAdvBins;
-    flexBoostTable.valueSize = SIZE_INT;
-    flexBoostTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins (NOTE THIS IS DIFFERENT TO THE VALUES!!)
-    flexBoostTable.xSize = 6;
-    flexBoostTable.values = configPage10.flexBoostAdj;
-    flexBoostTable.axisX = configPage10.flexBoostBins;
-    fuelTempTable.valueSize = SIZE_BYTE;
-    fuelTempTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    fuelTempTable.xSize = 6;
-    fuelTempTable.values = configPage10.fuelTempValues;
-    fuelTempTable.axisX = configPage10.fuelTempBins;
-
-    knockWindowStartTable.valueSize = SIZE_BYTE;
-    knockWindowStartTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    knockWindowStartTable.xSize = 6;
-    knockWindowStartTable.values = configPage10.knock_window_angle;
-    knockWindowStartTable.axisX = configPage10.knock_window_rpms;
-    knockWindowDurationTable.valueSize = SIZE_BYTE;
-    knockWindowDurationTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    knockWindowDurationTable.xSize = 6;
-    knockWindowDurationTable.values = configPage10.knock_window_dur;
-    knockWindowDurationTable.axisX = configPage10.knock_window_rpms;
-
-    oilPressureProtectTable.valueSize = SIZE_BYTE;
-    oilPressureProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    oilPressureProtectTable.xSize = 4;
-    oilPressureProtectTable.values = configPage10.oilPressureProtMins;
-    oilPressureProtectTable.axisX = configPage10.oilPressureProtRPM;
-
-    coolantProtectTable.valueSize = SIZE_BYTE;
-    coolantProtectTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    coolantProtectTable.xSize = 6;
-    coolantProtectTable.values = configPage9.coolantProtRPM;
-    coolantProtectTable.axisX = configPage9.coolantProtTemp;
-
-
-    fanPWMTable.valueSize = SIZE_BYTE;
-    fanPWMTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    fanPWMTable.xSize = 4;
-    fanPWMTable.values = configPage9.PWMFanDuty;
-    fanPWMTable.axisX = configPage6.fanPWMBins;
-
-    rollingCutTable.valueSize = SIZE_BYTE;
-    rollingCutTable.axisSize = SIZE_SIGNED_BYTE; //X axis is SIGNED for this table. 
-    rollingCutTable.xSize = 4;
-    rollingCutTable.values = configPage15.rollingProtCutPercent;
-    rollingCutTable.axisX = configPage15.rollingProtRPMDelta;
-
-    wmiAdvTable.valueSize = SIZE_BYTE;
-    wmiAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
-    wmiAdvTable.xSize = 6;
-    wmiAdvTable.values = configPage10.wmiAdvAdj;
-    wmiAdvTable.axisX = configPage10.wmiAdvBins;
-
-    cltCalibrationTable.valueSize = SIZE_INT;
-    cltCalibrationTable.axisSize = SIZE_INT;
-    cltCalibrationTable.xSize = 32;
-    cltCalibrationTable.values = cltCalibration_values;
-    cltCalibrationTable.axisX = cltCalibration_bins;
-
-    iatCalibrationTable.valueSize = SIZE_INT;
-    iatCalibrationTable.axisSize = SIZE_INT;
-    iatCalibrationTable.xSize = 32;
-    iatCalibrationTable.values = iatCalibration_values;
-    iatCalibrationTable.axisX = iatCalibration_bins;
-
-    o2CalibrationTable.valueSize = SIZE_BYTE;
-    o2CalibrationTable.axisSize = SIZE_INT;
-    o2CalibrationTable.xSize = 32;
-    o2CalibrationTable.values = o2Calibration_values;
-    o2CalibrationTable.axisX = o2Calibration_bins;
+    construct2dTables();
     
     //Setup the calibration tables
-    loadCalibration();
-
-    
+    loadCalibration();   
 
     //Set the pin mappings
     if((configPage2.pinMapping == 255) || (configPage2.pinMapping == 0)) //255 = EEPROM value in a blank AVR; 0 = EEPROM value in new FRAM

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -434,6 +434,7 @@ void loop(void)
 
       //Begin the fuel calculation
       //Calculate an injector pulsewidth from the VE
+      currentStatus.afrTarget = calculateAfrTarget(afrTable, currentStatus, configPage2, configPage6);
       currentStatus.corrections = correctionsFuel();
 
       currentStatus.PW1 = PW(req_fuel_uS, currentStatus.VE, currentStatus.MAP, currentStatus.corrections, inj_opentime_uS);

--- a/speeduino/table2d.cpp
+++ b/speeduino/table2d.cpp
@@ -13,6 +13,35 @@ Note that this may clear some of the existing values of the table
 #include "globals.h"
 #endif
 
+static void construct2dTable(table2D &table, uint8_t valueSize, uint8_t axisSize, uint8_t length, void *values, void *bins) {
+  table.valueSize = valueSize;
+  table.axisSize = axisSize;
+  table.xSize = length;
+  table.values = values;
+  table.axisX = bins;
+  table.lastInput = INT16_MAX;
+  table.lastXMax = INT16_MAX;
+  table.lastXMin = INT16_MAX;
+}
+
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins) {
+  construct2dTable(table, SIZE_BYTE, SIZE_BYTE, length, values, bins);
+}
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, int8_t *bins) {
+  construct2dTable(table, SIZE_BYTE, SIZE_SIGNED_BYTE, length, values, bins);
+}
+void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint16_t *bins) {
+  construct2dTable(table, SIZE_INT, SIZE_INT, length, values, bins);
+}
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint16_t *bins) {
+  construct2dTable(table, SIZE_BYTE, SIZE_INT, length, values, bins);
+}
+void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint8_t *bins) {
+  construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+}
+void construct2dTable(table2D &table, uint8_t length, int16_t *values, uint8_t *bins) {
+  construct2dTable(table, SIZE_INT, SIZE_BYTE, length, values, bins);
+}
 
 static inline uint8_t getCacheTime(void) {
 #if !defined(UNIT_TEST)

--- a/speeduino/table2d.h
+++ b/speeduino/table2d.h
@@ -36,6 +36,13 @@ struct table2D {
   byte cacheTime; //Tracks when the last cache value was set so it can expire after x seconds. A timeout is required to pickup when a tuning value is changed, otherwise the old cached value will continue to be returned as the X value isn't changing. 
 };
 
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint8_t *bins);
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, int8_t *bins);
+void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint16_t *bins);
+void construct2dTable(table2D &table, uint8_t length, uint8_t *values, uint16_t *bins);
+void construct2dTable(table2D &table, uint8_t length, uint16_t *values, uint8_t *bins);
+void construct2dTable(table2D &table, uint8_t length, int16_t *values, uint8_t *bins);
+
 int16_t table2D_getAxisValue(struct table2D *fromTable, byte X_in);
 int16_t table2D_getRawValue(struct table2D *fromTable, byte X_index);
 

--- a/test/test_fuel/test_PW.cpp
+++ b/test/test_fuel/test_PW.cpp
@@ -2,7 +2,7 @@
 #include <speeduino.h>
 #include <unity.h>
 #include "test_PW.h"
-#include "init.h"
+// #include "init.h"
 #include "../test_utils.h"
 
 #define PW_ALLOWED_ERROR  30
@@ -30,7 +30,7 @@ int injOpen;
 
 void test_PW_setCommon()
 {
-  initialiseAll();
+  // initialiseAll();
   REQ_FUEL = 1060;
   VE = 130;
   MAP = 94;

--- a/test/test_fuel/test_PW.cpp
+++ b/test/test_fuel/test_PW.cpp
@@ -9,16 +9,15 @@
 void testPW(void)
 {
   SET_UNITY_FILENAME() {
-
-  RUN_TEST(test_PW_No_Multiply);
-  RUN_TEST(test_PW_MAP_Multiply);
-  RUN_TEST(test_PW_MAP_Multiply_Compatibility);
-  RUN_TEST(test_PW_AFR_Multiply);
-  RUN_TEST(test_PW_Large_Correction);
-  RUN_TEST(test_PW_Very_Large_Correction);
-  RUN_TEST(test_PW_4Cyl_PW0);
-  RUN_TEST(test_PW_Limit_Long_Revolution);
-  RUN_TEST(test_PW_Limit_90pct);
+    RUN_TEST_P(test_PW_No_Multiply);
+    RUN_TEST_P(test_PW_MAP_Multiply);
+    RUN_TEST_P(test_PW_MAP_Multiply_Compatibility);
+    RUN_TEST_P(test_PW_AFR_Multiply);
+    RUN_TEST_P(test_PW_Large_Correction);
+    RUN_TEST_P(test_PW_Very_Large_Correction);
+    RUN_TEST_P(test_PW_4Cyl_PW0);
+    RUN_TEST_P(test_PW_Limit_Long_Revolution);
+    RUN_TEST_P(test_PW_Limit_90pct);
   }
 }
 

--- a/test/test_fuel/test_PW.cpp
+++ b/test/test_fuel/test_PW.cpp
@@ -2,6 +2,7 @@
 #include <speeduino.h>
 #include <unity.h>
 #include "test_PW.h"
+#include "init.h"
 #include "../test_utils.h"
 
 #define PW_ALLOWED_ERROR  30
@@ -29,6 +30,7 @@ int injOpen;
 
 void test_PW_setCommon()
 {
+  initialiseAll();
   REQ_FUEL = 1060;
   VE = 130;
   MAP = 94;
@@ -151,6 +153,8 @@ void test_PW_4Cyl_PW0(void)
 //Tests the PW Limit calculation for a normal scenario
 void test_PW_Limit_90pct(void)
 {
+  test_PW_setCommon();
+
   revolutionTime = 10000UL; //6000 rpm
   configPage2.dutyLim = 90;
 
@@ -162,6 +166,8 @@ void test_PW_Limit_90pct(void)
 //Occurs at approx. 915rpm
 void test_PW_Limit_Long_Revolution(void)
 {
+  test_PW_setCommon();
+
   revolutionTime = 100000UL; //600 rpm, below 915rpm cutover point
   configPage2.dutyLim = 90;
   configPage2.strokes = TWO_STROKE;

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -5,6 +5,7 @@
 #include "../test_utils.h"
 #include "init.h"
 #include "sensors.h"
+#include "speeduino.h"
 #include "../test_utils.h"
 
 void test_corrections_MAE(void);
@@ -20,10 +21,10 @@ void testCorrections()
   test_corrections_cranking();
   test_corrections_ASE();
   test_corrections_floodclear();
+  test_corrections_bat();
   /*
   RUN_TEST_P(test_corrections_closedloop); //Not written yet
   RUN_TEST_P(test_corrections_flex); //Not written yet
-  RUN_TEST_P(test_corrections_bat); //Not written yet
   RUN_TEST_P(test_corrections_iatdensity); //Not written yet
   RUN_TEST_P(test_corrections_baro); //Not written yet
   RUN_TEST_P(test_corrections_launch); //Not written yet
@@ -343,10 +344,43 @@ void test_corrections_flex(void)
 {
 
 }
+
+uint8_t correctionBatVoltage(void);
+
+static void setup_battery_correction(void) {
+  initialiseAll();
+
+  configPage6.voltageCorrectionBins[0]      = 60;
+  configPage6.injVoltageCorrectionValues[0] = 115;
+  configPage6.voltageCorrectionBins[1]      = 70;
+  configPage6.injVoltageCorrectionValues[1] = 110;
+  configPage6.voltageCorrectionBins[2]      = 80;
+  configPage6.injVoltageCorrectionValues[2] = 105;
+  configPage6.voltageCorrectionBins[3]      = 90;
+  configPage6.injVoltageCorrectionValues[3] = 100;
+  configPage6.voltageCorrectionBins[4]      = 100;
+  configPage6.injVoltageCorrectionValues[4] = 95;
+  configPage6.voltageCorrectionBins[5]      = 110;
+  configPage6.injVoltageCorrectionValues[5] = 90;
+}
+
+static void test_corrections_bat_mode_wholePw(void) {
+  setup_battery_correction();
+
+  configPage2.battVCorMode = BATTV_COR_MODE_WHOLE;
+  currentStatus.battery10 = 75;
+  configPage2.injOpen = 10;
+  inj_opentime_uS = configPage2.injOpen * 100U;
+
+  TEST_ASSERT_EQUAL(108U, correctionBatVoltage() );
+  TEST_ASSERT_EQUAL(configPage2.injOpen * 100U, inj_opentime_uS );
+}
+
 void test_corrections_bat(void)
 {
-
+  RUN_TEST_P(test_corrections_bat_mode_wholePw);
 }
+
 void test_corrections_iatdensity(void)
 {
 

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -19,8 +19,8 @@ void testCorrections()
   test_corrections_MAE(); //MAP based accel enrichment corrections
   test_corrections_cranking();
   test_corrections_ASE();
+  test_corrections_floodclear();
   /*
-  RUN_TEST_P(test_corrections_floodclear); //Not written yet
   RUN_TEST_P(test_corrections_closedloop); //Not written yet
   RUN_TEST_P(test_corrections_flex); //Not written yet
   RUN_TEST_P(test_corrections_bat); //Not written yet
@@ -302,10 +302,39 @@ void test_corrections_ASE(void)
   RUN_TEST_P(test_corrections_ASE_taper);
 }
 
+uint8_t correctionFloodClear(void);
+
+static void test_corrections_floodclear_no_crank_inactive(void) {
+  BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
+  configPage4.floodClear = 90;
+  currentStatus.TPS = configPage4.floodClear + 10;
+
+  TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+}
+
+static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
+  BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
+  configPage4.floodClear = 90;
+  currentStatus.TPS = configPage4.floodClear - 10;
+
+  TEST_ASSERT_EQUAL(100U, correctionFloodClear() );
+}
+
+static void test_corrections_floodclear_crank_above_threshold_active(void) {
+  BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
+  configPage4.floodClear = 90;
+  currentStatus.TPS = configPage4.floodClear + 10;
+
+  TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
+}
+
 void test_corrections_floodclear(void)
 {
-
+  RUN_TEST_P(test_corrections_floodclear_no_crank_inactive);
+  RUN_TEST_P(test_corrections_floodclear_crank_below_threshold_inactive);
+  RUN_TEST_P(test_corrections_floodclear_crank_above_threshold_active);
 }
+
 void test_corrections_closedloop(void)
 {
 

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -22,13 +22,11 @@ void testCorrections()
   test_corrections_ASE();
   test_corrections_floodclear();
   test_corrections_bat();
+  test_corrections_launch();
   /*
   RUN_TEST_P(test_corrections_closedloop); //Not written yet
   RUN_TEST_P(test_corrections_flex); //Not written yet
-  RUN_TEST_P(test_corrections_iatdensity); //Not written yet
-  RUN_TEST_P(test_corrections_baro); //Not written yet
-  RUN_TEST_P(test_corrections_launch); //Not written yet
-  RUN_TEST_P(test_corrections_dfco); //Not written yet
+  RUN_TEST_P(); //Not written yet
   */
   }
 }
@@ -381,17 +379,54 @@ void test_corrections_bat(void)
   RUN_TEST_P(test_corrections_bat_mode_wholePw);
 }
 
-void test_corrections_iatdensity(void)
-{
+uint8_t correctionLaunch(void);
 
-}
-void test_corrections_baro(void)
-{
+static void test_corrections_launch_inactive(void) {
+  initialiseAll();
 
+  currentStatus.launchingHard = false;
+  currentStatus.launchingSoft = false;
+  configPage6.lnchFuelAdd = 25;
+
+  TEST_ASSERT_EQUAL(100U, correctionLaunch() );
 }
+
+static void test_corrections_launch_hard(void) {
+  initialiseAll();
+
+  currentStatus.launchingHard = true;
+  currentStatus.launchingSoft = false;
+  configPage6.lnchFuelAdd = 25;
+
+  TEST_ASSERT_EQUAL(125U, correctionLaunch() );
+}
+
+static void test_corrections_launch_soft(void) {
+  initialiseAll();
+
+  currentStatus.launchingHard = false;
+  currentStatus.launchingSoft = true;
+  configPage6.lnchFuelAdd = 25;
+
+  TEST_ASSERT_EQUAL(125U, correctionLaunch() );
+}
+
+static void test_corrections_launch_both(void) {
+  initialiseAll();
+
+  currentStatus.launchingHard = true;
+  currentStatus.launchingSoft = true;
+  configPage6.lnchFuelAdd = 25;
+
+  TEST_ASSERT_EQUAL(125U, correctionLaunch() );
+}
+
 void test_corrections_launch(void)
 {
-
+  RUN_TEST_P(test_corrections_launch_inactive);
+  RUN_TEST_P(test_corrections_launch_hard);
+  RUN_TEST_P(test_corrections_launch_soft);
+  RUN_TEST_P(test_corrections_launch_both);
 }
 
 void setup_DFCO_on()

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -33,28 +33,34 @@ void testCorrections()
 
 void test_corrections_WUE_active(void)
 {
+  initialiseAll();
+
   //Check for WUE being active
   currentStatus.coolant = 0;
-  ((uint8_t*)WUETable.axisX)[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET; //Set a WUE end value of 120
+  configPage4.wueBins[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET; //Set a WUE end value of 120
   correctionWUE();
   TEST_ASSERT_BIT_HIGH(BIT_ENGINE_WARMUP, currentStatus.engine);
 }
 
 void test_corrections_WUE_inactive(void)
 {
+  initialiseAll();
+
   //Check for WUE being inactive due to the temp being too high
   currentStatus.coolant = 200;
-  ((uint8_t*)WUETable.axisX)[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET; //Set a WUE end value of 120
+  configPage4.wueBins[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET; //Set a WUE end value of 120
   correctionWUE();
   TEST_ASSERT_BIT_LOW(BIT_ENGINE_WARMUP, currentStatus.engine);
 }
 
 void test_corrections_WUE_inactive_value(void)
 {
+  initialiseAll();
+
   //Check for WUE being set to the final row of the WUE curve if the coolant is above the max WUE temp
   currentStatus.coolant = 200;
-  ((uint8_t*)WUETable.axisX)[9] = 100;
-  ((uint8_t*)WUETable.values)[9] = 123; //Use a value other than 100 here to ensure we are using the non-default value
+  configPage4.wueBins[9] = 100;
+  configPage2.wueValues[9] = 123; //Use a value other than 100 here to ensure we are using the non-default value
 
   //Force invalidate the cache
   WUETable.cacheTime = currentStatus.secl - 1;
@@ -64,22 +70,24 @@ void test_corrections_WUE_inactive_value(void)
 
 void test_corrections_WUE_active_value(void)
 {
+  initialiseAll();
+
   //Check for WUE being made active and returning a correct interpolated value
   currentStatus.coolant = 80;
   //Set some fake values in the table axis. Target value will fall between points 6 and 7
-  ((uint8_t*)WUETable.axisX)[0] = 0;
-  ((uint8_t*)WUETable.axisX)[1] = 0;
-  ((uint8_t*)WUETable.axisX)[2] = 0;
-  ((uint8_t*)WUETable.axisX)[3] = 0;
-  ((uint8_t*)WUETable.axisX)[4] = 0;
-  ((uint8_t*)WUETable.axisX)[5] = 0;
-  ((uint8_t*)WUETable.axisX)[6] = 70 + CALIBRATION_TEMPERATURE_OFFSET;
-  ((uint8_t*)WUETable.axisX)[7] = 90 + CALIBRATION_TEMPERATURE_OFFSET;
-  ((uint8_t*)WUETable.axisX)[8] = 100 + CALIBRATION_TEMPERATURE_OFFSET;
-  ((uint8_t*)WUETable.axisX)[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET;
+  configPage4.wueBins[0] = 0;
+  configPage4.wueBins[1] = 0;
+  configPage4.wueBins[2] = 0;
+  configPage4.wueBins[3] = 0;
+  configPage4.wueBins[4] = 0;
+  configPage4.wueBins[5] = 0;
+  configPage4.wueBins[6] = 70 + CALIBRATION_TEMPERATURE_OFFSET;
+  configPage4.wueBins[7] = 90 + CALIBRATION_TEMPERATURE_OFFSET;
+  configPage4.wueBins[8] = 100 + CALIBRATION_TEMPERATURE_OFFSET;
+  configPage4.wueBins[9] = 120 + CALIBRATION_TEMPERATURE_OFFSET;
 
-  ((uint8_t*)WUETable.values)[6] = 120;
-  ((uint8_t*)WUETable.values)[7] = 130;
+  configPage2.wueValues[6] = 120;
+  configPage2.wueValues[7] = 130;
 
   //Force invalidate the cache
   WUETable.cacheTime = currentStatus.secl - 1;
@@ -99,6 +107,7 @@ void test_corrections_WUE(void)
 extern uint16_t correctionCranking(void);
 
 static void test_corrections_cranking_inactive(void) {
+  initialiseAll();
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ASE);
   configPage10.crankingEnrichTaper = 0U;
@@ -304,6 +313,8 @@ void test_corrections_ASE(void)
 uint8_t correctionFloodClear(void);
 
 static void test_corrections_floodclear_no_crank_inactive(void) {
+  initialiseAll();
+
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;
@@ -312,6 +323,8 @@ static void test_corrections_floodclear_no_crank_inactive(void) {
 }
 
 static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
+  initialiseAll();
+
   BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear - 10;
@@ -320,6 +333,8 @@ static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
 }
 
 static void test_corrections_floodclear_crank_above_threshold_active(void) {
+  initialiseAll();
+
   BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -139,13 +139,13 @@ static void test_corrections_cranking_taper_noase(void) {
   }
 
   // Should be half way between the interpolated table value and 100%.
-  TEST_ASSERT_EQUAL(113U, correctionCranking() );
+  TEST_ASSERT_INT_WITHIN(1, 113U, correctionCranking() );
   
   // Final taper step
   for (uint8_t index=configPage10.crankingEnrichTaper/2U; index<configPage10.crankingEnrichTaper-2U; ++index) {
     (void)correctionCranking();
   }
-  TEST_ASSERT_EQUAL(101U, correctionCranking() );
+  TEST_ASSERT_INT_WITHIN(1, 101U, correctionCranking() );
 
   // Taper finished
   TEST_ASSERT_EQUAL(100U, correctionCranking());
@@ -175,13 +175,13 @@ static void test_corrections_cranking_taper_withase(void) {
   }
 
   // Should be half way between the interpolated table value and 100%.
-  TEST_ASSERT_EQUAL(175U, correctionCranking() );
+  TEST_ASSERT_INT_WITHIN(1, 175U, correctionCranking() );
   
   // Final taper step
   for (uint8_t index=configPage10.crankingEnrichTaper/2U; index<configPage10.crankingEnrichTaper-2U; ++index) {
     (void)correctionCranking();
   }
-  TEST_ASSERT_EQUAL(102U, correctionCranking() );
+  TEST_ASSERT_INT_WITHIN(1, 102U, correctionCranking() );
 
   // Taper finished
   TEST_ASSERT_EQUAL(100U, correctionCranking());
@@ -262,14 +262,14 @@ static void test_corrections_ASE_taper(void) {
   }
 
   // Should be half way between the interpolated table value and 100%.
-  TEST_ASSERT_EQUAL(113, correctionASE());
+  TEST_ASSERT_INT_WITHIN(1, 113, correctionASE());
   TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ASE));
   
   // Final taper step
   for (uint8_t index=configPage2.aseTaperTime/2U; index<configPage2.aseTaperTime-2U; ++index) {
     (void)correctionASE();
   }
-  TEST_ASSERT_EQUAL(103U, correctionASE() );
+  TEST_ASSERT_INT_WITHIN(1, 103U, correctionASE() );
 
   // Taper finished
   TEST_ASSERT_EQUAL(100U, correctionASE());  

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -5,6 +5,7 @@
 #include "../test_utils.h"
 #include "init.h"
 #include "sensors.h"
+#include "../test_utils.h"
 
 void test_corrections_MAE(void);
 
@@ -19,14 +20,14 @@ void testCorrections()
   test_corrections_cranking();
   test_corrections_ASE();
   /*
-  RUN_TEST(test_corrections_floodclear); //Not written yet
-  RUN_TEST(test_corrections_closedloop); //Not written yet
-  RUN_TEST(test_corrections_flex); //Not written yet
-  RUN_TEST(test_corrections_bat); //Not written yet
-  RUN_TEST(test_corrections_iatdensity); //Not written yet
-  RUN_TEST(test_corrections_baro); //Not written yet
-  RUN_TEST(test_corrections_launch); //Not written yet
-  RUN_TEST(test_corrections_dfco); //Not written yet
+  RUN_TEST_P(test_corrections_floodclear); //Not written yet
+  RUN_TEST_P(test_corrections_closedloop); //Not written yet
+  RUN_TEST_P(test_corrections_flex); //Not written yet
+  RUN_TEST_P(test_corrections_bat); //Not written yet
+  RUN_TEST_P(test_corrections_iatdensity); //Not written yet
+  RUN_TEST_P(test_corrections_baro); //Not written yet
+  RUN_TEST_P(test_corrections_launch); //Not written yet
+  RUN_TEST_P(test_corrections_dfco); //Not written yet
   */
   }
 }
@@ -90,10 +91,10 @@ void test_corrections_WUE_active_value(void)
 
 void test_corrections_WUE(void)
 {
-  RUN_TEST(test_corrections_WUE_active);
-  RUN_TEST(test_corrections_WUE_inactive);
-  RUN_TEST(test_corrections_WUE_active_value);
-  RUN_TEST(test_corrections_WUE_inactive_value);
+  RUN_TEST_P(test_corrections_WUE_active);
+  RUN_TEST_P(test_corrections_WUE_inactive);
+  RUN_TEST_P(test_corrections_WUE_active_value);
+  RUN_TEST_P(test_corrections_WUE_inactive_value);
 }
 
 extern uint16_t correctionCranking(void);
@@ -212,10 +213,10 @@ static void test_corrections_cranking_taper_withase(void) {
 
 void test_corrections_cranking(void)
 {
-  RUN_TEST(test_corrections_cranking_inactive);
-  RUN_TEST(test_corrections_cranking_cranking);
-  RUN_TEST(test_corrections_cranking_taper_noase);
-  RUN_TEST(test_corrections_cranking_taper_withase);
+  RUN_TEST_P(test_corrections_cranking_inactive);
+  RUN_TEST_P(test_corrections_cranking_cranking);
+  RUN_TEST_P(test_corrections_cranking_taper_noase);
+  RUN_TEST_P(test_corrections_cranking_taper_withase);
 }
 
 extern uint8_t correctionASE(void);
@@ -296,9 +297,9 @@ static void test_corrections_ASE_taper(void) {
 
 void test_corrections_ASE(void)
 {
-  RUN_TEST(test_corrections_ASE_inactive_cranking);
-  RUN_TEST(test_corrections_ASE_initial);
-  RUN_TEST(test_corrections_ASE_taper);
+  RUN_TEST_P(test_corrections_ASE_inactive_cranking);
+  RUN_TEST_P(test_corrections_ASE_initial);
+  RUN_TEST_P(test_corrections_ASE_taper);
 }
 
 void test_corrections_floodclear(void)
@@ -446,13 +447,13 @@ void test_corrections_dfco_taper_ign()
 
 void test_corrections_dfco()
 {
-  RUN_TEST(test_corrections_dfco_on);
-  RUN_TEST(test_corrections_dfco_off_RPM);
-  RUN_TEST(test_corrections_dfco_off_TPS);
-  RUN_TEST(test_corrections_dfco_off_delay);
-  RUN_TEST(test_corrections_dfco_taper);
-  RUN_TEST(test_corrections_dfco_taper_fuel);
-  RUN_TEST(test_corrections_dfco_taper_ign);
+  RUN_TEST_P(test_corrections_dfco_on);
+  RUN_TEST_P(test_corrections_dfco_off_RPM);
+  RUN_TEST_P(test_corrections_dfco_off_TPS);
+  RUN_TEST_P(test_corrections_dfco_off_delay);
+  RUN_TEST_P(test_corrections_dfco_taper);
+  RUN_TEST_P(test_corrections_dfco_taper_fuel);
+  RUN_TEST_P(test_corrections_dfco_taper_ign);
 }
 
 //**********************************************************************************************************************
@@ -619,13 +620,12 @@ void test_corrections_TAE_50pc_warmup_taper()
 
 void test_corrections_TAE()
 {
-  RUN_TEST(test_corrections_TAE_negative_tpsdot);
-  RUN_TEST(test_corrections_TAE_no_rpm_taper);
-  RUN_TEST(test_corrections_TAE_50pc_rpm_taper);
-  RUN_TEST(test_corrections_TAE_110pc_rpm_taper);
-  RUN_TEST(test_corrections_TAE_under_threshold);
-  RUN_TEST(test_corrections_TAE_50pc_warmup_taper);	
-  RUN_TEST(test_corrections_TAE_50pc_warmup_taper);
+  RUN_TEST_P(test_corrections_TAE_negative_tpsdot);
+  RUN_TEST_P(test_corrections_TAE_no_rpm_taper);
+  RUN_TEST_P(test_corrections_TAE_50pc_rpm_taper);
+  RUN_TEST_P(test_corrections_TAE_110pc_rpm_taper);
+  RUN_TEST_P(test_corrections_TAE_under_threshold);
+  RUN_TEST_P(test_corrections_TAE_50pc_warmup_taper);
 }
 
 
@@ -798,10 +798,10 @@ void test_corrections_MAE_50pc_warmup_taper()
 
 void test_corrections_MAE()
 {
-  RUN_TEST(test_corrections_MAE_negative_tpsdot);
-  RUN_TEST(test_corrections_MAE_no_rpm_taper);
-  RUN_TEST(test_corrections_MAE_50pc_rpm_taper);
-  RUN_TEST(test_corrections_MAE_110pc_rpm_taper);
-  RUN_TEST(test_corrections_MAE_under_threshold);
-  RUN_TEST(test_corrections_MAE_50pc_warmup_taper);
+  RUN_TEST_P(test_corrections_MAE_negative_tpsdot);
+  RUN_TEST_P(test_corrections_MAE_no_rpm_taper);
+  RUN_TEST_P(test_corrections_MAE_50pc_rpm_taper);
+  RUN_TEST_P(test_corrections_MAE_110pc_rpm_taper);
+  RUN_TEST_P(test_corrections_MAE_under_threshold);
+  RUN_TEST_P(test_corrections_MAE_50pc_warmup_taper);
 }

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -23,10 +23,9 @@ void testCorrections()
   test_corrections_floodclear();
   test_corrections_bat();
   test_corrections_launch();
+  test_corrections_flex();
   /*
   RUN_TEST_P(test_corrections_closedloop); //Not written yet
-  RUN_TEST_P(test_corrections_flex); //Not written yet
-  RUN_TEST_P(); //Not written yet
   */
   }
 }
@@ -353,9 +352,79 @@ void test_corrections_closedloop(void)
 {
 
 }
+
+uint8_t correctionFlex(void);
+
+static void setupFlexFuelTable(void) {
+  configPage10.flexFuelBins[0] = 0;
+  configPage10.flexFuelAdj[0] = 0;
+  configPage10.flexFuelBins[1] = 10;
+  configPage10.flexFuelAdj[1] = 20;
+  configPage10.flexFuelBins[2] = 30;
+  configPage10.flexFuelAdj[2] = 40;
+  configPage10.flexFuelBins[3] = 50;
+  configPage10.flexFuelAdj[3] = 80;
+  configPage10.flexFuelBins[4] = 60;
+  configPage10.flexFuelAdj[4] = 120;
+  configPage10.flexFuelBins[5] = 70;
+  configPage10.flexFuelAdj[5] = 150;
+}
+
+static void test_corrections_flex_flex_off(void) {
+  initialiseAll();
+  setupFlexFuelTable();
+  configPage2.flexEnabled = false;
+  currentStatus.ethanolPct = 65;
+  TEST_ASSERT_EQUAL(100U, correctionFlex() );
+}
+
+static void test_corrections_flex_flex_on(void) {
+  initialiseAll();
+  setupFlexFuelTable();
+  configPage2.flexEnabled = true;
+  currentStatus.ethanolPct = 65;
+  TEST_ASSERT_EQUAL(135U, correctionFlex() );
+}
+
+uint8_t correctionFuelTemp(void);
+
+static void setupFuelTempTable(void) {
+  configPage10.fuelTempBins[0] = 0;
+  configPage10.fuelTempValues[0] = 0;
+  configPage10.fuelTempBins[1] = 10;
+  configPage10.fuelTempValues[1] = 20;
+  configPage10.fuelTempBins[2] = 30;
+  configPage10.fuelTempValues[2] = 40;
+  configPage10.fuelTempBins[3] = 50;
+  configPage10.fuelTempValues[3] = 80;
+  configPage10.fuelTempBins[4] = 60;
+  configPage10.fuelTempValues[4] = 120;
+  configPage10.fuelTempBins[5] = 70;
+  configPage10.fuelTempValues[5] = 150;  
+}
+
+static void test_corrections_fueltemp_off(void) {
+  initialiseAll();
+  setupFuelTempTable();
+  configPage2.flexEnabled = false;
+  currentStatus.fuelTemp = 65 - CALIBRATION_TEMPERATURE_OFFSET;
+  TEST_ASSERT_EQUAL(100U, correctionFuelTemp() );
+}
+
+static void test_corrections_fueltemp_on(void) {
+  initialiseAll();
+  setupFuelTempTable();
+  configPage2.flexEnabled = true;
+  currentStatus.fuelTemp = 65 - CALIBRATION_TEMPERATURE_OFFSET;
+  TEST_ASSERT_EQUAL(135U, correctionFuelTemp() );
+}
+
 void test_corrections_flex(void)
 {
-
+  RUN_TEST_P(test_corrections_flex_flex_off);
+  RUN_TEST_P(test_corrections_flex_flex_on);
+  RUN_TEST_P(test_corrections_fueltemp_off);
+  RUN_TEST_P(test_corrections_fueltemp_on);
 }
 
 uint8_t correctionBatVoltage(void);

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -206,7 +206,7 @@ static void test_corrections_ASE_inactive_cranking(void)
 
   // Taper finished
   TEST_ASSERT_EQUAL(100U, correctionASE());
-  TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ASE));
+  TEST_ASSERT_BIT_LOW(BIT_ENGINE_ASE, currentStatus.engine);
 }
 
 static inline void setup_correctionASE(void) {
@@ -249,7 +249,7 @@ static void test_corrections_ASE_initial(void)
 
   // Should be half way between the 2 table values.
   TEST_ASSERT_EQUAL(125, correctionASE());
-  TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ASE));
+  TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ASE, currentStatus.engine);
 }
 
 static void test_corrections_ASE_taper(void) {
@@ -266,7 +266,7 @@ static void test_corrections_ASE_taper(void) {
 
   // Should be half way between the interpolated table value and 100%.
   TEST_ASSERT_INT_WITHIN(1, 113, correctionASE());
-  TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ASE));
+  TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ASE, currentStatus.engine);
   
   // Final taper step
   for (uint8_t index=configPage2.aseTaperTime/2U; index<configPage2.aseTaperTime-2U; ++index) {
@@ -991,8 +991,8 @@ static void test_corrections_TAE_no_rpm_taper()
 
   TEST_ASSERT_EQUAL(750, currentStatus.tpsDOT); //DOT is 750%/s (25 * 30)
   TEST_ASSERT_EQUAL((100+132), accelValue);
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE_negative_tpsdot()
@@ -1012,8 +1012,8 @@ static void test_corrections_TAE_negative_tpsdot()
 
   TEST_ASSERT_EQUAL(-750, currentStatus.tpsDOT); //DOT is 750%/s (25 * 30)
   TEST_ASSERT_EQUAL(configPage2.decelAmount, accelValue);
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE_50pc_rpm_taper()
@@ -1032,8 +1032,8 @@ static void test_corrections_TAE_50pc_rpm_taper()
 
   TEST_ASSERT_EQUAL(750, currentStatus.tpsDOT); //DOT is 750%/s (25 * 30)
   TEST_ASSERT_EQUAL((100+66), accelValue);
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE_110pc_rpm_taper()
@@ -1052,8 +1052,8 @@ static void test_corrections_TAE_110pc_rpm_taper()
 
   TEST_ASSERT_EQUAL(750, currentStatus.tpsDOT); //DOT is 750%/s (25 * 30)
   TEST_ASSERT_EQUAL(100, accelValue); //Should be no AE as we're above the RPM taper end point
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE_under_threshold()
@@ -1073,8 +1073,8 @@ static void test_corrections_TAE_under_threshold()
 
   TEST_ASSERT_EQUAL(90, currentStatus.tpsDOT); //DOT is 90%/s (3% * 30)
   TEST_ASSERT_EQUAL(100, accelValue); //Should be no AE as we're above the RPM taper end point
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged off
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged off
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE_50pc_warmup_taper()
@@ -1100,8 +1100,8 @@ static void test_corrections_TAE_50pc_warmup_taper()
 
   TEST_ASSERT_EQUAL(750, currentStatus.tpsDOT); //DOT is 750%/s (25 * 30)
   TEST_ASSERT_EQUAL((100+165), accelValue); //Total AE should be 132 + (50% * 50%) = 132 * 1.25 = 165
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+  TEST_ASSERT_BIT_LOW(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_TAE()
@@ -1160,8 +1160,8 @@ static void test_corrections_MAE_negative_tpsdot()
 
   TEST_ASSERT_EQUAL(-400, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL(configPage2.decelAmount, accelValue);
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_DCC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_MAE_no_rpm_taper()
@@ -1181,7 +1181,7 @@ static void test_corrections_MAE_no_rpm_taper()
 
   TEST_ASSERT_EQUAL(400, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL((100+132), accelValue);
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_MAE_50pc_rpm_taper()
@@ -1202,7 +1202,7 @@ static void test_corrections_MAE_50pc_rpm_taper()
 
   TEST_ASSERT_EQUAL(400, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL((100+66), accelValue);
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_MAE_110pc_rpm_taper()
@@ -1223,7 +1223,7 @@ static void test_corrections_MAE_110pc_rpm_taper()
 
   TEST_ASSERT_EQUAL(400, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL(100, accelValue); //Should be no AE as we're above the RPM taper end point
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_MAE_under_threshold()
@@ -1245,7 +1245,7 @@ static void test_corrections_MAE_under_threshold()
 
   TEST_ASSERT_EQUAL(240, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL(100, accelValue); //Should be no AE as we're above the RPM taper end point
-	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged off
+	TEST_ASSERT_BIT_LOW(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged off
 }
 
 static void test_corrections_MAE_50pc_warmup_taper()
@@ -1272,7 +1272,7 @@ static void test_corrections_MAE_50pc_warmup_taper()
 
   TEST_ASSERT_EQUAL(400, currentStatus.mapDOT);
   TEST_ASSERT_EQUAL((100+165), accelValue); 
-	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
+	TEST_ASSERT_BIT_HIGH(BIT_ENGINE_ACC, currentStatus.engine); //Confirm AE is flagged on
 }
 
 static void test_corrections_MAE()

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -8,29 +8,9 @@
 #include "speeduino.h"
 #include "../test_utils.h"
 
-void test_corrections_MAE(void);
+extern byte correctionWUE(void);
 
-void testCorrections()
-{
-  SET_UNITY_FILENAME() {
-
-  test_corrections_WUE();
-  test_corrections_dfco();
-  test_corrections_TAE(); //TPS based accel enrichment corrections
-  test_corrections_MAE(); //MAP based accel enrichment corrections
-  test_corrections_cranking();
-  test_corrections_ASE();
-  test_corrections_floodclear();
-  test_corrections_bat();
-  test_corrections_launch();
-  test_corrections_flex();
-  /*
-  RUN_TEST_P(test_corrections_closedloop); //Not written yet
-  */
-  }
-}
-
-void test_corrections_WUE_active(void)
+static void test_corrections_WUE_active(void)
 {
   initialiseAll();
 
@@ -41,7 +21,7 @@ void test_corrections_WUE_active(void)
   TEST_ASSERT_BIT_HIGH(BIT_ENGINE_WARMUP, currentStatus.engine);
 }
 
-void test_corrections_WUE_inactive(void)
+static void test_corrections_WUE_inactive(void)
 {
   initialiseAll();
 
@@ -52,7 +32,7 @@ void test_corrections_WUE_inactive(void)
   TEST_ASSERT_BIT_LOW(BIT_ENGINE_WARMUP, currentStatus.engine);
 }
 
-void test_corrections_WUE_inactive_value(void)
+static void test_corrections_WUE_inactive_value(void)
 {
   initialiseAll();
 
@@ -67,7 +47,7 @@ void test_corrections_WUE_inactive_value(void)
   TEST_ASSERT_EQUAL(123, correctionWUE() );
 }
 
-void test_corrections_WUE_active_value(void)
+static void test_corrections_WUE_active_value(void)
 {
   initialiseAll();
 
@@ -95,7 +75,7 @@ void test_corrections_WUE_active_value(void)
   TEST_ASSERT_EQUAL(125, correctionWUE() );
 }
 
-void test_corrections_WUE(void)
+static void test_corrections_WUE(void)
 {
   RUN_TEST_P(test_corrections_WUE_active);
   RUN_TEST_P(test_corrections_WUE_inactive);
@@ -218,7 +198,7 @@ static void test_corrections_cranking_taper_withase(void) {
   TEST_ASSERT_EQUAL(100U, correctionCranking());
 } 
 
-void test_corrections_cranking(void)
+static void test_corrections_cranking(void)
 {
   RUN_TEST_P(test_corrections_cranking_inactive);
   RUN_TEST_P(test_corrections_cranking_cranking);
@@ -302,7 +282,7 @@ static void test_corrections_ASE_taper(void) {
   TEST_ASSERT_EQUAL(100U, correctionASE());  
 }
 
-void test_corrections_ASE(void)
+static void test_corrections_ASE(void)
 {
   RUN_TEST_P(test_corrections_ASE_inactive_cranking);
   RUN_TEST_P(test_corrections_ASE_initial);
@@ -341,14 +321,14 @@ static void test_corrections_floodclear_crank_above_threshold_active(void) {
   TEST_ASSERT_EQUAL(0U, correctionFloodClear() );
 }
 
-void test_corrections_floodclear(void)
+static void test_corrections_floodclear(void)
 {
   RUN_TEST_P(test_corrections_floodclear_no_crank_inactive);
   RUN_TEST_P(test_corrections_floodclear_crank_below_threshold_inactive);
   RUN_TEST_P(test_corrections_floodclear_crank_above_threshold_active);
 }
 
-void test_corrections_closedloop(void)
+static void test_corrections_closedloop(void)
 {
 
 }
@@ -419,7 +399,7 @@ static void test_corrections_fueltemp_on(void) {
   TEST_ASSERT_EQUAL(135U, correctionFuelTemp() );
 }
 
-void test_corrections_flex(void)
+static void test_corrections_flex(void)
 {
   RUN_TEST_P(test_corrections_flex_flex_off);
   RUN_TEST_P(test_corrections_flex_flex_on);
@@ -458,7 +438,7 @@ static void test_corrections_bat_mode_wholePw(void) {
   TEST_ASSERT_EQUAL(configPage2.injOpen * 100U, inj_opentime_uS );
 }
 
-void test_corrections_bat(void)
+static void test_corrections_bat(void)
 {
   RUN_TEST_P(test_corrections_bat_mode_wholePw);
 }
@@ -505,7 +485,7 @@ static void test_corrections_launch_both(void) {
   TEST_ASSERT_EQUAL(125U, correctionLaunch() );
 }
 
-void test_corrections_launch(void)
+static void test_corrections_launch(void)
 {
   RUN_TEST_P(test_corrections_launch_inactive);
   RUN_TEST_P(test_corrections_launch_hard);
@@ -513,7 +493,10 @@ void test_corrections_launch(void)
   RUN_TEST_P(test_corrections_launch_both);
 }
 
-void setup_DFCO_on()
+extern bool correctionDFCO(void);
+extern uint8_t dfcoDelay;
+
+static void setup_DFCO_on()
 {
   //Sets all the required conditions to have the DFCO be active
   configPage2.dfcoEnabled = 1; //Ensure DFCO option is turned on
@@ -531,14 +514,14 @@ void setup_DFCO_on()
   dfcoDelay = 20;
 }
 //**********************************************************************************************************************
-void test_corrections_dfco_on(void)
+static void test_corrections_dfco_on(void)
 {
   //Test under ideal conditions that DFCO goes active
   setup_DFCO_on();
 
   TEST_ASSERT_TRUE(correctionDFCO());
 }
-void test_corrections_dfco_off_RPM()
+static void test_corrections_dfco_off_RPM()
 {
   //Test that DFCO comes on and then goes off when the RPM drops below threshold
   setup_DFCO_on();
@@ -547,7 +530,7 @@ void test_corrections_dfco_off_RPM()
   currentStatus.RPM = 1000; //Set the current simulated RPM below the threshold + hyster
   TEST_ASSERT_FALSE(correctionDFCO()); //Test DFCO is now off
 }
-void test_corrections_dfco_off_TPS()
+static void test_corrections_dfco_off_TPS()
 {
   //Test that DFCO comes on and then goes off when the TPS goes above the required threshold (ie not off throttle)
   setup_DFCO_on();
@@ -556,7 +539,7 @@ void test_corrections_dfco_off_TPS()
   currentStatus.TPS = 10; //Set the current simulated TPS to be above the threshold
   TEST_ASSERT_FALSE(correctionDFCO()); //Test DFCO is now off
 }
-void test_corrections_dfco_off_delay()
+static void test_corrections_dfco_off_delay()
 {
   //Test that DFCO comes will not activate if there has not been a long enough delay
   //The steup function below simulates a 2 second delay
@@ -567,7 +550,7 @@ void test_corrections_dfco_off_delay()
 
   TEST_ASSERT_FALSE(correctionDFCO()); //Make sure DFCO does not come on
 }
-void setup_DFCO_taper_on()
+static void setup_DFCO_taper_on()
 {
   //Test that DFCO comes will not activate if there has not been a long enough delay
   //The steup function below simulates a 2 second delay
@@ -582,7 +565,11 @@ void setup_DFCO_taper_on()
   //Set the threshold to be 2.5 seconds, above the simulated delay of 2s
   configPage2.dfcoDelay = 250;
 }
-void test_corrections_dfco_taper()
+
+extern byte correctionDFCOfuel(void);
+extern uint8_t dfcoTaper;
+
+static void test_corrections_dfco_taper()
 {
   setup_DFCO_taper_on();
 
@@ -590,7 +577,7 @@ void test_corrections_dfco_taper()
   correctionDFCOfuel();
   TEST_ASSERT_EQUAL(20, dfcoTaper); //Check if value was reset to setting
 }
-void test_corrections_dfco_taper_fuel()
+static void test_corrections_dfco_taper_fuel()
 {
   setup_DFCO_taper_on();
 
@@ -609,7 +596,10 @@ void test_corrections_dfco_taper_fuel()
   configPage9.dfcoTaperEnable = 0; //Disable
   TEST_ASSERT_EQUAL(0, correctionDFCOfuel());
 }
-void test_corrections_dfco_taper_ign()
+
+extern int8_t correctionDFCOignition(int8_t advance);
+
+static void test_corrections_dfco_taper_ign()
 {
   setup_DFCO_taper_on();
 
@@ -627,7 +617,7 @@ void test_corrections_dfco_taper_ign()
   TEST_ASSERT_EQUAL(20, correctionDFCOignition(20));
 }
 
-void test_corrections_dfco()
+static void test_corrections_dfco()
 {
   RUN_TEST_P(test_corrections_dfco_on);
   RUN_TEST_P(test_corrections_dfco_off_RPM);
@@ -640,7 +630,7 @@ void test_corrections_dfco()
 
 //**********************************************************************************************************************
 //Setup a basic TAE enrichment curve, threshold etc that are common to all tests. Specifica values maybe updated in each individual test
-void test_corrections_TAE_setup()
+static void test_corrections_TAE_setup()
 {
   configPage2.aeMode = AE_MODE_TPS; //Set AE to TPS
 
@@ -671,7 +661,9 @@ void test_corrections_TAE_setup()
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_DCC); //Make sure AE is turned off
 }
 
-void test_corrections_TAE_no_rpm_taper()
+extern uint16_t correctionAccel(void);
+
+static void test_corrections_TAE_no_rpm_taper()
 {
   test_corrections_TAE_setup();
 
@@ -691,7 +683,7 @@ void test_corrections_TAE_no_rpm_taper()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE_negative_tpsdot()
+static void test_corrections_TAE_negative_tpsdot()
 {
   test_corrections_TAE_setup();
 
@@ -712,7 +704,7 @@ void test_corrections_TAE_negative_tpsdot()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE_50pc_rpm_taper()
+static void test_corrections_TAE_50pc_rpm_taper()
 {
   test_corrections_TAE_setup();
 
@@ -732,7 +724,7 @@ void test_corrections_TAE_50pc_rpm_taper()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE_110pc_rpm_taper()
+static void test_corrections_TAE_110pc_rpm_taper()
 {
   test_corrections_TAE_setup();
 
@@ -752,7 +744,7 @@ void test_corrections_TAE_110pc_rpm_taper()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE_under_threshold()
+static void test_corrections_TAE_under_threshold()
 {
   test_corrections_TAE_setup();
 
@@ -773,7 +765,7 @@ void test_corrections_TAE_under_threshold()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE_50pc_warmup_taper()
+static void test_corrections_TAE_50pc_warmup_taper()
 {
   test_corrections_TAE_setup();
 
@@ -800,7 +792,7 @@ void test_corrections_TAE_50pc_warmup_taper()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_TAE()
+static void test_corrections_TAE()
 {
   RUN_TEST_P(test_corrections_TAE_negative_tpsdot);
   RUN_TEST_P(test_corrections_TAE_no_rpm_taper);
@@ -813,7 +805,7 @@ void test_corrections_TAE()
 
 //**********************************************************************************************************************
 //Setup a basic MAE enrichment curve, threshold etc that are common to all tests. Specifica values maybe updated in each individual test
-void test_corrections_MAE_setup()
+static void test_corrections_MAE_setup()
 {
   configPage2.aeMode = AE_MODE_MAP; //Set AE to TPS
 
@@ -844,7 +836,7 @@ void test_corrections_MAE_setup()
   BIT_CLEAR(currentStatus.engine, BIT_ENGINE_DCC); //Make sure AE is turned off
 }
 
-void test_corrections_MAE_negative_tpsdot()
+static void test_corrections_MAE_negative_tpsdot()
 {
   test_corrections_MAE_setup();
 
@@ -867,7 +859,7 @@ void test_corrections_MAE_negative_tpsdot()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_DCC)); //Confirm AE is flagged on
 }
 
-void test_corrections_MAE_no_rpm_taper()
+static void test_corrections_MAE_no_rpm_taper()
 {
   test_corrections_MAE_setup();
 
@@ -887,7 +879,7 @@ void test_corrections_MAE_no_rpm_taper()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
 }
 
-void test_corrections_MAE_50pc_rpm_taper()
+static void test_corrections_MAE_50pc_rpm_taper()
 {
   test_corrections_MAE_setup();
 
@@ -908,7 +900,7 @@ void test_corrections_MAE_50pc_rpm_taper()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
 }
 
-void test_corrections_MAE_110pc_rpm_taper()
+static void test_corrections_MAE_110pc_rpm_taper()
 {
   test_corrections_MAE_setup();
 
@@ -929,7 +921,7 @@ void test_corrections_MAE_110pc_rpm_taper()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
 }
 
-void test_corrections_MAE_under_threshold()
+static void test_corrections_MAE_under_threshold()
 {
   test_corrections_MAE_setup();
 
@@ -951,7 +943,7 @@ void test_corrections_MAE_under_threshold()
 	TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged off
 }
 
-void test_corrections_MAE_50pc_warmup_taper()
+static void test_corrections_MAE_50pc_warmup_taper()
 {
   test_corrections_MAE_setup();
 
@@ -978,7 +970,7 @@ void test_corrections_MAE_50pc_warmup_taper()
 	TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.engine, BIT_ENGINE_ACC)); //Confirm AE is flagged on
 }
 
-void test_corrections_MAE()
+static void test_corrections_MAE()
 {
   RUN_TEST_P(test_corrections_MAE_negative_tpsdot);
   RUN_TEST_P(test_corrections_MAE_no_rpm_taper);
@@ -986,4 +978,21 @@ void test_corrections_MAE()
   RUN_TEST_P(test_corrections_MAE_110pc_rpm_taper);
   RUN_TEST_P(test_corrections_MAE_under_threshold);
   RUN_TEST_P(test_corrections_MAE_50pc_warmup_taper);
+}
+
+void testCorrections()
+{
+  SET_UNITY_FILENAME() {
+    test_corrections_WUE();
+    test_corrections_dfco();
+    test_corrections_TAE(); //TPS based accel enrichment corrections
+    test_corrections_MAE(); //MAP based accel enrichment corrections
+    test_corrections_cranking();
+    test_corrections_ASE();
+    test_corrections_floodclear();
+    test_corrections_bat();
+    test_corrections_launch();
+    test_corrections_flex();
+    test_corrections_closedloop();
+  }
 }

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -485,6 +485,8 @@ void test_corrections_TAE_setup()
 
 void test_corrections_TAE_no_rpm_taper()
 {
+  test_corrections_TAE_setup();
+
   //Disable the taper
   currentStatus.RPM = 2000;
   configPage2.aeTaperMin = 50; //5000
@@ -502,6 +504,8 @@ void test_corrections_TAE_no_rpm_taper()
 
 void test_corrections_TAE_50pc_rpm_taper()
 {
+  test_corrections_TAE_setup();
+
   //RPM is 50% of the way through the taper range
   currentStatus.RPM = 3000;
   configPage2.aeTaperMin = 10; //1000
@@ -519,6 +523,8 @@ void test_corrections_TAE_50pc_rpm_taper()
 
 void test_corrections_TAE_110pc_rpm_taper()
 {
+  test_corrections_TAE_setup();
+
   //RPM is 110% of the way through the taper range, which should result in no additional AE
   currentStatus.RPM = 5400;
   configPage2.aeTaperMin = 10; //1000
@@ -536,6 +542,8 @@ void test_corrections_TAE_110pc_rpm_taper()
 
 void test_corrections_TAE_under_threshold()
 {
+  test_corrections_TAE_setup();
+
   //RPM is 50% of the way through the taper range, but TPS value will be below threshold
   currentStatus.RPM = 3000;
   configPage2.aeTaperMin = 10; //1000
@@ -554,6 +562,8 @@ void test_corrections_TAE_under_threshold()
 
 void test_corrections_TAE_50pc_warmup_taper()
 {
+  test_corrections_TAE_setup();
+
   //Disable the RPM taper
   currentStatus.RPM = 2000;
   configPage2.aeTaperMin = 50; //5000
@@ -578,16 +588,10 @@ void test_corrections_TAE_50pc_warmup_taper()
 
 void test_corrections_TAE()
 {
-  test_corrections_TAE_setup();
-
-
   RUN_TEST(test_corrections_TAE_no_rpm_taper);
-	BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC); //Flag must be cleared between tests
   RUN_TEST(test_corrections_TAE_50pc_rpm_taper);
-	BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC); //Flag must be cleared between tests
   RUN_TEST(test_corrections_TAE_110pc_rpm_taper);
-	BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC); //Flag must be cleared between tests
   RUN_TEST(test_corrections_TAE_under_threshold);
-	BIT_CLEAR(currentStatus.engine, BIT_ENGINE_ACC); //Flag must be cleared between tests
   RUN_TEST(test_corrections_TAE_50pc_warmup_taper);	
+  RUN_TEST(test_corrections_TAE_50pc_warmup_taper);
 }

--- a/test/test_fuel/test_corrections.h
+++ b/test/test_fuel/test_corrections.h
@@ -1,13 +1,1 @@
 void testCorrections();
-void test_corrections_WUE(void);
-void test_corrections_cranking(void);
-void test_corrections_ASE(void);
-void test_corrections_floodclear(void);
-void test_corrections_closedloop(void);
-void test_corrections_flex(void);
-void test_corrections_bat(void);
-void test_corrections_iatdensity(void);
-void test_corrections_baro(void);
-void test_corrections_launch(void);
-void test_corrections_dfco(void);
-void test_corrections_TAE(void);

--- a/test/test_fuel/test_fuel.cpp
+++ b/test/test_fuel/test_fuel.cpp
@@ -19,7 +19,6 @@ void setup()
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
-    initialiseAll(); //Run the main initialise function
     testCorrections();
     testPW();
     testStaging();

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -7,13 +7,12 @@
 void testStaging(void)
 {
   SET_UNITY_FILENAME() {
-
-  RUN_TEST(test_Staging_Off);
-  RUN_TEST(test_Staging_4cyl_Auto_Inactive);
-  RUN_TEST(test_Staging_4cyl_Table_Inactive);
-  RUN_TEST(test_Staging_4cyl_Auto_50pct);
-  RUN_TEST(test_Staging_4cyl_Auto_33pct);
-  RUN_TEST(test_Staging_4cyl_Table_50pct);
+    RUN_TEST(test_Staging_Off);
+    RUN_TEST(test_Staging_4cyl_Auto_Inactive);
+    RUN_TEST(test_Staging_4cyl_Table_Inactive);
+    RUN_TEST(test_Staging_4cyl_Auto_50pct);
+    RUN_TEST(test_Staging_4cyl_Auto_33pct);
+    RUN_TEST(test_Staging_4cyl_Table_50pct);
   }
 }
 

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -3,6 +3,7 @@
 #include <unity.h>
 #include "test_staging.h"
 #include "../test_utils.h"
+#include "init.h"
 
 void testStaging(void)
 {
@@ -18,6 +19,8 @@ void testStaging(void)
 
 void test_Staging_setCommon()
 {
+  initialiseAll();
+  
   configPage2.nCylinders = 4;
   currentStatus.RPM = 3000;
   currentStatus.fuelLoad = 50;

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -3,7 +3,7 @@
 #include <unity.h>
 #include "test_staging.h"
 #include "../test_utils.h"
-#include "init.h"
+// #include "init.h"
 
 void testStaging(void)
 {
@@ -19,7 +19,7 @@ void testStaging(void)
 
 void test_Staging_setCommon()
 {
-  initialiseAll();
+  // initialiseAll();
   
   configPage2.nCylinders = 4;
   currentStatus.RPM = 3000;

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -53,7 +53,7 @@ void test_Staging_Off(void)
 
   uint32_t pwLimit = 9000; //90% duty cycle at 6000rpm
   calculateStaging(pwLimit);
-  TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_LOW(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }
 
 void test_Staging_4cyl_Auto_Inactive(void)
@@ -76,7 +76,7 @@ void test_Staging_4cyl_Auto_Inactive(void)
   TEST_ASSERT_EQUAL(7000, currentStatus.PW2);
   TEST_ASSERT_EQUAL(0, currentStatus.PW3);
   TEST_ASSERT_EQUAL(0, currentStatus.PW4);
-  TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_LOW(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }
 
 void test_Staging_4cyl_Table_Inactive(void)
@@ -103,7 +103,7 @@ void test_Staging_4cyl_Table_Inactive(void)
   TEST_ASSERT_EQUAL(7000, currentStatus.PW2);
   TEST_ASSERT_EQUAL(0, currentStatus.PW3);
   TEST_ASSERT_EQUAL(0, currentStatus.PW4);
-  TEST_ASSERT_FALSE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_LOW(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }
 
 void test_Staging_4cyl_Auto_50pct(void)
@@ -125,7 +125,7 @@ void test_Staging_4cyl_Auto_50pct(void)
   TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW2);
   TEST_ASSERT_EQUAL(9000, currentStatus.PW3);
   TEST_ASSERT_EQUAL(9000, currentStatus.PW4);
-  TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_HIGH(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }
 
 void test_Staging_4cyl_Auto_33pct(void)
@@ -147,7 +147,7 @@ void test_Staging_4cyl_Auto_33pct(void)
   TEST_ASSERT_EQUAL(pwLimit, currentStatus.PW2);
   TEST_ASSERT_EQUAL(6000, currentStatus.PW3);
   TEST_ASSERT_EQUAL(6000, currentStatus.PW4);
-  TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_HIGH(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }
 
 void test_Staging_4cyl_Table_50pct(void)
@@ -177,5 +177,5 @@ void test_Staging_4cyl_Table_50pct(void)
   TEST_ASSERT_EQUAL(4000, currentStatus.PW2);
   TEST_ASSERT_EQUAL(2500, currentStatus.PW3);
   TEST_ASSERT_EQUAL(2500, currentStatus.PW4);
-  TEST_ASSERT_TRUE(BIT_CHECK(currentStatus.status4, BIT_STATUS4_STAGING_ACTIVE));
+  TEST_ASSERT_BIT_HIGH(BIT_STATUS4_STAGING_ACTIVE, currentStatus.status4);
 }

--- a/test/test_ign/main.cpp
+++ b/test/test_ign/main.cpp
@@ -1,0 +1,30 @@
+#include <Arduino.h>
+#include <unity.h>
+
+void testIgnCorrections(void);
+
+#define UNITY_EXCLUDE_DETAILS
+
+void setup()
+{
+    pinMode(LED_BUILTIN, OUTPUT);
+
+    // NOTE!!! Wait for >2 secs
+    // if board doesn't support software reset via Serial.DTR/RTS
+    delay(2000);
+
+    UNITY_BEGIN();    // IMPORTANT LINE!
+
+    testIgnCorrections();
+
+    UNITY_END(); // stop unit testing
+}
+
+void loop()
+{
+    // Blink to indicate end of test
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(250);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(250);
+}

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -1,0 +1,778 @@
+#include <unity.h>
+#include "globals.h"
+#include "corrections.h"
+#include "init.h"
+#include "idle.h"
+#include "../test_utils.h"
+#include "sensors.h"
+
+extern int8_t correctionFixedTiming(int8_t advance);
+
+static void test_correctionFixedTiming_inactive(void) {
+    configPage2.fixAngEnable = 0;
+    configPage4.FixAng = 13;
+
+    TEST_ASSERT_EQUAL(8, correctionFixedTiming(8));
+}
+
+static void test_correctionFixedTiming_active(void) {
+    configPage2.fixAngEnable = 1;
+    configPage4.FixAng = 13;
+
+    TEST_ASSERT_EQUAL(configPage4.FixAng, correctionFixedTiming(8));
+}
+
+static void test_correctionFixedTiming(void) {
+    RUN_TEST_P(test_correctionFixedTiming_inactive);
+    RUN_TEST_P(test_correctionFixedTiming_active);
+}
+
+extern int8_t correctionCLTadvance(int8_t advance);
+
+static void setup_clt_advance_table(void) {
+  initialiseAll();
+  TEST_DATA_P uint8_t bins[] = { 60, 70, 80, 90, 100, 110 };
+  TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
+  populate_2dtable_P(&CLTAdvanceTable, values, bins);
+}
+
+static void test_correctionCLTadvance_lookup(void) {
+    setup_clt_advance_table();
+
+    currentStatus.coolant = 105 - CALIBRATION_TEMPERATURE_OFFSET;
+    TEST_ASSERT_EQUAL(1, correctionCLTadvance(8));
+}
+
+static void test_correctionCLTadvance(void) {
+    RUN_TEST_P(test_correctionCLTadvance_lookup);
+}
+
+static void test_correctionCrankingFixedTiming_nocrank_inactive(void) {
+    setup_clt_advance_table();
+    BIT_CLEAR(currentStatus.engine, BIT_ENGINE_CRANK);
+    configPage2.crkngAddCLTAdv = 0;
+    configPage4.CrankAng = 8;
+
+    TEST_ASSERT_EQUAL(-7, correctionCrankingFixedTiming(-7));
+}
+
+static void test_correctionCrankingFixedTiming_crank_fixed(void) {
+    setup_clt_advance_table();
+    BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
+    configPage2.crkngAddCLTAdv = 0;
+    configPage4.CrankAng = 8;
+
+    TEST_ASSERT_EQUAL(configPage4.CrankAng, correctionCrankingFixedTiming(-7));
+}
+
+static void test_correctionCrankingFixedTiming_crank_coolant(void) {
+    setup_clt_advance_table();
+    BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
+    configPage2.crkngAddCLTAdv = 1;
+    configPage4.CrankAng = 8;
+
+    TEST_ASSERT_EQUAL(14, correctionCrankingFixedTiming(8));
+}
+
+static void test_correctionCrankingFixedTiming(void) {
+    RUN_TEST_P(test_correctionCrankingFixedTiming_nocrank_inactive);
+    RUN_TEST_P(test_correctionCrankingFixedTiming_crank_fixed);
+    RUN_TEST_P(test_correctionCrankingFixedTiming_crank_coolant);
+}
+
+extern int8_t correctionFlexTiming(int8_t advance);
+
+static void setup_flexAdv(void) {
+  initialiseAll();
+  TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
+  TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
+  populate_2dtable_P(&flexAdvTable, values, bins);
+
+  configPage2.flexEnabled = 1;
+  currentStatus.ethanolPct = 55;
+}
+
+static void test_correctionFlexTiming_inactive(void) {
+    setup_flexAdv();
+    configPage2.flexEnabled = 0;
+
+    TEST_ASSERT_EQUAL(-7, correctionFlexTiming(-7));
+}
+
+static void test_correctionFlexTiming_table_lookup(void) {
+    setup_flexAdv();
+
+    TEST_ASSERT_EQUAL(-14, correctionFlexTiming(8));
+    TEST_ASSERT_EQUAL(18-OFFSET_IGNITION, currentStatus.flexIgnCorrection);    
+}
+
+static void test_correctionFlexTiming(void) {
+    RUN_TEST_P(test_correctionFlexTiming_inactive);
+    RUN_TEST_P(test_correctionFlexTiming_table_lookup);
+}
+
+extern int8_t correctionWMITiming(int8_t advance);
+
+static void setup_WMIAdv(void) {
+    initialiseAll();
+
+    configPage10.wmiEnabled= 1;
+    configPage10.wmiAdvEnabled = 1;
+    BIT_CLEAR(currentStatus.status4, BIT_STATUS4_WMI_EMPTY);
+    configPage10.wmiTPS = 50;
+    currentStatus.TPS = configPage10.wmiTPS + 1;
+    configPage10.wmiRPM = 30;
+    currentStatus.RPM = configPage10.wmiRPM + 1U;
+    configPage10.wmiMAP = 75;
+    currentStatus.MAP = (configPage10.wmiMAP*2L)+1L;
+    configPage10.wmiIAT = 155;
+    currentStatus.IAT = configPage10.wmiIAT - CALIBRATION_TEMPERATURE_OFFSET + 1;
+
+    TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
+    TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
+    populate_2dtable_P(&wmiAdvTable, values, bins);
+}
+
+static void test_correctionWMITiming_table_lookup(void) {
+    setup_WMIAdv();
+
+    TEST_ASSERT_EQUAL(-24, correctionWMITiming(8));
+}
+
+static void test_correctionWMITiming_wmidisabled_inactive(void) {
+    setup_WMIAdv();
+    configPage10.wmiEnabled= 0;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+
+
+static void test_correctionWMITiming_wmiadvdisabled_inactive(void) {
+    setup_WMIAdv();
+    configPage10.wmiAdvEnabled = 0;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+
+static void test_correctionWMITiming_empty_inactive(void) {
+    setup_WMIAdv();
+    BIT_SET(currentStatus.status4, BIT_STATUS4_WMI_EMPTY);
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+
+static void test_correctionWMITiming_tpslow_inactive(void) {
+    setup_WMIAdv();
+    currentStatus.TPS = configPage10.wmiTPS - 1;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+
+static void test_correctionWMITiming_rpmlow_inactive(void) {
+    setup_WMIAdv();
+    currentStatus.RPM = configPage10.wmiRPM - 1U;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+   
+static void test_correctionWMITiming_maplow_inactive(void) {
+    setup_WMIAdv();
+    currentStatus.MAP = (configPage10.wmiMAP*2)-1;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}
+    
+static void test_correctionWMITiming_iatlow_inactive(void) {
+    setup_WMIAdv();
+    currentStatus.IAT = configPage10.wmiIAT - CALIBRATION_TEMPERATURE_OFFSET - 1;
+
+    TEST_ASSERT_EQUAL(8, correctionWMITiming(8));
+}   
+
+static void test_correctionWMITiming(void) {
+    RUN_TEST_P(test_correctionWMITiming_table_lookup);
+    RUN_TEST_P(test_correctionWMITiming_tpslow_inactive);
+    RUN_TEST_P(test_correctionWMITiming_wmidisabled_inactive);
+    RUN_TEST_P(test_correctionWMITiming_wmiadvdisabled_inactive);
+    RUN_TEST_P(test_correctionWMITiming_empty_inactive);
+    RUN_TEST_P(test_correctionWMITiming_tpslow_inactive);
+    RUN_TEST_P(test_correctionWMITiming_rpmlow_inactive);
+    RUN_TEST_P(test_correctionWMITiming_maplow_inactive);
+    RUN_TEST_P(test_correctionWMITiming_iatlow_inactive);
+}
+
+extern int8_t correctionIATretard(int8_t advance);
+
+static void setup_IATRetard(void) {
+  initialiseAll();
+
+  TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
+  TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
+  populate_2dtable_P(&IATRetardTable, values, bins);
+
+  currentStatus.IAT = 75;
+}
+
+static void test_correctionIATretard_table_lookup(void) {
+    setup_IATRetard();
+
+    TEST_ASSERT_EQUAL(-19, correctionIATretard(-11));
+}
+
+static void test_correctionIATretard(void) {
+    RUN_TEST_P(test_correctionIATretard_table_lookup);
+}
+
+extern int8_t correctionIdleAdvance(int8_t advance);
+
+static void setup_idleadv_tps(void) {
+    configPage2.idleAdvAlgorithm = IDLEADVANCE_ALGO_TPS;
+    configPage2.idleAdvTPS = 30;
+    currentStatus.TPS = configPage2.idleAdvTPS - 1U;
+}
+
+static void setup_idleadv_ctps(void) {
+    configPage2.idleAdvAlgorithm = IDLEADVANCE_ALGO_CTPS;
+    currentStatus.CTPSActive = 1;
+}
+
+static void setup_correctionIdleAdvance(void) {
+    initialiseAll();
+
+    TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
+    TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
+    populate_2dtable_P(&idleAdvanceTable, values, bins);
+  
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_ADDED;
+    configPage2.idleAdvDelay = 5;
+    configPage2.idleAdvRPM = 20;
+    configPage2.vssMode = 0;
+    configPage6.iacAlgorithm = IAC_ALGORITHM_NONE;
+    configPage9.idleAdvStartDelay = 0U;
+
+    runSecsX10 = configPage2.idleAdvDelay * 5;
+    BIT_SET(currentStatus.engine, BIT_ENGINE_RUN);
+    currentStatus.RPM = (configPage2.idleAdvRPM * 100) - 1U;
+    currentStatus.CLIdleTarget = (currentStatus.RPM-100)/100;
+    
+    setup_idleadv_tps();
+    // Run once to initialise internal state
+    correctionIdleAdvance(8);
+}
+
+static void test_correctionIdleAdvance_tps_lookup_nodelay(void) {
+    setup_correctionIdleAdvance();
+
+    setup_idleadv_tps();
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_ADDED;
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_SWITCHED;
+    TEST_ASSERT_EQUAL(15, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_ctps_lookup_nodelay(void) {
+    setup_correctionIdleAdvance();
+
+    setup_idleadv_ctps();
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_ADDED;
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_SWITCHED;
+    TEST_ASSERT_EQUAL(15, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_inactive_notrunning(void) {
+    setup_correctionIdleAdvance();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    BIT_CLEAR(currentStatus.engine, BIT_ENGINE_RUN);
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_modeoff(void) {
+    setup_correctionIdleAdvance();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    configPage2.idleAdvEnabled = IDLEADVANCE_MODE_OFF;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_rpmtoohigh(void) {
+    setup_correctionIdleAdvance();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    currentStatus.RPM = (configPage2.idleAdvRPM * 100)+1;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_vsslimit(void) {
+    setup_correctionIdleAdvance();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    configPage2.vssMode = 1;
+    configPage2.idleAdvVss = 15;
+    currentStatus.vss = configPage2.idleAdvVss + 1;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_tpslimit(void) {
+    setup_correctionIdleAdvance();
+    setup_idleadv_tps();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    currentStatus.TPS = configPage2.idleAdvTPS + 1U;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_ctpsinactive(void) {
+    setup_correctionIdleAdvance();
+    setup_idleadv_ctps();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    currentStatus.CTPSActive = 0;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_noadvance_rundelay(void) {
+    setup_correctionIdleAdvance();
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+    runSecsX10 = (configPage2.idleAdvDelay * 5)-1;
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance_delay(void) {
+    setup_correctionIdleAdvance();
+    configPage9.idleAdvStartDelay = 3;
+    BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+    TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
+    TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
+}
+
+static void test_correctionIdleAdvance(void) {
+    RUN_TEST_P(test_correctionIdleAdvance_tps_lookup_nodelay);
+    RUN_TEST_P(test_correctionIdleAdvance_ctps_lookup_nodelay);
+    RUN_TEST_P(test_correctionIdleAdvance_inactive_notrunning);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_modeoff);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_rpmtoohigh);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_vsslimit);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_tpslimit);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_ctpsinactive);
+    RUN_TEST_P(test_correctionIdleAdvance_noadvance_rundelay);
+    RUN_TEST_P(test_correctionIdleAdvance_delay);
+}
+
+extern int8_t correctionSoftRevLimit(int8_t advance);
+
+static void setup_correctionSoftRevLimit(void) {
+    initialiseAll();
+  
+    configPage6.engineProtectType = PROTECT_CUT_IGN;
+    configPage4.SoftRevLim = 50;
+    configPage4.SoftLimMax = 1;
+    configPage4.SoftLimRetard = -5;
+    configPage2.SoftLimitMode = SOFT_LIMIT_FIXED;
+
+    currentStatus.RPMdiv100 = configPage4.SoftRevLim + 1;
+    softLimitTime = 0;
+
+    BIT_CLEAR(LOOP_TIMER, BIT_TIMER_10HZ);
+}
+
+static void test_correctionSoftRevLimit_modes(void) {
+    setup_correctionSoftRevLimit();
+    configPage4.SoftLimRetard = -5;
+
+    configPage2.SoftLimitMode = SOFT_LIMIT_FIXED;
+    TEST_ASSERT_EQUAL(-5, correctionSoftRevLimit(8));
+    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SFTLIM , currentStatus.spark);
+
+    configPage2.SoftLimitMode = SOFT_LIMIT_RELATIVE;
+    TEST_ASSERT_EQUAL(13, correctionSoftRevLimit(8));
+    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SFTLIM , currentStatus.spark);
+}
+
+static void test_correctionSoftRevLimit_inactive_protecttype(void) {
+    setup_correctionSoftRevLimit();
+
+    configPage6.engineProtectType = PROTECT_CUT_OFF;
+    TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+
+    configPage6.engineProtectType = PROTECT_CUT_FUEL;
+    TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+}
+
+static void test_correctionSoftRevLimit_inactive_rpmtoohigh(void) {
+    setup_correctionSoftRevLimit();
+    TEST_ASSERT_EQUAL(-5, correctionSoftRevLimit(8));
+
+    currentStatus.RPMdiv100 = configPage4.SoftRevLim-1;
+    TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+}
+
+static void test_correctionSoftRevLimit_timeout(void) {
+    setup_correctionSoftRevLimit();
+    configPage4.SoftLimMax = 3;
+    BIT_SET(LOOP_TIMER, BIT_TIMER_10HZ);
+    TEST_ASSERT_EQUAL(-5, correctionSoftRevLimit(8));
+    TEST_ASSERT_EQUAL(-5, correctionSoftRevLimit(8));
+    TEST_ASSERT_EQUAL(-5, correctionSoftRevLimit(8));
+    TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
+}
+
+static void test_correctionSoftRevLimit(void) {
+    RUN_TEST_P(test_correctionSoftRevLimit_modes);
+    RUN_TEST_P(test_correctionSoftRevLimit_inactive_protecttype);
+    RUN_TEST_P(test_correctionSoftRevLimit_inactive_rpmtoohigh);
+    RUN_TEST_P(test_correctionSoftRevLimit_timeout);
+}
+
+extern int8_t correctionNitrous(int8_t advance);
+
+static void test_correctionNitrous_disabled(void) {
+    configPage10.n2o_enable = 0;
+    TEST_ASSERT_EQUAL(13, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-13, correctionNitrous(-13));
+}
+
+static void test_correctionNitrous_stage1(void) {
+    configPage10.n2o_enable = 1;
+    configPage10.n2o_stage1_retard = 5;
+    configPage10.n2o_stage2_retard = 0;
+    
+    currentStatus.nitrous_status = NITROUS_STAGE1;
+    TEST_ASSERT_EQUAL(8, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-18, correctionNitrous(-13));
+    
+    currentStatus.nitrous_status = NITROUS_BOTH;
+    TEST_ASSERT_EQUAL(8, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-18, correctionNitrous(-13));
+}
+
+static void test_correctionNitrous_stage2(void) {
+    configPage10.n2o_enable = 1;
+    configPage10.n2o_stage1_retard = 0;
+    configPage10.n2o_stage2_retard = 5;
+    
+    currentStatus.nitrous_status = NITROUS_STAGE2;
+    TEST_ASSERT_EQUAL(8, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-18, correctionNitrous(-13));
+    
+    currentStatus.nitrous_status = NITROUS_BOTH;
+    TEST_ASSERT_EQUAL(8, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-18, correctionNitrous(-13));
+}
+
+static void test_correctionNitrous_stageboth(void) {
+    configPage10.n2o_enable = 1;
+    configPage10.n2o_stage1_retard = 3;
+    configPage10.n2o_stage2_retard = 5;
+      
+    currentStatus.nitrous_status = NITROUS_BOTH;
+    TEST_ASSERT_EQUAL(5, correctionNitrous(13));
+    TEST_ASSERT_EQUAL(-21, correctionNitrous(-13));
+}
+
+static void test_correctionNitrous(void) {
+    RUN_TEST_P(test_correctionNitrous_disabled);
+    RUN_TEST_P(test_correctionNitrous_stage1);
+    RUN_TEST_P(test_correctionNitrous_stage2);
+    RUN_TEST_P(test_correctionNitrous_stageboth);
+}
+
+extern int8_t correctionSoftLaunch(int8_t advance);
+
+static void setup_correctionSoftLaunch(void) {
+    configPage6.launchEnabled = 1;
+    configPage6.flatSArm = 20;
+    configPage6.lnchSoftLim = 40;
+    configPage10.lnchCtrlTPS = 80;
+    
+    currentStatus.clutchTrigger = 1;
+    currentStatus.clutchEngagedRPM = ((configPage6.flatSArm) * 100) - 100;
+    currentStatus.RPM = ((configPage6.lnchSoftLim) * 100) + 100;
+    currentStatus.TPS = configPage10.lnchCtrlTPS + 1;
+}
+
+static void test_correctionSoftLaunch_on(void) {
+    setup_correctionSoftLaunch();
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(configPage6.lnchRetard, correctionSoftLaunch(-8));
+    TEST_ASSERT_TRUE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch_off_disabled(void) {
+    setup_correctionSoftLaunch();
+    configPage6.launchEnabled = 0;
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
+    TEST_ASSERT_FALSE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch_off_noclutchtrigger(void) {
+    setup_correctionSoftLaunch();
+    currentStatus.clutchTrigger = 0;
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
+    TEST_ASSERT_FALSE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch_off_clutchrpmlow(void) {
+    setup_correctionSoftLaunch();
+    currentStatus.clutchEngagedRPM = (configPage6.flatSArm * 100) + 1;
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
+    TEST_ASSERT_FALSE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch_off_rpmlimit(void) {
+    setup_correctionSoftLaunch();
+    currentStatus.RPM = (configPage6.lnchSoftLim * 100) - 1;
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
+    TEST_ASSERT_FALSE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch_off_tpslow(void) {
+    setup_correctionSoftLaunch();
+    currentStatus.TPS = configPage10.lnchCtrlTPS - 1;
+    configPage6.lnchRetard = -3;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
+    TEST_ASSERT_FALSE(currentStatus.launchingSoft);
+    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+}
+
+static void test_correctionSoftLaunch(void) {
+    RUN_TEST_P(test_correctionSoftLaunch_on);
+    RUN_TEST_P(test_correctionSoftLaunch_off_disabled);
+    RUN_TEST_P(test_correctionSoftLaunch_off_noclutchtrigger);
+    RUN_TEST_P(test_correctionSoftLaunch_off_clutchrpmlow);
+    RUN_TEST_P(test_correctionSoftLaunch_off_rpmlimit);
+    RUN_TEST_P(test_correctionSoftLaunch_off_tpslow);
+}
+
+extern int8_t correctionSoftFlatShift(int8_t advance);
+
+static void setup_correctionSoftFlatShift(void) {
+    configPage6.flatSEnable = 1;
+    configPage6.flatSArm = 10;
+    configPage6.flatSSoftWin = 10;
+    
+    currentStatus.clutchTrigger = 1;
+    currentStatus.clutchEngagedRPM = ((configPage6.flatSArm) * 100) + 500;
+    currentStatus.RPM = currentStatus.clutchEngagedRPM + 600;
+}
+
+static void test_correctionSoftFlatShift_on(void) {
+    setup_correctionSoftFlatShift();
+    configPage6.flatSRetard = -3;
+
+    TEST_ASSERT_EQUAL(configPage6.flatSRetard, correctionSoftFlatShift(-8));
+    TEST_ASSERT_BIT_HIGH(BIT_SPARK2_FLATSS, currentStatus.spark2);
+}
+
+static void test_correctionSoftFlatShift_off_disabled(void) {
+    setup_correctionSoftFlatShift();
+    configPage6.flatSRetard = -3;
+    configPage6.flatSEnable = 0;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+}
+
+static void test_correctionSoftFlatShift_off_noclutchtrigger(void) {
+    setup_correctionSoftFlatShift();
+    configPage6.flatSRetard = -3;
+    currentStatus.clutchTrigger = 0;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+}
+
+static void test_correctionSoftFlatShift_off_clutchrpmtoolow(void) {
+    setup_correctionSoftFlatShift();
+    configPage6.flatSRetard = -3;
+    currentStatus.clutchEngagedRPM = ((configPage6.flatSArm) * 100) - 500;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+}
+
+static void test_correctionSoftFlatShift_off_rpmnotinwindow(void) {
+    setup_correctionSoftFlatShift();
+    configPage6.flatSRetard = -3;
+    currentStatus.RPM = (currentStatus.clutchEngagedRPM - (configPage6.flatSSoftWin * 100) ) - 100;
+
+    TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
+    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+}
+
+static void test_correctionSoftFlatShift(void) {
+    RUN_TEST_P(test_correctionSoftFlatShift_on);
+    RUN_TEST_P(test_correctionSoftFlatShift_off_disabled);
+    RUN_TEST_P(test_correctionSoftFlatShift_off_noclutchtrigger);
+    RUN_TEST_P(test_correctionSoftFlatShift_off_clutchrpmtoolow);
+    RUN_TEST_P(test_correctionSoftFlatShift_off_rpmnotinwindow);
+}
+
+extern int8_t correctionKnock(int8_t advance);
+
+static void setup_correctionKnock(void) {
+    configPage10.knock_mode = KNOCK_MODE_DIGITAL;
+    configPage10.knock_count = 5U;
+    configPage10.knock_firstStep = 3U;
+    knockCounter = configPage10.knock_count + 1;
+//   TEST_DATA_P uint8_t startBins[] = { 30, 40, 50, 60, 70, 80 };
+//   TEST_DATA_P uint8_t startValues[] = { 30, 25, 20, 15, 10, 5 };
+//   populate_2dtable_P(&knockWindowStartTable, startValues, startBins);
+
+//   TEST_DATA_P uint8_t durationBins[] = { 30, 40, 50, 60, 70, 80 };
+//   TEST_DATA_P uint8_t durationValues[] = { 30, 25, 20, 15, 10, 5 };
+//   populate_2dtable_P(&knockWindowDurationTable, durationValues, durationBins);
+}
+
+static void test_correctionKnock_firstStep(void) {
+    setup_correctionKnock();
+
+    TEST_ASSERT_EQUAL(-11, correctionKnock(-8));
+}
+
+static void test_correctionKnock_disabled_modeoff(void) {
+    setup_correctionKnock();
+    configPage10.knock_mode = KNOCK_MODE_OFF;
+    TEST_ASSERT_EQUAL(-8, correctionKnock(-8));
+}
+
+static void test_correctionKnock_disabled_counttoolow(void) {
+    setup_correctionKnock();
+    knockCounter = configPage10.knock_count - 1;
+    TEST_ASSERT_EQUAL(-8, correctionKnock(-8));
+}
+
+static void test_correctionKnock_disabled_knockactive(void) {
+    setup_correctionKnock();
+    currentStatus.knockActive = true;
+    TEST_ASSERT_EQUAL(-8, correctionKnock(-8));
+}
+
+static void test_correctionKnock(void) {
+    RUN_TEST_P(test_correctionKnock_firstStep);
+    RUN_TEST_P(test_correctionKnock_disabled_modeoff);
+    RUN_TEST_P(test_correctionKnock_disabled_counttoolow);
+    RUN_TEST_P(test_correctionKnock_disabled_knockactive);
+}
+
+static void setup_correctionsDwell(void) {
+    initialiseAll();
+    configPage4.sparkDur = 10;
+    configPage2.perToothIgn = false;
+    configPage4.dwellErrCorrect = 0;
+    configPage4.sparkMode = IGN_MODE_WASTED;
+
+    currentStatus.actualDwell = 770;
+    currentStatus.battery10 = 95;
+
+    revolutionTime = 666;
+
+    TEST_DATA_P uint8_t bins[] = { 60,  70,  80,  90,  100, 110 };
+    TEST_DATA_P uint8_t values[] = { 130, 125, 120, 115, 110, 90 };
+    populate_2dtable_P(&dwellVCorrectionTable, values, bins);   
+}
+
+static void test_correctionsDwell_nopertooth(void) {
+    setup_correctionsDwell();
+
+    currentStatus.battery10 = 105;
+    configPage2.nCylinders = 8;
+
+    configPage4.sparkMode = IGN_MODE_WASTED;
+    TEST_ASSERT_EQUAL(296, correctionsDwell(800));
+
+    configPage4.sparkMode = IGN_MODE_SINGLE;
+    TEST_ASSERT_EQUAL(74, correctionsDwell(800));
+
+    configPage4.sparkMode = IGN_MODE_ROTARY;
+    configPage10.rotaryType = ROTARY_IGN_RX8;
+    TEST_ASSERT_EQUAL(296, correctionsDwell(800));
+
+    configPage4.sparkMode = IGN_MODE_ROTARY;
+    configPage10.rotaryType = ROTARY_IGN_FC;
+    TEST_ASSERT_EQUAL(74, correctionsDwell(800));
+}
+
+static void test_correctionsDwell_pertooth(void) {
+    setup_correctionsDwell();
+
+    currentStatus.battery10 = 105;
+    configPage2.perToothIgn = true;
+    configPage4.dwellErrCorrect = 1;
+    configPage4.sparkMode = IGN_MODE_WASTED;
+
+    currentStatus.actualDwell = 200;
+    TEST_ASSERT_EQUAL(444, correctionsDwell(800));
+
+    currentStatus.actualDwell = 1400;
+    TEST_ASSERT_EQUAL(296, correctionsDwell(800));
+}
+
+static void test_correctionsDwell_wasted_nopertooth_largerevolutiontime(void) {
+    setup_correctionsDwell();
+
+    currentStatus.dwellCorrection = 55;
+    currentStatus.battery10 = 105;
+    revolutionTime = 5000;
+    TEST_ASSERT_EQUAL(800, correctionsDwell(800));
+}
+
+static void test_correctionsDwell_initialises_current_actualDwell(void) {
+    setup_correctionsDwell();
+
+    currentStatus.actualDwell = 0;
+    correctionsDwell(777);
+    TEST_ASSERT_EQUAL(777, currentStatus.actualDwell);
+}
+
+static void test_correctionsDwell_sets_dwellCorrection(void) {
+    setup_correctionsDwell();
+
+    currentStatus.dwellCorrection = UINT8_MAX;
+    currentStatus.battery10 = 90;
+    correctionsDwell(777);
+    TEST_ASSERT_EQUAL(115, currentStatus.dwellCorrection);
+}
+
+static void test_correctionsDwell(void) {
+    RUN_TEST_P(test_correctionsDwell_nopertooth);
+    RUN_TEST_P(test_correctionsDwell_pertooth);
+    RUN_TEST_P(test_correctionsDwell_wasted_nopertooth_largerevolutiontime);
+    RUN_TEST_P(test_correctionsDwell_initialises_current_actualDwell);
+    RUN_TEST_P(test_correctionsDwell_sets_dwellCorrection);
+}
+
+void testIgnCorrections(void) {
+    test_correctionFixedTiming();
+    test_correctionCLTadvance();
+    test_correctionCrankingFixedTiming();
+    test_correctionFlexTiming();
+    test_correctionWMITiming();
+    test_correctionIATretard();
+    test_correctionIdleAdvance();
+    test_correctionSoftRevLimit();
+    test_correctionNitrous();
+    test_correctionSoftLaunch();
+    test_correctionSoftFlatShift();
+    test_correctionKnock();
+    // correctionDFCOignition() is tested in the fueling unit tests, since it is tightly coupled to fuel DFCO
+    test_correctionsDwell();
+}

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -856,6 +856,8 @@ static void test_correctionsDwell(void) {
 }
 
 void testIgnCorrections(void) {
+    Unity.TestFile = __FILE__;
+
     test_correctionFixedTiming();
     test_correctionCLTadvance();
     test_correctionCrankingFixedTiming();

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -430,12 +430,12 @@ static void setup_correctionSoftRevLimit(void) {
 static void assert_correctionSoftRevLimit(int8_t advance) {
     configPage2.SoftLimitMode = SOFT_LIMIT_FIXED;
     TEST_ASSERT_EQUAL(configPage4.SoftLimRetard, correctionSoftRevLimit(advance));
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SFTLIM , currentStatus.spark);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS2_SFTLIM , currentStatus.status2);
 
-    BIT_CLEAR(currentStatus.spark, BIT_SPARK_SFTLIM);
+    BIT_CLEAR(currentStatus.status2, BIT_STATUS2_SFTLIM);
     configPage2.SoftLimitMode = SOFT_LIMIT_RELATIVE;
     TEST_ASSERT_EQUAL(advance-configPage4.SoftLimRetard, correctionSoftRevLimit(advance));
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SFTLIM , currentStatus.spark);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS2_SFTLIM , currentStatus.status2);
 }
 
 static void test_correctionSoftRevLimit_modes(void) {
@@ -449,14 +449,14 @@ static void test_correctionSoftRevLimit_inactive_protecttype(void) {
     setup_correctionSoftRevLimit();
 
     configPage6.engineProtectType = PROTECT_CUT_OFF;
-    BIT_SET(currentStatus.spark, BIT_SPARK_SFTLIM);
+    BIT_SET(currentStatus.status2, BIT_STATUS2_SFTLIM);
     TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SFTLIM , currentStatus.status2);
 
     configPage6.engineProtectType = PROTECT_CUT_FUEL;
-    BIT_SET(currentStatus.spark, BIT_SPARK_SFTLIM);
+    BIT_SET(currentStatus.status2, BIT_STATUS2_SFTLIM);
     TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SFTLIM , currentStatus.status2);
 }
 
 static void test_correctionSoftRevLimit_inactive_rpmtoohigh(void) {
@@ -464,9 +464,9 @@ static void test_correctionSoftRevLimit_inactive_rpmtoohigh(void) {
     assert_correctionSoftRevLimit(8);
 
     currentStatus.RPMdiv100 = configPage4.SoftRevLim-1;
-    BIT_SET(currentStatus.spark, BIT_SPARK_SFTLIM);
+    BIT_SET(currentStatus.status2, BIT_STATUS2_SFTLIM);
     TEST_ASSERT_EQUAL(8, correctionSoftRevLimit(8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SFTLIM , currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SFTLIM , currentStatus.status2);
 }
 
 static void test_correctionSoftRevLimit_timeout(void) {
@@ -563,14 +563,14 @@ static void test_correctionSoftLaunch_on(void) {
     configPage6.lnchRetard = -3;
     TEST_ASSERT_EQUAL(configPage6.lnchRetard, correctionSoftLaunch(-8));
     TEST_ASSERT_TRUE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 
     configPage6.lnchRetard = 3;
     currentStatus.launchingSoft = false;
-    BIT_CLEAR(currentStatus.spark, BIT_SPARK_SLAUNCH);
+    BIT_CLEAR(currentStatus.status2, BIT_STATUS2_SLAUNCH);
     TEST_ASSERT_EQUAL(configPage6.lnchRetard, correctionSoftLaunch(8));
     TEST_ASSERT_TRUE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch_off_disabled(void) {
@@ -580,7 +580,7 @@ static void test_correctionSoftLaunch_off_disabled(void) {
 
     TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
     TEST_ASSERT_FALSE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch_off_noclutchtrigger(void) {
@@ -590,7 +590,7 @@ static void test_correctionSoftLaunch_off_noclutchtrigger(void) {
 
     TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
     TEST_ASSERT_FALSE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch_off_clutchrpmlow(void) {
@@ -600,7 +600,7 @@ static void test_correctionSoftLaunch_off_clutchrpmlow(void) {
 
     TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
     TEST_ASSERT_FALSE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch_off_rpmlimit(void) {
@@ -610,7 +610,7 @@ static void test_correctionSoftLaunch_off_rpmlimit(void) {
 
     TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
     TEST_ASSERT_FALSE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch_off_tpslow(void) {
@@ -620,7 +620,7 @@ static void test_correctionSoftLaunch_off_tpslow(void) {
 
     TEST_ASSERT_EQUAL(-8, correctionSoftLaunch(-8));
     TEST_ASSERT_FALSE(currentStatus.launchingSoft);
-    TEST_ASSERT_BIT_LOW(BIT_SPARK_SLAUNCH, currentStatus.spark);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS2_SLAUNCH, currentStatus.status2);
 }
 
 static void test_correctionSoftLaunch(void) {
@@ -643,7 +643,7 @@ static void setup_correctionSoftFlatShift(void) {
     currentStatus.clutchEngagedRPM = ((configPage6.flatSArm) * 100) + 500;
     currentStatus.RPM = currentStatus.clutchEngagedRPM + 600;
 
-    BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_CLEAR(currentStatus.status5, BIT_STATUS5_FLATSS);
 }
 
 static void test_correctionSoftFlatShift_on(void) {
@@ -651,11 +651,11 @@ static void test_correctionSoftFlatShift_on(void) {
     configPage6.flatSRetard = -3;
 
     TEST_ASSERT_EQUAL(configPage6.flatSRetard, correctionSoftFlatShift(-8));
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS5_FLATSS, currentStatus.status5);
 
-    BIT_CLEAR(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_CLEAR(currentStatus.status5, BIT_STATUS5_FLATSS);
     TEST_ASSERT_EQUAL(configPage6.flatSRetard, correctionSoftFlatShift(3));
-    TEST_ASSERT_BIT_HIGH(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_HIGH(BIT_STATUS5_FLATSS, currentStatus.status5);
 }
 
 static void test_correctionSoftFlatShift_off_disabled(void) {
@@ -663,9 +663,9 @@ static void test_correctionSoftFlatShift_off_disabled(void) {
     configPage6.flatSRetard = -3;
     configPage6.flatSEnable = 0;
 
-    BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_SET(currentStatus.status5, BIT_STATUS5_FLATSS);
     TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS5_FLATSS, currentStatus.status5);
 }
 
 static void test_correctionSoftFlatShift_off_noclutchtrigger(void) {
@@ -673,9 +673,9 @@ static void test_correctionSoftFlatShift_off_noclutchtrigger(void) {
     configPage6.flatSRetard = -3;
     currentStatus.clutchTrigger = 0;
 
-    BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_SET(currentStatus.status5, BIT_STATUS5_FLATSS);
     TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS5_FLATSS, currentStatus.status5);
 }
 
 static void test_correctionSoftFlatShift_off_clutchrpmtoolow(void) {
@@ -683,9 +683,9 @@ static void test_correctionSoftFlatShift_off_clutchrpmtoolow(void) {
     configPage6.flatSRetard = -3;
     currentStatus.clutchEngagedRPM = ((configPage6.flatSArm) * 100) - 500;
 
-    BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_SET(currentStatus.status5, BIT_STATUS5_FLATSS);
     TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS5_FLATSS, currentStatus.status5);
 }
 
 static void test_correctionSoftFlatShift_off_rpmnotinwindow(void) {
@@ -693,9 +693,9 @@ static void test_correctionSoftFlatShift_off_rpmnotinwindow(void) {
     configPage6.flatSRetard = -3;
     currentStatus.RPM = (currentStatus.clutchEngagedRPM - (configPage6.flatSSoftWin * 100) ) - 100;
 
-    BIT_SET(currentStatus.spark2, BIT_SPARK2_FLATSS);
+    BIT_SET(currentStatus.status5, BIT_STATUS5_FLATSS);
     TEST_ASSERT_EQUAL(-8, correctionSoftFlatShift(-8));
-    TEST_ASSERT_BIT_LOW(BIT_SPARK2_FLATSS, currentStatus.spark2);
+    TEST_ASSERT_BIT_LOW(BIT_STATUS5_FLATSS, currentStatus.status5);
 }
 
 static void test_correctionSoftFlatShift(void) {
@@ -706,13 +706,14 @@ static void test_correctionSoftFlatShift(void) {
     RUN_TEST_P(test_correctionSoftFlatShift_off_rpmnotinwindow);
 }
 
+#if 0 // Wait until Noisymime is done with knock implementation
 extern int8_t correctionKnock(int8_t advance);
 
 static void setup_correctionKnock(void) {
     configPage10.knock_mode = KNOCK_MODE_DIGITAL;
     configPage10.knock_count = 5U;
     configPage10.knock_firstStep = 3U;
-    knockCounter = configPage10.knock_count + 1;
+    // knockCounter = configPage10.knock_count + 1;
 //   TEST_DATA_P uint8_t startBins[] = { 30, 40, 50, 60, 70, 80 };
 //   TEST_DATA_P uint8_t startValues[] = { 30, 25, 20, 15, 10, 5 };
 //   populate_2dtable_P(&knockWindowStartTable, startValues, startBins);
@@ -745,12 +746,9 @@ static void test_correctionKnock_disabled_knockactive(void) {
     currentStatus.knockActive = true;
     TEST_ASSERT_EQUAL(-8, correctionKnock(-8));
 }
+#endif
 
 static void test_correctionKnock(void) {
-    RUN_TEST_P(test_correctionKnock_firstStep);
-    RUN_TEST_P(test_correctionKnock_disabled_modeoff);
-    RUN_TEST_P(test_correctionKnock_disabled_counttoolow);
-    RUN_TEST_P(test_correctionKnock_disabled_knockactive);
 }
 
 static void setup_correctionsDwell(void) {

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -1,10 +1,12 @@
 #include <unity.h>
 #include "globals.h"
 #include "corrections.h"
-#include "init.h"
+// #include "init.h"
 #include "idle.h"
 #include "../test_utils.h"
 #include "sensors.h"
+
+extern void construct2dTables(void);
 
 extern int8_t correctionFixedTiming(int8_t advance);
 
@@ -30,7 +32,8 @@ static void test_correctionFixedTiming(void) {
 extern int8_t correctionCLTadvance(int8_t advance);
 
 static void setup_clt_advance_table(void) {
-  initialiseAll();
+  construct2dTables();
+  initialiseCorrections();
   TEST_DATA_P uint8_t bins[] = { 60, 70, 80, 90, 100, 110 };
   TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
   populate_2dtable_P(&CLTAdvanceTable, values, bins);
@@ -84,7 +87,8 @@ static void test_correctionCrankingFixedTiming(void) {
 extern int8_t correctionFlexTiming(int8_t advance);
 
 static void setup_flexAdv(void) {
-  initialiseAll();
+  construct2dTables();
+  initialiseCorrections();
   TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
   TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
   populate_2dtable_P(&flexAdvTable, values, bins);
@@ -115,7 +119,8 @@ static void test_correctionFlexTiming(void) {
 extern int8_t correctionWMITiming(int8_t advance);
 
 static void setup_WMIAdv(void) {
-    initialiseAll();
+    construct2dTables();
+    initialiseCorrections();
 
     configPage10.wmiEnabled= 1;
     configPage10.wmiAdvEnabled = 1;
@@ -205,7 +210,8 @@ static void test_correctionWMITiming(void) {
 extern int8_t correctionIATretard(int8_t advance);
 
 static void setup_IATRetard(void) {
-  initialiseAll();
+  construct2dTables();
+  initialiseCorrections();
 
   TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
   TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
@@ -238,7 +244,8 @@ static void setup_idleadv_ctps(void) {
 }
 
 static void setup_correctionIdleAdvance(void) {
-    initialiseAll();
+    construct2dTables();
+    initialiseCorrections();
 
     TEST_DATA_P uint8_t bins[] = { 30, 40, 50, 60, 70, 80 };
     TEST_DATA_P uint8_t values[] = { 30, 25, 20, 15, 10, 5 };
@@ -363,8 +370,9 @@ static void test_correctionIdleAdvance(void) {
 extern int8_t correctionSoftRevLimit(int8_t advance);
 
 static void setup_correctionSoftRevLimit(void) {
-    initialiseAll();
-  
+    construct2dTables();
+    initialiseCorrections();
+
     configPage6.engineProtectType = PROTECT_CUT_IGN;
     configPage4.SoftRevLim = 50;
     configPage4.SoftLimMax = 1;
@@ -675,7 +683,9 @@ static void test_correctionKnock(void) {
 }
 
 static void setup_correctionsDwell(void) {
-    initialiseAll();
+    construct2dTables();
+    initialiseCorrections();
+    
     configPage4.sparkDur = 10;
     configPage2.perToothIgn = false;
     configPage4.dwellErrCorrect = 0;

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -70,8 +70,9 @@ static void test_correctionCrankingFixedTiming_crank_coolant(void) {
     BIT_SET(currentStatus.engine, BIT_ENGINE_CRANK);
     configPage2.crkngAddCLTAdv = 1;
     configPage4.CrankAng = 8;
+    currentStatus.coolant = 105 - CALIBRATION_TEMPERATURE_OFFSET;
 
-    TEST_ASSERT_EQUAL(14, correctionCrankingFixedTiming(8));
+    TEST_ASSERT_EQUAL(1, correctionCrankingFixedTiming(8));
 }
 
 static void test_correctionCrankingFixedTiming(void) {

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -763,12 +763,25 @@ static void test_correctionsDwell_sets_dwellCorrection(void) {
     TEST_ASSERT_EQUAL(115, currentStatus.dwellCorrection);
 }
 
+static void test_correctionsDwell_uses_batvcorrection(void) {
+    setup_correctionsDwell();
+    configPage2.nCylinders = 8;
+    configPage4.sparkMode = IGN_MODE_WASTED;
+
+    currentStatus.battery10 = 105;
+    TEST_ASSERT_EQUAL(296, correctionsDwell(800));
+
+    currentStatus.battery10 = 65;
+    TEST_ASSERT_EQUAL(337, correctionsDwell(800));
+}
+
 static void test_correctionsDwell(void) {
     RUN_TEST_P(test_correctionsDwell_nopertooth);
     RUN_TEST_P(test_correctionsDwell_pertooth);
     RUN_TEST_P(test_correctionsDwell_wasted_nopertooth_largerevolutiontime);
     RUN_TEST_P(test_correctionsDwell_initialises_current_actualDwell);
     RUN_TEST_P(test_correctionsDwell_sets_dwellCorrection);
+    RUN_TEST_P(test_correctionsDwell_uses_batvcorrection);
 }
 
 void testIgnCorrections(void) {

--- a/test/test_math/test_division.cpp
+++ b/test/test_math/test_division.cpp
@@ -168,7 +168,6 @@ void test_maths_udiv_32_16_perf(void)
 
     auto nativeTest = [] (uint16_t index, uint32_t &checkSum) { checkSum += (uint32_t)indexToDividend(index) / (uint32_t)index; };
     auto optimizedTest = [] (uint16_t index, uint32_t &checkSum) { checkSum += udiv_32_16(indexToDividend(index), index); };
-    TEST_MESSAGE("udiv_32_16");
     auto comparison = compare_executiontime<uint16_t, uint32_t>(iters, start_index, end_index, step, nativeTest, optimizedTest);
     
     // The checksums will be different due to rounding. This is only
@@ -189,7 +188,6 @@ void test_maths_div100_s16_perf(void)
 
     auto nativeTest = [] (int16_t index, int32_t &checkSum) { checkSum += (int16_t)index / (int16_t)100; };
     auto optimizedTest = [] (int16_t index, int32_t &checkSum) { checkSum += div100(index); };
-    TEST_MESSAGE("div100_s16");
     auto comparison = compare_executiontime<int16_t, int32_t>(iters, start_index, end_index, step, nativeTest, optimizedTest);
     
     // The checksums will be different due to rounding. This is only
@@ -200,6 +198,26 @@ void test_maths_div100_s16_perf(void)
 #endif
 }
 
+void test_maths_div10_s16_perf(void)
+{
+  // Unit test to confirm using div100 to divide by 10 is quicker than straight division by 10.
+#if defined(ARDUINO_ARCH_AVR)
+  constexpr int16_t iters = 1;
+  constexpr int16_t start_index = -3213;
+  constexpr int16_t end_index = 3213;
+  constexpr int16_t step = 17;
+  
+  auto nativeTest = [] (int16_t index, int32_t &checkSum) { checkSum += (int16_t)index / (int16_t)10; };
+  auto optimizedTest = [] (int16_t index, int32_t &checkSum) { checkSum += div100((int16_t)(index * 10)); };
+  auto comparison = compare_executiontime<int16_t, int32_t>(iters, start_index, end_index, step, nativeTest, optimizedTest);
+  
+  // The checksums will be different due to rounding. This is only
+  // here to force the compiler to run the loops above
+  TEST_ASSERT_INT32_WITHIN(UINT32_MAX/2, comparison.timeA.result, comparison.timeB.result);
+
+  TEST_ASSERT_LESS_THAN(comparison.timeA.durationMicros, comparison.timeB.durationMicros);
+#endif
+}
 
 void test_maths_div100_s32_perf(void)
 {
@@ -211,7 +229,6 @@ void test_maths_div100_s32_perf(void)
 
     auto nativeTest = [] (int32_t index, int32_t &checkSum) { checkSum += (int32_t)index / (int32_t)100; };
     auto optimizedTest = [] (int32_t index, int32_t &checkSum) { checkSum += div100(index); };
-    TEST_MESSAGE("div100_s32");
     auto comparison = compare_executiontime<int32_t, int32_t>(iters, start_index, end_index, step, nativeTest, optimizedTest);
     
     // The checksums will be different due to rounding. This is only
@@ -234,6 +251,7 @@ void testDivision(void) {
   RUN_TEST(test_maths_udiv_32_16_perf);
   RUN_TEST(test_maths_div360);
   RUN_TEST(test_maths_div100_s16_perf);
+  RUN_TEST(test_maths_div10_s16_perf);
   RUN_TEST(test_maths_div100_s32_perf);
   }
 }

--- a/test/test_tables/tests_tables.cpp
+++ b/test/test_tables/tests_tables.cpp
@@ -1,18 +1,11 @@
-//#include <Arduino.h>
-#include <string.h> // memcpy
+// #include <string.h> // memcpy
 #include <unity.h>
 #include <stdio.h>
 #include "tests_tables.h"
 #include "table3d.h"
 #include "../test_utils.h"
 
-#define _countof(x) (sizeof(x) / sizeof (x[0]))
-
-#if defined(PROGMEM)
-const PROGMEM table3d_value_t values[] = {
-#else
-const table3d_value_t values[] = {
-#endif
+TEST_DATA_P table3d_value_t values[] = {
  //0    1    2   3     4    5    6    7    8    9   10   11   12   13    14   15
 34,  34,  34,  34,  34,  34,  34,  34,  34,  35,  35,  35,  35,  35,  35,  35, 
 34,  35,  36,  37,  39,  41,  42,  43,  43,  44,  44,  44,  44,  44,  44,  44, 
@@ -31,13 +24,12 @@ const table3d_value_t values[] = {
 104, 106, 107, 108, 109, 109, 110, 110, 110, 110, 110, 110, 110, 110, 110, 110, 
 109, 111, 112, 113, 114, 114, 114, 115, 115, 115, 114, 114, 114, 114, 114, 114, 
   };
-static const table3d_axis_t tempXAxis[] = {500, 700, 900, 1200, 1600, 2000, 2500, 3100, 3500, 4100, 4700, 5300, 5900, 6500, 6750, 7000};
-static const table3d_axis_t xMin = tempXAxis[0];
-static const table3d_axis_t xMax = tempXAxis[_countof(tempXAxis)-1];
-static const table3d_axis_t tempYAxis[] = { 16, 26, 30, 36, 40, 46, 50, 56, 60, 66, 70, 76, 86, 90, 96, 100};
-static const table3d_axis_t yMin = tempYAxis[0];
-static const table3d_axis_t yMax = tempYAxis[_countof(tempYAxis)-1];
-
+TEST_DATA_P table3d_axis_t tempXAxis[] = { 500, 700, 900, 1200, 1600, 2000, 2500, 3100, 3500, 4100, 4700, 5300, 5900, 6500, 6750, 7000};
+static constexpr table3d_axis_t xMin = tempXAxis[0];
+static constexpr table3d_axis_t xMax = tempXAxis[_countof(tempXAxis)-1];
+TEST_DATA_P table3d_axis_t tempYAxis[] = { 16, 26, 30, 36, 40, 46, 50, 56, 60, 66, 70, 76, 86, 90, 96, 100};
+static constexpr table3d_axis_t yMin = tempYAxis[0];
+static constexpr table3d_axis_t yMax = tempYAxis[_countof(tempYAxis)-1];
 
 static table3d16RpmLoad testTable;
 
@@ -65,51 +57,7 @@ void setup_TestTable(void)
       ----------------------------------------------------------------------------------------------------------------
          500 |  700 |  900 | 1200 | 1600 | 2000 | 2500 | 3100 | 3500 | 4100 | 4700 | 5300 | 5900 | 6500 | 6750 | 7000
   */
-
-  //
-  // NOTE: USE OF ITERATORS HERE IS DELIBERATE. IT INCLUDES THEM IN THE UNIT TESTS, giving
-  // them some coverage
-  //
-  {
-    table_axis_iterator itX = testTable.axisX.begin();
-    const table3d_axis_t *pXValue = tempXAxis;
-    while (!itX.at_end())
-    {
-      *itX = *pXValue;
-      ++pXValue;
-      ++itX;
-    }
-  }
-  {
-    table_axis_iterator itY = testTable.axisY.begin();
-    const table3d_axis_t *pYValue = tempYAxis;
-    while (!itY.at_end())
-    {
-      *itY = *pYValue;
-      ++pYValue;
-      ++itY;
-    }
-  }
-
-  {
-    table_value_iterator itZ = testTable.values.begin();
-    const table3d_value_t *pZValue = values;
-    while (!itZ.at_end())
-    {
-      table_row_iterator itRow = *itZ;
-      while (!itRow.at_end())
-      {
-#if defined(PROGMEM)
-        *itRow = pgm_read_byte(pZValue);
-#else
-        *itRow = *pZValue;
-#endif
-        ++pZValue;
-        ++itRow;
-      }
-      ++itZ;
-    }
-  }
+  populate_table_P(testTable, tempXAxis, tempYAxis, values);
 }
 
 void testTables()

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <unity.h>
 #include <Arduino.h>
+#include "table2d.h"
 
 // Unity macro to reduce memory usage (RAM, .bss)
 //
@@ -105,4 +106,12 @@ static inline void populate_table_P(table3d_t &table,
       ++itZ;
     }
   }
+}
+
+static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin) {
+  for (uint8_t index=0; index<pTable->xSize; ++index) {
+    ((uint8_t*)pTable->values)[index] = value;
+    ((uint8_t*)pTable->axisX)[index] = bin;
+  }
+  pTable->cacheTime = UINT8_MAX;
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -8,6 +8,16 @@
 #include "table2d.h"
 #include "table3d.h"
 
+template<size_t MAX_LEN, size_t N>
+constexpr void STR_LEN_CHECK(char const (&)[N]) 
+{
+    static_assert(N < MAX_LEN, "String overflow!");
+}
+
+#if !defined(_countof)
+#define _countof(x) (sizeof(x) / sizeof (x[0]))
+#endif
+
 // Unity macro to reduce memory usage (RAM, .bss)
 //
 // Unity supplied RUN_TEST captures the function name
@@ -20,6 +30,8 @@
 #define RUN_TEST_P(func) \
   { \
     char funcName[128]; \
+    constexpr size_t bufferLen = _countof(funcName); \
+    STR_LEN_CHECK<bufferLen>(#func); \
     strcpy_P(funcName, PSTR(#func)); \
     UnityDefaultTestRun(func, funcName, __LINE__); \
   }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -4,7 +4,9 @@
 #include <stdint.h>
 #include <unity.h>
 #include <Arduino.h>
+#include <unity.h>
 #include "table2d.h"
+#include "table3d.h"
 
 // Unity macro to reduce memory usage (RAM, .bss)
 //
@@ -45,7 +47,6 @@ for ( UNITY_FILENAME_RESTORE, _ufname_done = ufname_set(__FILE__);              
     _ufname_done; _ufname_done = 0 )
 
 // ============================ end SET_UNITY_FILENAME ============================ 
-
 
 // Store test data in flash, if feasible.
 #if defined(PROGMEM)
@@ -108,10 +109,32 @@ static inline void populate_table_P(table3d_t &table,
   }
 }
 
+
+// Populate a 2d table with constant values
 static inline void populate_2dtable(table2D *pTable, uint8_t value, uint8_t bin) {
   for (uint8_t index=0; index<pTable->xSize; ++index) {
     ((uint8_t*)pTable->values)[index] = value;
     ((uint8_t*)pTable->axisX)[index] = bin;
   }
   pTable->cacheTime = UINT8_MAX;
+}
+
+template <typename TValue, typename TBin>
+static inline void populate_2dtable(table2D *pTable, const TValue values[], const TBin bins[]) {
+  memcpy(pTable->axisX, bins, pTable->xSize * sizeof(TBin));
+  memcpy(pTable->values, values, pTable->xSize * sizeof(TValue));
+  pTable->cacheTime = UINT8_MAX;
+}
+
+// Populate a 2d table (from PROGMEM if available)
+// You would typically declare the 2 source arrays using TEST_DATA_P
+template <typename TValue, typename TBin>
+static inline void populate_2dtable_P(table2D *pTable, const TValue values[], const TBin bins[]) {
+#if defined(PROGMEM)
+  memcpy_P(pTable->axisX, bins, pTable->xSize * sizeof(TBin));
+  memcpy_P(pTable->values, values, pTable->xSize * sizeof(TValue));
+  pTable->cacheTime = UINT8_MAX;
+#else
+  populate_2dtable(pTable, values, bins)
+#endif
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <unity.h>
+#include <Arduino.h>
 
 // Unity macro to reduce memory usage (RAM, .bss)
 //
@@ -20,16 +21,20 @@
     UnityDefaultTestRun(func, funcName, __LINE__); \
   }
 
-static __inline__ uint8_t ufname_set(const char *newFName)
+// ============================ SET_UNITY_FILENAME ============================ 
+
+static inline uint8_t ufname_set(const char *newFName)
 {
     Unity.TestFile = newFName;
     return 1;
 }
-static __inline__ void ufname_szrestore(char** __s)
+
+static inline void ufname_szrestore(char** __s)
 {
     Unity.TestFile = *__s;
     __asm__ volatile ("" ::: "memory");
 }
+
 
 #define UNITY_FILENAME_RESTORE char* _ufname_saved                           \
     __attribute__((__cleanup__(ufname_szrestore))) = (char*)Unity.TestFile
@@ -37,3 +42,67 @@ static __inline__ void ufname_szrestore(char** __s)
 #define SET_UNITY_FILENAME()                                                        \
 for ( UNITY_FILENAME_RESTORE, _ufname_done = ufname_set(__FILE__);                  \
     _ufname_done; _ufname_done = 0 )
+
+// ============================ end SET_UNITY_FILENAME ============================ 
+
+
+// Store test data in flash, if feasible.
+#if defined(PROGMEM)
+#define TEST_DATA_P static constexpr PROGMEM
+#else
+#define TEST_DATA_P static constexpr
+#endif
+
+// Populate a 3d table (from PROGMEM if available)
+// You wuld typically declare the 3 source arrays usin TEST_DATA_P
+template <typename table3d_t>
+static inline void populate_table_P(table3d_t &table, 
+                                  const table3d_axis_t *pXValues,   // PROGMEM if available
+                                  const table3d_axis_t *pYValues,   // PROGMEM if available
+                                  const table3d_value_t *pZValues)  // PROGMEM if available
+{
+  {
+    table_axis_iterator itX = table.axisX.begin();
+    while (!itX.at_end())
+    {
+#if defined(PROGMEM)
+      *itX = (table3d_axis_t)pgm_read_word(pXValues);
+#else
+      *itX = *pXValues;
+#endif      
+      ++pXValues;
+      ++itX;
+    }
+  }  
+  {
+    table_axis_iterator itY = table.axisY.begin();
+    while (!itY.at_end())
+    {
+#if defined(PROGMEM)
+      *itY = (table3d_axis_t)pgm_read_word(pYValues);
+#else
+      *itY = *pYValues;
+#endif      
+      ++pYValues;
+      ++itY;
+    }
+  }
+  {
+    table_value_iterator itZ = table.values.begin();
+    while (!itZ.at_end())
+    {
+      table_row_iterator itRow = *itZ;
+      while (!itRow.at_end())
+      {
+#if defined(PROGMEM)
+        *itRow = pgm_read_byte(pZValues);
+#else
+        *itRow = *pZValues;
+#endif
+        ++pZValues;
+        ++itRow;
+      }
+      ++itZ;
+    }
+  }
+}


### PR DESCRIPTION
Add unit tests for all ignition and fuel corrections (110+ unit tests).

Only changes to firmware code are to support unit test-ability:

1. Separated out calculation of `currentStatus.afrTarget` from `correctionAFRClosedLoop`. It was impossible to unit test `correctionAFRClosedLoop` when it was self-modifying the test conditions.
2. `initialiseCorrections` resets the EGO PID object, to allow multiple EGO PID tests (and for test repeatability).
3. (minor) Separated 2D table initialization from `initialiseAll` - reduces test binary size by 66%.

In addition to new unit tests, the PR reworks the existing DFCO tests so they [test behavior, not implementation](https://testing.googleblog.com/2013/08/testing-on-toilet-test-behavior-not.html).