### PR TITLE
Remove PIO environments that do not build...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -142,7 +142,6 @@ build_flags = ${env:black_F407VE.build_flags} -DUSE_SPI_EEPROM
 extends = env:black_F407VE
 build_flags = ${env:black_F407VE.build_flags} -DFRAM_AS_EEPROM
 
-
 ;STM32 Official core
 [env:BlackPill_F401CC]
 platform = ststm32
@@ -185,36 +184,6 @@ upload_protocol = dfu
 debug_tool = stlink
 monitor_speed = 115200
 
-[env:bluepill_f103c8]
-platform = ststm32
-framework = arduino
-; framework-arduinoststm32
-board = bluepill_f103c8_128k
-lib_deps = 
-	EEPROM
-	stm32duino/STM32duino RTC @ 1.2.0
-	${common.lib_deps}
-build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11 -Os -DCORE_STM32_OFFICIAL -UBOARD_MAX_IO_PINS
-
-;SAMD21
-[env:samd21]
-platform = atmelsam
-framework = arduino
-board = zeroUSB
-build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11
-upload_protocol = sam-ba
-
-;SAME51
-[env:same51]
-platform = atmelsam
-framework = arduino
-board = adafruit_feather_m4_can
-build_flags = -DUSE_LIBDIVIDE -fpermissive -std=gnu++11
-upload_protocol = sam-ba
-
-[env:custom_monitor_speedrate]
-monitor_speed = 115200
-
 [platformio]
 src_dir=speeduino
 default_envs = megaatmega2560
@@ -222,13 +191,6 @@ default_envs = megaatmega2560
 ; This allows developers to make private/local PIO configuration changes without 
 ; triggering Git changes in their dev tooling (E.g. VS Code)  
 extra_configs = local.ini
-;The following lines are for testing / experimentation only. Comment the line above to try them out
-;default_envs = black_F407VE
-;default_envs = teensy35
-;default_envs = teensy40
-;env_default = LaunchPad_tm4c1294ncpdt
-;env_default = genericSTM32F103RB
-;env_default = bluepill_f103c8
 
 [env]
 test_build_src = yes


### PR DESCRIPTION
...again! (a merge issue in an earlier PR out them back into `platform.ini`)