### PR TITLE
Unit Tests: provide correct filename in test messages

### DIFF
--- a/test/test_decoders/FordST170/ForsdST170.cpp
+++ b/test/test_decoders/FordST170/ForsdST170.cpp
@@ -4,6 +4,7 @@
 #include "FordST170.h"
 #include "scheduler.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 extern uint16_t ignition1EndTooth;
 extern uint16_t ignition2EndTooth;
@@ -159,7 +160,7 @@ void test_fordst170_newIgn_12_trigNeg360_1()
 
 void testFordST170()
 {
-    Unity.TestFile = __FILE__;
+    SET_UNITY_FILENAME() {
 
     RUN_TEST(test_fordst170_newIgn_12_trig0_1);
     RUN_TEST(test_fordst170_newIgn_12_trig90_1);
@@ -170,4 +171,6 @@ void testFordST170()
     RUN_TEST(test_fordst170_newIgn_12_trigNeg180_1);
     RUN_TEST(test_fordst170_newIgn_12_trigNeg270_1);
     RUN_TEST(test_fordst170_newIgn_12_trigNeg360_1);
+    
+    }
 }

--- a/test/test_decoders/FordST170/ForsdST170.cpp
+++ b/test/test_decoders/FordST170/ForsdST170.cpp
@@ -159,6 +159,8 @@ void test_fordst170_newIgn_12_trigNeg360_1()
 
 void testFordST170()
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_fordst170_newIgn_12_trig0_1);
     RUN_TEST(test_fordst170_newIgn_12_trig90_1);
     RUN_TEST(test_fordst170_newIgn_12_trig180_1);

--- a/test/test_decoders/NGC/test_ngc.cpp
+++ b/test/test_decoders/NGC/test_ngc.cpp
@@ -4,6 +4,7 @@
 #include "test_ngc.h"
 #include "scheduler.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 extern uint16_t ignition1EndTooth;
 extern uint16_t ignition2EndTooth;
@@ -133,7 +134,7 @@ void test_ngc_newIgn_12_trigNeg360_1()
 
 void testNGC()
 {
-    Unity.TestFile = __FILE__;
+   SET_UNITY_FILENAME() {
 
     RUN_TEST(test_ngc_newIgn_12_trig0_1);
     RUN_TEST(test_ngc_newIgn_12_trig90_1);
@@ -144,4 +145,5 @@ void testNGC()
     RUN_TEST(test_ngc_newIgn_12_trigNeg180_1);
     RUN_TEST(test_ngc_newIgn_12_trigNeg270_1);
     RUN_TEST(test_ngc_newIgn_12_trigNeg360_1);
+   }
 }

--- a/test/test_decoders/NGC/test_ngc.cpp
+++ b/test/test_decoders/NGC/test_ngc.cpp
@@ -133,6 +133,8 @@ void test_ngc_newIgn_12_trigNeg360_1()
 
 void testNGC()
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_ngc_newIgn_12_trig0_1);
     RUN_TEST(test_ngc_newIgn_12_trig90_1);
     RUN_TEST(test_ngc_newIgn_12_trig180_1);

--- a/test/test_decoders/Nissan360/Nissan360.cpp
+++ b/test/test_decoders/Nissan360/Nissan360.cpp
@@ -157,6 +157,8 @@ void test_nissan360_newIgn_12_trigNeg360_1()
 
 void testNissan360()
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_nissan360_newIgn_12_trig0_1);
     RUN_TEST(test_nissan360_newIgn_12_trig90_1);
     RUN_TEST(test_nissan360_newIgn_12_trig180_1);

--- a/test/test_decoders/Nissan360/Nissan360.cpp
+++ b/test/test_decoders/Nissan360/Nissan360.cpp
@@ -4,6 +4,7 @@
 #include "Nissan360.h"
 #include "scheduler.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 extern uint16_t ignition1EndTooth;
 extern uint16_t ignition2EndTooth;
@@ -157,7 +158,8 @@ void test_nissan360_newIgn_12_trigNeg360_1()
 
 void testNissan360()
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
+
 
     RUN_TEST(test_nissan360_newIgn_12_trig0_1);
     RUN_TEST(test_nissan360_newIgn_12_trig90_1);
