### PR TITLE
Remove volatile from PIN_MASK variable declarations

### DIFF
--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -21,9 +21,9 @@ uint8_t MC33810_BIT_IGN7 = 7;
 uint8_t MC33810_BIT_IGN8 = 8;
 
 volatile PORT_TYPE *mc33810_1_pin_port;
-volatile PINMASK_TYPE mc33810_1_pin_mask;
+PINMASK_TYPE mc33810_1_pin_mask;
 volatile PORT_TYPE *mc33810_2_pin_port;
-volatile PINMASK_TYPE mc33810_2_pin_mask;
+PINMASK_TYPE mc33810_2_pin_mask;
 
 void initMC33810(void)
 {

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -6,9 +6,9 @@
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
 extern volatile PORT_TYPE *mc33810_1_pin_port;
-extern volatile PINMASK_TYPE mc33810_1_pin_mask;
+extern PINMASK_TYPE mc33810_1_pin_mask;
 extern volatile PORT_TYPE *mc33810_2_pin_port;
-extern volatile PINMASK_TYPE mc33810_2_pin_mask;
+extern PINMASK_TYPE mc33810_2_pin_mask;
 
 //#define MC33810_ONOFF_CMD   3
 static const uint8_t MC33810_ONOFF_CMD = 0x30; //48 in decimal

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -29,25 +29,25 @@ byte boostCounter;
 byte vvtCounter;
 
 volatile PORT_TYPE *boost_pin_port;
-volatile PINMASK_TYPE boost_pin_mask;
+PINMASK_TYPE boost_pin_mask;
 volatile PORT_TYPE *n2o_stage1_pin_port;
-volatile PINMASK_TYPE n2o_stage1_pin_mask;
+PINMASK_TYPE n2o_stage1_pin_mask;
 volatile PORT_TYPE *n2o_stage2_pin_port;
-volatile PINMASK_TYPE n2o_stage2_pin_mask;
+PINMASK_TYPE n2o_stage2_pin_mask;
 volatile PORT_TYPE *n2o_arming_pin_port;
-volatile PINMASK_TYPE n2o_arming_pin_mask;
+PINMASK_TYPE n2o_arming_pin_mask;
 volatile PORT_TYPE *aircon_comp_pin_port;
-volatile PINMASK_TYPE aircon_comp_pin_mask;
+PINMASK_TYPE aircon_comp_pin_mask;
 volatile PORT_TYPE *aircon_fan_pin_port;
-volatile PINMASK_TYPE aircon_fan_pin_mask;
+PINMASK_TYPE aircon_fan_pin_mask;
 volatile PORT_TYPE *aircon_req_pin_port;
-volatile PINMASK_TYPE aircon_req_pin_mask;
+PINMASK_TYPE aircon_req_pin_mask;
 volatile PORT_TYPE *vvt1_pin_port;
-volatile PINMASK_TYPE vvt1_pin_mask;
+PINMASK_TYPE vvt1_pin_mask;
 volatile PORT_TYPE *vvt2_pin_port;
-volatile PINMASK_TYPE vvt2_pin_mask;
+PINMASK_TYPE vvt2_pin_mask;
 volatile PORT_TYPE *fan_pin_port;
-volatile PINMASK_TYPE fan_pin_mask;
+PINMASK_TYPE fan_pin_mask;
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
 volatile bool fan_pwm_state;

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -86,11 +86,11 @@ void wmiControl(void);
 #define WMI_TANK_IS_EMPTY() ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 1)
 
 extern volatile PORT_TYPE *vvt1_pin_port;
-extern volatile PINMASK_TYPE vvt1_pin_mask;
+extern PINMASK_TYPE vvt1_pin_mask;
 extern volatile PORT_TYPE *vvt2_pin_port;
-extern volatile PINMASK_TYPE vvt2_pin_mask;
+extern PINMASK_TYPE vvt2_pin_mask;
 extern volatile PORT_TYPE *fan_pin_port;
-extern volatile PINMASK_TYPE fan_pin_mask;
+extern PINMASK_TYPE fan_pin_mask;
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
 extern uint16_t fan_pwm_max_count; //Used for variable PWM frequency

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -28,53 +28,53 @@ struct table3d4RpmLoad dwellTable; ///< 4x4 Dwell map
 
 /// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;
-volatile PINMASK_TYPE inj1_pin_mask;
+PINMASK_TYPE inj1_pin_mask;
 volatile PORT_TYPE *inj2_pin_port;
-volatile PINMASK_TYPE inj2_pin_mask;
+PINMASK_TYPE inj2_pin_mask;
 volatile PORT_TYPE *inj3_pin_port;
-volatile PINMASK_TYPE inj3_pin_mask;
+PINMASK_TYPE inj3_pin_mask;
 volatile PORT_TYPE *inj4_pin_port;
-volatile PINMASK_TYPE inj4_pin_mask;
+PINMASK_TYPE inj4_pin_mask;
 volatile PORT_TYPE *inj5_pin_port;
-volatile PINMASK_TYPE inj5_pin_mask;
+PINMASK_TYPE inj5_pin_mask;
 volatile PORT_TYPE *inj6_pin_port;
-volatile PINMASK_TYPE inj6_pin_mask;
+PINMASK_TYPE inj6_pin_mask;
 volatile PORT_TYPE *inj7_pin_port;
-volatile PINMASK_TYPE inj7_pin_mask;
+PINMASK_TYPE inj7_pin_mask;
 volatile PORT_TYPE *inj8_pin_port;
-volatile PINMASK_TYPE inj8_pin_mask;
+PINMASK_TYPE inj8_pin_mask;
 
 volatile PORT_TYPE *ign1_pin_port;
-volatile PINMASK_TYPE ign1_pin_mask;
+PINMASK_TYPE ign1_pin_mask;
 volatile PORT_TYPE *ign2_pin_port;
-volatile PINMASK_TYPE ign2_pin_mask;
+PINMASK_TYPE ign2_pin_mask;
 volatile PORT_TYPE *ign3_pin_port;
-volatile PINMASK_TYPE ign3_pin_mask;
+PINMASK_TYPE ign3_pin_mask;
 volatile PORT_TYPE *ign4_pin_port;
-volatile PINMASK_TYPE ign4_pin_mask;
+PINMASK_TYPE ign4_pin_mask;
 volatile PORT_TYPE *ign5_pin_port;
-volatile PINMASK_TYPE ign5_pin_mask;
+PINMASK_TYPE ign5_pin_mask;
 volatile PORT_TYPE *ign6_pin_port;
-volatile PINMASK_TYPE ign6_pin_mask;
+PINMASK_TYPE ign6_pin_mask;
 volatile PORT_TYPE *ign7_pin_port;
-volatile PINMASK_TYPE ign7_pin_mask;
+PINMASK_TYPE ign7_pin_mask;
 volatile PORT_TYPE *ign8_pin_port;
-volatile PINMASK_TYPE ign8_pin_mask;
+PINMASK_TYPE ign8_pin_mask;
 
 volatile PORT_TYPE *tach_pin_port;
-volatile PINMASK_TYPE tach_pin_mask;
+PINMASK_TYPE tach_pin_mask;
 volatile PORT_TYPE *pump_pin_port;
-volatile PINMASK_TYPE pump_pin_mask;
+PINMASK_TYPE pump_pin_mask;
 
 volatile PORT_TYPE *flex_pin_port;
-volatile PINMASK_TYPE flex_pin_mask;
+PINMASK_TYPE flex_pin_mask;
 
 volatile PORT_TYPE *triggerPri_pin_port;
-volatile PINMASK_TYPE triggerPri_pin_mask;
+PINMASK_TYPE triggerPri_pin_mask;
 volatile PORT_TYPE *triggerSec_pin_port;
-volatile PINMASK_TYPE triggerSec_pin_mask;
+PINMASK_TYPE triggerSec_pin_mask;
 volatile PORT_TYPE *triggerThird_pin_port;
-volatile PINMASK_TYPE triggerThird_pin_mask;
+PINMASK_TYPE triggerThird_pin_mask;
 
 //These are variables used across multiple files
 byte fpPrimeTime = 0; ///< The time (in seconds, based on @ref statuses.secl) that the fuel pump started priming

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -212,53 +212,53 @@ extern struct table3d4RpmLoad dwellTable; //4x4 Dwell map
 
 //These are for the direct port manipulation of the injectors, coils and aux outputs
 extern volatile PORT_TYPE *inj1_pin_port;
-extern volatile PINMASK_TYPE inj1_pin_mask;
+extern PINMASK_TYPE inj1_pin_mask;
 extern volatile PORT_TYPE *inj2_pin_port;
-extern volatile PINMASK_TYPE inj2_pin_mask;
+extern PINMASK_TYPE inj2_pin_mask;
 extern volatile PORT_TYPE *inj3_pin_port;
-extern volatile PINMASK_TYPE inj3_pin_mask;
+extern PINMASK_TYPE inj3_pin_mask;
 extern volatile PORT_TYPE *inj4_pin_port;
-extern volatile PINMASK_TYPE inj4_pin_mask;
+extern PINMASK_TYPE inj4_pin_mask;
 extern volatile PORT_TYPE *inj5_pin_port;
-extern volatile PINMASK_TYPE inj5_pin_mask;
+extern PINMASK_TYPE inj5_pin_mask;
 extern volatile PORT_TYPE *inj6_pin_port;
-extern volatile PINMASK_TYPE inj6_pin_mask;
+extern PINMASK_TYPE inj6_pin_mask;
 extern volatile PORT_TYPE *inj7_pin_port;
-extern volatile PINMASK_TYPE inj7_pin_mask;
+extern PINMASK_TYPE inj7_pin_mask;
 extern volatile PORT_TYPE *inj8_pin_port;
-extern volatile PINMASK_TYPE inj8_pin_mask;
+extern PINMASK_TYPE inj8_pin_mask;
 
 extern volatile PORT_TYPE *ign1_pin_port;
-extern volatile PINMASK_TYPE ign1_pin_mask;
+extern PINMASK_TYPE ign1_pin_mask;
 extern volatile PORT_TYPE *ign2_pin_port;
-extern volatile PINMASK_TYPE ign2_pin_mask;
+extern PINMASK_TYPE ign2_pin_mask;
 extern volatile PORT_TYPE *ign3_pin_port;
-extern volatile PINMASK_TYPE ign3_pin_mask;
+extern PINMASK_TYPE ign3_pin_mask;
 extern volatile PORT_TYPE *ign4_pin_port;
-extern volatile PINMASK_TYPE ign4_pin_mask;
+extern PINMASK_TYPE ign4_pin_mask;
 extern volatile PORT_TYPE *ign5_pin_port;
-extern volatile PINMASK_TYPE ign5_pin_mask;
+extern PINMASK_TYPE ign5_pin_mask;
 extern volatile PORT_TYPE *ign6_pin_port;
-extern volatile PINMASK_TYPE ign6_pin_mask;
+extern PINMASK_TYPE ign6_pin_mask;
 extern volatile PORT_TYPE *ign7_pin_port;
-extern volatile PINMASK_TYPE ign7_pin_mask;
+extern PINMASK_TYPE ign7_pin_mask;
 extern volatile PORT_TYPE *ign8_pin_port;
-extern volatile PINMASK_TYPE ign8_pin_mask;
+extern PINMASK_TYPE ign8_pin_mask;
 
 extern volatile PORT_TYPE *tach_pin_port;
-extern volatile PINMASK_TYPE tach_pin_mask;
+extern PINMASK_TYPE tach_pin_mask;
 extern volatile PORT_TYPE *pump_pin_port;
-extern volatile PINMASK_TYPE pump_pin_mask;
+extern PINMASK_TYPE pump_pin_mask;
 
 extern volatile PORT_TYPE *flex_pin_port;
-extern volatile PINMASK_TYPE flex_pin_mask;
+extern PINMASK_TYPE flex_pin_mask;
 
 extern volatile PORT_TYPE *triggerPri_pin_port;
-extern volatile PINMASK_TYPE triggerPri_pin_mask;
+extern PINMASK_TYPE triggerPri_pin_mask;
 extern volatile PORT_TYPE *triggerSec_pin_port;
-extern volatile PINMASK_TYPE triggerSec_pin_mask;
+extern PINMASK_TYPE triggerSec_pin_mask;
 extern volatile PORT_TYPE *triggerThird_pin_port;
-extern volatile PINMASK_TYPE triggerThird_pin_mask;
+extern PINMASK_TYPE triggerThird_pin_mask;
 
 extern byte triggerInterrupt;
 extern byte triggerInterrupt2;

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -35,11 +35,11 @@ unsigned long idle_pwm_target_value;
 long idle_cl_target_rpm;
 
 volatile PORT_TYPE *idle_pin_port;
-volatile PINMASK_TYPE idle_pin_mask;
+PINMASK_TYPE idle_pin_mask;
 volatile PORT_TYPE *idle2_pin_port;
-volatile PINMASK_TYPE idle2_pin_mask;
+PINMASK_TYPE idle2_pin_mask;
 volatile PORT_TYPE *idleUpOutput_pin_port;
-volatile PINMASK_TYPE idleUpOutput_pin_mask;
+PINMASK_TYPE idleUpOutput_pin_mask;
 
 static table2D_u8_u8_10 iacPWMTable(&configPage6.iacBins, &configPage6.iacOLPWMVal);
 static table2D_u8_u8_10 iacStepTable(&configPage6.iacBins, &configPage6.iacOLStepVal);


### PR DESCRIPTION
The volatile modifier isn't needed as they are never written to after initialization.