### PR TITLE
Limit EEPROM includes and types to board CPP files

### DIFF
--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -12,6 +12,7 @@
 #else
   #include <EEPROM.h>
 #endif
+#include "board_eeprom_adapter.hpp"
 
 // Prescaler values for timers 1-3-4-5. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
 #define TIMER_PRESCALER_OFF  ((0<<CS12)|(0<<CS11)|(0<<CS10))
@@ -284,31 +285,10 @@ static uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return EEPROM.read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    EEPROM.write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return EEPROM.length();
-  }
-}
-
 /** @brief Get the EEPROM storage API for the board */
 storage_api_t getBoardStorageApi(void)
 {
-  return {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
-  };
+  return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
 #endif //CORE_AVR

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -7,7 +7,11 @@
 #include "idle.h"
 #include "scheduler.h"
 #include "timers.h"
-#include EEPROM_LIB_H
+#ifdef USE_SPI_EEPROM
+  #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+#else
+  #include <EEPROM.h>
+#endif
 
 // Prescaler values for timers 1-3-4-5. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
 #define TIMER_PRESCALER_OFF  ((0<<CS12)|(0<<CS11)|(0<<CS10))
@@ -251,7 +255,7 @@ void boardInitPins(void)
   // Do nothing
 }
 
-uint16_t getEepromWriteBlockSize(const statuses &current)
+static uint16_t getEepromWriteBlockSize(const statuses &current)
 {
 #if defined(USE_SPI_EEPROM)
   //For use with common Winbond SPI EEPROMs Eg W25Q16JV
@@ -280,9 +284,31 @@ uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-EEPROM_t& getEEPROM(void) 
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
+}
+
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getBoardStorageApi(void)
 {
-  return EEPROM;
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
+  };
 }
 
 #endif //CORE_AVR

--- a/speeduino/board_avr2560.h
+++ b/speeduino/board_avr2560.h
@@ -53,15 +53,6 @@ static constexpr uint32_t ticksToMicros(COMPARE_TYPE ticks)
 
 #define TS_SERIAL_BUFFER_SIZE (256+7+1) //Size of the serial buffer used by new comms protocol. The largest single packet is the O2 calibration which is 256 bytes + 7 bytes of overhead
 #define FPU_MAX_SIZE 0 //Size of the FPU buffer. 0 means no FPU.
-#ifdef USE_SPI_EEPROM
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  class SPI_EEPROM_Class;
-  using EEPROM_t = SPI_EEPROM_Class;
-#else
-  #define EEPROM_LIB_H <EEPROM.h>
-  class EEPROMClass;
-  using EEPROM_t = EEPROMClass;
-#endif
 #ifdef PLATFORMIO
   #define RTC_LIB_H <TimeLib.h>
 #else

--- a/speeduino/board_definition.h
+++ b/speeduino/board_definition.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <Arduino.h>
 #include "type_traits.h"
+#include "storage_api.h"
 
 /**
  * @brief Initialise the board, including USB comms
@@ -39,21 +40,8 @@ void jumpToBootloader(void);
 /** @brief Get the board temp for display in TunerStudio (optional) */
 uint8_t getSystemTemp(void);
 
-struct statuses;
-
-/**
- * @brief The maximum number of write operations that will be performed in one go.
- * 
- * If this number is too large, we will kill system responsiveness since EEPROM
- * writes are slow. E.g. Each write takes ~3ms on the AVR
- * 
- * This is board specific, since EEPROM write speed is dependent on the
- * EEPROM type and CPU speed. 
- * 
- * @param current So the function can scale the number of writes based on system state
- * @return uint8_t The maximum number of writes.
- */
-uint16_t getEepromWriteBlockSize(const statuses &current);
+/** @brief Get the storage API for the board */
+storage_api_t getBoardStorageApi(void);
 
 // Include a specific header for a board.
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
@@ -83,9 +71,6 @@ void boardInitRTC(void);
 // It is important that we cast this to the actual overflow limit of the timer. 
 // The compare variables type can be wider than the timer overflow.
 #define SET_COMPARE(compare, value) (compare) = (COMPARE_TYPE)(value)
