### PR TITLE
Only create preprocessor error when BOARD_H is not defined and not when architecture not in big long list

### DIFF
--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -100,7 +100,9 @@
   #define CORE_SAM
   #define INJ_CHANNELS 8
   #define IGN_CHANNELS 8
-#else
+#endif
+
+#ifndef BOARD_H
   #error Incorrect board selected. Please select the correct board (Usually Mega 2560) and upload again
 #endif
 


### PR DESCRIPTION
Really only want to cause this error when BOARD_H is not defined. 

Reason for this change is i am pulling in speeduino and compiling from CMAKE using my own board_h. I don't want to have to edit and maintain my own globals.h when i can just define BOARD_H from the CMAKE.