### PR TITLE
Introduced maximum MAP threshold for decel enleanment

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1475,9 +1475,12 @@ page = 15
       airConIdleUpRPMAdder          = scalar,  U08,   96,  "Added Target RPM", 10.0, 0.0, 0.0,    250.0,    0
       airConPwmFanMinDuty           = scalar,  U08,   97,  "%",      0.5,        0.0,     0.0,    100.0,    1
 
-      rollingProtRPMDelta           = array,   S08,   98,    [4], "RPM",     10.0,    0,   -1000,   0,    0           
-      rollingProtCutPercent         = array,   U08,   102,   [4],    "%",    1.0,    0,   0,    100,      0
-      Unused15_106_255              = array,   U08,   106,   [150],   "%", 1.0,   0.0,     0.0,      255,    0
+      rollingProtRPMDelta           = array,   S08,   98,    [4], "RPM",    10.0,     0,   -1000,      0,      0           
+      rollingProtCutPercent         = array,   U08,   102,   [4],    "%",    1.0,     0,       0,    100,      0
+
+      decelMaxMAP                  = scalar,  U08,   106,   "kPa",    1,      0,     0,     255,       0
+
+      Unused15_107_255              = array,   U08,   107,   [149],   "%",   1.0,   0.0,     0.0,     255,    0
 
 ;-------------------------------------------------------------------------------
 
@@ -1666,6 +1669,7 @@ page = 15
     defaultValue = aeColdTaperMin, 0
     defaultValue = aeColdTaperMax, 60
     defaultValue = decelAmount, 100
+    defaultValue = decelMaxMAP, 100
     defaultValue = aeMode, 0 ;Set aeMode to TPS
     defaultValue = batVoltCorrect, 0
     defaultValue = aeApplyMode, 0
@@ -2156,6 +2160,7 @@ menuDialog = main
   taeMinChange      = "The minimum absolute change in TPS in order to engage AE. Typical values are 0-3%"
   maeMinChange      = "The minimum absolute change in MAP in order to engage AE. Typical values are 0-5%"
   decelAmount       = "Reduces fuel compared to VE table during deceleration. 100% means no reduction in fuel amount and 0% means all fuel is cut during decel (Do not confuse this with DFCO). Recommended to use values between 100 and 70%. Default: 100%. Works with both TPS and MAP based AE."
+  decelMaxMAP      = "Threshold that decel enleanment is active below."
   dfcoRPM           = "The RPM above which DFCO will be active. Typically set a few hundred RPM above maximum idle speed"
   dfcoHyster        = "Hysteresis for DFCO RPM. 200-300 RPM is typical for this, however a higher value may be needed if the RPM is fluctuating around the cutout speed"
   dfcoTPSThresh     = "The TPS value below which DFCO will be active. Typical value is 5%-10%, but higher may be needed if TPS signal is noisy"
@@ -2636,6 +2641,7 @@ menuDialog = main
 
     dialog = decelEnleanment, "Deceleration Enleanment"
         field = "Fuel Amount",         decelAmount
+        field = "Active Below"         decelMaxMAP
 
   dialog = accelEnrichments_coldAdj, "Acceleration Enrichment cold adjustment"
         field = "Cold adjustment",      aeColdPct

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -321,7 +321,7 @@ uint16_t correctionAccel(void)
           activateMAPDOT = abs(currentStatus.mapDOT);
           currentStatus.AEEndTime = micros_safe() + ((unsigned long)configPage2.aeTime * 10000); //Set the time in the future where the enrichment will be turned off. taeTime is stored as mS / 10, so multiply it by 100 to get it in uS
           //Check if the MAP rate of change is negative or positive. Negative means decelarion.
-          if (currentStatus.mapDOT < 0)
+          if ( (currentStatus.mapDOT) < 0 && (currentStatus.MAP < configPage15.decelMaxMAP) )
           {
             BIT_SET(currentStatus.engine, BIT_ENGINE_DCC); //Mark deceleration enleanment as active.
             accelValue = configPage2.decelAmount; //In decel, use the decel fuel amount as accelValue
@@ -387,7 +387,7 @@ uint16_t correctionAccel(void)
           activateTPSDOT = abs(currentStatus.tpsDOT);
           currentStatus.AEEndTime = micros_safe() + ((unsigned long)configPage2.aeTime * 10000); //Set the time in the future where the enrichment will be turned off. taeTime is stored as mS / 10, so multiply it by 100 to get it in uS
           //Check if the TPS rate of change is negative or positive. Negative means decelarion.
-          if (currentStatus.tpsDOT < 0)
+          if ( (currentStatus.tpsDOT < 0) && (currentStatus.MAP < configPage15.decelMaxMAP) )
           {
             BIT_SET(currentStatus.engine, BIT_ENGINE_DCC); //Mark deceleration enleanment as active.
             accelValue = configPage2.decelAmount; //In decel, use the decel fuel amount as accelValue

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1438,9 +1438,11 @@ struct config15 {
 
   int8_t rollingProtRPMDelta[4]; // Signed RPM value representing how much below the RPM limit. Divided by 10
   byte rollingProtCutPercent[4];
+
+  byte decelMaxMAP;
   
-  //Bytes 106-255
-  byte Unused15_106_255[150];
+  //Bytes 107-255
+  byte Unused15_107_255[149];
 
 #if defined(CORE_AVR)
   };

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -681,6 +681,7 @@ void doUpdates(void)
     configPage2.maeMinChange = 2; //Default is 2% minimum change to match prior behaviour.
 
     configPage2.decelAmount = 100; //Default decel fuel amount is 100%, so no change in fueling in decel as before.
+    configPage15.decelMaxMAP = 100;
     //full status structure has been changed. Update programmable outputs settings to match.
     for (uint8_t y = 0; y < sizeof(configPage13.outputPin); y++)
     {


### PR DESCRIPTION
I had been experiencing some rich stumbles when letting off of the throttle, so I decided to give decel enleanment a try. A value of 80% worked very well for city driving. Completely took care of the stumble. However, I noticed that when I lifted just a little bit under boost, decel enleanment kicked in and I was left with 80% of my usual fueling. 13.6:1 AFR near 300 kPa. I have added a MAP limit for decel enleanment to prevent this from happening. Without this feature, decel enleanment is unusable to me.

<img width="707" alt="image" src="https://github.com/noisymime/speeduino/assets/23057594/535247a4-3e30-41a9-8413-941bafa3f1c7">

<img width="685" alt="image" src="https://github.com/noisymime/speeduino/assets/23057594/dfc6db97-d017-47a8-b276-0e8b2e3c9567">