-
-/** @brief Access the EEPROM singleton */
-EEPROM_t& getEEPROM(void);
 
 /** @brief The longest period of time (in uS) that the timer can permit */
 constexpr uint32_t MAX_TIMER_PERIOD = ticksToMicros((numeric_limits<COMPARE_TYPE>::max)());

--- a/speeduino/board_eeprom_adapter.hpp
+++ b/speeduino/board_eeprom_adapter.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @brief Used internally by the board to create storage_api_t instances. 
+ * 
+ * This is not intended for use by user code. 
+ * 
+ * It's only purpose is to reduce code duplication between the different board files, as the 
+ * implementation of the storage API is mostly the same across boards.
+ * 
+ * It is assumed that a global instance named `EEPROM` is available prior to including this file.
+ */
+#pragma once
+#include "storage_api.h"
+
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    (void)EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
+}
+
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getEEPROMStorageApi(uint16_t (*getMaxWriteBlockSize)(const statuses &))
+{
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = getMaxWriteBlockSize,
+  };
+}

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -1,4 +1,5 @@
 #if defined(NATIVE_BOARD)
+#include <EEPROM.h>
 #include "board_native.h"
 #include "auxiliaries.h"
 #include "idle.h"
@@ -93,14 +94,37 @@ void boardInitPins(void)
   // Do nothing
 }
 
-uint16_t getEepromWriteBlockSize(const statuses &)
-{
+
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
+
+  uint16_t getEepromWriteBlockSize(const statuses &)
+  {
     return 64U;
+  }
+
 }
 
-EEPROM_t& getEEPROM(void) 
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getBoardStorageApi(void)
 {
-  return EEPROM;
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = EEPROMApi::getEepromWriteBlockSize,
+  };
 }
-
 #endif

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -5,6 +5,7 @@
 #include "idle.h"
 #include "scheduler.h"
 #include "timers.h"
+#include "board_eeprom_adapter.hpp"
 
 #define IGNITION_INTERRUPT_NAME(index) CONCAT(CONCAT(ignitionSchedule, index), Interrupt)
 #define FUEL_INTERRUPT_NAME(index) CONCAT(CONCAT(fuelSchedule, index), Interrupt)