@@ -168,4 +170,5 @@ void testNissan360()
     RUN_TEST(test_nissan360_newIgn_12_trigNeg180_1);
     RUN_TEST(test_nissan360_newIgn_12_trigNeg270_1);
     RUN_TEST(test_nissan360_newIgn_12_trigNeg360_1);
+  }
 }

--- a/test/test_decoders/dual_wheel/dual_wheel.cpp
+++ b/test/test_decoders/dual_wheel/dual_wheel.cpp
@@ -3,6 +3,7 @@
 #include <unity.h>
 #include "dual_wheel.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 
 void test_setup_dualwheel_12_1()
@@ -324,7 +325,7 @@ void test_dualwheel_newIgn_4()
 
 void testDualWheel()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_dualwheel_newIgn_12_1_trig0_1);
   RUN_TEST(test_dualwheel_newIgn_12_1_trig90_1);
@@ -349,4 +350,6 @@ void testDualWheel()
 */
   //RUN_TEST(test_dualwheel_newIgn_60_2_trig181_2);
   //RUN_TEST(test_dualwheel_newIgn_60_2_trig182_2);
+
+  }
 }

--- a/test/test_decoders/dual_wheel/dual_wheel.cpp
+++ b/test/test_decoders/dual_wheel/dual_wheel.cpp
@@ -324,6 +324,8 @@ void test_dualwheel_newIgn_4()
 
 void testDualWheel()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_dualwheel_newIgn_12_1_trig0_1);
   RUN_TEST(test_dualwheel_newIgn_12_1_trig90_1);
   RUN_TEST(test_dualwheel_newIgn_12_1_trig180_1);

--- a/test/test_decoders/missing_tooth/missing_tooth.cpp
+++ b/test/test_decoders/missing_tooth/missing_tooth.cpp
@@ -344,6 +344,8 @@ void test_missingtooth_newIgn_4()
 
 void testMissingTooth()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_missingtooth_newIgn_36_1_trig0_1);
   RUN_TEST(test_missingtooth_newIgn_36_1_trig90_1);
   RUN_TEST(test_missingtooth_newIgn_36_1_trig180_1);

--- a/test/test_decoders/missing_tooth/missing_tooth.cpp
+++ b/test/test_decoders/missing_tooth/missing_tooth.cpp
@@ -3,6 +3,7 @@
 #include <unity.h>
 #include "missing_tooth.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 void test_setup_36_1()
 {
@@ -344,7 +345,7 @@ void test_missingtooth_newIgn_4()
 
 void testMissingTooth()
 {
-  Unity.TestFile = __FILE__;
+   SET_UNITY_FILENAME() {
 
   RUN_TEST(test_missingtooth_newIgn_36_1_trig0_1);
   RUN_TEST(test_missingtooth_newIgn_36_1_trig90_1);
@@ -368,4 +369,5 @@ void testMissingTooth()
 
   //RUN_TEST(test_missingtooth_newIgn_60_2_trig181_2);
   //RUN_TEST(test_missingtooth_newIgn_60_2_trig182_2);
+   }
 }

--- a/test/test_decoders/renix/renix.cpp
+++ b/test/test_decoders/renix/renix.cpp
@@ -3,6 +3,7 @@
 #include <unity.h>
 #include "renix.h"
 #include "schedule_calcs.h"
+#include "../../test_utils.h"
 
 void test_setup_renix44()
 {
@@ -310,7 +311,7 @@ void test_Renix_newIgn_66_trig181_2()
 
 void testRenix()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_Renix_newIgn_44_trig0_1);
   RUN_TEST(test_Renix_newIgn_44_trig90_1);
@@ -334,5 +335,5 @@ void testRenix()
 
   RUN_TEST(test_Renix_newIgn_66_trig0_2);
   RUN_TEST(test_Renix_newIgn_66_trig181_2);
-           
+  }           
 }

--- a/test/test_decoders/renix/renix.cpp
+++ b/test/test_decoders/renix/renix.cpp
@@ -310,6 +310,8 @@ void test_Renix_newIgn_66_trig181_2()
 
 void testRenix()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_Renix_newIgn_44_trig0_1);
   RUN_TEST(test_Renix_newIgn_44_trig90_1);
   RUN_TEST(test_Renix_newIgn_44_trig180_1);

--- a/test/test_fuel/test_PW.cpp
+++ b/test/test_fuel/test_PW.cpp
@@ -7,6 +7,8 @@
 
 void testPW(void)
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_PW_No_Multiply);
   RUN_TEST(test_PW_MAP_Multiply);
   RUN_TEST(test_PW_MAP_Multiply_Compatibility);

