### PR TITLE
Make O2 IAT and CLT sensor curves visible

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -244,22 +244,21 @@
    ;----------------------------------------------------------------------------
 
     endianness          = little
-    nPages              = 15
-    pageSize            = 128,   288,     288,    128,     288,    128,    240,     384,    192,    192,    288,    192,    128,    288,    256
+    nPages              = 16
+    pageSize            = 128,   288,     288,    128,     288,    128,    240,     384,    192,    192,    288,    192,    128,    288,    256,  352
 
     ; New commands
-    pageIdentifier      = "\$tsCanId\x01", "\$tsCanId\x02", "\$tsCanId\x03", "\$tsCanId\x04", "\$tsCanId\x05", "\$tsCanId\x06", "\$tsCanId\x07", "\$tsCanId\x08", "\$tsCanId\x09", "\$tsCanId\x0A", "\$tsCanId\x0B", "\$tsCanId\x0C", "\$tsCanId\x0D", "\$tsCanId\x0E", "\$tsCanId\x0F"
-    pageReadCommand     = "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c"
-    pageValueWrite      = "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v"
-    pageChunkWrite      = "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v"
-    crc32CheckCommand   = "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i", "d%2i"
+    pageIdentifier      = "\$tsCanId\x01", "\$tsCanId\x02", "\$tsCanId\x03", "\$tsCanId\x04", "\$tsCanId\x05", "\$tsCanId\x06", "\$tsCanId\x07", "\$tsCanId\x08", "\$tsCanId\x09", "\$tsCanId\x0A", "\$tsCanId\x0B", "\$tsCanId\x0C", "\$tsCanId\x0D", "\$tsCanId\x0E", "\$tsCanId\x0F", "\$tsCanId\x10"
+    burnCommand         = "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i"
+    pageReadCommand     = "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c", "p%2i%2o%2c"
+    pageValueWrite      = "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v"
+    pageChunkWrite      = "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v", "M%2i%2o%2c%v"
 #if COMMS_COMPAT
     ;Comms compat mode uses a different burn command in order to slow down the EEPROM burn rate
     burnCommand         = "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i", "B%2i"
 #else
     burnCommand         = "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i", "b%2i"
 #endif
-
 
 #if mcu_stm32
     blockingFactor = 121
@@ -1481,6 +1480,19 @@ page = 15
 
 ;-------------------------------------------------------------------------------
 
+;--------------------------------------------------
+;Alternate Method to view/edit O2 IAT and CLT maps (Page 16), size 352 bytes
+;--------------------------------------------------
+page = 16
+      o2Calibration_bins      = array,  U16,      0,    [32],    "ADC",  1.0,     0,       0,    1023,      0
+      o2Calibration_values    = array,  U08,      64,   [32],    "AFR",  0.1,     0.0,     7,    25.5,      1
+	  iatCalibration_bins     = array,  U16,      96,   [32],    "ADC",  1.0,     0,       0,    1023,      0
+      iatCalibration_values   = array,  U16,      160,  [32],    "degC", 1.0,     -40,   -40,    214,       0
+	  cltCalibration_bins     = array,  U16,      224,  [32],    "ADC",  1.0,     0,       0,    1023,      0
+      cltCalibration_values   = array,  U16,      288,  [32],    "degC", 1.0,     -40,   -40,    214,       0
+	  
+;-------------------------------------------------------------------------------
+
 [EventTriggers]
       triggeredPageRefresh = 1, { vssRefresh > 0 }
 
@@ -1914,6 +1926,10 @@ menuDialog = main
       subMenu = engine_constants,   "Engine Constants"
       subMenu = injChars,           "Injector Characteristics"
       subMenu = triggerSettings,    "Trigger Setup"
+      groupMenu = "O2 IAT CLT Sensor Calibration"
+        groupChildMenu = sensor_cal_O2,      "O2 Sensor Table"
+        groupChildMenu = sensor_cal_IAT,     "IAT Sensor Table"
+        groupChildMenu = sensor_cal_CLT,     "CLT Sensor Table"
       ;subMenu = OLED,               "OLED Setup"
       subMenu = airdensity_curve,   "IAT Density"
       subMenu = baroFuel_curve,     "Barometric Correction"
@@ -2540,6 +2556,21 @@ menuDialog = main
         panel = engine_constants_warning, North
         panel = engine_constants_west, West
         panel = engine_constants_east, East
+
+		
+;Alternate IAT CLT and O2 sensor calibration
+    dialog = sensor_cal_O2 "",
+        field = "!This Setting for Advanced Users Only. Others use Tools -> Calibrate AFR Sensor."
+	      panel = O2SensorCal_Curve
+        
+    dialog = sensor_cal_IAT "",
+        field = "!This Setting for Advanced Users Only. Others use Tools -> Calibrate Temperature Sensors."
+	      panel = iatSensorCal_Curve
+        
+    dialog = sensor_cal_CLT "",
+        field = "!This Setting for Advanced Users Only. Others use Tools -> Calibrate Temperature Sensors."    
+		    panel = cltSensorCal_Curve
+     
 
 ; Flex fuel stuff
     dialog = flexFuelSettings, "", yAxis