@@ -95,36 +96,15 @@ void boardInitPins(void)
 }
 
 
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return EEPROM.read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    EEPROM.write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return EEPROM.length();
-  }
-
-  uint16_t getEepromWriteBlockSize(const statuses &)
-  {
-    return 64U;
-  }
-
+static uint16_t getEepromWriteBlockSize(const statuses &)
+{
+  return 64U;
 }
 
 /** @brief Get the EEPROM storage API for the board */
 storage_api_t getBoardStorageApi(void)
 {
-  return {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = EEPROMApi::getEepromWriteBlockSize,
-  };
+  return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
+
 #endif

--- a/speeduino/board_native.h
+++ b/speeduino/board_native.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <array>
 #include <limits>
-#include <EEPROM.h>
 #include <USBAPI.h>
 #include "../lib/ArduinoFake/SoftwareTimer.h"
 
@@ -153,8 +152,5 @@ constexpr const _Tp& min(const _Tp& __a, const _Tp& __b) {
 #define SECONDARY_SERIAL_T decltype(Serial)
 
 #define RTC_LIB_H <time.h>
-#define EEPROM_LIB_H <EEPROM.h>
-class EEPROMClass;
-using EEPROM_t = EEPROMClass;
 
 #endif // NATIVE_BOARD

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -152,9 +152,6 @@ STM32RTC& rtc = STM32RTC::getInstance();
     ***********************************************************************************************************
     * General
     */
-    #ifndef FLASH_LENGTH
-      #define FLASH_LENGTH 8192
-    #endif
     delay(10);
 
     #ifndef HAVE_HWSERIAL2 //Hack to get the code to compile on BlackPills
@@ -243,9 +240,9 @@ STM32RTC& rtc = STM32RTC::getInstance();
     ***********************************************************************************************************
     * Schedules
     */
-    Timer1.setOverflow(0xFFFF, TICK_FORMAT);
-    Timer2.setOverflow(0xFFFF, TICK_FORMAT);
-    Timer3.setOverflow(0xFFFF, TICK_FORMAT);
+    Timer1.setOverflow((numeric_limits<COMPARE_TYPE>::max)(), TICK_FORMAT);
+    Timer2.setOverflow((numeric_limits<COMPARE_TYPE>::max)(), TICK_FORMAT);
+    Timer3.setOverflow((numeric_limits<COMPARE_TYPE>::max)(), TICK_FORMAT);
 
     Timer1.setPrescaleFactor(((Timer1.getTimerClkFreq()/1000000) * TIMER_RESOLUTION)-1);   //4us resolution
     Timer2.setPrescaleFactor(((Timer2.getTimerClkFreq()/1000000) * TIMER_RESOLUTION)-1);   //4us resolution
@@ -279,7 +276,7 @@ STM32RTC& rtc = STM32RTC::getInstance();
     Timer3.attachInterrupt(3, FUEL_INTERRUPT_NAME(3));
     Timer3.attachInterrupt(4, FUEL_INTERRUPT_NAME(4));
     #if (INJ_CHANNELS >= 5)
-    Timer5.setOverflow(0xFFFF, TICK_FORMAT);
+    Timer5.setOverflow((numeric_limits<COMPARE_TYPE>::max)(), TICK_FORMAT);
     Timer5.setPrescaleFactor(((Timer5.getTimerClkFreq()/1000000) * TIMER_RESOLUTION)-1);   //4us resolution
     #if ( STM32_CORE_VERSION_MAJOR < 2 )
     Timer5.setMode(1, TIMER_OUTPUT_COMPARE);
@@ -319,7 +316,7 @@ STM32RTC& rtc = STM32RTC::getInstance();
     Timer2.attachInterrupt(3, IGNITION_INTERRUPT_NAME(3));
     Timer2.attachInterrupt(4, IGNITION_INTERRUPT_NAME(4));
     #if (IGN_CHANNELS >= 5)
-    Timer4.setOverflow(0xFFFF, TICK_FORMAT);
+    Timer4.setOverflow((numeric_limits<COMPARE_TYPE>::max)(), TICK_FORMAT);
     Timer4.setPrescaleFactor(((Timer4.getTimerClkFreq()/1000000) * TIMER_RESOLUTION)-1);   //4us resolution
     #if ( STM32_CORE_VERSION_MAJOR < 2 )
     Timer4.setMode(1, TIMER_OUTPUT_COMPARE);
@@ -358,9 +355,9 @@ STM32RTC& rtc = STM32RTC::getInstance();
 
   uint16_t freeRam()
   {
-    uint32_t freeRam;
-    uint32_t stackTop;
-    uint32_t heapTop;
+    uint32_t freeRam = 0;
+    uint32_t stackTop = 0;
+    uint32_t heapTop = 0;
 
     // current position of the stack.
     stackTop = (uint32_t)&stackTop;
@@ -371,8 +368,7 @@ STM32RTC& rtc = STM32RTC::getInstance();
     free(hTop);
     freeRam = stackTop - heapTop;
 
-    if(freeRam>0xFFFF){return 0xFFFF;}
-    else{return freeRam;}
+    return min((uint32_t)(numeric_limits<uint16_t>::max)(), freeRam);
   }
 
   void doSystemReset( void )

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -7,7 +7,16 @@
 #include "HardwareTimer.h"
 #include "timers.h"
 #include "comms_secondary.h"
-#include EEPROM_LIB_H
+
+#if defined(SRAM_AS_EEPROM) // Use 4K battery backed SRAM, requires a 3V continuous source (like battery) connected to Vbat pin
+  #include "src/BackupSram/BackupSramAsEEPROM.h"
+#elif defined(USE_SPI_EEPROM) // Use M25Qxx SPI flash on BlackF407VE
+  #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+#elif defined(FRAM_AS_EEPROM) // Use FRAM like FM25xxx, MB85RSxxx or any SPI compatible
+  #include "src/FRAM/Fram.h"
+#else //default case, internal flash as EEPROM
+  #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+#endif
 
 #if HAL_CAN_MODULE_ENABLED
 //This activates CAN1 interface on STM32, but it's named as Can0, because that's how Teensy implementation is done
@@ -420,7 +429,7 @@ void boardInitPins(void)
   // Do nothing
 }
 
-uint16_t getEepromWriteBlockSize(const statuses &current)
+static uint16_t getEepromWriteBlockSize(const statuses &current)
 {
 #if defined(USE_SPI_EEPROM)
   //For use with common Winbond SPI EEPROMs Eg W25Q16JV
@@ -438,9 +447,31 @@ uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-EEPROM_t& getEEPROM(void) 
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
+}
+
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getBoardStorageApi(void)
 {
-  return EEPROM;
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
+  };
 }
 
 #endif

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -10,13 +10,49 @@
 
 #if defined(SRAM_AS_EEPROM) // Use 4K battery backed SRAM, requires a 3V continuous source (like battery) connected to Vbat pin
   #include "src/BackupSram/BackupSramAsEEPROM.h"
