### PR TITLE
Add the fuel menu and re-organize some stuff

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1992,11 +1992,15 @@ menuDialog = main
 
    menu = "Settings"
       subMenu = engine_constants,   "Engine Constants"
-      subMenu = injChars,           "Injector Characteristics"
       subMenu = triggerSettings,    "Trigger Setup"
       ;subMenu = OLED,               "OLED Setup"
-      subMenu = airdensity_curve,   "IAT Density"
-      subMenu = baroFuel_curve,     "Barometric Correction"
+      subMenu = std_separator
+      groupMenu = "Limits/protection"
+        groupChildMenu = engineProtection,          "Engine Protection Settings"
+        groupChildMenu = revLimiterDialog,          "Rev Limiters",                 { engineProtectType }
+        groupChildMenu = boostCut,                  "Boost Cut",                    { engineProtectType }
+        groupChildMenu = oilPressureProtection,     "Oil Pressure Cut",             { engineProtectType }
+        groupChildMenu = afrProtect,                "Lean Power Cut",               { engineProtectType }
       subMenu = reset_control,      "Reset Control"
 
       subMenu = std_separator
@@ -2007,17 +2011,8 @@ menuDialog = main
       subMenu = std_separator
       subMenu = prgm_out_config,  "Programmable outputs"
 
-   menu = "&Tuning"
+   menu = "&Tables"
       subMenu = std_realtime,       "Realtime Display"
-      subMenu = accelEnrichments,   "Acceleration Enrichment"
-      subMenu = egoControl,         "AFR/O2", 3
-      groupMenu = "Engine Protection"
-        groupChildMenu = engineProtection,          "Common Engine Protection"
-        groupChildMenu = revLimiterDialog,          "Rev Limiters",             { engineProtectType }
-        groupChildMenu = boostCut,                  "Boost Cut",                { engineProtectType }
-        groupChildMenu = oilPressureProtection,     "Oil Pressure",             { engineProtectType }
-        groupChildMenu = afrProtect,                "AFR Protection",           { engineProtectType }
-      subMenu = flexFuel,           "Flex Fuel",        2
       subMenu = veTableDialog,      "VE Table",       0
       subMenu = sparkTbl,           "Spark Table",    2
       subMenu = afrTable1Tbl,       "AFR Target Table",       5
@@ -2030,8 +2025,21 @@ menuDialog = main
       subMenu = inj_trimad_B,       "Sequential fuel trim (5-8)", 9, { nFuelChannels >= 5 }
       subMenu = std_separator
       subMenu = stagingTableDialog, "Staged Injection", 10, { nCylinders <= 4 || injType == 1 } ; Can't do staging on more than 4 cylinder engines unless TBI is used
+
+   menu = "&Fuel"
+      subMenu = injChars,           "Injector Characteristics"
       subMenu = std_separator
-      subMenu = fuelTemp_curve,     "Fuel Temp Correction", { flexEnabled }
+      subMenu = crankPW,              "Cranking Settings"
+      subMenu = primePW,              "Priming Pulsewidth"
+      subMenu = warmup,               "Warmup Enrichment (WUE)"
+      subMenu = ASE,                  "Afterstart Enrichment (ASE)"
+      subMenu = std_separator
+      subMenu = accelEnrichments,     "Acceleration Enrichment"
+      subMenu = airdensity_curve,     "IAT Correction"
+      subMenu = baroFuel_curve,       "Barometric Correction"
+      subMenu = egoControl,           "AFR/O2 control",   3
+      subMenu = flexFuel,             "Flex Fuel",        2
+      subMenu = fuelTemp_curve,       "Fuel Temp Correction", { flexEnabled }
 
    menu = "&Spark"
       subMenu = sparkSettings,          "Spark Settings"
@@ -2044,12 +2052,7 @@ menuDialog = main
       subMenu = knockSettings,          "Knock Settings"
       subMenu = rotary_ignition,        "Rotary Ignition",    { sparkMode == 4 }
 
-   menu = "&Startup/Idle"
-        subMenu = crankPW,              "Cranking Settings"
-        subMenu = primePW,              "Priming Pulsewidth"
-        subMenu = warmup,               "Warmup Enrichment"
-        subMenu = ASE,                  "Afterstart Enrichment (ASE)"
-        subMenu = std_separator
+   menu = "&Idle"
         subMenu = idleSettings,         "Idle Control"
         subMenu = iacClosedLoop_curve,  "Idle - RPM targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 || iacAlgorithm == 7 || idleAdvEnabled >= 1 }
         subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6}
@@ -3176,11 +3179,11 @@ menuDialog = main
         panel = oil_pressure_prot_curve, { oilPressureEnable && oilPressureProtEnbl }
 
     ; AFR engine protection dialog
-    dialog = afrProtect, "AFR Protection", yAxis
-        field = "AFR protection is used to prevent engine from running lean"
-        field = "#Note: This function requires wideband sensor and proper AFR table"
+    dialog = afrProtect, "Lean Power Cut", yAxis
+        field = "Lean power cut is used to prevent engine from running lean"
+        field = "#Note: This function requires wideband sensor and proper AFR/Lambda table"
         field = ""
-        field = "Enable AFR protection ", afrProtectEnabled, {egoType == 2}
+        field = "Enable lean power cut", afrProtectEnabled, {egoType == 2}
         field = "Minimum manifold air pressure ", afrProtectMAP, {afrProtectEnabled}
         field = "Minimum engine RPM ", afrProtectRPM, {afrProtectEnabled}
         field = "Minimum throttle position ", afrProtectTPS, {afrProtectEnabled}
@@ -3197,7 +3200,7 @@ menuDialog = main
         indicator = { engineProtectRPM   }, "Rev Limiter Off",      "Rev Limiter ON",      green, black, red,      black
         indicator = { engineProtectMAP   }, "Boost Limit OFF",      "Boost Limit ON",      green, black, red,      black
         indicator = { engineProtectOil   }, "Oil Pres. Protect OFF","Oil Pres. Protect ON",green, black, red,      black
-        indicator = { engineProtectAFR   }, "AFR Protect OFF",      "AFR Protect ON",      green, black, red,      black
+        indicator = { engineProtectAFR   }, "Lean power cut OFF",      "Lean power cut ON",      green, black, red,      black
         indicator = { engineProtectCoolant }, "Coolant Protect OFF", "Coolant Protect ON", green, black, red,      black
 
     dialog = engineProtectionWest, "Engine Protection"


### PR DESCRIPTION
* Move all the corrections (cranking, iat, clt, accel, baro) under the Fuel menu
* Move injector configuration under the Fuel menu
* Move lambda and flex to Fuel menu
* Rename "Tuning" to "Tables" to display proper icon in TS
* Rename "Startup/Idle" menu to "Idle" as it no longer handles crank enrichment
* Move "Engine protection" to Settings and rename it "Limits/protection"
* Rename "AFR protection" to "Lean power cut" as lambda is not a AFR ratio