--- a/test/test_fuel/test_PW.cpp
+++ b/test/test_fuel/test_PW.cpp
@@ -2,12 +2,13 @@
 #include <speeduino.h>
 #include <unity.h>
 #include "test_PW.h"
+#include "../test_utils.h"
 
 #define PW_ALLOWED_ERROR  30
 
 void testPW(void)
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_PW_No_Multiply);
   RUN_TEST(test_PW_MAP_Multiply);
@@ -18,6 +19,7 @@ void testPW(void)
   RUN_TEST(test_PW_4Cyl_PW0);
   RUN_TEST(test_PW_Limit_Long_Revolution);
   RUN_TEST(test_PW_Limit_90pct);
+  }
 }
 
 int16_t REQ_FUEL;

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -6,6 +6,8 @@
 
 void testCorrections()
 {
+  Unity.TestFile = __FILE__;
+
   test_corrections_WUE();
   test_corrections_dfco();
   test_corrections_TAE(); //TPS based accel enrichment corrections

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -2,11 +2,12 @@
 #include <corrections.h>
 #include <unity.h>
 #include "test_corrections.h"
+#include "../test_utils.h"
 
 
 void testCorrections()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   test_corrections_WUE();
   test_corrections_dfco();
@@ -23,6 +24,7 @@ void testCorrections()
   RUN_TEST(test_corrections_launch); //Not written yet
   RUN_TEST(test_corrections_dfco); //Not written yet
   */
+  }
 }
 
 void test_corrections_WUE_active(void)

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -5,6 +5,8 @@
 
 void testStaging(void)
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_Staging_Off);
   RUN_TEST(test_Staging_4cyl_Auto_Inactive);
   RUN_TEST(test_Staging_4cyl_Table_Inactive);

--- a/test/test_fuel/test_staging.cpp
+++ b/test/test_fuel/test_staging.cpp
@@ -2,10 +2,11 @@
 #include <speeduino.h>
 #include <unity.h>
 #include "test_staging.h"
+#include "../test_utils.h"
 
 void testStaging(void)
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_Staging_Off);
   RUN_TEST(test_Staging_4cyl_Auto_Inactive);
@@ -13,6 +14,7 @@ void testStaging(void)
   RUN_TEST(test_Staging_4cyl_Auto_50pct);
   RUN_TEST(test_Staging_4cyl_Auto_33pct);
   RUN_TEST(test_Staging_4cyl_Table_50pct);
+  }
 }
 
 void test_Staging_setCommon()

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -982,7 +982,7 @@ static void test_partial_sync(void)
 
 void testFuelScheduleInit()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   run_1_cylinder_4stroke_tests();
   run_1_cylinder_2stroke_tests();
@@ -1001,4 +1001,5 @@ void testFuelScheduleInit()
   run_oddfire_tests();
 
   RUN_TEST_P(test_partial_sync);
+  }
 }

--- a/test/test_init/test_fuel_schedule_init.cpp
+++ b/test/test_init/test_fuel_schedule_init.cpp
@@ -982,6 +982,8 @@ static void test_partial_sync(void)
 
 void testFuelScheduleInit()
 {
+  Unity.TestFile = __FILE__;
+
   run_1_cylinder_4stroke_tests();
   run_1_cylinder_2stroke_tests();
   run_2_cylinder_4stroke_tests();

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -336,7 +336,7 @@ static void test_partial_sync(void)
 
 void testIgnitionScheduleInit()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   run_1_cylinder_4stroke_tests();
   run_2_cylinder_4stroke_tests();
@@ -347,4 +347,5 @@ void testIgnitionScheduleInit()
   run_8_cylinder_4stroke_tests();
 
   RUN_TEST_P(test_partial_sync);
+  }
 }