+  BackupSramAsEEPROM EEPROM;
 #elif defined(USE_SPI_EEPROM) // Use M25Qxx SPI flash on BlackF407VE
   #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+    #if defined(STM32F407xx)
+      SPIClass SPI_for_flash(PB5, PB4, PB3); //SPI1_MOSI, SPI1_MISO, SPI1_SCK
+    #else //Blue/Black Pills
+      SPIClass SPI_for_flash(PB15, PB14, PB13);
+    #endif
+ 
+    //winbond W25Q16 SPI flash EEPROM emulation
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{255UL, 4096UL, 31, 0x00100000UL};
+    Flash_SPI_Config SPIconfig{USE_SPI_EEPROM, SPI_for_flash};
+    SPI_EEPROM_Class EEPROM(EmulatedEEPROMMconfig, SPIconfig);
 #elif defined(FRAM_AS_EEPROM) // Use FRAM like FM25xxx, MB85RSxxx or any SPI compatible
   #include "src/FRAM/Fram.h"
+  #if defined(STM32F407xx)
+    SPIClass SPI_for_FRAM(PB5, PB4, PB3); //SPI1_MOSI, SPI1_MISO, SPI1_SCK
+    FramClass EEPROM(PB0, SPI_for_FRAM);
+  #else //Blue/Black Pills
+    SPIClass SPI_for_FRAM(PB15, PB14, PB13);
+    FramClass EEPROM(PB12, SPI_for_FRAM);
+  #endif
 #else //default case, internal flash as EEPROM
   #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+  #if defined(STM32F7xx)
+    #if defined(DUAL_BANK)
+      EEPROM_Emulation_Config EmulatedEEPROMMconfig{4UL, 131072UL, 2047UL, 0x08120000UL};
+    #else
+      EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 262144UL, 4095UL, 0x08180000UL};
+    #endif
+    InternalSTM32F7_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+  #elif defined(STM32F401xC)
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 4095UL, 0x08020000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+  #elif defined(STM32F411xE)
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 131072UL, 4095UL, 0x08040000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+  #else //default case, internal flash as EEPROM for STM32F4
+    EEPROM_Emulation_Config EmulatedEEPROMMconfig{4UL, 131072UL, 2047UL, 0x08080000UL};
+    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
+  #endif
 #endif
