### PR TITLE
Provide hook for developer local PIO configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ speeduino.ino.cpp
 test/output_export.cpp
 misra/.results
 ~$*
+local.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -150,6 +150,10 @@ monitor_speed = 115200
 [platformio]
 src_dir=speeduino
 default_envs = megaatmega2560
+; local.ini is ignored via .gitignore
+; This allows developers to make private/local PIO configuration changes without 
+; triggering Git changes in their dev tooling (E.g. VS Code)  
+extra_configs = local.ini
 ;The following lines are for testing / experimentation only. Comment the line above to try them out
 ;default_envs = black_F407VE
 ;default_envs = teensy35

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,12 +25,12 @@ test_ignore = test_table3d_native
 ;This environment is the same as the above, however compiles for 6 channels of fuel and 3 channels of ignition
 [env:megaatmega2560-6-3]
 extends = env:megaatmega2560
-build_flags = -DUSE_LIBDIVIDE -O3 -ffast-math -fshort-enums -funroll-loops -Wall -Wextra -std=c99 -DINJ_CHANNELS=6 -DIGN_CHANNELS=3
+build_flags = ${env:megaatmega2560.build_flags} -DINJ_CHANNELS=6 -DIGN_CHANNELS=3
 
 ;As the above, however compiles for 8 channels of fuel and only a single ignition channel
 [env:megaatmega2560-8-1]
 extends = env:megaatmega2560
-build_flags = -DUSE_LIBDIVIDE -O3 -ffast-math -fshort-enums -funroll-loops -Wall -Wextra -std=c99 -DINJ_CHANNELS=8 -DIGN_CHANNELS=1
+build_flags = ${env:megaatmega2560.build_flags} -DINJ_CHANNELS=8 -DIGN_CHANNELS=1
 
 [env:megaatmega2561]
 extends = env:megaatmega2560


### PR DESCRIPTION
Occasionally I need to change the PIO configuration for testing or analysis purposes. It'd be useful to keep those changes, but they are only used by me so shouldn't be checked in. This leads to 2 possible problems:

1. Accidentally committing `platform.ini` as part of other changes
2. Changing `platform.ini` triggers my dev tooling (VS Code Git plugin) into showing `platform.ini` as changed (annoying)

This PR allows an extra PIO config file (`local.ini`) that is ignored by Git.