--- a/test/test_init/test_ignition_schedule_init.cpp
+++ b/test/test_init/test_ignition_schedule_init.cpp
@@ -336,6 +336,8 @@ static void test_partial_sync(void)
 
 void testIgnitionScheduleInit()
 {
+  Unity.TestFile = __FILE__;
+
   run_1_cylinder_4stroke_tests();
   run_2_cylinder_4stroke_tests();
   run_3_cylinder_4stroke_tests();

--- a/test/test_init/tests_init.cpp
+++ b/test/test_init/tests_init.cpp
@@ -304,7 +304,7 @@ void test_initialisation_input_user_pin_does_not_override_outputpin(void)
 
 void testInitialisation()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST_P(test_initialisation_complete);
   RUN_TEST_P(test_initialisation_ports);
@@ -318,4 +318,5 @@ void testInitialisation()
   RUN_TEST_P(test_initialisation_outputs_reset_control_override_board_default);
   RUN_TEST_P(test_initialisation_user_pin_override_board_default);
   RUN_TEST_P(test_initialisation_input_user_pin_does_not_override_outputpin);
+  }
 }

--- a/test/test_init/tests_init.cpp
+++ b/test/test_init/tests_init.cpp
@@ -304,6 +304,8 @@ void test_initialisation_input_user_pin_does_not_override_outputpin(void)
 
 void testInitialisation()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST_P(test_initialisation_complete);
   RUN_TEST_P(test_initialisation_ports);
   RUN_TEST_P(test_initialisation_outputs_V03);

--- a/test/test_math/test_division.cpp
+++ b/test/test_math/test_division.cpp
@@ -222,6 +222,8 @@ void test_maths_div100_s32_perf(void)
 }
 
 void testDivision(void) {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_maths_div100_U16);
   RUN_TEST(test_maths_div100_U32);
   RUN_TEST(test_maths_div100_S16);

--- a/test/test_math/test_division.cpp
+++ b/test/test_math/test_division.cpp
@@ -3,6 +3,7 @@
 #include "maths.h"
 #include "crankMaths.h"
 #include "../timer.hpp"
+#include "../test_utils.h"
 
 
 template <typename T>
@@ -222,7 +223,7 @@ void test_maths_div100_s32_perf(void)
 }
 
 void testDivision(void) {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_maths_div100_U16);
   RUN_TEST(test_maths_div100_U32);
@@ -234,4 +235,5 @@ void testDivision(void) {
   RUN_TEST(test_maths_div360);
   RUN_TEST(test_maths_div100_s16_perf);
   RUN_TEST(test_maths_div100_s32_perf);
+  }
 }

--- a/test/test_math/tests_percent.cpp
+++ b/test/test_math/tests_percent.cpp
@@ -2,6 +2,7 @@
 #include "test_fp_support.h"
 #include "maths.h"
 #include "../timer.hpp"
+#include "../test_utils.h"
 
 static void test_percent(uint8_t percent, uint16_t value) {
   assert_rounded_div((uint32_t)percent*value, 100, percentage(percent, value));
@@ -107,7 +108,7 @@ void test_maths_percentage_perf(void)
 
 void testPercent()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_maths_percent_U8);
   RUN_TEST(test_maths_percent_U16);
@@ -115,4 +116,5 @@ void testPercent()
   RUN_TEST(test_maths_halfpercent_U16);
   RUN_TEST(test_maths_halfPercentage_perf);
   RUN_TEST(test_maths_percentage_perf);
+  }
 }

--- a/test/test_math/tests_percent.cpp
+++ b/test/test_math/tests_percent.cpp
@@ -107,6 +107,8 @@ void test_maths_percentage_perf(void)
 
 void testPercent()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_maths_percent_U8);
   RUN_TEST(test_maths_percent_U16);
   RUN_TEST(test_maths_halfpercent_U8);

--- a/test/test_schedule_calcs/test_adjust_crank_angle.cpp
+++ b/test/test_schedule_calcs/test_adjust_crank_angle.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <unity.h>
 #include "schedule_calcs.h"
+#include "../test_utils.h"
 
 static void nullIgnCallback(void) {};
 
@@ -75,9 +76,10 @@ void test_adjust_crank_angle_running()
 
 void test_adjust_crank_angle()
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_adjust_crank_angle_pending_below_minrevolutions);
     RUN_TEST(test_adjust_crank_angle_pending_above_minrevolutions);
     RUN_TEST(test_adjust_crank_angle_running);
+  }
 }

--- a/test/test_schedule_calcs/test_adjust_crank_angle.cpp
+++ b/test/test_schedule_calcs/test_adjust_crank_angle.cpp
@@ -75,6 +75,8 @@ void test_adjust_crank_angle_running()
 
 void test_adjust_crank_angle()
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_adjust_crank_angle_pending_below_minrevolutions);
     RUN_TEST(test_adjust_crank_angle_pending_above_minrevolutions);
     RUN_TEST(test_adjust_crank_angle_running);

