### PR TITLE
Tweak the test harness to improve STM32 testing

### DIFF
--- a/test/device_test_harness.h
+++ b/test/device_test_harness.h
@@ -17,10 +17,18 @@ void setup(void (*runAllTests)(void))
 #if !defined(SIMULATOR)
     delay(5000);
 #endif
+    while (!Serial) {
+        ; // Wait for serial connection
+    }
 
     UNITY_BEGIN();    // IMPORTANT LINE!
 
     runAllTests();
+
+    // A small delay here helps STM32
+#if !defined(SIMULATOR)
+    delay(500);
+#endif
 
     UNITY_END(); // stop unit testing
 


### PR DESCRIPTION
I'm seeing occasional disconnection errors when running unit tests. I **think** UNITY_END() terminates the serial connection: this seems to happen before the host desktop machine finishes receiving the test results.