### PR TITLE
Move board specifc #defines into board headers

### DIFF
--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -41,7 +41,8 @@
 #else
   #define RTC_LIB_H <Time.h>
 #endif
-
+constexpr uint16_t BLOCKING_FACTOR = 121;
+constexpr uint16_t TABLE_BLOCKING_FACTOR = 64;
 #define pinIsReserved(pin)  ( ((pin) == 0) ) //Forbidden pins like USB on other boards
 
 /*

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -40,6 +40,8 @@
 #define SERIAL_BUFFER_SIZE 517 //Size of the serial buffer used by new comms protocol. For SD transfers this must be at least 512 + 1 (flag) + 4 (sector)
 #define FPU_MAX_SIZE 32 //Size of the FPU buffer. 0 means no FPU.
 #define TIMER_RESOLUTION 4
+constexpr uint16_t BLOCKING_FACTOR = 121;
+constexpr uint16_t TABLE_BLOCKING_FACTOR = 64;
 
 //Select one for EEPROM,the default is EEPROM emulation on internal flash.
 //#define SRAM_AS_EEPROM /*Use 4K battery backed SRAM, requires a 3V continuous source (like battery) connected to Vbat pin */

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -27,6 +27,8 @@
 #define RTC_ENABLED
 #define RTC_LIB_H "TimeLib.h"
 #define SD_CONFIG  SdioConfig(FIFO_SDIO) //Set Teensy to use SDIO in FIFO mode. This is the fastest SD mode on Teensy as it offloads most of the writes
+constexpr uint16_t BLOCKING_FACTOR = 251;
+constexpr uint16_t TABLE_BLOCKING_FACTOR = 256;
 
 #define PWM_FAN_AVAILABLE
 #define pinIsReserved(pin)  ( ((pin) == 0) || ((pin) == 1) || ((pin) == 3) || ((pin) == 4) ) //Forbidden pins like USB

--- a/speeduino/board_teensy41.h
+++ b/speeduino/board_teensy41.h
@@ -23,6 +23,8 @@ typedef int eeprom_address_t;
 #define SD_LOGGING //SD logging enabled by default for Teensy 4.1 as it has the slot built in
 #define RTC_LIB_H "TimeLib.h"
 #define SD_CONFIG  SdioConfig(FIFO_SDIO) //Set Teensy to use SDIO in FIFO mode. This is the fastest SD mode on Teensy as it offloads most of the writes
+constexpr uint16_t BLOCKING_FACTOR = 251;
+constexpr uint16_t TABLE_BLOCKING_FACTOR = 256;
 
 //#define PWM_FAN_AVAILABLE
 #define pinIsReserved(pin)  ( ((pin) == 0) || ((pin) == 42) || ((pin) == 43) || ((pin) == 44) || ((pin) == 45) || ((pin) == 46) || ((pin) == 47) || pinIsSerial((pin)) ) //Forbidden pins like USB

--- a/speeduino/comms.h
+++ b/speeduino/comms.h
@@ -10,17 +10,6 @@
 #ifndef COMMS_H
 #define COMMS_H
 
-#if defined(CORE_TEENSY)
-  #define BLOCKING_FACTOR       251
-  #define TABLE_BLOCKING_FACTOR 256
-#elif defined(CORE_STM32)
-  #define BLOCKING_FACTOR       121
-  #define TABLE_BLOCKING_FACTOR 64
-#elif defined(CORE_AVR)
-  #define BLOCKING_FACTOR       121
-  #define TABLE_BLOCKING_FACTOR 64
-#endif
-
 extern Stream *pPrimarySerial;
 #define primarySerial (*pPrimarySerial)
 


### PR DESCRIPTION
Move definition of `BLOCKING_FACTOR` & `TABLE_BLOCKING_FACTOR` into the board headers. This avoids board specific code in `comms.h`.