--- a/test/test_schedule_calcs/test_ign_calcs.cpp
+++ b/test/test_schedule_calcs/test_ign_calcs.cpp
@@ -4,6 +4,7 @@
 #include "schedule_calcs.h"
 #include "crankMaths.h"
 #include "decoders.h"
+#include "../test_utils.h"
 
 #define _countof(x) (sizeof(x) / sizeof (x[0]))
 
@@ -612,9 +613,10 @@ void test_rotary_channel_calcs(void)
 
 void test_calc_ign_timeout(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_calc_ign_timeout_360);
     RUN_TEST(test_calc_ign_timeout_720);
     RUN_TEST(test_rotary_channel_calcs);
+  }
 }

--- a/test/test_schedule_calcs/test_ign_calcs.cpp
+++ b/test/test_schedule_calcs/test_ign_calcs.cpp
@@ -612,6 +612,8 @@ void test_rotary_channel_calcs(void)
 
 void test_calc_ign_timeout(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_calc_ign_timeout_360);
     RUN_TEST(test_calc_ign_timeout_720);
     RUN_TEST(test_rotary_channel_calcs);

--- a/test/test_schedule_calcs/test_inj_calcs.cpp
+++ b/test/test_schedule_calcs/test_inj_calcs.cpp
@@ -279,6 +279,8 @@ static void test_calc_inj_timeout_720()
 // 
 void test_calc_inj_timeout(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_calc_inj_timeout_360);
     RUN_TEST(test_calc_inj_timeout_720);
 }

--- a/test/test_schedule_calcs/test_inj_calcs.cpp
+++ b/test/test_schedule_calcs/test_inj_calcs.cpp
@@ -3,6 +3,7 @@
 #include "test_calcs_common.h"
 #include "schedule_calcs.h"
 #include "crankMaths.h"
+#include "../test_utils.h"
 
 #define _countof(x) (sizeof(x) / sizeof (x[0]))
 
@@ -279,8 +280,9 @@ static void test_calc_inj_timeout_720()
 // 
 void test_calc_inj_timeout(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_calc_inj_timeout_360);
     RUN_TEST(test_calc_inj_timeout_720);
+  }
 }

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 #define TIMEOUT 1000
@@ -130,7 +130,7 @@ void test_accuracy_duration_ign8(void)
 
 void test_accuracy_duration(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_accuracy_duration_inj1);
     RUN_TEST(test_accuracy_duration_inj2);
@@ -165,4 +165,5 @@ void test_accuracy_duration(void)
 #if INJ_CHANNELS >= 8
     RUN_TEST(test_accuracy_duration_ign8);
 #endif
+  }
 }

--- a/test/test_schedules/test_accuracy_duration.cpp
+++ b/test/test_schedules/test_accuracy_duration.cpp
@@ -130,6 +130,8 @@ void test_accuracy_duration_ign8(void)
 
 void test_accuracy_duration(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_accuracy_duration_inj1);
     RUN_TEST(test_accuracy_duration_inj2);
     RUN_TEST(test_accuracy_duration_inj3);

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -133,6 +133,8 @@ void test_accuracy_timeout_ign8(void)
 
 void test_accuracy_timeout(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_accuracy_timeout_inj1);
     RUN_TEST(test_accuracy_timeout_inj2);
     RUN_TEST(test_accuracy_timeout_inj3);

--- a/test/test_schedules/test_accuracy_timeout.cpp
+++ b/test/test_schedules/test_accuracy_timeout.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 #include "scheduledIO.h"
 
@@ -133,7 +133,7 @@ void test_accuracy_timeout_ign8(void)
 
 void test_accuracy_timeout(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_accuracy_timeout_inj1);
     RUN_TEST(test_accuracy_timeout_inj2);
@@ -168,4 +168,5 @@ void test_accuracy_timeout(void)
 #if IGN_CHANNELS >= 8
     RUN_TEST(test_accuracy_timeout_ign8);
 #endif
+  }
 }

--- a/test/test_schedules/test_status_initial_off.cpp
+++ b/test/test_schedules/test_status_initial_off.cpp
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 void test_status_initial_off_inj1(void)
@@ -118,7 +118,7 @@ void test_status_initial_off_ign8(void)
 
 void test_status_initial_off(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_status_initial_off_inj1);
     RUN_TEST(test_status_initial_off_inj2);
