### PR TITLE
RealdashCAN Serial Send Protocol.

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -836,7 +836,7 @@ page = 9
       enable_secondarySerial    = bits,   U08,     0, [0:0], "Disable", "Enable"
       intcan_available          = bits,   U08,     0, [1:1], "Disable", "Enable"
       enable_intcan             = bits,   U08,     0, [2:2], "Disable", "Enable"
-      secondarySerialProtocol   = bits,   U08,     0, [3:6], "Generic (Fixed List)". "Generic (ini File)". "CAN", "msDroid", "Real Dash", "Tuner Studio", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+      secondarySerialProtocol   = bits,   U08,     0, [3:6], "Generic (Fixed List)". "Generic (ini File)". "CAN", "msDroid", "Real Dash", "Tuner Studio", "RealdashCAN Serial", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
     
       caninput_sel0a            = bits,   U08,     1, [0:1], "Off", "INVALID", "Analog_local", "Digital_local"
       caninput_sel0b            = bits,   U08,     1, [2:3], "Off", "External Source", "Analog_local", "Digital_local"

--- a/speeduino/RealdashCan.cpp
+++ b/speeduino/RealdashCan.cpp
@@ -1,0 +1,40 @@
+ 
+#include "RealdashCan.h"
+
+
+
+RdCanSender::RdCanSender()
+{
+}
+
+ 
+void RdCanSender::sendRdCanFrame(uint16_t id, uint16_t byte1, uint16_t byte2, uint16_t byte3, uint16_t byte4,uint16_t byte5,uint16_t byte6,uint16_t byte7,uint16_t byte8)
+   {
+     memcpy(frameData, &byte1, 1);
+     memcpy(frameData + 1, &byte2, 1);
+     memcpy(frameData + 2, &byte3, 1);
+     memcpy(frameData + 3, &byte4, 1);
+     memcpy(frameData + 4, &byte5, 1);
+     memcpy(frameData + 5, &byte6, 1);
+     memcpy(frameData + 6, &byte7, 1);
+     memcpy(frameData + 7, &byte8, 1);
+     SendCANFrameToSerial(id, frameData);
+   }
+
+ void RdCanSender::SendCANFrameToSerial(unsigned long canFrameId, const byte *frameData)
+   {
+    
+     { 
+       // the 4 byte identifier at the beginning of each CAN frame
+       // this is required for RealDash to 'catch-up' on ongoing stream of CAN frames
+       const byte serialBlockTag[4] = {0x44, 0x33, 0x22, 0x11};
+       Serial3.write(serialBlockTag, 4);       
+
+       // the CAN frame id number (as 32bit little endian value)
+       Serial3.write((const byte *)&canFrameId, 4);
+              
+       //  CAN frame payload
+       Serial3.write(frameData, 8);
+    
+     }
+   }

--- a/speeduino/RealdashCan.h
+++ b/speeduino/RealdashCan.h
@@ -1,0 +1,21 @@
+
+
+#ifndef RealdashCan_h
+#define RealdashCan_h
+#include "Arduino.h"
+
+
+class RdCanSender
+{
+public:
+  RdCanSender();
+
+  void sendRdCanFrame(uint16_t id, uint16_t byte1, uint16_t byte2, uint16_t byte3, uint16_t byte4,uint16_t byte5, uint16_t byte6, uint16_t byte7, uint16_t byte8);
+
+private:
+  void SendCANFrameToSerial(unsigned long canFrameId, const byte *frameData);
+
+  uint8_t frameData[8];
+};
+
+#endif

--- a/speeduino/comms_secondary.cpp
+++ b/speeduino/comms_secondary.cpp
@@ -160,31 +160,31 @@ void secondserial_Command(void)
 
 void RealdashCAN(void)
 {
-  static uint16_t contrl = 0; 
+  static uint16_t control = 0; 
 
   static uint16_t baseId = 0x200;
 
-  if (contrl < LOG_ENTRY_SIZE)
+  if (control < LOG_ENTRY_SIZE)
   {
     rdCanSender1.sendRdCanFrame(
         baseId,
-        getTSLogEntry(contrl),
-        getTSLogEntry(contrl + 1),
-        getTSLogEntry(contrl + 2),
-        getTSLogEntry(contrl + 3),
-        getTSLogEntry(contrl + 4),
-        getTSLogEntry(contrl + 5),
-        getTSLogEntry(contrl + 6),
-        getTSLogEntry(contrl + 7));
+        getTSLogEntry(control),
+        getTSLogEntry(control + 1),
+        getTSLogEntry(control + 2),
+        getTSLogEntry(control + 3),
+        getTSLogEntry(control + 4),
+        getTSLogEntry(control + 5),
+        getTSLogEntry(control + 6),
+        getTSLogEntry(control + 7));
 
     baseId++;
-    contrl = (contrl + 8);
+    control = (control + 8);
 
-    if (contrl >= LOG_ENTRY_SIZE)
+    if (control >= LOG_ENTRY_SIZE)
 
     {
       baseId = 0x200;
-      contrl = 0;
+      control = 0;
     }
   }
 }

--- a/speeduino/comms_secondary.h
+++ b/speeduino/comms_secondary.h
@@ -10,11 +10,13 @@
 #define SECONDARY_SERIAL_PROTO_MSDROID        3
 #define SECONDARY_SERIAL_PROTO_REALDASH       4
 #define SECONDARY_SERIAL_PROTO_TUNERSTUDIO    5
+#define SECONDARY_SERIAL_REALDASHCAN          6
+
 
 extern SECONDARY_SERIAL_T *pSecondarySerial;
 #define secondarySerial (*pSecondarySerial)
 
 void secondserial_Command(void);//This is the heart of the Command Line Interpreter.  All that needed to be done was to make it human readable.
 void sendCancommand(uint8_t cmdtype , uint16_t canadddress, uint8_t candata1, uint8_t candata2, uint16_t sourcecanAddress);
-
+void RealdashCAN(void);
 #endif // COMMS_SECONDARY_H

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -275,6 +275,11 @@ void __attribute__((always_inline)) loop(void)
           if (secondarySerial.available() > 0)  { secondserial_Command(); }
         #else
           if (secondarySerial.available() > SERIAL_BUFFER_THRESHOLD) { secondserial_Command(); } //Special case for AVR units. This prevents potential overflow of the receive buffer
+        
+          if ((configPage9.secondarySerialProtocol == SECONDARY_SERIAL_REALDASHCAN) && (BIT_CHECK(LOOP_TIMER, BIT_TIMER_200HZ)))
+          {
+            RealdashCAN();
+          }                 
         #endif
       }
       #if defined (NATIVE_CAN_AVAILABLE)


### PR DESCRIPTION
Implementation of the RealdashCAN serial protocol on Speeduino serial 03. I am implementing the RealdashCAN Serial protocol on Speeduino Serial 03 with Mega 2560. -The code takes all the data and sends it every 8 bytes with a specific ID and sends it at a frequency of 200Hz. -Connection to Realdash is done as RealdashCAN. -Only some are mapped in XML, for now. -I’m planning to implement CAN Broadcast for the STM32 platform, so the same XML can be used. Anyone who can do testing will be of great help.


XML File:

[https://github.com/celturbo/RealDash-extras/tree/Speeduino-XML/RealDash-CAN/XML-files/speeduino](url)

![image](https://github.com/user-attachments/assets/ff91a518-eb6f-4139-803d-cb4e9fd72ed4)

![image](https://github.com/user-attachments/assets/36b0036e-88db-4434-a021-8a5a057684ca)
