### PR TITLE
Move board specific I/O pin type selection into board headers

### DIFF
--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -29,7 +29,7 @@ void setMC33810_1_INACTIVE(void) { mc33810_1_pin.setPinLow(); }
 void setMC33810_2_ACTIVE(void) { mc33810_2_pin.setPinHigh(); }
 void setMC33810_2_INACTIVE(void) { mc33810_2_pin.setPinLow(); }
 
-void initMC33810(void)
+void __attribute__((optimize("Os"))) initMC33810(void)
 {
     //Set pin port/masks
     mc33810_1_pin.setPin(pinMC33810_1_CS, OUTPUT);

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -81,19 +81,11 @@ static __attribute__((optimize("Os"))) void initAirConRequestPin(const config15 
   aircon_req_pin.setPin(pin, getAirConRequestPinMode(page15));
 }
 
-#if defined(CORE_TEENSY) || defined(CORE_STM32)
-static outputPin_t boost_pin;
-static outputPin_t n2o_stage1_pin;
-static outputPin_t n2o_stage2_pin;
-static outputPin_t aircon_comp_pin;
-static outputPin_t aircon_fan_pin;
-#else
-static fastOutputPin_t boost_pin;
-static fastOutputPin_t n2o_stage1_pin;
-static fastOutputPin_t n2o_stage2_pin;
-static fastOutputPin_t aircon_comp_pin;
-static fastOutputPin_t aircon_fan_pin;
-#endif
+static boardOutputPin_t boost_pin;
+static boardOutputPin_t n2o_stage1_pin;
+static boardOutputPin_t n2o_stage2_pin;
+static boardOutputPin_t aircon_comp_pin;
+static boardOutputPin_t aircon_fan_pin;
 
 static __attribute__((optimize("Os"))) void initializeBoostPin(uint8_t pin)
 {
@@ -387,11 +379,7 @@ static inline void checkAirConRPMLockout(void)
  * Fuel pump control
  */
 
-#if(defined(CORE_TEENSY) || defined(CORE_STM32))
-static outputPin_t pump_pin;
-#else
-static fastOutputPin_t pump_pin;
-#endif
+static boardOutputPin_t pump_pin;
 
 static __attribute__((optimize("Os"))) void initialisePumpPin(uint8_t pin) 
 { 
@@ -433,11 +421,7 @@ bool __attribute__((optimize("Os"))) initialiseFuelPump(const config2 &page2, ui
 Fan control
 */
 
-#if(defined(CORE_TEENSY) || defined(CORE_STM32))
-static outputPin_t fan_pin;
-#else
-static fastOutputPin_t fan_pin;
-#endif
+static boardOutputPin_t fan_pin;
 
 static __attribute__((optimize("Os"))) void initialiseFanPin(uint8_t pin) 
 { 
@@ -590,13 +574,8 @@ void fanControl(void)
   }
 }
 
-#if(defined(CORE_TEENSY) || defined(CORE_STM32))
-static outputPin_t vvt1_pin;
-static outputPin_t vvt2_pin;
-#else
-static fastOutputPin_t vvt1_pin;
-static fastOutputPin_t vvt2_pin;
-#endif
+static boardOutputPin_t vvt1_pin;
+static boardOutputPin_t vvt2_pin;
 
 static __attribute__((optimize("Os"))) void initialiseVvtPins(uint8_t pin1, uint8_t pin2) 
 { 

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -16,6 +16,7 @@ A full copy of the license may be found in the projects root directory
 #include "atomic.h"
 #include "src/pins/fastInputPin.h"
 #include "src/pins/fastOutputPin.h"
+#include "src/pins/outputPin.h"
 
 constexpr uint8_t SIMPLE_BOOST_P = 1U;
 constexpr uint8_t SIMPLE_BOOST_I = 1U;
@@ -81,40 +82,19 @@ static void initAirConRequestPin(const config15 &page15, uint8_t pin)
 }
 
 #if defined(CORE_TEENSY) || defined(CORE_STM32)
-
-#define BOOST_PIN_LOW()         (digitalWrite(pinBoost, LOW))
-#define BOOST_PIN_HIGH()        (digitalWrite(pinBoost, HIGH))
-static void initializeBoostPin(uint8_t pin)
-{
-  pinMode(pin, OUTPUT);
-}
-#define N2O_STAGE1_PIN_LOW()    (digitalWrite(configPage10.n2o_stage1_pin, LOW))
-#define N2O_STAGE1_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage1_pin, HIGH))
-#define N2O_STAGE2_PIN_LOW()    (digitalWrite(configPage10.n2o_stage2_pin, LOW))
-#define N2O_STAGE2_PIN_HIGH()   (digitalWrite(configPage10.n2o_stage2_pin, HIGH))
-static void initialiseN2oPins(const config10 &page10)
-{
-  pinMode(page10.n2o_stage1_pin, OUTPUT);
-  pinMode(page10.n2o_stage2_pin, OUTPUT);
-  initialiseN2oArmPin(page10);
-}
-#define AIRCON_PIN_LOW()        (digitalWrite(pinAirConComp, LOW))
-#define AIRCON_PIN_HIGH()       (digitalWrite(pinAirConComp, HIGH))
-#define AIRCON_FAN_PIN_LOW()    (digitalWrite(pinAirConFan, LOW))
-#define AIRCON_FAN_PIN_HIGH()   (digitalWrite(pinAirConFan, HIGH))
-
-static void initAirConCompressorPin(uint8_t pin)
-{
-  pinMode(pin, OUTPUT);
-}
-static void initAirConFanPin(uint8_t pin)
-{
-  pinMode(pin, OUTPUT);
-}
-
+static outputPin_t boost_pin;
+static outputPin_t n2o_stage1_pin;
+static outputPin_t n2o_stage2_pin;
+static outputPin_t aircon_comp_pin;
+static outputPin_t aircon_fan_pin;
 #else
-
 static fastOutputPin_t boost_pin;
+static fastOutputPin_t n2o_stage1_pin;
+static fastOutputPin_t n2o_stage2_pin;
+static fastOutputPin_t aircon_comp_pin;
+static fastOutputPin_t aircon_fan_pin;
+#endif
+
 #define BOOST_PIN_LOW()         ATOMIC() { boost_pin.setPinLow(); }
 #define BOOST_PIN_HIGH()        ATOMIC() { boost_pin.setPinHigh(); }
 static void initializeBoostPin(uint8_t pin)
@@ -122,22 +102,17 @@ static void initializeBoostPin(uint8_t pin)
   boost_pin.setPin(pin, OUTPUT);
 }
 
-static fastOutputPin_t n2o_stage1_pin;
-static fastOutputPin_t n2o_stage2_pin;
-
 #define N2O_STAGE1_PIN_LOW()    ATOMIC() { n2o_stage1_pin.setPinLow(); }
 #define N2O_STAGE1_PIN_HIGH()   ATOMIC() { n2o_stage1_pin.setPinHigh(); }
 #define N2O_STAGE2_PIN_LOW()    ATOMIC() { n2o_stage2_pin.setPinLow(); }
 #define N2O_STAGE2_PIN_HIGH()   ATOMIC() { n2o_stage2_pin.setPinHigh(); }
+
 static void initialiseN2oPins(const config10 &page10)
 {
   n2o_stage1_pin.setPin(page10.n2o_stage1_pin, OUTPUT);
   n2o_stage2_pin.setPin(page10.n2o_stage2_pin, OUTPUT);
   initialiseN2oArmPin(page10);
 }
-static fastOutputPin_t aircon_comp_pin;
-static fastOutputPin_t aircon_fan_pin;
-
 // Note the below macros cannot use ATOMIC() as they are called from within ternary operators. 
 // The ATOMIC is instead placed around the ternary call below
 #define AIRCON_PIN_LOW()        aircon_comp_pin.setPinLow()
@@ -153,7 +128,6 @@ static void initAirConFanPin(uint8_t pin)
 {
   aircon_fan_pin.setPin(pin, OUTPUT);
 }
-#endif
 
 #define AIRCON_ON()             ATOMIC() { ((((configPage15.airConCompPol)==1)) ? AIRCON_PIN_LOW() : AIRCON_PIN_HIGH()); currentStatus.airconCompressorOn = true; }
 #define AIRCON_OFF()            ATOMIC() { ((((configPage15.airConCompPol)==1)) ? AIRCON_PIN_HIGH() : AIRCON_PIN_LOW()); currentStatus.airconCompressorOn = false; }
@@ -427,15 +401,10 @@ static inline void checkAirConRPMLockout(void)
  */
 
 #if(defined(CORE_TEENSY) || defined(CORE_STM32))
-#define FUEL_PUMP_PIN_HIGH()  digitalWrite(pinFuelPump, HIGH)
-#define FUEL_PUMP_PIN_LOW()   digitalWrite(pinFuelPump, LOW) 
-static inline void initialisePumpPin(uint8_t pin) 
-{ 
-  pinMode(pin, OUTPUT);
-}
+static outputPin_t pump_pin;
 #else
-
 static fastOutputPin_t pump_pin;
+#endif
 
 static inline void initialisePumpPin(uint8_t pin) 
 { 
@@ -444,8 +413,6 @@ static inline void initialisePumpPin(uint8_t pin)
 
 #define FUEL_PUMP_PIN_HIGH() pump_pin.setPinHigh()
 #define FUEL_PUMP_PIN_LOW()  pump_pin.setPinLow()
-
-#endif
 
 void fuelPumpOn(void)
 {
@@ -483,12 +450,10 @@ Fan control
 */
 
 #if(defined(CORE_TEENSY) || defined(CORE_STM32))
-#define FAN_PIN_LOW()           (digitalWrite(pinFan, LOW))
-#define FAN_PIN_HIGH()          (digitalWrite(pinFan, HIGH))
-static void initialiseFanPin(uint8_t pin) { UNUSED(pin); /* Do nothing */}
+static outputPin_t fan_pin;
 #else
-
 static fastOutputPin_t fan_pin;
+#endif
 
 #define FAN_PIN_LOW()           fan_pin.setPinLow()
 #define FAN_PIN_HIGH()          fan_pin.setPinHigh()
@@ -497,8 +462,6 @@ static void initialiseFanPin(uint8_t pin)
 { 
   fan_pin.setPin(pin, OUTPUT);
 }
-
-#endif
 
 void fanOn(void) 
 {
@@ -647,21 +610,12 @@ void fanControl(void)
 }
 
 #if(defined(CORE_TEENSY) || defined(CORE_STM32))
-
-#define VVT1_PIN_LOW()          (digitalWrite(pinVVT_1, LOW))
-#define VVT1_PIN_HIGH()         (digitalWrite(pinVVT_1, HIGH))
-#define VVT2_PIN_LOW()          (digitalWrite(pinVVT_2, LOW))
-#define VVT2_PIN_HIGH()         (digitalWrite(pinVVT_2, HIGH))
-
-static inline void initialiseVvtPins(uint8_t pin1, uint8_t pin2) 
-{ 
-  pinMode(pin1, OUTPUT);
-  pinMode(pin2, OUTPUT);
-}
+static outputPin_t vvt1_pin;
+static outputPin_t vvt2_pin;
 #else
-
 static fastOutputPin_t vvt1_pin;
 static fastOutputPin_t vvt2_pin;
+#endif
 
 #define VVT1_PIN_LOW()          ATOMIC() { vvt1_pin.setPinLow(); }
 #define VVT1_PIN_HIGH()         ATOMIC() { vvt1_pin.setPinHigh(); }
@@ -673,8 +627,6 @@ static inline void initialiseVvtPins(uint8_t pin1, uint8_t pin2)
   vvt1_pin.setPin(pin1, OUTPUT);
   vvt2_pin.setPin(pin2, OUTPUT);
 }
-
-#endif
 
 void initialiseAuxPWM(void)
 {

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -40,7 +40,7 @@ static byte vvtCounter;
 
 static fastInputPin_t n2o_arming_pin;
 
-static inline uint8_t getN2oArmPinPolarity(const config10 &page10)
+static __attribute__((optimize("Os"))) uint8_t getN2oArmPinPolarity(const config10 &page10)
 {
   if(page10.n2o_pin_polarity == 1U) 
   { 
@@ -48,7 +48,7 @@ static inline uint8_t getN2oArmPinPolarity(const config10 &page10)
   }
   return INPUT;
 }
-static void initialiseN2oArmPin(const config10 &page10)
+static __attribute__((optimize("Os"))) void initialiseN2oArmPin(const config10 &page10)
 {
   if(configPage10.n2o_enable!=0U && !pinIsReserved(page10.n2o_arming_pin))
   {
@@ -60,7 +60,7 @@ static void initialiseN2oArmPin(const config10 &page10)
 
 static fastInputPin_t aircon_req_pin;
 
-static uint8_t getAirConRequestPinMode(const config15 &page15)
+static __attribute__((optimize("Os"))) uint8_t getAirConRequestPinMode(const config15 &page15)
 {
   if(page15.airConReqPol)
   {
@@ -76,7 +76,7 @@ static uint8_t getAirConRequestPinMode(const config15 &page15)
   }
 }
 
-static void initAirConRequestPin(const config15 &page15, uint8_t pin)
+static __attribute__((optimize("Os"))) void initAirConRequestPin(const config15 &page15, uint8_t pin)
 {
   aircon_req_pin.setPin(pin, getAirConRequestPinMode(page15));
 }
@@ -95,23 +95,23 @@ static fastOutputPin_t aircon_comp_pin;
 static fastOutputPin_t aircon_fan_pin;
 #endif
 
-static void initializeBoostPin(uint8_t pin)
+static __attribute__((optimize("Os"))) void initializeBoostPin(uint8_t pin)
 {
   boost_pin.setPin(pin, OUTPUT);
 }
 
-static void initialiseN2oPins(const config10 &page10)
+static __attribute__((optimize("Os"))) void initialiseN2oPins(const config10 &page10)
 {
   n2o_stage1_pin.setPin(page10.n2o_stage1_pin, OUTPUT);
   n2o_stage2_pin.setPin(page10.n2o_stage2_pin, OUTPUT);
   initialiseN2oArmPin(page10);
 }
 
-static void initAirConCompressorPin(uint8_t pin)
+static __attribute__((optimize("Os"))) void initAirConCompressorPin(uint8_t pin)
 {
   aircon_comp_pin.setPin(pin, OUTPUT);
 }
-static void initAirConFanPin(uint8_t pin)
+static __attribute__((optimize("Os"))) void initAirConFanPin(uint8_t pin)
 {
   aircon_fan_pin.setPin(pin, OUTPUT);
 }
@@ -165,7 +165,7 @@ static inline void checkAirConRPMLockout(void);
 /*
 Air Conditioning Control
 */
-void initialiseAirCon(void)
+void __attribute__((optimize("Os"))) initialiseAirCon(void)
 {
   if( (configPage15.airConEnable) &&
       !pinIsReserved(pinAirConRequest) &&
@@ -393,7 +393,7 @@ static outputPin_t pump_pin;
 static fastOutputPin_t pump_pin;
 #endif
 
-static inline void initialisePumpPin(uint8_t pin) 
+static __attribute__((optimize("Os"))) void initialisePumpPin(uint8_t pin) 
 { 
   pump_pin.setPin(pin, OUTPUT);
 }
@@ -413,7 +413,7 @@ void fuelPumpOff(void)
   }
 }
 
-bool initialiseFuelPump(const config2 &page2, uint8_t pumpPin)
+bool __attribute__((optimize("Os"))) initialiseFuelPump(const config2 &page2, uint8_t pumpPin)
 {
   initialisePumpPin(pumpPin);
   fuelPumpOff();  //Initialise program with the fuel pump in the off state
@@ -439,7 +439,7 @@ static outputPin_t fan_pin;
 static fastOutputPin_t fan_pin;
 #endif
 
-static void initialiseFanPin(uint8_t pin) 
+static __attribute__((optimize("Os"))) void initialiseFanPin(uint8_t pin) 
 { 
   fan_pin.setPin(pin, OUTPUT);
 }
@@ -457,7 +457,7 @@ void fanOff(void)
   }
 }
 
-void initialiseFan(uint8_t fanPin)
+void __attribute__((optimize("Os"))) initialiseFan(uint8_t fanPin)
 {
   pinMode(pinFan, OUTPUT);
   initialiseFanPin(fanPin);
@@ -598,13 +598,13 @@ static fastOutputPin_t vvt1_pin;
 static fastOutputPin_t vvt2_pin;
 #endif
 
-static inline void initialiseVvtPins(uint8_t pin1, uint8_t pin2) 
+static __attribute__((optimize("Os"))) void initialiseVvtPins(uint8_t pin1, uint8_t pin2) 
 { 
   vvt1_pin.setPin(pin1, OUTPUT);
   vvt2_pin.setPin(pin2, OUTPUT);
 }
 
-void initialiseAuxPWM(void)
+void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
 {
   initializeBoostPin(pinBoost);
   initialiseVvtPins(pinVVT_1, pinVVT_2);

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -95,17 +95,10 @@ static fastOutputPin_t aircon_comp_pin;
 static fastOutputPin_t aircon_fan_pin;
 #endif
 
-#define BOOST_PIN_LOW()         ATOMIC() { boost_pin.setPinLow(); }
-#define BOOST_PIN_HIGH()        ATOMIC() { boost_pin.setPinHigh(); }
 static void initializeBoostPin(uint8_t pin)
 {
   boost_pin.setPin(pin, OUTPUT);
 }
-
-#define N2O_STAGE1_PIN_LOW()    ATOMIC() { n2o_stage1_pin.setPinLow(); }
-#define N2O_STAGE1_PIN_HIGH()   ATOMIC() { n2o_stage1_pin.setPinHigh(); }
-#define N2O_STAGE2_PIN_LOW()    ATOMIC() { n2o_stage2_pin.setPinLow(); }
-#define N2O_STAGE2_PIN_HIGH()   ATOMIC() { n2o_stage2_pin.setPinHigh(); }
 
 static void initialiseN2oPins(const config10 &page10)
 {
@@ -113,12 +106,6 @@ static void initialiseN2oPins(const config10 &page10)
   n2o_stage2_pin.setPin(page10.n2o_stage2_pin, OUTPUT);
   initialiseN2oArmPin(page10);
 }
-// Note the below macros cannot use ATOMIC() as they are called from within ternary operators. 
-// The ATOMIC is instead placed around the ternary call below
-#define AIRCON_PIN_LOW()        aircon_comp_pin.setPinLow()
-#define AIRCON_PIN_HIGH()       aircon_comp_pin.setPinHigh()
-#define AIRCON_FAN_PIN_LOW()    aircon_fan_pin.setPinLow()
-#define AIRCON_FAN_PIN_HIGH()   aircon_fan_pin.setPinHigh()
 
 static void initAirConCompressorPin(uint8_t pin)
 {
@@ -129,10 +116,10 @@ static void initAirConFanPin(uint8_t pin)
   aircon_fan_pin.setPin(pin, OUTPUT);
 }
 
-#define AIRCON_ON()             ATOMIC() { ((((configPage15.airConCompPol)==1)) ? AIRCON_PIN_LOW() : AIRCON_PIN_HIGH()); currentStatus.airconCompressorOn = true; }
-#define AIRCON_OFF()            ATOMIC() { ((((configPage15.airConCompPol)==1)) ? AIRCON_PIN_HIGH() : AIRCON_PIN_LOW()); currentStatus.airconCompressorOn = false; }
-#define AIRCON_FAN_ON()         ATOMIC() { ((((configPage15.airConFanPol)==1)) ? AIRCON_FAN_PIN_LOW() : AIRCON_FAN_PIN_HIGH()); currentStatus.airconFanOn = true; }
-#define AIRCON_FAN_OFF()        ATOMIC() { ((((configPage15.airConFanPol)==1)) ? AIRCON_FAN_PIN_HIGH() : AIRCON_FAN_PIN_LOW()); currentStatus.airconFanOn = false; }
+#define AIRCON_ON()             ATOMIC() { ((((configPage15.airConCompPol)==1)) ? aircon_comp_pin.setPinLow() : aircon_comp_pin.setPinHigh()); currentStatus.airconCompressorOn = true; }
+#define AIRCON_OFF()            ATOMIC() { ((((configPage15.airConCompPol)==1)) ? aircon_comp_pin.setPinHigh() : aircon_comp_pin.setPinLow()); currentStatus.airconCompressorOn = false; }
+#define AIRCON_FAN_ON()         ATOMIC() { ((((configPage15.airConFanPol)==1)) ? aircon_fan_pin.setPinLow() : aircon_fan_pin.setPinHigh()); currentStatus.airconFanOn = true; }
+#define AIRCON_FAN_OFF()        ATOMIC() { ((((configPage15.airConFanPol)==1)) ? aircon_fan_pin.setPinHigh() : aircon_fan_pin.setPinLow()); currentStatus.airconFanOn = false; }
 
 #define VVT_TIME_DELAY_MULTIPLIER  50
 
@@ -411,20 +398,17 @@ static inline void initialisePumpPin(uint8_t pin)
   pump_pin.setPin(pin, OUTPUT);
 }
 
-#define FUEL_PUMP_PIN_HIGH() pump_pin.setPinHigh()
-#define FUEL_PUMP_PIN_LOW()  pump_pin.setPinLow()
-
 void fuelPumpOn(void)
 {
   ATOMIC() { 
-    FUEL_PUMP_PIN_HIGH();
+    pump_pin.setPinHigh();
     currentStatus.fuelPumpOn = true;
   }
 }
 void fuelPumpOff(void)
 {
   ATOMIC() { 
-    FUEL_PUMP_PIN_LOW();
+    pump_pin.setPinLow();
     currentStatus.fuelPumpOn = false;
   }
 }
@@ -455,9 +439,6 @@ static outputPin_t fan_pin;
 static fastOutputPin_t fan_pin;
 #endif
 
-#define FAN_PIN_LOW()           fan_pin.setPinLow()
-#define FAN_PIN_HIGH()          fan_pin.setPinHigh()
-
 static void initialiseFanPin(uint8_t pin) 
 { 
   fan_pin.setPin(pin, OUTPUT);
@@ -466,13 +447,13 @@ static void initialiseFanPin(uint8_t pin)
 void fanOn(void) 
 {
   ATOMIC() { 
-    ((configPage6.fanInv) ? FAN_PIN_LOW() : FAN_PIN_HIGH()); 
+    ((configPage6.fanInv) ? fan_pin.setPinLow() : fan_pin.setPinHigh()); 
   }
 }
 void fanOff(void)
 {
   ATOMIC() { 
-    ((configPage6.fanInv) ? FAN_PIN_HIGH() : FAN_PIN_LOW()); 
+    ((configPage6.fanInv) ? fan_pin.setPinHigh() : fan_pin.setPinLow()); 
   }
 }
 
@@ -616,11 +597,6 @@ static outputPin_t vvt2_pin;
 static fastOutputPin_t vvt1_pin;
 static fastOutputPin_t vvt2_pin;
 #endif
-
-#define VVT1_PIN_LOW()          ATOMIC() { vvt1_pin.setPinLow(); }
-#define VVT1_PIN_HIGH()         ATOMIC() { vvt1_pin.setPinHigh(); }
-#define VVT2_PIN_LOW()          ATOMIC() { vvt2_pin.setPinLow(); }
-#define VVT2_PIN_HIGH()         ATOMIC() { vvt2_pin.setPinHigh(); }
 
 static inline void initialiseVvtPins(uint8_t pin1, uint8_t pin2) 
 { 
@@ -856,7 +832,7 @@ void boostControl(void)
       else{ currentStatus.boostDuty = get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM) * 2 * 100; }
 
       if(currentStatus.boostDuty > 10000) { currentStatus.boostDuty = 10000; } //Safety check
-      if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
+      if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
       else
       {
         boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
@@ -896,7 +872,7 @@ void boostControl(void)
           }
 
           bool PIDcomputed = boostPID.Compute(get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100/2); //Compute() returns false if the required interval has not yet passed.
-          if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
+          if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
           else
           {
             if(PIDcomputed == true)
@@ -926,7 +902,7 @@ void boostControl(void)
     if(currentStatus.boostDuty >= 10000)
     {
       DISABLE_BOOST_TIMER(); //Turn off the compare unit (ie turn off the interrupt) if boost duty is 100%
-      BOOST_PIN_HIGH(); //Turn on boost pin if duty is 100%
+      boost_pin.setPinHigh(); //Turn on boost pin if duty is 100%
     }
     else if(currentStatus.boostDuty > 0)
     {
@@ -944,19 +920,19 @@ void boostControl(void)
 
 void vvt1On(void)
 {
-  VVT1_PIN_HIGH();
+  vvt1_pin.setPinHigh();
 }
 void vvt1Off(void)
 {
-  VVT1_PIN_LOW();
+  vvt1_pin.setPinLow();
 }
 void vvt2On(void)
 {
-  VVT2_PIN_HIGH();
+  vvt2_pin.setPinHigh();
 }
 void vvt2Off(void)
 {
-  VVT2_PIN_LOW();
+  vvt2_pin.setPinLow();
 }
 
 void vvtControl(void)
@@ -1182,7 +1158,7 @@ void nitrousControl(void)
       {
         currentStatus.nitrous_status += NITROUS_STAGE1;
         currentStatus.nitrousActive = true;
-        N2O_STAGE1_PIN_HIGH();
+        n2o_stage1_pin.setPinHigh();
       }
       if(configPage10.n2o_enable == NITROUS_STAGE2) //This is really just a sanity check
       {
@@ -1190,7 +1166,7 @@ void nitrousControl(void)
         {
           currentStatus.nitrous_status += NITROUS_STAGE2;
           currentStatus.nitrousActive = true;
-          N2O_STAGE2_PIN_HIGH();
+          n2o_stage2_pin.setPinHigh();
         }
       }
     }
@@ -1200,8 +1176,8 @@ void nitrousControl(void)
   {
     if(configPage10.n2o_enable > 0)
     {
-      N2O_STAGE1_PIN_LOW();
-      N2O_STAGE2_PIN_LOW();
+      n2o_stage1_pin.setPinLow();
+      n2o_stage2_pin.setPinLow();
     }
   }
 }
@@ -1284,7 +1260,7 @@ void boostDisable(void)
   boostPID.Initialize(); //This resets the ITerm value to prevent rubber banding
   currentStatus.boostDuty = 0;
   DISABLE_BOOST_TIMER(); //Turn off timer
-  BOOST_PIN_LOW(); //Make sure solenoid is off (0% duty)
+  boost_pin.setPinLow(); //Make sure solenoid is off (0% duty)
 }
 
 //The interrupt to control the Boost PWM
@@ -1293,9 +1269,9 @@ void boostInterrupt(void)
   if (boost_pwm_state == true)
   {
     #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
-    BOOST_PIN_HIGH();
+    boost_pin.setPinHigh();
     #else
-    BOOST_PIN_LOW();  // Switch pin to low
+    boost_pin.setPinLow();  // Switch pin to low
     #endif
     SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + (boost_pwm_max_count - boost_pwm_cur_value) );
     boost_pwm_state = false;
@@ -1303,9 +1279,9 @@ void boostInterrupt(void)
   else
   {
     #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
-    BOOST_PIN_LOW();
+    boost_pin.setPinLow();
     #else
-    BOOST_PIN_HIGH();  // Switch pin high
+    boost_pin.setPinHigh();  // Switch pin high
     #endif
     SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + boost_pwm_target_value);
     boost_pwm_cur_value = boost_pwm_target_value;

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -76,36 +76,17 @@ static __attribute__((optimize("Os"))) uint8_t getAirConRequestPinMode(const con
   }
 }
 
-static __attribute__((optimize("Os"))) void initAirConRequestPin(const config15 &page15, uint8_t pin)
-{
-  aircon_req_pin.setPin(pin, getAirConRequestPinMode(page15));
-}
-
 static boardOutputPin_t boost_pin;
 static boardOutputPin_t n2o_stage1_pin;
 static boardOutputPin_t n2o_stage2_pin;
 static boardOutputPin_t aircon_comp_pin;
 static boardOutputPin_t aircon_fan_pin;
 
-static __attribute__((optimize("Os"))) void initializeBoostPin(uint8_t pin)
-{
-  boost_pin.setPin(pin, OUTPUT);
-}
-
 static __attribute__((optimize("Os"))) void initialiseN2oPins(const config10 &page10)
 {
   n2o_stage1_pin.setPin(page10.n2o_stage1_pin, OUTPUT);
   n2o_stage2_pin.setPin(page10.n2o_stage2_pin, OUTPUT);
   initialiseN2oArmPin(page10);
-}
-
-static __attribute__((optimize("Os"))) void initAirConCompressorPin(uint8_t pin)
-{
-  aircon_comp_pin.setPin(pin, OUTPUT);
-}
-static __attribute__((optimize("Os"))) void initAirConFanPin(uint8_t pin)
-{
-  aircon_fan_pin.setPin(pin, OUTPUT);
 }
 
 #define AIRCON_ON()             ATOMIC() { ((((configPage15.airConCompPol)==1)) ? aircon_comp_pin.setPinLow() : aircon_comp_pin.setPinHigh()); currentStatus.airconCompressorOn = true; }
@@ -179,14 +160,14 @@ void __attribute__((optimize("Os"))) initialiseAirCon(void)
     currentStatus.airconTurningOn = false;
     currentStatus.airconCltLockout = false;
     currentStatus.airconFanOn = false;
-    initAirConRequestPin(configPage15, pinAirConRequest);
-    initAirConCompressorPin(pinAirConComp);
+    aircon_req_pin.setPin(pinAirConRequest, getAirConRequestPinMode(configPage15));
+    aircon_comp_pin.setPin(pinAirConComp, OUTPUT);
   
     AIRCON_OFF();
 
     if((configPage15.airConFanEnabled) && (pinIsReserved(pinAirConFan)))
     {
-      initAirConFanPin(pinAirConFan);
+      aircon_fan_pin.setPin(pinAirConFan, OUTPUT);
       AIRCON_FAN_OFF();
       acStandAloneFanIsEnabled = true;
     }
@@ -381,11 +362,6 @@ static inline void checkAirConRPMLockout(void)
 
 static boardOutputPin_t pump_pin;
 
-static __attribute__((optimize("Os"))) void initialisePumpPin(uint8_t pin) 
-{ 
-  pump_pin.setPin(pin, OUTPUT);
-}
-
 void fuelPumpOn(void)
 {
   ATOMIC() { 
@@ -403,7 +379,7 @@ void fuelPumpOff(void)
 
 bool __attribute__((optimize("Os"))) initialiseFuelPump(const config2 &page2, uint8_t pumpPin)
 {
-  initialisePumpPin(pumpPin);
+  pump_pin.setPin(pumpPin, OUTPUT);
   fuelPumpOff();  //Initialise program with the fuel pump in the off state
 
   //Begin priming the fuel pump. This is turned off in the low resolution, 1s interrupt in timers.ino
@@ -423,11 +399,6 @@ Fan control
 
 static boardOutputPin_t fan_pin;
 
-static __attribute__((optimize("Os"))) void initialiseFanPin(uint8_t pin) 
-{ 
-  fan_pin.setPin(pin, OUTPUT);
-}
-
 void fanOn(void) 
 {
   ATOMIC() { 
@@ -443,8 +414,7 @@ void fanOff(void)
 
 void __attribute__((optimize("Os"))) initialiseFan(uint8_t fanPin)
 {
-  pinMode(pinFan, OUTPUT);
-  initialiseFanPin(fanPin);
+  fan_pin.setPin(fanPin, OUTPUT);
   fanOff();  //Initialise program with the fan in the off state
   currentStatus.fanOn = false;
   currentStatus.fanDuty = 0;
@@ -585,7 +555,7 @@ static __attribute__((optimize("Os"))) void initialiseVvtPins(uint8_t pin1, uint
 
 void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
 {
-  initializeBoostPin(pinBoost);
+  boost_pin.setPin(pinBoost, OUTPUT);
   initialiseVvtPins(pinVVT_1, pinVVT_2);
   initialiseN2oPins(configPage10);
 

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -148,7 +148,11 @@ static void airConFanOff(void)
 
 static bool isWmiTankEmpty(void)
 {
-  return ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 1);
+  if (configPage10.wmiEmptyEnabled) 
+  {
+    return (configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty);
+  }
+  return true;
 }
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -89,14 +89,67 @@ static __attribute__((optimize("Os"))) void initialiseN2oPins(const config10 &pa
   initialiseN2oArmPin(page10);
 }
 
-#define AIRCON_ON()             ATOMIC() { ((((configPage15.airConCompPol)==1)) ? aircon_comp_pin.setPinLow() : aircon_comp_pin.setPinHigh()); currentStatus.airconCompressorOn = true; }
-#define AIRCON_OFF()            ATOMIC() { ((((configPage15.airConCompPol)==1)) ? aircon_comp_pin.setPinHigh() : aircon_comp_pin.setPinLow()); currentStatus.airconCompressorOn = false; }
-#define AIRCON_FAN_ON()         ATOMIC() { ((((configPage15.airConFanPol)==1)) ? aircon_fan_pin.setPinLow() : aircon_fan_pin.setPinHigh()); currentStatus.airconFanOn = true; }
-#define AIRCON_FAN_OFF()        ATOMIC() { ((((configPage15.airConFanPol)==1)) ? aircon_fan_pin.setPinHigh() : aircon_fan_pin.setPinLow()); currentStatus.airconFanOn = false; }
+static void airConOn(void)
+{
+  ATOMIC() { 
+    if (configPage15.airConCompPol)
+    {
+      aircon_comp_pin.setPinLow();
+    }
+    else
+    {
+      aircon_comp_pin.setPinHigh();
+    }
+    currentStatus.airconCompressorOn = true; 
+  }  
+}
+static void airConOff(void)
+{
+  ATOMIC() { 
+    if (configPage15.airConCompPol)
+    {
+      aircon_comp_pin.setPinHigh();
+    }
+    else
+    {
+      aircon_comp_pin.setPinLow();
+    }
+    currentStatus.airconCompressorOn = false; 
+  }
+}
+static void airConFanOn(void)
+{
+  ATOMIC() { 
+    if (configPage15.airConFanPol)
+    {
+      aircon_fan_pin.setPinLow();
+    }
+    else
+    {
+      aircon_fan_pin.setPinHigh();
+    }
+    currentStatus.airconFanOn = true; 
+  }
+}
+static void airConFanOff(void)
+{
+  ATOMIC() { 
+    if (configPage15.airConFanPol)
+    {
+      aircon_fan_pin.setPinHigh();
+    }
+    else
+    {
+      aircon_fan_pin.setPinLow();
+    }
+    currentStatus.airconFanOn = false; 
+  }
+}
 
-#define VVT_TIME_DELAY_MULTIPLIER  50
-
-#define WMI_TANK_IS_EMPTY() ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 1)
+static bool isWmiTankEmpty(void)
+{
+  return ((configPage10.wmiEmptyEnabled) ? ((configPage10.wmiEmptyPolarity) ? digitalRead(pinWMIEmpty) : !digitalRead(pinWMIEmpty)) : 1);
+}
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
 volatile bool fan_pwm_state;
@@ -163,12 +216,12 @@ void __attribute__((optimize("Os"))) initialiseAirCon(void)
     aircon_req_pin.setPin(pinAirConRequest, getAirConRequestPinMode(configPage15));
     aircon_comp_pin.setPin(pinAirConComp, OUTPUT);
   
-    AIRCON_OFF();
+    airConOff();
 
     if((configPage15.airConFanEnabled) && (pinIsReserved(pinAirConFan)))
     {
       aircon_fan_pin.setPin(pinAirConFan, OUTPUT);
-      AIRCON_FAN_OFF();
+      airConFanOff();
       acStandAloneFanIsEnabled = true;
     }
     else
@@ -243,13 +296,13 @@ void airConControl(void)
       // Stand-alone fan operation
       if(acStandAloneFanIsEnabled == true)
       {
-        AIRCON_FAN_ON();
+        airConFanOn();
       }
 
       // Start the A/C compressor after the "Compressor On" delay period
       if(acStartDelay >= configPage15.airConCompOnDelay)
       {
-        AIRCON_ON();
+        airConOn();
       }
       else
       {
@@ -263,10 +316,10 @@ void airConControl(void)
       // Stand-alone fan operation
       if(acStandAloneFanIsEnabled == true)
       {
-        AIRCON_FAN_OFF();
+        airConFanOff();
       }
 
-      AIRCON_OFF();
+      airConOff();
       acStartDelay = 0;
     }
   }
@@ -897,6 +950,7 @@ void vvtControl(void)
     //Calculate the current cam angle for miata trigger
     if( configPage4.TrigPattern == 9 ) { currentStatus.vvt1Angle = getCamAngle_Miata9905(); }
 
+    constexpr uint32_t VVT_TIME_DELAY_MULTIPLIER = 50;
     if( (vvtIsHot == true) || ((runSecsX10 - vvtWarmTime) >= (configPage4.vvtDelay * VVT_TIME_DELAY_MULTIPLIER)) ) 
     {
       vvtIsHot = true;
@@ -1139,7 +1193,7 @@ void wmiControl(void)
   // wmi can only work when vvt2 is disabled 
   if( (configPage10.vvt2Enabled == 0) && (configPage10.wmiEnabled >= 1) )
   {
-    if( WMI_TANK_IS_EMPTY() )
+    if( isWmiTankEmpty() )
     {
      currentStatus.wmiTankEmpty = false;
       if( (currentStatus.TPS >= configPage10.wmiTPS) && (currentStatus.RPMdiv100 >= configPage10.wmiRPM) && ( (currentStatus.MAP / 2) >= configPage10.wmiMAP) && ( temperatureAddOffset(currentStatus.IAT) >= configPage10.wmiIAT) )

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <avr/interrupt.h>
 #include <avr/io.h>
+#include "src/pins/fastInputPin.h"
+#include "src/pins/fastOutputPin.h"
 
 /*
 ***********************************************************************************************************
@@ -170,3 +172,6 @@ static inline void IGN8_TIMER_DISABLE(void) { TIMSK3 &= ~(1 << OCIE3B); } //Repl
 * CAN / Second serial
 */
 #define SECONDARY_SERIAL_T HardwareSerial
+
+using boardInputPin_t = fastInputPin_t;
+using boardOutputPin_t = fastOutputPin_t;

--- a/speeduino/board_native.h
+++ b/speeduino/board_native.h
@@ -6,6 +6,8 @@
 #include <limits>
 #include <USBAPI.h>
 #include "../lib/ArduinoFake/SoftwareTimer.h"
+#include "src/pins/inputPin.h"
+#include "src/pins/outputPin.h"
 
 /*
 ***********************************************************************************************************
@@ -152,5 +154,8 @@ constexpr const _Tp& min(const _Tp& __a, const _Tp& __b) {
 #define SECONDARY_SERIAL_T decltype(Serial)
 
 #define RTC_LIB_H <time.h>
+
+using boardInputPin_t = inputPin_t;
+using boardOutputPin_t = outputPin_t;
 
 #endif // NATIVE_BOARD

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -7,6 +7,8 @@
 #include <HardwareSerial.h>
 #include "STM32RTC.h"
 #include <SPI.h>
+#include "src/pins/inputPin.h"
+#include "src/pins/outputPin.h"
 
 #define CORE_STM32
 
@@ -338,3 +340,6 @@ extern STM32_CAN Can0;
 #else //libmaple core aka STM32DUINO
   #define SECONDARY_SERIAL_T HardwareSerial
 #endif
+
+using boardInputPin_t = inputPin_t;
+using boardOutputPin_t = outputPin_t;

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -3,6 +3,8 @@
 /** DO NOT INCLUDE DIRECTLY - should be included via board_definition.h */
 
 #include <Arduino.h>
+#include "src/pins/inputPin.h"
+#include "src/pins/outputPin.h"
 
 #define CORE_TEENSY35
 
@@ -177,3 +179,6 @@ static inline void IGN8_TIMER_DISABLE(void)  {FTM3_C7SC &= ~FTM_CSC_CHIE;}
 
 #include <FlexCAN_T4.h>
 #define NATIVE_CAN_AVAILABLE
+
+using boardInputPin_t = inputPin_t;
+using boardOutputPin_t = outputPin_t;

--- a/speeduino/board_teensy41.h
+++ b/speeduino/board_teensy41.h
@@ -4,6 +4,8 @@
 
 #include <Arduino.h>
 #include <limits>
+#include "src/pins/inputPin.h"
+#include "src/pins/outputPin.h"
 
 #define CORE_TEENSY41
 
@@ -217,3 +219,6 @@ static inline void IGN8_TIMER_DISABLE(void)  {TMR4_CSCTRL3 &= ~TMR_CSCTRL_TCF1EN
 
 #include <FlexCAN_T4.h>
 #define NATIVE_CAN_AVAILABLE //Disable for now as it causes lockup 
+
+using boardInputPin_t = inputPin_t;
+using boardOutputPin_t = outputPin_t;

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -129,10 +129,6 @@ static inputPin_t triggerSec_pin;
 static inputPin_t triggerThird_pin;
 #endif
 
-#define READ_PRI_TRIGGER() (triggerPri_pin.isPinHigh())
-#define READ_SEC_TRIGGER() (triggerSec_pin.isPinHigh())
-#define READ_THIRD_TRIGGER() (triggerThird_pin.isPinHigh())
-
 #define TOOTH_CRANK 0
 #define TOOTH_CAM_SECONDARY 1
 #define TOOTH_CAM_TERTIARY  2
@@ -180,26 +176,26 @@ static inline void addToothLogEntry(unsigned long toothTime, byte whichTooth)
       if(currentStatus.compositeTriggerUsed == 4)
       {
         // we want to display both cams so swap the values round to display primary as cam1 and secondary as cam2, include the crank in the data as the third output
-        if(READ_SEC_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
-        if(READ_THIRD_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); }
-        if(READ_PRI_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
+        if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
+        if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); }
+        if(triggerPri_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
         if(whichTooth > TOOTH_CAM_SECONDARY) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_TRIG); }
       }
       else
       {
         // we want to display crank and one of the cams
-        if(READ_PRI_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
+        if(triggerPri_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
         if(currentStatus.compositeTriggerUsed == 3)
         { 
           // display cam2 and also log data for cam 1
-          if(READ_THIRD_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } // only the COMPOSITE_LOG_SEC value is visualised hence the swapping of the data
-          if(READ_SEC_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); } 
+          if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } // only the COMPOSITE_LOG_SEC value is visualised hence the swapping of the data
+          if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); } 
         } 
         else
         { 
           // display cam1 and also log data for cam 2 - this is the historic composite view
-          if(READ_SEC_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } 
-          if(READ_THIRD_TRIGGER() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
+          if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } 
+          if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
         }
         if(whichTooth > TOOTH_CRANK) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_TRIG); }
       }  
@@ -240,7 +236,7 @@ void loggerPrimaryISR(void)
   2) If the primary trigger is FALLING, then check whether the primary is currently LOW
   If either of these are true, the primary decoder function is called
   */
-  if( ( (currentStatus.decoder.primary.edge == RISING) && (READ_PRI_TRIGGER() == HIGH) ) || ( (currentStatus.decoder.primary.edge == FALLING) && (READ_PRI_TRIGGER() == LOW) ) || (currentStatus.decoder.primary.edge == CHANGE) )
+  if( ( (currentStatus.decoder.primary.edge == RISING) && (triggerPri_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.primary.edge == FALLING) && (triggerPri_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.primary.edge == CHANGE) )
   {
     currentStatus.decoder.primary.callback();
     validEdge = true;
@@ -272,7 +268,7 @@ void loggerSecondaryISR(void)
   3) The secondary trigger is CHANGING
   If any of these are true, the primary decoder function is called
   */
-  if( ( (currentStatus.decoder.secondary.edge == RISING) && (READ_SEC_TRIGGER() == HIGH) ) || ( (currentStatus.decoder.secondary.edge == FALLING) && (READ_SEC_TRIGGER() == LOW) ) || (currentStatus.decoder.secondary.edge == CHANGE) )
+  if( ( (currentStatus.decoder.secondary.edge == RISING) && (triggerSec_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.secondary.edge == FALLING) && (triggerSec_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.secondary.edge == CHANGE) )
   {
     currentStatus.decoder.secondary.callback();
   }
@@ -299,7 +295,7 @@ void loggerTertiaryISR(void)
   */
 
 
-  if( ( (currentStatus.decoder.tertiary.edge == RISING) && ( READ_THIRD_TRIGGER() == HIGH) ) || ( (currentStatus.decoder.tertiary.edge == FALLING) && (READ_THIRD_TRIGGER() == LOW) ) || (currentStatus.decoder.tertiary.edge == CHANGE) )
+  if( ( (currentStatus.decoder.tertiary.edge == RISING) && ( triggerThird_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.tertiary.edge == FALLING) && (triggerThird_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.tertiary.edge == CHANGE) )
   {
     currentStatus.decoder.tertiary.callback();
   }
@@ -625,7 +621,7 @@ static void triggerPri_missingTooth(void)
                 toothCurrentCount = 1;
                 if (configPage4.trigPatternSec == SEC_TRIGGER_POLL) // at tooth one check if the cam sensor is high or low in poll level mode
                 {
-                  if (configPage4.PollLevelPolarity == READ_SEC_TRIGGER()) { revolutionOne = 1; }
+                  if (configPage4.PollLevelPolarity == triggerSec_pin.isPinHigh()) { revolutionOne = 1; }
                   else { revolutionOne = 0; }
                 }
                 else {revolutionOne = !revolutionOne;} //Flip sequential revolution tracker if poll level is not used
@@ -1683,21 +1679,21 @@ static void triggerPri_4G63(void)
     {
       triggerSecFilterTime = 0;
       //New secondary method of determining sync
-      if(READ_PRI_TRIGGER() == true)
+      if(triggerPri_pin.isPinHigh() == true)
       {
-        if(READ_SEC_TRIGGER() == true) { revolutionOne = true; }
+        if(triggerSec_pin.isPinHigh() == true) { revolutionOne = true; }
         else { revolutionOne = false; }
       }
       else
       {
-        if( (READ_SEC_TRIGGER() == false) && (revolutionOne == true) ) 
+        if( (triggerSec_pin.isPinHigh() == false) && (revolutionOne == true) ) 
         { 
           //Crank is low, cam is low and the crank pulse STARTED when the cam was high. 
           if(configPage2.nCylinders == 4) { toothCurrentCount = 1; } //Means we're at 5* BTDC on a 4G63 4 cylinder
           //else if(configPage2.nCylinders == 6) { toothCurrentCount = 8; } 
         } 
         //If sequential is ever enabled, the below toothCurrentCount will need to change:
-        else if( (READ_SEC_TRIGGER() == true) && (revolutionOne == true) ) 
+        else if( (triggerSec_pin.isPinHigh() == true) && (revolutionOne == true) ) 
         { 
           //Crank is low, cam is high and the crank pulse STARTED when the cam was high. 
           if(configPage2.nCylinders == 4) { toothCurrentCount = 5; } //Means we're at 5* BTDC on a 4G63 4 cylinder
@@ -1731,7 +1727,7 @@ static void triggerSec_4G63(void)
 
       triggerFilterTime = 1500; //If this is removed, can have trouble getting sync again after the engine is turned off (but ECU not reset).
       triggerSecFilterTime = triggerSecFilterTime >> 1; //Divide the secondary filter time by 2 again, making it 25%. Only needed when cranking
-      if(READ_PRI_TRIGGER() == true)
+      if(triggerPri_pin.isPinHigh() == true)
       {
         if(configPage2.nCylinders == 4)
         { 
@@ -1759,7 +1755,7 @@ static void triggerSec_4G63(void)
       if( (decoderStatus.syncStatus==SyncStatus::Full) && (configPage2.nCylinders == 4) )
       {
         triggerSecFilterTime_duration = (micros() - secondaryLastToothTime1) >> 1;
-        if(READ_PRI_TRIGGER() == true)
+        if(triggerPri_pin.isPinHigh() == true)
         {
           //Whilst we're cranking and have sync, we need to watch for noise pulses.
           if(toothCurrentCount != 8) 
@@ -3133,7 +3129,7 @@ static void triggerSec_Nissan360(void)
   if(configPage4.TrigEdgeSec == 0) { trigEdge = LOW; }
   else { trigEdge = HIGH; }
 
-  if( (secondaryToothCount == 0) || (READ_SEC_TRIGGER() == trigEdge) ) { secondaryToothCount = toothCurrentCount; } //This occurs on the first rotation upon powerup OR the start of a secondary window
+  if( (secondaryToothCount == 0) || (triggerSec_pin.isPinHigh() == trigEdge) ) { secondaryToothCount = toothCurrentCount; } //This occurs on the first rotation upon powerup OR the start of a secondary window
   else
   {
     //If we reach here, we are at the end of a secondary window
@@ -3776,7 +3772,7 @@ static void triggerPri_Harley(void)
   setFilter(curGap); // Filtering adjusted according to setting
   if (curGap > triggerFilterTime)
   {
-    if ( READ_PRI_TRIGGER() == HIGH) // Has to be the same as in main() trigger-attach, for readability we do it this way.
+    if ( triggerPri_pin.isPinHigh() == HIGH) // Has to be the same as in main() trigger-attach, for readability we do it this way.
     {
         decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
         targetGap = lastGap ; //Gap is the Time to next toothtrigger, so we know where we are
@@ -4261,7 +4257,7 @@ static void triggerSec_420a(void)
 {
   //Secondary trigger is only on falling edge
 
-  if(READ_PRI_TRIGGER() == true)
+  if(triggerPri_pin.isPinHigh() == true)
   {
     //Secondary signal is falling and primary signal is HIGH
     if( decoderStatus.syncStatus!=SyncStatus::Full )
@@ -4740,7 +4736,7 @@ static void triggerPri_NGC(void)
 {
   curTime = micros();
   // We need to know the polarity of the missing tooth to determine position
-  if (READ_PRI_TRIGGER() == HIGH) {
+  if (triggerPri_pin.isPinHigh() == HIGH) {
     toothLastToothRisingTime = curTime;
     return;
   }
@@ -4856,7 +4852,7 @@ static void triggerSec_NGC4(void)
   curTime2 = micros();
 
   // We need to know the polarity of the missing tooth to determine position
-  if (READ_SEC_TRIGGER() == HIGH) {
+  if (triggerSec_pin.isPinHigh() == HIGH) {
     toothLastSecToothRisingTime = curTime2;
     return;
   }
@@ -5089,7 +5085,7 @@ static void triggerPri_Vmax(void)
 {
   bool primaryEdge = configPage4.TrigEdge == 0;
   curTime = micros();
-  if(READ_PRI_TRIGGER() == primaryEdge){// Forwarded from the config page to setup the primary trigger edge (rising or falling). Inverting VR-conditioners require FALLING, non-inverting VR-conditioners require RISING in the Trigger edge setup.
+  if(triggerPri_pin.isPinHigh() == primaryEdge){// Forwarded from the config page to setup the primary trigger edge (rising or falling). Inverting VR-conditioners require FALLING, non-inverting VR-conditioners require RISING in the Trigger edge setup.
     curGap2 = curTime;
     curGap = curTime - toothLastToothTime;
     if ( (curGap >= triggerFilterTime) ){

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -119,15 +119,9 @@ TESTABLE_STATIC decoder_status_t decoderStatus;
 static libdivide::libdivide_s16_t divTriggerToothAngle;
 #endif
 
-#if defined(CORE_AVR)
-static fastInputPin_t triggerPri_pin;
-static fastInputPin_t triggerSec_pin;
-static fastInputPin_t triggerThird_pin;
-#else
-static inputPin_t triggerPri_pin;
-static inputPin_t triggerSec_pin;
-static inputPin_t triggerThird_pin;
-#endif
+static boardInputPin_t triggerPri_pin;
+static boardInputPin_t triggerSec_pin;
+static boardInputPin_t triggerThird_pin;
 
 #define TOOTH_CRANK 0
 #define TOOTH_CAM_SECONDARY 1

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -45,6 +45,7 @@ A full copy of the license may be found in the projects root directory
 #include "decoder_builder.h"
 #include "scheduledIO_ign.h"
 #include "src/pins/fastInputPin.h"
+#include "src/pins/inputPin.h"
 
 static void triggerRoverMEMSCommon(void);
 static inline void triggerRecordVVT1Angle (void);
@@ -118,19 +119,19 @@ TESTABLE_STATIC decoder_status_t decoderStatus;
 static libdivide::libdivide_s16_t divTriggerToothAngle;
 #endif
 
+#if defined(CORE_AVR)
 static fastInputPin_t triggerPri_pin;
 static fastInputPin_t triggerSec_pin;
 static fastInputPin_t triggerThird_pin;
-
-#if defined(CORE_AVR)
-  #define READ_PRI_TRIGGER() (triggerPri_pin.isPinHigh())
-  #define READ_SEC_TRIGGER() (triggerSec_pin.isPinHigh())
-  #define READ_THIRD_TRIGGER() (triggerThird_pin.isPinHigh())
 #else
-  #define READ_PRI_TRIGGER() digitalRead(pinTrigger)
-  #define READ_SEC_TRIGGER() digitalRead(pinTrigger2)
-  #define READ_THIRD_TRIGGER() digitalRead(pinTrigger3)  
+static inputPin_t triggerPri_pin;
+static inputPin_t triggerSec_pin;
+static inputPin_t triggerThird_pin;
 #endif
+
+#define READ_PRI_TRIGGER() (triggerPri_pin.isPinHigh())
+#define READ_SEC_TRIGGER() (triggerSec_pin.isPinHigh())
+#define READ_THIRD_TRIGGER() (triggerThird_pin.isPinHigh())
 
 #define TOOTH_CRANK 0
 #define TOOTH_CAM_SECONDARY 1

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -29,6 +29,7 @@ A full copy of the license may be found in the projects root directory
 #include "polling.hpp"
 #include "decoders.h"
 #include "src/pins/fastInputPin.h"
+#include "src/pins/inputPin.h"
 
 uint8_t statusSensors = 0;
 
@@ -956,19 +957,15 @@ uint8_t getAnalogKnock(void)
 }
 
 #if defined(CORE_AVR)
-  static fastInputPin_t flex_pin;
-  static inline void initialiseFlexPin(uint8_t pin)
-  {
-    flex_pin.setPin(pin, INPUT);
-  }
-  #define READ_FLEX() (flex_pin.isPinHigh())
+static fastInputPin_t flex_pin;
 #else
-  #define READ_FLEX() digitalRead(pinFlex)==HIGH
-  static inline void initialiseFlexPin(uint8_t pin)
-  {
-    pinMode(pin, INPUT);
-  }
+static inputPin_t flex_pin;
 #endif
+
+static inline void initialiseFlexPin(uint8_t pin)
+{
+  flex_pin.setPin(pin, INPUT);
+}
 
 /*
  * The interrupt function for reading the flex sensor frequency and pulse width
@@ -976,7 +973,7 @@ uint8_t getAnalogKnock(void)
  */
 void flexPulse(void)
 {
-  if(READ_FLEX() == true)
+  if(flex_pin.isPinHigh())
   {
     uint16_t tempPW = clamp(micros() - flexStartTime, 0UL, (unsigned long)UINT16_MAX); //Calculate the pulse width
     flexPulseWidth = LOW_PASS_FILTER(tempPW, configPage4.FILTER_FLEX, flexPulseWidth);

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -958,11 +958,6 @@ uint8_t getAnalogKnock(void)
 
 static boardInputPin_t flex_pin;
 
-static inline void initialiseFlexPin(uint8_t pin)
-{
-  flex_pin.setPin(pin, INPUT);
-}
-
 /*
  * The interrupt function for reading the flex sensor frequency and pulse width
  * flexCounter value is incremented with every pulse and reset back to 0 once per second
@@ -981,7 +976,7 @@ void flexPulse(void)
   }
 }
 
-void initialiseFlexSensor(config2 &page2, statuses &current, uint8_t pin)
+void __attribute__((optimize("Os"))) initialiseFlexSensor(config2 &page2, statuses &current, uint8_t pin)
 {
   current.ethanolPct = 0;
 
@@ -990,7 +985,7 @@ void initialiseFlexSensor(config2 &page2, statuses &current, uint8_t pin)
   {
     // Standard GM / Continental flex sensor requires pullup, but this should be onboard.
     // The internal pullup will not work (Requires ~3.3k)!
-    initialiseFlexPin(pin);
+    flex_pin.setPin(pin, INPUT);
 
     attachInterrupt(digitalPinToInterrupt(pinFlex), flexPulse, CHANGE); 
   }  

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -956,11 +956,7 @@ uint8_t getAnalogKnock(void)
   return (uint8_t)fastMap10Bit(readAnalogSensor(pinKnock), 0U, 255U);
 }
 
-#if defined(CORE_AVR)
-static fastInputPin_t flex_pin;
-#else
-static inputPin_t flex_pin;
-#endif
+static boardInputPin_t flex_pin;
 
 static inline void initialiseFlexPin(uint8_t pin)
 {

--- a/speeduino/src/pins/fastOutputPin.cpp
+++ b/speeduino/src/pins/fastOutputPin.cpp
@@ -1,5 +1,5 @@
 #include "fastOutputPin.h"
-#include "atomic.h"
+#include "../../atomic.h"
 
 // LCOV_EXCL_START
 // Exclude low level pin manipulation from coverage as it's not testable in a meaningful way

--- a/speeduino/src/pins/fastOutputPin.cpp
+++ b/speeduino/src/pins/fastOutputPin.cpp
@@ -1,4 +1,5 @@
 #include "fastOutputPin.h"
+#include "atomic.h"
 
 // LCOV_EXCL_START
 // Exclude low level pin manipulation from coverage as it's not testable in a meaningful way
@@ -13,13 +14,13 @@ void fastOutputPin_t::setPin(uint8_t pin, uint8_t mode)
 /** @brief Set the pin high */
 void fastOutputPin_t::setPinHigh(void)
 {
-    *_port_pin.port |= _port_pin.mask;
+    ATOMIC() { *_port_pin.port |= _port_pin.mask; }
 }
 
 /** @brief Set the pin low */
 void fastOutputPin_t::setPinLow(void)
 {
-    *_port_pin.port &= ~_port_pin.mask;
+    ATOMIC() { *_port_pin.port &= ~_port_pin.mask; }
 }
 
 // LCOV_EXCL_STOP

--- a/speeduino/src/pins/inputPin.cpp
+++ b/speeduino/src/pins/inputPin.cpp
@@ -1,0 +1,16 @@
+#include "inputPin.h"
+
+// LCOV_EXCL_START
+// Exclude low level pin manipulation from coverage as it's not testable in a meaningful way
+
+void inputPin_t::setPin(uint8_t pin, uint8_t mode) 
+{
+    pinMode(pin, mode);
+    _pin = pin;
+}
+
+bool inputPin_t::isPinHigh(void) const {
+    return digitalRead(_pin) == HIGH;
+}
+
+// LCOV_EXCL_STOP

--- a/speeduino/src/pins/inputPin.h
+++ b/speeduino/src/pins/inputPin.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <Arduino.h>
+#include <stdint.h>
+
+/** 
+ * @brief A class for input pin operations. 
+ * 
+ * Call setPin() to initialize the pin, then call isPinHigh() to check if the pin is set high.
+ * 
+ * @note Must have same signature as fastInputPin_t to allow for interchangeable use.
+ */
+class inputPin_t 
+{
+public:
+  /** @brief Set the input pin */
+  void setPin(uint8_t pin, uint8_t mode = INPUT);
+
+  /** @brief Check if the pin is set high */
+  bool isPinHigh(void) const;
+
+  /** @brief Check if the pin is set low */
+  bool isPinLow(void) const
+  {
+    return !isPinHigh();
+  }
+
+private:
+  uint8_t _pin = 0;
+};

--- a/speeduino/src/pins/outputPin.cpp
+++ b/speeduino/src/pins/outputPin.cpp
@@ -1,5 +1,5 @@
 #include "outputPin.h"
-#include "atomic.h"
+#include "../../atomic.h"
 
 // LCOV_EXCL_START
 // Exclude low level pin manipulation from coverage as it's not testable in a meaningful way

--- a/speeduino/src/pins/outputPin.cpp
+++ b/speeduino/src/pins/outputPin.cpp
@@ -1,0 +1,24 @@
+#include "outputPin.h"
+
+// LCOV_EXCL_START
+// Exclude low level pin manipulation from coverage as it's not testable in a meaningful way
+
+void outputPin_t::setPin(uint8_t pin, uint8_t mode)
+{
+    pinMode(pin, mode);
+    _pin = pin;
+}
+
+/** @brief Set the pin high */
+void outputPin_t::setPinHigh(void)
+{
+    digitalWrite(_pin, HIGH);
+}
+
+/** @brief Set the pin low */
+void outputPin_t::setPinLow(void)
+{
+    digitalWrite(_pin, LOW);
+}
+
+// LCOV_EXCL_STOP

--- a/speeduino/src/pins/outputPin.cpp
+++ b/speeduino/src/pins/outputPin.cpp
@@ -1,4 +1,5 @@
 #include "outputPin.h"
+#include "atomic.h"
 
 // LCOV_EXCL_START
 // Exclude low level pin manipulation from coverage as it's not testable in a meaningful way
@@ -12,13 +13,13 @@ void outputPin_t::setPin(uint8_t pin, uint8_t mode)
 /** @brief Set the pin high */
 void outputPin_t::setPinHigh(void)
 {
-    digitalWrite(_pin, HIGH);
+   ATOMIC() { digitalWrite(_pin, HIGH); }
 }
 
 /** @brief Set the pin low */
 void outputPin_t::setPinLow(void)
 {
-    digitalWrite(_pin, LOW);
+  ATOMIC() { digitalWrite(_pin, LOW); }
 }
 
 // LCOV_EXCL_STOP

--- a/speeduino/src/pins/outputPin.h
+++ b/speeduino/src/pins/outputPin.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <Arduino.h>
+#include <stdint.h>
+
+/** 
+ * @brief A class for output pin operations. Must have same signature as fastOutputPin_t to allow for interchangeable use.
+ * 
+ * Call setPin() to initialize the pin, then call setPinHigh() to set the pin high.
+ */
+class outputPin_t 
+{
+public:
+  /** @brief Set the output pin */
+  void setPin(uint8_t pin, uint8_t mode = OUTPUT);
+
+  /** @brief Set the pin high */
+  void setPinHigh(void);
+
+  /** @brief Set the pin low */
+  void setPinLow(void);
+
+private:
+  uint8_t _pin = 0;
+};

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -21,6 +21,7 @@ Timers are typically low resolution (Compared to Schedulers), with maximum frequ
 #include "scheduledIO_ign.h"
 #include "scheduledIO_inj.h"
 #include "src/pins/fastOutputPin.h"
+#include "src/pins/outputPin.h"
 
 volatile uint16_t lastRPM_100ms; //Need to record this for rpmDOT calculation
 volatile byte loop5ms;
@@ -54,18 +55,17 @@ void initialiseTimers(void)
 }
 
 #if defined(CORE_TEENSY) || defined(CORE_STM32)
-  #define TACHO_PULSE_LOW()         (digitalWrite(pinTachOut, LOW))
-  #define TACHO_PULSE_HIGH()        (digitalWrite(pinTachOut, HIGH))
-  static void initTachoPin(uint8_t pin) { UNUSED(pin); /* Do nothing*/}
- #else
-  #define TACHO_PULSE_HIGH()        (tach_pin.setPinHigh())
-  #define TACHO_PULSE_LOW()         (tach_pin.setPinLow())
-  static fastOutputPin_t tach_pin;
-  static void initTachoPin(uint8_t pin) 
-  { 
-    tach_pin.setPin(pin, OUTPUT);
-  }
+static outputPin_t tach_pin;
+#else
+static fastOutputPin_t tach_pin;
 #endif
+
+static void initTachoPin(uint8_t pin) 
+{ 
+  tach_pin.setPin(pin, OUTPUT);
+}
+#define TACHO_PULSE_HIGH()        (tach_pin.setPinHigh())
+#define TACHO_PULSE_LOW()         (tach_pin.setPinLow())
 
 void initTacho(uint8_t tachoPin)
 {

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -41,7 +41,7 @@ volatile uint16_t tachoSweepAccum;
 volatile uint8_t testInjectorPulseCount = 0;
 volatile uint8_t testIgnitionPulseCount = 0;
 
-void initialiseTimers(void)
+void __attribute__((optimize("Os"))) initialiseTimers(void)
 {
   lastRPM_100ms = 0;
   loop5ms = 0;
@@ -51,20 +51,14 @@ void initialiseTimers(void)
   loop100ms = 0;
   loop250ms = 0;
   loopSec = 0;
-  tachoOutputFlag = TACHO_INACTIVE;
 }
 
 static boardOutputPin_t tach_pin;
 
-static void initTachoPin(uint8_t pin) 
-{ 
-  tach_pin.setPin(pin, OUTPUT);
-}
-
-void initTacho(uint8_t tachoPin)
+void __attribute__((optimize("Os"))) initTacho(uint8_t tachoPin)
 {
-  pinMode(tachoPin, OUTPUT);
-  initTachoPin(tachoPin);
+  tach_pin.setPin(tachoPin, OUTPUT);
+  tachoOutputFlag = TACHO_INACTIVE;
 }
 
 void tachoPulseHigh(void)

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -64,8 +64,6 @@ static void initTachoPin(uint8_t pin)
 { 
   tach_pin.setPin(pin, OUTPUT);
 }
-#define TACHO_PULSE_HIGH()        (tach_pin.setPinHigh())
-#define TACHO_PULSE_LOW()         (tach_pin.setPinLow())
 
 void initTacho(uint8_t tachoPin)
 {
@@ -75,12 +73,12 @@ void initTacho(uint8_t tachoPin)
 
 void tachoPulseHigh(void)
 {
-  TACHO_PULSE_HIGH();
+  tach_pin.setPinHigh();
 }
 
 void tachoPulseLow(void)
 {
-  TACHO_PULSE_LOW();
+  tach_pin.setPinLow();
 }
 
 static inline void applyOverDwellCheck(IgnitionSchedule &schedule, uint32_t targetOverdwellTime) {
@@ -160,7 +158,7 @@ void oneMSInterval(void)
     //Check for half speed tacho
     if( (configPage2.tachoDiv == 0) || (currentStatus.tachoAlt == true) ) 
     { 
-      TACHO_PULSE_LOW();
+      tach_pin.setPinLow();
       //ms_counter is cast down to a byte as the tacho duration can only be in the range of 1-6, so no extra resolution above that is required
       tachoEndTime = (uint8_t)ms_counter + configPage2.tachoDuration;
       tachoOutputFlag = ACTIVE;
@@ -177,7 +175,7 @@ void oneMSInterval(void)
     //If the tacho output is already active, check whether it's reached it's end time
     if((uint8_t)ms_counter == tachoEndTime)
     {
-      TACHO_PULSE_HIGH();
+      tach_pin.setPinHigh();
       tachoOutputFlag = TACHO_INACTIVE;
     }
   }

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -54,11 +54,7 @@ void initialiseTimers(void)
   tachoOutputFlag = TACHO_INACTIVE;
 }
 
-#if defined(CORE_TEENSY) || defined(CORE_STM32)
-static outputPin_t tach_pin;
-#else
-static fastOutputPin_t tach_pin;
-#endif
+static boardOutputPin_t tach_pin;
 
 static void initTachoPin(uint8_t pin) 
 { 


### PR DESCRIPTION
Replace multiple pre-processor based pin type selection, macros & functions with a single board specific type.

1. Add `inputPin_t` and `outputPin_t` which are API compatible with `fastInputPin_t` and `fastOutputPin_t`, but wrap `digitalRead`/`digitalWrite`
2. Each board header aliases `boardInputPin_t` and `boardOutputPin_t` as needed
