### PR TITLE
Add SRAM, SPI & FRAM based EEPROM STM32 environments to CI build

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -44,7 +44,7 @@ jobs:
       run: platformio run -e teensy35 -e teensy36 -e teensy41
 
     - name: Build test STM32
-      run: platformio run -e black_F407VE -e BlackPill_F401CC -e BlackPill_F411CE_USB
+      run: platformio run -e black_F407VE -e BlackPill_F401CC -e BlackPill_F411CE_USB -e black_F407VE-EEPROM-SRAM -e black_F407VE-EEPROM-SPI -e black_F407VE-EEPROM-FRAM
 
     - name: Upload to Speeduino server
       if: github.event_name != 'pull_request' && github.repository_owner == 'speeduino' && github.ref_name == 'master'

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,9 +82,7 @@ build_flags = -DTEENSY_INIT_USB_DELAY_AFTER=40
 ;STM32 Official core
 [env:black_F407VE]
 platform = ststm32
-;platform = https://github.com/platformio/platform-ststm32.git
 framework = arduino
-;board = genericSTM32F407VET6
 board = black_f407ve
 ; RTC library fixed to 1.2.0, because in newer than that the RTC fails to keep up time. At least up to 1.3.7 version
 lib_deps = stm32duino/STM32duino RTC @ 1.2.0, greiman/SdFat, SimplyAtomic, elapsedMillis
@@ -93,6 +91,20 @@ build_flags = -DUSE_LIBDIVIDE -std=gnu++11 -UBOARD_MAX_IO_PINS -DENABLE_HWSERIAL
 upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
+
+; For testing only
+[env:black_F407VE-EEPROM-SRAM]
+extends = env:black_F407VE
+build_flags = ${env:black_F407VE.build_flags} -DSRAM_AS_EEPROM
+; For testing only
+[env:black_F407VE-EEPROM-SPI]
+extends = env:black_F407VE
+build_flags = ${env:black_F407VE.build_flags} -DUSE_SPI_EEPROM
+; For testing only
+[env:black_F407VE-EEPROM-FRAM]
+extends = env:black_F407VE
+build_flags = ${env:black_F407VE.build_flags} -DFRAM_AS_EEPROM
+
 
 ;STM32 Official core
 [env:BlackPill_F401CC]
@@ -133,7 +145,6 @@ monitor_speed = 115200
 [env:bluepill_f103c8]
 platform = ststm32
 framework = arduino
-; framework-arduinoststm32
 board = bluepill_f103c8_128k
 lib_deps = EEPROM, stm32duino/STM32duino RTC @ 1.2.0, SimplyAtomic
 ;build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-Map,output.map


### PR DESCRIPTION
IMO, the CI build is missing some build environments:
* STM + SRAM based EEPROM
* STM + SPI based EEPROM
* STM + FRAM based EEPROM