### PR TITLE
Make the native ATOMIC implementation re-entrant

### DIFF
--- a/lib/ArduinoFake/SoftwareTimer.cpp
+++ b/lib/ArduinoFake/SoftwareTimer.cpp
@@ -61,13 +61,18 @@ public:
     }
 
     /** @brief Halt event notification */
-    void stop(void)
+    bool stop(void)
     {
-        halt = true;
-        if (tickThread.joinable())
-        {
-            tickThread.join();
+        if (!halt)
+        { 
+            halt = true;
+            if (tickThread.joinable())
+            {
+                tickThread.join();
+            }
+            return true;
         }
+        return false;
     }
 
 private:
@@ -149,12 +154,14 @@ void software_timer_t::onNextTick(counter_t nextTick)
 }
 
 TickEventGuard::TickEventGuard(void)
+: _stopped(getTicker().stop())
 {
-    getTicker().stop();
 }
 TickEventGuard::~TickEventGuard()
 {
-    getTicker().start();
+    if (_stopped) {
+        getTicker().start();
+    }
 }
 
 #endif

--- a/lib/ArduinoFake/SoftwareTimer.h
+++ b/lib/ArduinoFake/SoftwareTimer.h
@@ -53,6 +53,8 @@ public:
     TickEventGuard(void);
     /** @brief Resume tick event generation */
     ~TickEventGuard();
+private:
+    bool _stopped = false;
 };
 
 #endif


### PR DESCRIPTION
Allow nested ATOMIC() calls on the native platform. I.e.
```
ATOMIC() {
  ATOMIC {
  }
}
```

Required for test coverage.