@@ -4849,6 +4880,37 @@ cmdVSSratio6 =      "E\x99\x06"
           yBins           = wmiAdvAdj
           size            = 400, 200
 
+; Curve for map sample angle start window vs RPM
+        curve = map_sample_startAngle_Curve, "MAP Sample Start Angle"
+            columnLabel = "RPM", "Start Angle"
+            xAxis = 0, 7000, 6
+            yAxis = 0, 720, 5
+            xBins = MAPSampleRPMBins , rpm
+            yBins = MAPSampleStrtAng 
+			
+; Curve for O2 Sensor Calibration
+        curve = O2SensorCal_Curve, "O2 Sensor Calibration"
+            columnLabel = "ADC", "AFR"
+            xAxis = 0, 1023, 32
+            yAxis = 7, 25, 32
+            xBins = o2Calibration_bins
+            yBins = o2Calibration_values 
+
+; Curve for iat Sensor Calibration
+        curve = iatSensorCal_Curve, "iat Sensor Calibration"
+            columnLabel = "ADC", "degC"
+            xAxis = 0, 1023, 32
+            yAxis = -40, 214, 32
+            xBins = iatCalibration_bins
+            yBins = iatCalibration_values 
+			
+; Curve for clt Sensor Calibration
+        curve = cltSensorCal_Curve, "clt Sensor Calibration"
+            columnLabel = "ADC", "degC"
+            xAxis = 0, 1023, 32
+            yAxis = -40, 214, 32
+            xBins = cltCalibration_bins
+            yBins = cltCalibration_values 
 
 [TableEditor]
    ;       table_id,    map3d_id,    "title",      page

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1484,11 +1484,11 @@ page = 15
 ;Alternate Method to view/edit O2 IAT and CLT maps (Page 16), size 352 bytes
 ;--------------------------------------------------
 page = 16
-      o2Calibration_bins      = array,  U16,      0,    [32],    "ADC",  1.0,     0,       0,    1023,      0
+      o2Calibration_bins      = array,  U16,      0,    [32],    "V",    0.0048876,     0,       0,    5,   3
       o2Calibration_values    = array,  U08,      64,   [32],    "AFR",  0.1,     0.0,     7,    25.5,      1
-	  iatCalibration_bins     = array,  U16,      96,   [32],    "ADC",  1.0,     0,       0,    1023,      0
+	    iatCalibration_bins     = array,  U16,      96,   [32],    "V",    0.0048876,     0,       0,    5,   3
       iatCalibration_values   = array,  U16,      160,  [32],    "degC", 1.0,     -40,   -40,    214,       0
-	  cltCalibration_bins     = array,  U16,      224,  [32],    "ADC",  1.0,     0,       0,    1023,      0
+	    cltCalibration_bins     = array,  U16,      224,  [32],    "V",    0.0048876,     0,       0,    5,   3
       cltCalibration_values   = array,  U16,      288,  [32],    "degC", 1.0,     -40,   -40,    214,       0
 	  
 ;-------------------------------------------------------------------------------
@@ -1925,6 +1925,10 @@ menuDialog = main
    menu = "Settings"
       subMenu = engine_constants,   "Engine Constants"
       subMenu = injChars,           "Injector Characteristics"
+	    groupMenu = "O2 IAT CLT Sensor Calibration"
+        groupChildMenu = sensor_cal_O2,      "O2 Sensor Table"
+        groupChildMenu = sensor_cal_IAT,     "IAT Sensor Table"
+        groupChildMenu = sensor_cal_CLT,     "CLT Sensor Table"
       subMenu = triggerSettings,    "Trigger Setup"
       groupMenu = "O2 IAT CLT Sensor Calibration"
         groupChildMenu = sensor_cal_O2,      "O2 Sensor Table"
@@ -4890,24 +4894,24 @@ cmdVSSratio6 =      "E\x99\x06"
 			
 ; Curve for O2 Sensor Calibration
         curve = O2SensorCal_Curve, "O2 Sensor Calibration"
-            columnLabel = "ADC", "AFR"
-            xAxis = 0, 1023, 32
+            columnLabel = "Volts", "AFR"
+            xAxis = 0, 5, 32
             yAxis = 7, 25, 32
             xBins = o2Calibration_bins
             yBins = o2Calibration_values 
 
 ; Curve for iat Sensor Calibration
         curve = iatSensorCal_Curve, "iat Sensor Calibration"
-            columnLabel = "ADC", "degC"
-            xAxis = 0, 1023, 32
+            columnLabel = "Volts", "degC"
+            xAxis = 0, 5, 32
             yAxis = -40, 214, 32
             xBins = iatCalibration_bins
             yBins = iatCalibration_values 
 			
 ; Curve for clt Sensor Calibration
         curve = cltSensorCal_Curve, "clt Sensor Calibration"