@@ -153,4 +153,5 @@ void test_status_initial_off(void)
 #if IGN_CHANNELS >= 8
     RUN_TEST(test_status_initial_off_ign8);
 #endif
+  }
 }

--- a/test/test_schedules/test_status_initial_off.cpp
+++ b/test/test_schedules/test_status_initial_off.cpp
@@ -118,6 +118,8 @@ void test_status_initial_off_ign8(void)
 
 void test_status_initial_off(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_status_initial_off_inj1);
     RUN_TEST(test_status_initial_off_inj2);
     RUN_TEST(test_status_initial_off_inj3);

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 #define TIMEOUT 1000
@@ -156,7 +156,7 @@ void test_status_off_to_pending_ign8(void)
 
 void test_status_off_to_pending(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_status_off_to_pending_inj1);
     RUN_TEST(test_status_off_to_pending_inj2);
@@ -191,4 +191,5 @@ void test_status_off_to_pending(void)
 #if IGN_CHANNELS >= 8
     RUN_TEST(test_status_off_to_pending_ign8);
 #endif
+  }
 }

--- a/test/test_schedules/test_status_off_to_pending.cpp
+++ b/test/test_schedules/test_status_off_to_pending.cpp
@@ -156,6 +156,8 @@ void test_status_off_to_pending_ign8(void)
 
 void test_status_off_to_pending(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_status_off_to_pending_inj1);
     RUN_TEST(test_status_off_to_pending_inj2);
     RUN_TEST(test_status_off_to_pending_inj3);

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 #define TIMEOUT 1000
@@ -172,7 +172,7 @@ void test_status_pending_to_running_ign8(void)
 
 void test_status_pending_to_running(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_status_pending_to_running_inj1);
     RUN_TEST(test_status_pending_to_running_inj2);
@@ -191,4 +191,5 @@ void test_status_pending_to_running(void)
     RUN_TEST(test_status_pending_to_running_ign6);
     RUN_TEST(test_status_pending_to_running_ign7);
     RUN_TEST(test_status_pending_to_running_ign8);
+  }
 }

--- a/test/test_schedules/test_status_pending_to_running.cpp
+++ b/test/test_schedules/test_status_pending_to_running.cpp
@@ -172,6 +172,8 @@ void test_status_pending_to_running_ign8(void)
 
 void test_status_pending_to_running(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_status_pending_to_running_inj1);
     RUN_TEST(test_status_pending_to_running_inj2);
     RUN_TEST(test_status_pending_to_running_inj3);

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 #define TIMEOUT 1000
@@ -172,7 +172,7 @@ void test_status_running_to_off_ign8(void)
 
 void test_status_running_to_off(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_status_running_to_off_inj1);
     RUN_TEST(test_status_running_to_off_inj2);
@@ -191,4 +191,5 @@ void test_status_running_to_off(void)
     RUN_TEST(test_status_running_to_off_ign6);
     RUN_TEST(test_status_running_to_off_ign7);
     RUN_TEST(test_status_running_to_off_ign8);
+  }
 }

--- a/test/test_schedules/test_status_running_to_off.cpp
+++ b/test/test_schedules/test_status_running_to_off.cpp
@@ -172,6 +172,8 @@ void test_status_running_to_off_ign8(void)
 
 void test_status_running_to_off(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_status_running_to_off_inj1);
     RUN_TEST(test_status_running_to_off_inj2);
     RUN_TEST(test_status_running_to_off_inj3);

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -204,6 +204,8 @@ void test_status_running_to_pending_ign8(void)
 
 void test_status_running_to_pending(void)
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_status_running_to_pending_inj1);
     RUN_TEST(test_status_running_to_pending_inj2);
     RUN_TEST(test_status_running_to_pending_inj3);

--- a/test/test_schedules/test_status_running_to_pending.cpp
+++ b/test/test_schedules/test_status_running_to_pending.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 #include <unity.h>
-
+#include "../test_utils.h"
 #include "scheduler.h"
 
 #define TIMEOUT 1000
@@ -204,7 +204,7 @@ void test_status_running_to_pending_ign8(void)
 
 void test_status_running_to_pending(void)
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_status_running_to_pending_inj1);
     RUN_TEST(test_status_running_to_pending_inj2);