+#include "board_eeprom_adapter.hpp"
 
 #if HAL_CAN_MODULE_ENABLED
 //This activates CAN1 interface on STM32, but it's named as Can0, because that's how Teensy implementation is done
@@ -32,46 +68,6 @@ Default CAN3 pins are PA8 & PA15. Alternative (ALT) pins are PB3 & PB4.
 #if defined SD_LOGGING
     SPIClass SD_SPI(PC12, PC11, PC10); //SPI3_MOSI, SPI3_MISO, SPI3_SCK
 #endif
-
-#if defined(SRAM_AS_EEPROM)
-    BackupSramAsEEPROM EEPROM;
-#elif defined(USE_SPI_EEPROM)
-    #if defined(STM32F407xx)
-      SPIClass SPI_for_flash(PB5, PB4, PB3); //SPI1_MOSI, SPI1_MISO, SPI1_SCK
-    #else //Blue/Black Pills
-      SPIClass SPI_for_flash(PB15, PB14, PB13);
-    #endif
- 
-    //winbond W25Q16 SPI flash EEPROM emulation
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{255UL, 4096UL, 31, 0x00100000UL};
-    Flash_SPI_Config SPIconfig{USE_SPI_EEPROM, SPI_for_flash};
-    SPI_EEPROM_Class EEPROM(EmulatedEEPROMMconfig, SPIconfig);
-#elif defined(FRAM_AS_EEPROM) //https://github.com/VitorBoss/FRAM
-    #if defined(STM32F407xx)
-      SPIClass SPI_for_FRAM(PB5, PB4, PB3); //SPI1_MOSI, SPI1_MISO, SPI1_SCK
-      FramClass EEPROM(PB0, SPI_for_FRAM);
-    #else //Blue/Black Pills
-      SPIClass SPI_for_FRAM(PB15, PB14, PB13);
-      FramClass EEPROM(PB12, SPI_for_FRAM);
-    #endif
-#elif defined(STM32F7xx)
-  #if defined(DUAL_BANK)
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{4UL, 131072UL, 2047UL, 0x08120000UL};
-  #else
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 262144UL, 4095UL, 0x08180000UL};
-  #endif
-    InternalSTM32F7_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-#elif defined(STM32F401xC)
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{1UL, 131072UL, 4095UL, 0x08020000UL};
-    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-#elif defined(STM32F411xE)
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{2UL, 131072UL, 4095UL, 0x08040000UL};
-    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-#else //default case, internal flash as EEPROM for STM32F4
-    EEPROM_Emulation_Config EmulatedEEPROMMconfig{4UL, 131072UL, 2047UL, 0x08080000UL};
-    InternalSTM32F4_EEPROM_Class EEPROM(EmulatedEEPROMMconfig);
-#endif
-
 
 HardwareTimer Timer1(TIM1);
 HardwareTimer Timer2(TIM2);
