### PR TITLE
modified poll level mode

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1288,7 +1288,9 @@ page = 10
 
       oilPressureProtTime   = scalar, U08,    190, "seconds", 0.1, 0.0, 0.0, 25, 1
 
-      unused11_190_191      = array,  U08,    191,  [1], "RPM",  100.0,      0.0,  100,     25500,    0
+      PollLevelTeeth  = scalar,  U08,      191,  "",        1,      0,   1,      255,    1
+
+      ;unused11_190_191      = array,  U08,    191,  [1], "RPM",  100.0,      0.0,  100,     25500,    0
 
 ;Page 11 is the fuel map and axis bins only
 page = 11
@@ -2060,7 +2062,8 @@ menuDialog = main
   TrigPattern       = "The type of input trigger decoder to be used."
   useResync         = "If enabled, sync will be rechecked once every full cycle from the cam input. This is good for accuracy, however if your cam input is noisy then this can cause issues."
   trigPatternSec    = "Cam mode/type also known as Secondary Trigger Pattern."
-  PollLevelPol      = "The level of the cam trigger input will be checked at tooth #1 and this defines if the level is supposed to be High or Low at 1st phase of the engine."
+  PollLevelPol      = "The level of the cam trigger input will be checked at tooth # and this defines if the level is supposed to be High or Low at 1st phase of the engine."
+  PollLevelTeeth    = "The crank teeth at witch the level of the cam trigger will be checked"
   numTeeth          = "Number of teeth on Primary Wheel."
   TrigSpeed         = "Primary trigger speed."
   missingTeeth      = "Number of Missing teeth on Primary Wheel."
@@ -2942,7 +2945,8 @@ menuDialog = main
         field = "cranking before the injectors and coils are fired"
         field = "Trigger edge",                   TrigEdge      { TrigPattern != 4 && TrigPattern != 22 } ;4G63 uses both edges ;NGC uses both edges
         field = "Secondary trigger edge",         TrigEdgeSec,  { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec != 2) || TrigPattern == 2 || TrigPattern == 9 || TrigPattern == 12 || TrigPattern == 18 || TrigPattern == 19 || TrigPattern == 20 || TrigPattern == 21 || TrigPattern == 24 || TrigPattern == 25 } ;Missing tooth, dual wheel and Miata 9905, weber-marelli, ST170, DRZ400 Renix, Rover MEMS, K6A
-        field = "Level for 1st phase",             PollLevelPol,   { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec == 2) }
+        field = "Level for 1st phase",            PollLevelPol,   { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec == 2) }
+        field = "Check at tooth #",               PollLevelTeeth, { (TrigPattern == 0 && TrigSpeed == 0 && trigPatternSec == 2) }
         field = "Missing Tooth Secondary type",   trigPatternSec,   { (TrigPattern == 0&& TrigSpeed == 0) || TrigPattern == 25 }
         field = "Trigger Filter",                 TrigFilter,   { TrigPattern != 13 }
         field = "Re-sync every cycle",            useResync,    { TrigPattern == 2 || TrigPattern == 4 || TrigPattern == 7 || TrigPattern == 12 || TrigPattern == 9 || TrigPattern == 13 || TrigPattern == 18 || TrigPattern == 19  || TrigPattern == 21 } ;Dual wheel, 4G63, Audi 135, Nissan 360, Miata 99-05, weber-marelli. DRZ400

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -500,6 +500,15 @@ void triggerPri_missingTooth(void)
       {
         bool isMissingTooth = false;
 
+        if(( (currentStatus.hasSync == false) || (currentStatus.RPM < 2000)))
+        {
+          if ((configPage4.trigPatternSec == SEC_TRIGGER_POLL) && (configPage10.PollLevelTeeth > 1) && (toothCurrentCount == configPage10.PollLevelTeeth)) // at selected tooth check if the cam sensor is high or low in poll level mode
+          {          
+            if (configPage4.PollLevelPolarity == READ_SEC_TRIGGER()) { revolutionOne = 1; }
+            else { revolutionOne = 0; }
+          }
+        }
+
         /*
         Performance Optimisation:
         Only need to try and detect the missing tooth if:
@@ -539,7 +548,7 @@ void triggerPri_missingTooth(void)
                 else { currentStatus.startRevolutions = 0; }
                 
                 toothCurrentCount = 1;
-                if (configPage4.trigPatternSec == SEC_TRIGGER_POLL) // at tooth one check if the cam sensor is high or low in poll level mode
+                if ((configPage4.trigPatternSec == SEC_TRIGGER_POLL) && (configPage10.PollLevelTeeth == 1)) // at tooth one check if the cam sensor is high or low in poll level mode
                 {
                   if (configPage4.PollLevelPolarity == READ_SEC_TRIGGER()) { revolutionOne = 1; }
                   else { revolutionOne = 0; }

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1331,7 +1331,9 @@ struct config10 {
 
   byte oilPressureProtTime;
 
-  byte unused11_191_191;
+  int8_t PollLevelTeeth;
+
+  //byte unused11_191_191;
 
 #if defined(CORE_AVR)
   };


### PR DESCRIPTION
Added the option to poll at any teeth of the trigger wheel. This way you can use the stock cas in conjunction with a missing tooth trigger wheel to operate in sequential mode.  I know the config page 10 is not the best for the trigger settings but the page 4 is full. Please chime in to make the code better I am not a programmer, I just wanted to use my stock cas. 