@@ -223,4 +223,5 @@ void test_status_running_to_pending(void)
     RUN_TEST(test_status_running_to_pending_ign6);
     RUN_TEST(test_status_running_to_pending_ign7);
     RUN_TEST(test_status_running_to_pending_ign8);
+  }
 }

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -147,6 +147,8 @@ void test_table2d_all_decrementing(void)
 
 void testTable2d()
 {
+    Unity.TestFile = __FILE__;
+
     RUN_TEST(test_table2dLookup_50pct);
     RUN_TEST(test_table2dLookup_exactAxis);
     RUN_TEST(test_table2dLookup_overMax);

--- a/test/test_tables/test_table2d.cpp
+++ b/test/test_tables/test_table2d.cpp
@@ -4,6 +4,7 @@
 typedef uint8_t byte;
 #include "test_table2d.h"
 #include "table2d.h"
+#include "../test_utils.h"
 
 
 static constexpr uint8_t TEST_TABLE2D_SIZE = 9;
@@ -147,11 +148,12 @@ void test_table2d_all_decrementing(void)
 
 void testTable2d()
 {
-    Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
     RUN_TEST(test_table2dLookup_50pct);
     RUN_TEST(test_table2dLookup_exactAxis);
     RUN_TEST(test_table2dLookup_overMax);
     RUN_TEST(test_table2dLookup_underMin);
     RUN_TEST(test_table2d_all_decrementing); 
+  }
 }

--- a/test/test_tables/tests_tables.cpp
+++ b/test/test_tables/tests_tables.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include "tests_tables.h"
 #include "table3d.h"
+#include "../test_utils.h"
 
 #define _countof(x) (sizeof(x) / sizeof (x[0]))
 
@@ -113,7 +114,7 @@ void setup_TestTable(void)
 
 void testTables()
 {
-  Unity.TestFile = __FILE__;
+  SET_UNITY_FILENAME() {
 
   RUN_TEST(test_tableLookup_50pct);
   RUN_TEST(test_tableLookup_exact1Axis);
@@ -124,7 +125,8 @@ void testTables()
   RUN_TEST(test_tableLookup_underMinY);
   RUN_TEST(test_tableLookup_roundUp);
   //RUN_TEST(test_all_incrementing);
-  
+
+  }  
 }
 
 void test_tableLookup_50pct(void)

--- a/test/test_tables/tests_tables.cpp
+++ b/test/test_tables/tests_tables.cpp
@@ -113,6 +113,8 @@ void setup_TestTable(void)
 
 void testTables()
 {
+  Unity.TestFile = __FILE__;
+
   RUN_TEST(test_tableLookup_50pct);
   RUN_TEST(test_tableLookup_exact1Axis);
   RUN_TEST(test_tableLookup_exact2Axis);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,6 +1,9 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <unity.h>
+
 // Unity macro to reduce memory usage (RAM, .bss)
 //
 // Unity supplied RUN_TEST captures the function name
@@ -16,3 +19,21 @@
     strcpy_P(funcName, PSTR(#func)); \
     UnityDefaultTestRun(func, funcName, __LINE__); \
   }
+
+static __inline__ uint8_t ufname_set(const char *newFName)
+{
+    Unity.TestFile = newFName;
+    return 1;
+}
+static __inline__ void ufname_szrestore(char** __s)
+{
+    Unity.TestFile = *__s;
+    __asm__ volatile ("" ::: "memory");
+}
+
+#define UNITY_FILENAME_RESTORE char* _ufname_saved                           \
+    __attribute__((__cleanup__(ufname_szrestore))) = (char*)Unity.TestFile
+
+#define SET_UNITY_FILENAME()                                                        \
+for ( UNITY_FILENAME_RESTORE, _ufname_done = ufname_set(__FILE__);                  \
+    _ufname_done; _ufname_done = 0 )


### PR DESCRIPTION
This PR makes Unity tests print the correct filename in messages - which VS code output window will turn into a clickable link to take you directly to the failed assertion :grinning:

Because we place unit tests in separate cpp files from the cpp containing `UNITY_BEGIN()`, test messages (including failures) do not have the correct filename (they refer to the cpp file containing `UNITY_BEGIN()` rather than the file containing test).

See https://github.com/ThrowTheSwitch/Unity/issues/474#issue for description and workaround.