@@ -443,31 +439,10 @@ static uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return EEPROM.read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    EEPROM.write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return EEPROM.length();
-  }
-}
-
 /** @brief Get the EEPROM storage API for the board */
 storage_api_t getBoardStorageApi(void)
 {
-  return {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
-  };
+  return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
 #endif

--- a/speeduino/board_stm32_official.h
+++ b/speeduino/board_stm32_official.h
@@ -65,11 +65,6 @@ static constexpr uint32_t ticksToMicros(COMPARE_TYPE ticks)
 constexpr uint16_t BLOCKING_FACTOR = 121;
 constexpr uint16_t TABLE_BLOCKING_FACTOR = 64;
 
-//Select one for EEPROM,the default is EEPROM emulation on internal flash.
-//#define SRAM_AS_EEPROM /*Use 4K battery backed SRAM, requires a 3V continuous source (like battery) connected to Vbat pin */
-//#define USE_SPI_EEPROM PB0 /*Use M25Qxx SPI flash on BlackF407VE*/
-//#define FRAM_AS_EEPROM /*Use FRAM like FM25xxx, MB85RSxxx or any SPI compatible */
-
 #ifndef word
   #define word(h, l) (((h) << 8) | (l)) //word() function not defined for this platform in the main library
 #endif  
@@ -184,25 +179,8 @@ extern STM32RTC& rtc;
 ***********************************************************************************************************
 * EEPROM emulation
 */
-#if defined(SRAM_AS_EEPROM)
-  #define EEPROM_LIB_H "src/BackupSram/BackupSramAsEEPROM.h"
-  class BackupSramAsEEPROM;
-  using EEPROM_t = BackupSramAsEEPROM;    
-#elif defined(USE_SPI_EEPROM)
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  class SPI_EEPROM_Class;
-  using EEPROM_t = SPI_EEPROM_Class;    
-#elif defined(FRAM_AS_EEPROM) //https://github.com/VitorBoss/FRAM
-  #define EEPROM_LIB_H "src/FRAM/Fram.h"
-  class FramClass;
-  using EEPROM_t = FramClass;    
-#else //default case, internal flash as EEPROM
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  class InternalSTM32F4_EEPROM_Class;
-  using EEPROM_t = InternalSTM32F4_EEPROM_Class;    
-  #if defined(STM32F401xC)
-    #define SMALL_FLASH_MODE
-  #endif
+#if defined(STM32F401xC)
+  #define SMALL_FLASH_MODE
 #endif
 
 #define RTC_LIB_H "STM32RTC.h"

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -13,6 +13,7 @@
 #include "comms_secondary.h"
 #include <InternalTemperature.h>
 #include RTC_LIB_H
+#include "board_eeprom_adapter.hpp"
 
  //These are declared locally in comms_CAN now due to this issue: https://github.com/tonton81/FlexCAN_T4/issues/67
 // #if defined(__MK64FX512__)         // use for Teensy 3.5 only 
@@ -461,31 +462,10 @@ static uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return EEPROM.read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    EEPROM.write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return EEPROM.length();
-  }
-}
-
 /** @brief Get the EEPROM storage API for the board */
 storage_api_t getBoardStorageApi(void)
 {
-  return {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
-  };
+  return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
 #endif

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -1,6 +1,11 @@
 #include "board_definition.h"
 
 #if defined(CORE_TEENSY) && defined(CORE_TEENSY35)
+#ifdef USE_SPI_EEPROM
+  #include "src/SPIAsEEPROM/SPIAsEEPROM.h"
+#else
+  #include <EEPROM.h>
+#endif
 #include "auxiliaries.h"
 #include "idle.h"
 #include "scheduler.h"
@@ -8,7 +13,6 @@
 #include "comms_secondary.h"
 #include <InternalTemperature.h>
 #include RTC_LIB_H
-#include EEPROM_LIB_H
 
  //These are declared locally in comms_CAN now due to this issue: https://github.com/tonton81/FlexCAN_T4/issues/67
 // #if defined(__MK64FX512__)         // use for Teensy 3.5 only 
@@ -440,7 +444,7 @@ void boardInitPins(void)
   // Do nothing
 }
 
-uint16_t getEepromWriteBlockSize(const statuses &current)
+static uint16_t getEepromWriteBlockSize(const statuses &current)
 {
 #if defined(USE_SPI_EEPROM)
   //For use with common Winbond SPI EEPROMs Eg W25Q16JV
@@ -457,9 +461,31 @@ uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-EEPROM_t& getEEPROM(void) 
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
+}
+
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getBoardStorageApi(void)
 {
-  return EEPROM;
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
+  };
 }
 
 #endif

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -45,15 +45,6 @@ static constexpr uint32_t ticksToMicros(COMPARE_TYPE ticks)
 #define BOARD_MAX_DIGITAL_PINS 57
 #define BOARD_MAX_IO_PINS 57
 #define BOARD_MAX_ADC_PINS  26 //Number of analog pins