-            columnLabel = "ADC", "degC"
-            xAxis = 0, 1023, 32
+            columnLabel = "Volts", "degC"
+            xAxis = 0, 5, 32
             yAxis = -40, 214, 32
             xBins = cltCalibration_bins
             yBins = cltCalibration_values 

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1484,11 +1484,11 @@ page = 15
 ;Alternate Method to view/edit O2 IAT and CLT maps (Page 16), size 352 bytes
 ;--------------------------------------------------
 page = 16
-      o2Calibration_bins      = array,  U16,      0,    [32],    "V",    0.0048876,     0,       0,    5,   3
+      o2Calibration_bins      = array,  U16,      0,    [32],    "V",    0.00488758,     0,       0,    5,   3
       o2Calibration_values    = array,  U08,      64,   [32],    "AFR",  0.1,     0.0,     7,    25.5,      1
-	    iatCalibration_bins     = array,  U16,      96,   [32],    "V",    0.0048876,     0,       0,    5,   3
+	    iatCalibration_bins     = array,  U16,      96,   [32],    "V",    0.00488758,     0,       0,    5,   3
       iatCalibration_values   = array,  U16,      160,  [32],    "degC", 1.0,     -40,   -40,    214,       0
-	    cltCalibration_bins     = array,  U16,      224,  [32],    "V",    0.0048876,     0,       0,    5,   3
+	    cltCalibration_bins     = array,  U16,      224,  [32],    "V",    0.00488758,     0,       0,    5,   3
       cltCalibration_values   = array,  U16,      288,  [32],    "degC", 1.0,     -40,   -40,    214,       0
 	  
 ;-------------------------------------------------------------------------------

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1925,10 +1925,6 @@ menuDialog = main
    menu = "Settings"
       subMenu = engine_constants,   "Engine Constants"
       subMenu = injChars,           "Injector Characteristics"
-	    groupMenu = "O2 IAT CLT Sensor Calibration"
-        groupChildMenu = sensor_cal_O2,      "O2 Sensor Table"
-        groupChildMenu = sensor_cal_IAT,     "IAT Sensor Table"
-        groupChildMenu = sensor_cal_CLT,     "CLT Sensor Table"
       subMenu = triggerSettings,    "Trigger Setup"
       groupMenu = "O2 IAT CLT Sensor Calibration"
         groupChildMenu = sensor_cal_O2,      "O2 Sensor Table"
@@ -4884,14 +4880,7 @@ cmdVSSratio6 =      "E\x99\x06"
           yBins           = wmiAdvAdj
           size            = 400, 200
 
