### PR TITLE
Move definition of SET_COMPARE to board_definition.h

### DIFF
--- a/speeduino/board_definition.h
+++ b/speeduino/board_definition.h
@@ -62,3 +62,7 @@ uint8_t getSystemTemp(void);
 /** @brief Board specific RTC system initialisation (optional) */
 void boardInitRTC(void);
 #endif
+
+// It is important that we cast this to the actual overflow limit of the timer. 
+// The compare variables type can be wider than the timer overflow.
+#define SET_COMPARE(compare, value) compare = (COMPARE_TYPE)(value)

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -21,8 +21,6 @@ Hence we will preload the timer with 131 cycles to leave 125 until overflow (1ms
 
 #include "globals.h"
 
-#define SET_COMPARE(compare, value) compare = (COMPARE_TYPE)(value) // It is important that we cast this to the actual overflow limit of the timer. The compare variables type can be bigger than the timer overflow.
-
 #if(defined(CORE_TEENSY) || defined(CORE_STM32))
   #define TACHO_PULSE_LOW()         (digitalWrite(pinTachOut, LOW))
   #define TACHO_PULSE_HIGH()        (digitalWrite(pinTachOut, HIGH))


### PR DESCRIPTION
Since it's dependent on COMPARE_TYPE (which varies per board) instead of anything in `timers.cpp`