-#ifdef USE_SPI_EEPROM
-  #define EEPROM_LIB_H "src/SPIAsEEPROM/SPIAsEEPROM.h"
-  class SPI_EEPROM_Class;
-  using EEPROM_t = SPI_EEPROM_Class;
-#else
-  #define EEPROM_LIB_H <EEPROM.h>
-  class EEPROMClass;
-  using EEPROM_t = EEPROMClass;
-#endif
 #define RTC_ENABLED
 #define RTC_LIB_H "TimeLib.h"
 #define SD_CONFIG  SdioConfig(FIFO_SDIO) //Set Teensy to use SDIO in FIFO mode. This is the fastest SD mode on Teensy as it offloads most of the writes

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -9,6 +9,7 @@
 #include "comms_secondary.h"
 #include <InternalTemperature.h>
 #include RTC_LIB_H
+#include "board_eeprom_adapter.hpp"
 
 static void PIT_isr();
 static void TMR1_isr(void);
@@ -417,30 +418,10 @@ static uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return EEPROM.read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    EEPROM.write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return EEPROM.length();
-  }
-}
-
 /** @brief Get the EEPROM storage API for the board */
 storage_api_t getBoardStorageApi(void)
 {
-  return {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
-  };
+  return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
+
 #endif

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -1,6 +1,7 @@
 #include "board_definition.h"
 
 #if defined(CORE_TEENSY) && defined(__IMXRT1062__)
+#include <EEPROM.h>
 #include "auxiliaries.h"
 #include "idle.h"
 #include "scheduler.h"
@@ -8,7 +9,6 @@
 #include "comms_secondary.h"
 #include <InternalTemperature.h>
 #include RTC_LIB_H
-#include EEPROM_LIB_H
 
 static void PIT_isr();
 static void TMR1_isr(void);
@@ -404,7 +404,7 @@ void boardInitPins(void)
   if(configPage10.knock_mode == KNOCK_MODE_DIGITAL) { setPinHysteresis(configPage10.knock_pin); }
 }
 
-uint16_t getEepromWriteBlockSize(const statuses &current)
+static uint16_t getEepromWriteBlockSize(const statuses &current)
 {
   uint16_t maxWrite = 64;
 
@@ -417,9 +417,30 @@ uint16_t getEepromWriteBlockSize(const statuses &current)
   return maxWrite;
 }
 