-; Curve for map sample angle start window vs RPM
-        curve = map_sample_startAngle_Curve, "MAP Sample Start Angle"
-            columnLabel = "RPM", "Start Angle"
-            xAxis = 0, 7000, 6
-            yAxis = 0, 720, 5
-            xBins = MAPSampleRPMBins , rpm
-            yBins = MAPSampleStrtAng 
-			
+		
 ; Curve for O2 Sensor Calibration
         curve = O2SensorCal_Curve, "O2 Sensor Calibration"
             columnLabel = "Volts", "AFR"

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -893,11 +893,11 @@ void processSerialCommand(void)
       }
       else if(cmd == IAT_CALIBRATION_PAGE)
       {
-        processTemperatureCalibrationTableUpdate(calibrationLength, IAT_CALIBRATION_PAGE, iatCalibration_values, iatCalibration_bins);
+        processTemperatureCalibrationTableUpdate(calibrationLength, IAT_CALIBRATION_PAGE, configPage16.iatCalibration_values, configPage16.iatCalibration_bins);
       }
       else if(cmd == CLT_CALIBRATION_PAGE)
       {
-        processTemperatureCalibrationTableUpdate(calibrationLength, CLT_CALIBRATION_PAGE, cltCalibration_values, cltCalibration_bins);
+        processTemperatureCalibrationTableUpdate(calibrationLength, CLT_CALIBRATION_PAGE, configPage16.cltCalibration_values, configPage16.cltCalibration_bins);
       }
       else
       {

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -395,8 +395,8 @@ static void loadO2CalibrationChunk(uint16_t offset, uint16_t chunkSize)
     //As we're using an interpolated 2D table, we only need to store 32 values out of this 1024
     if( (x % 32U) == 0U )
     {
-      o2Calibration_values[offset/32U] = serialPayload[x+7U]; //O2 table stores 8 bit values
-      o2Calibration_bins[offset/32U]   = offset;
+      configPage16.o2Calibration_values[offset/32U] = serialPayload[x+7U]; //O2 table stores 8 bit values
+      configPage16.o2Calibration_bins[offset/32U]   = offset;
     }
 
     //Update the CRC

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -426,23 +426,23 @@ void legacySerialCommand(void)
       primarySerial.println(F("Coolant"));
       for (int x = 0; x < 32; x++)
       {
-        primarySerial.print(cltCalibration_bins[x]);
+        primarySerial.print(configPage16.cltCalibration_bins[x]);
         primarySerial.print(", ");
-        primarySerial.println(cltCalibration_values[x]);
+        primarySerial.println(configPage16.cltCalibration_values[x]);
       }
       primarySerial.println(F("Inlet temp"));
       for (int x = 0; x < 32; x++)
       {
-        primarySerial.print(iatCalibration_bins[x]);
+        primarySerial.print(configPage16.iatCalibration_bins[x]);
         primarySerial.print(", ");
-        primarySerial.println(iatCalibration_values[x]);
+        primarySerial.println(configPage16.iatCalibration_values[x]);
       }
       primarySerial.println(F("O2"));
       for (int x = 0; x < 32; x++)
       {
-        primarySerial.print(o2Calibration_bins[x]);
+        primarySerial.print(configPage16.o2Calibration_bins[x]);
         primarySerial.print(", ");
-        primarySerial.println(o2Calibration_values[x]);
+        primarySerial.println(configPage16.o2Calibration_values[x]);
       }
       primarySerial.println(F("WUE"));
       for (int x = 0; x < 10; x++)
@@ -1150,6 +1150,8 @@ void sendPageASCII(void)
 
     case warmupPage:
     case progOutsPage:
+	case O2IATCLTPage:
+	
     default:
     #ifndef SMALL_FLASH_MODE
         primarySerial.println(F("\nPage has not been implemented yet"));
@@ -1174,31 +1176,31 @@ void receiveCalibration(byte tableID)
   {
     case 0:
       //coolant table
-      pnt_TargetTable_values = (uint16_t *)&cltCalibration_values;
-      pnt_TargetTable_bins = (uint16_t *)&cltCalibration_bins;
+      pnt_TargetTable_values = (uint16_t *)&configPage16.cltCalibration_values;
+      pnt_TargetTable_bins = (uint16_t *)&configPage16.cltCalibration_bins;
       OFFSET = CALIBRATION_TEMPERATURE_OFFSET; //
       DIVISION_FACTOR = 10;
       break;
     case 1:
       //Inlet air temp table
-      pnt_TargetTable_values = (uint16_t *)&iatCalibration_values;
-      pnt_TargetTable_bins = (uint16_t *)&iatCalibration_bins;
+      pnt_TargetTable_values = (uint16_t *)&configPage16.iatCalibration_values;
+      pnt_TargetTable_bins = (uint16_t *)&configPage16.iatCalibration_bins;
       OFFSET = CALIBRATION_TEMPERATURE_OFFSET;
       DIVISION_FACTOR = 10;
       break;
     case 2:
       //O2 table
       //pnt_TargetTable = (byte *)&o2CalibrationTable;
-      pnt_TargetTable_values = (uint8_t *)&o2Calibration_values;
-      pnt_TargetTable_bins = (uint16_t *)&o2Calibration_bins;
+      pnt_TargetTable_values = (uint8_t *)&configPage16.o2Calibration_values;
+      pnt_TargetTable_bins = (uint16_t *)&configPage16.o2Calibration_bins;
       OFFSET = 0;
       DIVISION_FACTOR = 1;
       break;
 
     default:
       OFFSET = 0;
-      pnt_TargetTable_values = (uint16_t *)&iatCalibration_values;
-      pnt_TargetTable_bins = (uint16_t *)&iatCalibration_bins;
+      pnt_TargetTable_values = (uint16_t *)&configPage16.iatCalibration_values;
+      pnt_TargetTable_bins = (uint16_t *)&configPage16.iatCalibration_bins;
       DIVISION_FACTOR = 10;
       break; //Should never get here, but if we do, just fail back to main loop
   }

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -244,19 +244,20 @@ struct config9 configPage9;
 struct config10 configPage10;
 struct config13 configPage13;
 struct config15 configPage15;
+struct config16 configPage16;
 
 //byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
 //byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
 //byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
-uint16_t cltCalibration_bins[32];
-uint16_t cltCalibration_values[32];
+//uint16_t cltCalibration_bins[32];
+//uint16_t cltCalibration_values[32];
 struct table2D cltCalibrationTable;
-uint16_t iatCalibration_bins[32];
-uint16_t iatCalibration_values[32];
+//uint16_t iatCalibration_bins[32];
+//uint16_t iatCalibration_values[32];
 struct table2D iatCalibrationTable;
-uint16_t o2Calibration_bins[32];
-uint8_t o2Calibration_values[32];
+//uint16_t o2Calibration_bins[32];
+//uint8_t o2Calibration_values[32];
 struct table2D o2CalibrationTable; 
 
 //These function do checks on a pin to determine if it is already in use by another (higher importance) active function

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1466,6 +1466,25 @@ struct config15 {
   } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
 #endif
 
+/**
+Page 16 - Alternate Method of viewing and calibrating O2 CLT and IAT tables. - HRW
+352 bytes long. 
+*/
+struct config16 {
+  uint16_t o2Calibration_bins[32];  //64 bytes
+  uint8_t o2Calibration_values[32]; //32 bytes
+  uint16_t iatCalibration_bins[32]; //64 bytes
+  uint16_t iatCalibration_values[32]; //64 bytes
+  uint16_t cltCalibration_bins[32]; //64 bytes
+  uint16_t cltCalibration_values[32]; //64 bytes
+
+	
+#if defined(CORE_AVR)
+  };
+#else
+  } __attribute__((__packed__)); //The 32 bit systems require all structs to be fully packed
+#endif
+
 extern byte pinInjector1; //Output pin injector 1
 extern byte pinInjector2; //Output pin injector 2
 extern byte pinInjector3; //Output pin injector 3
