### PR TITLE
Performance: force angle<-->time conversions inline

### DIFF
--- a/speeduino/crankMaths.cpp
+++ b/speeduino/crankMaths.cpp
@@ -1,6 +1,7 @@
 #include <avr-fast-shift.h>
 #include "globals.h"
 #include "crankMaths.h"
+#include "preprocessor.h"
 
 #define SECOND_DERIV_ENABLED                0          
 
@@ -33,15 +34,17 @@ void setAngleConverterRevolutionTime(uint32_t revolutionTime) {
   degreesPerMicro = (uint16_t)fast_div_closest(UQ1X15_360, revolutionTime);
 }
 
-uint32_t angleToTimeMicroSecPerDegree(uint16_t angle) {
+BEGIN_LTO_ALWAYS_INLINE(uint32_t) angleToTimeMicroSecPerDegree(uint16_t angle) {
   UQ24X8_t micros = (uint32_t)angle * (uint32_t)microsPerDegree;
   return rshift_round<microsPerDegree_Shift>(micros);
 }
+END_LTO_INLINE()
 
-uint16_t timeToAngleDegPerMicroSec(uint32_t time) {
+BEGIN_LTO_ALWAYS_INLINE(uint16_t) timeToAngleDegPerMicroSec(uint32_t time) {
     uint32_t degFixed = time * (uint32_t)degreesPerMicro;
     return rshift_round<degreesPerMicro_Shift>(degFixed);
 }
+END_LTO_INLINE()
 
 #if SECOND_DERIV_ENABLED!=0
 void doCrankSpeedCalcs(void)

--- a/speeduino/preprocessor.h
+++ b/speeduino/preprocessor.h
@@ -63,3 +63,11 @@
 #define CONCAT(A, B) \
     CAT_HELPER(A, B)
 #endif
+
+/** @brief Force an out-of-line function (I.e. defined in a cpp file) to be inlined. */
+#define BEGIN_LTO_ALWAYS_INLINE(returnType) \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wattributes\"") \
+    returnType __attribute__((always_inline)) // cppcheck-suppress misra-c2012-20.7
+#define END_LTO_INLINE() \
+    _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
Sometimes `angleToTimeMicroSecPerDegree` & `timeToAngleDegPerMicroSec` are inlined by LTO, sometimes not. When not inlined there is a small performance hit of 1 to 2%.

This PR forces them inline.