### PR TITLE
Move calculation of EEPROM write block size into board cpp files

### DIFF
--- a/speeduino/board_definition.h
+++ b/speeduino/board_definition.h
@@ -38,6 +38,22 @@ void jumpToBootloader(void);
 /** @brief Get the board temp for display in TunerStudio (optional) */
 uint8_t getSystemTemp(void);
 
+struct statuses;
+
+/**
+ * @brief The maximum number of write operations that will be performed in one go.
+ * 
+ * If this number is too large, we will kill system responsiveness since EEPROM
+ * writes are slow. E.g. Each write takes ~3ms on the AVR
+ * 
+ * This is board specific, since EEPROM write speed is dependent on the
+ * EEPROM type and CPU speed. 
+ * 
+ * @param current So the function can scale the number of writes based on system state
+ * @return uint8_t The maximum number of writes.
+ */
+uint16_t getEepromWriteBlockSize(const statuses &current);
+
 // Include a specific header for a board.
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
   #include "board_avr2560.h"

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -93,4 +93,9 @@ void boardInitPins(void)
   // Do nothing
 }
 
+uint16_t getEepromWriteBlockSize(const statuses &)
+{
+    return 64U;
+}
+
 #endif

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -419,4 +419,22 @@ void boardInitPins(void)
   // Do nothing
 }
 
+uint16_t getEepromWriteBlockSize(const statuses &current)
+{
+#if defined(USE_SPI_EEPROM)
+  //For use with common Winbond SPI EEPROMs Eg W25Q16JV
+  uint16_t maxWrite = 20; //This needs tuning
+#else
+  uint16_t maxWrite = 64;
+#endif
+
+    // Write to EEPROM more aggressively if the engine is not running
+    if(current.RPM==0U)
+    { 
+      return maxWrite * 8U;
+    } 
+
+    return maxWrite;
+}
+
 #endif

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -439,4 +439,20 @@ void boardInitPins(void)
   // Do nothing
 }
 
+uint16_t getEepromWriteBlockSize(const statuses &current)
+{
+#if defined(USE_SPI_EEPROM)
+  //For use with common Winbond SPI EEPROMs Eg W25Q16JV
+  uint16_t maxWrite = 20; //This needs tuning
+#else
+  uint16_t maxWrite = 64;
+#endif
+  // Write to EEPROM more aggressively if the engine is not running
+  if(current.RPM==0U)
+  { 
+    return maxWrite * 8U;
+  } 
+
+  return maxWrite;
+}
 #endif

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -403,5 +403,17 @@ void boardInitPins(void)
   if(configPage10.knock_mode == KNOCK_MODE_DIGITAL) { setPinHysteresis(configPage10.knock_pin); }
 }
 
+uint16_t getEepromWriteBlockSize(const statuses &current)
+{
+  uint16_t maxWrite = 64;
+
+  // Write to EEPROM more aggressively if the engine is not running
+  if(current.RPM==0U)
+  { 
+    return maxWrite * 8U;
+  } 
+
+  return maxWrite;
+}
 
 #endif


### PR DESCRIPTION
The maximum number of EEPROM writes per save operation varies per board and type of EEPROM. So isolate the code in the Hardware Abstraction Layer. I.e. the various board*.cpp files.