@@ -1562,16 +1581,17 @@ extern struct config9 configPage9;
 extern struct config10 configPage10;
 extern struct config13 configPage13;
 extern struct config15 configPage15;
+extern struct config16 configPage16;
 //extern byte cltCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the coolant sensor calibration values */
 //extern byte iatCalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the inlet air temperature sensor calibration values */
 //extern byte o2CalibrationTable[CALIBRATION_TABLE_SIZE]; /**< An array containing the O2 sensor calibration values */
 
-extern uint16_t cltCalibration_bins[32];
-extern uint16_t cltCalibration_values[32];
-extern uint16_t iatCalibration_bins[32];
-extern uint16_t iatCalibration_values[32];
-extern uint16_t o2Calibration_bins[32];
-extern uint8_t  o2Calibration_values[32]; // Note 8-bit values
+//extern uint16_t cltCalibration_bins[32];
+//extern uint16_t cltCalibration_values[32];
+//extern uint16_t iatCalibration_bins[32];
+//extern uint16_t iatCalibration_values[32];
+//extern uint16_t o2Calibration_bins[32];
+//extern uint8_t  o2Calibration_values[32]; // Note 8-bit values
 extern struct table2D cltCalibrationTable; /**< A 32 bin array containing the coolant temperature sensor calibration values */
 extern struct table2D iatCalibrationTable; /**< A 32 bin array containing the inlet air temperature sensor calibration values */
 extern struct table2D o2CalibrationTable; /**< A 32 bin array containing the O2 sensor calibration values */

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -69,9 +69,9 @@ void construct2dTables(void) {
   construct2dTable(flexBoostTable,            _countof(configPage10.flexBoostAdj),              configPage10.flexBoostAdj,              configPage10.flexBoostBins);
   construct2dTable(knockWindowStartTable,      _countof(configPage10.knock_window_angle),        configPage10.knock_window_angle, configPage10.knock_window_rpms);
   construct2dTable(knockWindowDurationTable,   _countof(configPage10.knock_window_dur),          configPage10.knock_window_dur,   configPage10.knock_window_rpms);
-  construct2dTable(cltCalibrationTable,       _countof(cltCalibration_values), cltCalibration_values, cltCalibration_bins);
-  construct2dTable(iatCalibrationTable,       _countof(iatCalibration_values), iatCalibration_values, iatCalibration_bins);
-  construct2dTable(o2CalibrationTable,        _countof(o2Calibration_values),  o2Calibration_values,  o2Calibration_bins);
+  construct2dTable(cltCalibrationTable,       _countof(configPage16.cltCalibration_values), configPage16.cltCalibration_values, configPage16.cltCalibration_bins);
+  construct2dTable(iatCalibrationTable,       _countof(configPage16.iatCalibration_values), configPage16.iatCalibration_values, configPage16.iatCalibration_bins);
+  construct2dTable(o2CalibrationTable,        _countof(configPage16.o2Calibration_values),  configPage16.o2Calibration_values,  configPage16.o2Calibration_bins);
 }
 
 /** Initialise Speeduino for the main loop.
@@ -169,6 +169,7 @@ void initialiseAll(void)
     //Repoint the 2D table structs to the config pages that were just loaded
     construct2dTables();
     
+
     //Setup the calibration tables
     loadCalibration();   
 

--- a/speeduino/pages.cpp
+++ b/speeduino/pages.cpp
@@ -24,7 +24,7 @@
 //  2. Offset to intra-entity byte
 
 // Page sizes as defined in the .ini file
-constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 128, 288, 288, 128, 288, 128, 240, 384, 192, 192, 288, 192, 128, 288, 256 };
+constexpr const uint16_t PROGMEM ini_page_sizes[] = { 0, 128, 288, 288, 128, 288, 128, 240, 384, 192, 192, 288, 192, 128, 288, 256, 352 };
 
 // ========================= Table size calculations =========================
 // Note that these should be computed at compile time, assuming the correct
@@ -405,6 +405,12 @@ page_iterator_t map_page_offset_to_entity(uint8_t pageNumber, uint16_t offset)
       CHECK_TABLE(boostvvtPage2, offset, &boostTableLookupDuty, 0)
       CHECK_RAW(boostvvtPage2, offset, &configPage15, sizeof(configPage15), 1)
       END_OF_PAGE(boostvvtPage2, 2)
+    }
+	
+	case O2IATCLTPage: // Alternate method of viewing O2 IAT and CLT tables.
+    {
+      CHECK_RAW(O2IATCLTPage, offset, &configPage16, sizeof(configPage16), 0)
+      END_OF_PAGE(O2IATCLTPage, 1)
     }
 
     default:

--- a/speeduino/pages.h
+++ b/speeduino/pages.h
@@ -28,6 +28,7 @@ uint16_t getPageSize(byte pageNum /**< [in] The page number */ );
 #define progOutsPage  13
 #define ignMap2Page   14
 #define boostvvtPage2 15
