### PR TITLE
Round 2: use gcovr & exclude-throw-branches to exclude throwing functions from…

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         disable_search: true
-        files: ${{ env.PATH_ROOT }}.*
+        files: ${{ env.PATH_ROOT }}.lcov
         verbose: true 
 
     # This messes up CodeCov upload if done earlier


### PR DESCRIPTION
… branch coverage

See #1436