### PR TITLE
Pad page 12 (wmiMapPage) to match ini page size

### DIFF
--- a/test/test_pages/test_page.cpp
+++ b/test/test_pages/test_page.cpp
@@ -1,4 +1,3 @@
-#include <FastCRC.h>
 #include <unity.h>
 #include "pages.h"
 #include "../test_utils.h"


### PR DESCRIPTION
This will place the "end of page" entity at the correct offset. 
1. Static assertion for page sizes can now use an equality check
2. Other code can assume end of page offset==page size.