+#define O2IATCLTPage 16 // Alternate method of viewing O2 IAT and CLT tables.
 
 // ============================== Per-byte page access ==========================
 

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -25,12 +25,12 @@ A full copy of the license may be found in the projects root directory
 
 // Calibration data is stored at the end of the EEPROM (This is in case any further calibration tables are needed as they are large blocks)
 #define STORAGE_END 0xFFF       // Should be E2END?
-#define EEPROM_CALIBRATION_CLT_VALUES (STORAGE_END-sizeof(cltCalibration_values))
-#define EEPROM_CALIBRATION_CLT_BINS   (EEPROM_CALIBRATION_CLT_VALUES-sizeof(cltCalibration_bins))
-#define EEPROM_CALIBRATION_IAT_VALUES (EEPROM_CALIBRATION_CLT_BINS-sizeof(iatCalibration_values))
-#define EEPROM_CALIBRATION_IAT_BINS   (EEPROM_CALIBRATION_IAT_VALUES-sizeof(iatCalibration_bins))
-#define EEPROM_CALIBRATION_O2_VALUES  (EEPROM_CALIBRATION_IAT_BINS-sizeof(o2Calibration_values))
-#define EEPROM_CALIBRATION_O2_BINS    (EEPROM_CALIBRATION_O2_VALUES-sizeof(o2Calibration_bins))
+#define EEPROM_CALIBRATION_CLT_VALUES (STORAGE_END-sizeof(configPage16.cltCalibration_values))
+#define EEPROM_CALIBRATION_CLT_BINS   (EEPROM_CALIBRATION_CLT_VALUES-sizeof(configPage16.cltCalibration_bins))
+#define EEPROM_CALIBRATION_IAT_VALUES (EEPROM_CALIBRATION_CLT_BINS-sizeof(configPage16.iatCalibration_values))
+#define EEPROM_CALIBRATION_IAT_BINS   (EEPROM_CALIBRATION_IAT_VALUES-sizeof(configPage16.iatCalibration_bins))
+#define EEPROM_CALIBRATION_O2_VALUES  (EEPROM_CALIBRATION_IAT_BINS-sizeof(configPage16.o2Calibration_values))
+#define EEPROM_CALIBRATION_O2_BINS    (EEPROM_CALIBRATION_O2_VALUES-sizeof(configPage16.o2Calibration_bins))
 #define EEPROM_LAST_BARO              (EEPROM_CALIBRATION_O2_BINS-1)
 
 
@@ -324,6 +324,13 @@ void writeConfig(uint8_t pageNum)
       -----------------------------------------------------*/
       result = write_range((byte *)&configPage15, (byte *)&configPage15+sizeof(configPage15), result.changeWriteAddress(EEPROM_CONFIG15_START));
       break;
+	  
+	case O2IATCLTPage:
+      /*---------------------------------------------------
+      | Config page 16 (See storage.h for data layout)
+      -----------------------------------------------------*/
+      result = write_range((byte *)&configPage16, (byte *)&configPage16+sizeof(configPage16), result.changeWriteAddress(EEPROM_CONFIG16_START));
+      break;
 
     default:
       break;
@@ -481,6 +488,12 @@ void loadConfig(void)
   load_range(EEPROM_CONFIG15_START, (byte *)&configPage15, (byte *)&configPage15+sizeof(configPage15));  
 
   //*********************************************************************************************************************************************************************************