-EEPROM_t& getEEPROM(void) 
-{
-  return EEPROM;
+namespace EEPROMApi {
+
+  static inline byte read(uint16_t address)
+  {
+    return EEPROM.read(address);
+  }
+  static inline void write(uint16_t address, byte val)
+  {
+    EEPROM.write(address, val);
+  }
+  static inline uint16_t length(void)
+  {
+    return EEPROM.length();
+  }
 }
 
+/** @brief Get the EEPROM storage API for the board */
+storage_api_t getBoardStorageApi(void)
+{
+  return {
+    .read = EEPROMApi::read,
+    .write = EEPROMApi::write,
+    .length = EEPROMApi::length,
+    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
+  };
+}
 #endif

--- a/speeduino/board_teensy41.h
+++ b/speeduino/board_teensy41.h
@@ -68,9 +68,6 @@ static constexpr uint32_t ticksToMicros(COMPARE_TYPE ticks)
 #define BOARD_MAX_DIGITAL_PINS 54
 #define BOARD_MAX_IO_PINS 54
 #define BOARD_MAX_ADC_PINS  17 //Number of analog pins
-#define EEPROM_LIB_H <EEPROM.h>
-class EEPROMClass;
-using EEPROM_t = EEPROMClass;
 #define RTC_ENABLED
 #define SD_LOGGING //SD logging enabled by default for Teensy 4.1 as it has the slot built in
 #define RTC_LIB_H "TimeLib.h"

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -117,7 +117,7 @@ void initialiseAll(void)
 
     // Unit tests should be independent of any stored configuration on the board!
 #if !defined(UNIT_TEST)
-    setStorageAPI(getEEPROMStorageApi());
+    setStorageAPI(getBoardStorageApi());
     processResetStorageRequest();
     loadAllPages();
     loadAllCalibrationTables(); 

--- a/speeduino/statuses.cpp
+++ b/speeduino/statuses.cpp
@@ -1,0 +1,12 @@
+#include "statuses.h"
+#include "atomic.h"
+
+void setRpm(statuses &status, uint16_t rpm)
+{
+  ATOMIC()
+  {
+    status.RPM = rpm;
+    status.RPMdiv100 = div100(rpm);
+    status.longRPM = rpm;
+  }
+}

--- a/speeduino/statuses.h
+++ b/speeduino/statuses.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include "bit_manip.h"
-#include "atomic.h"
 #include "maths.h"
 #include "decoder_builder.h"
 
@@ -345,12 +344,4 @@ struct statuses {
  * @param status 
  * @param smallRpm 
  */
-static inline void setRpm(statuses &status, uint16_t rpm)
-{
-  ATOMIC()
-  {
-    status.RPM = rpm;
-    status.RPMdiv100 = div100(rpm);
-    status.longRPM = rpm;
-  }
-}
+void setRpm(statuses &status, uint16_t rpm);

--- a/speeduino/storage_api.cpp
+++ b/speeduino/storage_api.cpp
@@ -1,48 +1,8 @@
 #include "storage_api.h"
 #include "board_definition.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#include EEPROM_LIB_H //This is defined in the board .h files
-#pragma GCC diagnostic pop
 
-
-#if defined(CORE_AVR)
-#pragma GCC push_options
 // This minimizes RAM usage at no performance cost
 #pragma GCC optimize ("Os") 
-#endif
-
-// LCOV_EXCL_START
-// Exclude simple wrappers from code coverage
-namespace EEPROMApi {
-
-  static inline byte read(uint16_t address)
-  {
-    return getEEPROM().read(address);
-  }
-  static inline void write(uint16_t address, byte val)
-  {
-    getEEPROM().write(address, val);
-  }
-  static inline uint16_t length(void)
-  {
-    return getEEPROM().length();
-  }
-}
-// LCOV_EXCL_STOP
-
-// LCOV_EXCL_START
-// Exclude simple wrappers from code coverage
-storage_api_t getEEPROMStorageApi(void)
-{
-  return storage_api_t {
-    .read = EEPROMApi::read,
-    .write = EEPROMApi::write,
-    .length = EEPROMApi::length,
-    .getMaxWriteBlockSize = ::getEepromWriteBlockSize,
-  };  
-}
-// LCOV_EXCL_STOP
 
 bool update(const storage_api_t &api, uint16_t address, byte value) {
   if (api.read(address)!=value) {
@@ -108,7 +68,3 @@ __attribute__((noinline)) void fillBlock(const storage_api_t &api, uint16_t addr
     }
   }
 }
-
-#if defined(CORE_AVR)
-#pragma GCC pop_options
-#endif

--- a/speeduino/storage_api.h
+++ b/speeduino/storage_api.h
@@ -33,13 +33,6 @@ struct storage_api_t {
     uint16_t (*getMaxWriteBlockSize)(const statuses &current);
 };
 
-/** 
- * @brief Create a storage_api_t instance that wraps getEEPROM()
- * 
- * Applies the adapter pattern to provide storage_api_t from EEPROM_t 
- */
-storage_api_t getEEPROMStorageApi(void);
-
 /**
  * @brief Conditionally write a byte to storage if it differs from the one already saved.
  * 


### PR DESCRIPTION
Summary: Limit the scope of EEPROM includes and type to the board CPP files, instead of exposing `EEPROM_t` and `EEPROM_LIB_H`.

Rationale: the type of EEPROM varies by board *and* we already have a generic storage abstraction (`storage_api_t`). So expose `storage_api_t` from each board (via `getBoardStorageApi`) rather than the details of each EEPROM.