+  
+   //*********************************************************************************************************************************************************************************
+  //CONFIG PAGE (16) This is an alternate way to view and calibrate CLT, IAT and O2 tables. - HRW
+  load_range(EEPROM_CONFIG16_START, (byte *)&configPage16, (byte *)&configPage16+sizeof(configPage16));  
+
+  //*********************************************************************************************************************************************************************************
 }
 
 /** Read the calibration information from EEPROM.
@@ -491,14 +504,14 @@ void loadCalibration(void)
   // If you modify this function be sure to also modify writeCalibration();
   // it should be a mirror image of this function.
 
-  EEPROM.get(EEPROM_CALIBRATION_O2_BINS, o2Calibration_bins);
-  EEPROM.get(EEPROM_CALIBRATION_O2_VALUES, o2Calibration_values);
+  EEPROM.get(EEPROM_CALIBRATION_O2_BINS, configPage16.o2Calibration_bins);
+  EEPROM.get(EEPROM_CALIBRATION_O2_VALUES, configPage16.o2Calibration_values);
   
-  EEPROM.get(EEPROM_CALIBRATION_IAT_BINS, iatCalibration_bins);
-  EEPROM.get(EEPROM_CALIBRATION_IAT_VALUES, iatCalibration_values);
+  EEPROM.get(EEPROM_CALIBRATION_IAT_BINS, configPage16.iatCalibration_bins);
+  EEPROM.get(EEPROM_CALIBRATION_IAT_VALUES, configPage16.iatCalibration_values);
 
-  EEPROM.get(EEPROM_CALIBRATION_CLT_BINS, cltCalibration_bins);
-  EEPROM.get(EEPROM_CALIBRATION_CLT_VALUES, cltCalibration_values);
+  EEPROM.get(EEPROM_CALIBRATION_CLT_BINS, configPage16.cltCalibration_bins);
+  EEPROM.get(EEPROM_CALIBRATION_CLT_VALUES, configPage16.cltCalibration_values);
 }
 
 /** Write calibration tables to EEPROM.
@@ -510,32 +523,32 @@ void writeCalibration(void)
   // If you modify this function be sure to also modify loadCalibration();
   // it should be a mirror image of this function.
 
-  EEPROM.put(EEPROM_CALIBRATION_O2_BINS, o2Calibration_bins);
-  EEPROM.put(EEPROM_CALIBRATION_O2_VALUES, o2Calibration_values);
+  EEPROM.put(EEPROM_CALIBRATION_O2_BINS, configPage16.o2Calibration_bins);
+  EEPROM.put(EEPROM_CALIBRATION_O2_VALUES, configPage16.o2Calibration_values);
   
-  EEPROM.put(EEPROM_CALIBRATION_IAT_BINS, iatCalibration_bins);
-  EEPROM.put(EEPROM_CALIBRATION_IAT_VALUES, iatCalibration_values);
+  EEPROM.put(EEPROM_CALIBRATION_IAT_BINS, configPage16.iatCalibration_bins);
+  EEPROM.put(EEPROM_CALIBRATION_IAT_VALUES, configPage16.iatCalibration_values);
 
-  EEPROM.put(EEPROM_CALIBRATION_CLT_BINS, cltCalibration_bins);
-  EEPROM.put(EEPROM_CALIBRATION_CLT_VALUES, cltCalibration_values);
+  EEPROM.put(EEPROM_CALIBRATION_CLT_BINS, configPage16.cltCalibration_bins);
+  EEPROM.put(EEPROM_CALIBRATION_CLT_VALUES, configPage16.cltCalibration_values);
 }
 
 void writeCalibrationPage(uint8_t pageNum)
 {
   if(pageNum == O2_CALIBRATION_PAGE)
   {
-    EEPROM.put(EEPROM_CALIBRATION_O2_BINS, o2Calibration_bins);
-    EEPROM.put(EEPROM_CALIBRATION_O2_VALUES, o2Calibration_values);
+    EEPROM.put(EEPROM_CALIBRATION_O2_BINS, configPage16.o2Calibration_bins);
+    EEPROM.put(EEPROM_CALIBRATION_O2_VALUES, configPage16.o2Calibration_values);
   }
   else if(pageNum == IAT_CALIBRATION_PAGE)
   {
-    EEPROM.put(EEPROM_CALIBRATION_IAT_BINS, iatCalibration_bins);
-    EEPROM.put(EEPROM_CALIBRATION_IAT_VALUES, iatCalibration_values);
+    EEPROM.put(EEPROM_CALIBRATION_IAT_BINS, configPage16.iatCalibration_bins);
+    EEPROM.put(EEPROM_CALIBRATION_IAT_VALUES, configPage16.iatCalibration_values);
   }
   else if(pageNum == CLT_CALIBRATION_PAGE)
   {
-    EEPROM.put(EEPROM_CALIBRATION_CLT_BINS, cltCalibration_bins);
-    EEPROM.put(EEPROM_CALIBRATION_CLT_VALUES, cltCalibration_values);
+    EEPROM.put(EEPROM_CALIBRATION_CLT_BINS, configPage16.cltCalibration_bins);
+    EEPROM.put(EEPROM_CALIBRATION_CLT_VALUES, configPage16.cltCalibration_values);
   }
 }
 

--- a/speeduino/storage.h
+++ b/speeduino/storage.h
@@ -110,7 +110,7 @@
  * | 3682       |4           | O2 Calibration CRC32                 |                                    |
  * | 3686       |56          | Page CRC32 sums (4x14)               | Last first, 14 -> 1                |
  * | 3742       |1           | Baro value saved at init             | @ref EEPROM_LAST_BARO              |
- * | 3743       |64          | O2 Calibration Bins                  | @ref EEPROM_CALIBRATION_O2_BINS    |
+ * | 3743       |64          | O2 Calibration Bins                  | @ref EEPROM_CALIBRATION_O2_BINS    | @ref EEPROM_CONFIG16_START 
  * | 3807       |32          | O2 Calibration Values                | @ref EEPROM_CALIBRATION_O2_VALUES  |
  * | 3839       |64          | IAT Calibration Bins                 | @ref EEPROM_CALIBRATION_IAT_BINS   |
  * | 3903       |64          | IAT Calibration Values               | @ref EEPROM_CALIBRATION_IAT_VALUES |
@@ -186,6 +186,9 @@ extern uint32_t deferEEPROMWritesUntil;
 #define EEPROM_CONFIG15_START 3281
 #define EEPROM_CONFIG15_END   3457
 
+//Page 16 for alternate method of viewing CLT IAT and O2 Tables
+#define EEPROM_CONFIG16_START 3743
+#define EEPROM_CONFIG16_END   4095
 
 #define EEPROM_CALIBRATION_CLT_CRC  3674
 #define EEPROM_CALIBRATION_IAT_CRC  3678

--- a/speeduino/updates.cpp
+++ b/speeduino/updates.cpp
@@ -383,22 +383,22 @@ void doUpdates(void)
     //202008
 
     //MAJOR update to move the coolant, IAT and O2 calibrations to 2D tables
-    int y;
-    for(int x=0; x<(CALIBRATION_TABLE_SIZE/16); x++) //Each calibration table is 512 bytes long
-    {
-      y = EEPROM_CALIBRATION_CLT_OLD + (x * 16);
-      cltCalibration_values[x] = EEPROM.read(y);
-      cltCalibration_bins[x] = (x * 32);
+    // int y;
+    // for(int x=0; x<(CALIBRATION_TABLE_SIZE/16); x++) //Each calibration table is 512 bytes long
+    // {
+      // y = EEPROM_CALIBRATION_CLT_OLD + (x * 16);
+      // cltCalibration_values[x] = EEPROM.read(y);
+      // cltCalibration_bins[x] = (x * 32);
 
-      y = EEPROM_CALIBRATION_IAT_OLD + (x * 16);
-      iatCalibration_values[x] = EEPROM.read(y);
-      iatCalibration_bins[x] = (x * 32);
+      // y = EEPROM_CALIBRATION_IAT_OLD + (x * 16);
+      // iatCalibration_values[x] = EEPROM.read(y);
+      // iatCalibration_bins[x] = (x * 32);
 
-      y = EEPROM_CALIBRATION_O2_OLD + (x * 16);
-      o2Calibration_values[x] = EEPROM.read(y);
-      o2Calibration_bins[x] = (x * 32);
-    }
-    writeCalibration();
+      // y = EEPROM_CALIBRATION_O2_OLD + (x * 16);
+      // o2Calibration_values[x] = EEPROM.read(y);
+      // o2Calibration_bins[x] = (x * 32);
+    // }
+    // writeCalibration();
 
     //Oil and fuel pressure inputs were introduced. Disable them both by default
     configPage10.oilPressureProtEnbl = false;

--- a/speeduino/utilities.h
+++ b/speeduino/utilities.h
@@ -62,5 +62,8 @@ int16_t ProgrammableIOGetData(uint16_t index);
 #define PP_INC_10 11
 #define PP_INC_11 12
 #define PP_INC_12 13
+#define PP_INC_14 15
+#define PP_INC_15 16
+#define PP_INC_16 17
 
 #endif // UTILS_H


### PR DESCRIPTION
This PR makes the O2, IAT and CLT tables visible and adjustable in Tuner Studio. I did this for myself as I wanted to make a custom curve, but since a lot of people have trouble with making custom .inc files etc I thought others may benifit from this.. 

This is accomplished by moving the SRAM memory of the O2 IAT and CLT calibration tables to a new "page16." structure.
The actual EEPROM memory address and values are completely unchanged. No updates are required to existing calibrations. Only the structure in the SRAM is updated so that TunerStudio can read and write these values. The existing methods of calibrating using the Tools - > Calibrate XX Sensors menu is also maintained. There are no changes to the total RAM or EEPROM used.

The calibrations are visible as tables in a new submenu. The X axis is also scaled from ADC counts into Volts to make it a bit easier when developing a custom calibration. This could easily be reveresed and expressed as straight ADC counts if others feel that is more accurate.

So if you have always wondered what the 3 point therm generator was doing, now you can see. 

![Sensor cal overview](https://github.com/user-attachments/assets/14963949-7987-45c1-bfea-71b9ea2f4cd6)
![IAT sensor cal](https://github.com/user-attachments/assets/cae13aa4-d194-43df-bcbc-e8f6114f2487)

