### PR TITLE
Allow integerPID::Compute() to accept negative inputs

### DIFF
--- a/speeduino/src/PID/integerPID.cpp
+++ b/speeduino/src/PID/integerPID.cpp
@@ -49,38 +49,35 @@ bool integerPID::Compute(unsigned long now, long FeedForwardTerm)
    {
       /*Compute all the working error variables*/
 	   long input = *myInput;
-      if(input > 0) //Fail safe, should never be 0
+      long error = *mySetpoint - input;
+      long dInput = (input - lastInput);
+      FeedForwardTerm <<= PID_SHIFTS;
+
+      if (ki != 0)
       {
-         long error = *mySetpoint - input;
-         long dInput = (input - lastInput);
-         FeedForwardTerm <<= PID_SHIFTS;
-
-         if (ki != 0)
-         {
-            outputSum += (ki * error); //integral += error × dt
-            if(outputSum > outMax-FeedForwardTerm) { outputSum = outMax-FeedForwardTerm; }
-            else if(outputSum < outMin-FeedForwardTerm) { outputSum = outMin-FeedForwardTerm; }
-         }
-
-         /*Compute PID Output*/
-         long output;
-         
-         output = (kp * error);
-         if (ki != 0) { output += outputSum; }
-         if (kd != 0) { output -= (kd * dInput)>>2; }
-         output += FeedForwardTerm;
-
-         if(output > outMax) output = outMax;
-         else if(output < outMin) output = outMin;
-
-         *myOutput = output >> PID_SHIFTS;
-
-         /*Remember some variables for next time*/
-         lastInput = input;
-         lastTime = now;
-
-         return true;
+         outputSum += (ki * error); //integral += error × dt
+         if(outputSum > outMax-FeedForwardTerm) { outputSum = outMax-FeedForwardTerm; }
+         else if(outputSum < outMin-FeedForwardTerm) { outputSum = outMin-FeedForwardTerm; }
       }
+
+      /*Compute PID Output*/
+      long output;
+      
+      output = (kp * error);
+      if (ki != 0) { output += outputSum; }
+      if (kd != 0) { output -= (kd * dInput)>>2; }
+      output += FeedForwardTerm;
+
+      if(output > outMax) output = outMax;
+      else if(output < outMin) output = outMin;
+
+      *myOutput = output >> PID_SHIFTS;
+
+      /*Remember some variables for next time*/
+      lastInput = input;
+      lastTime = now;
+
+      return true;
    }
    return false;
 }

--- a/test/test_pid/test_integerPID.cpp
+++ b/test/test_pid/test_integerPID.cpp
@@ -115,20 +115,6 @@ static void test_integerPID_controller_direction_maintains_output_limits(void)
     TEST_ASSERT_GREATER_OR_EQUAL(-50, output);
 }
 
-static void test_integerPID_input_zero_failsafe(void)
-{
-    long input = 0;
-    long output = 3;
-    long setpoint = 100;
-
-    integerPID pid(&input, &output, &setpoint, 10, 10, 0, DIRECT);
-    pid.SetSampleTime(1);
-    pid.SetMode(AUTOMATIC);
-
-    TEST_ASSERT_FALSE(pid.Compute(NOW, 0));
-    TEST_ASSERT_EQUAL(3, output);
-}
-
 static void test_integerPID_reverse_direction(void)
 {
     long input = 10;
@@ -451,9 +437,12 @@ static void test_integerPID_set_controller_direction_runtime_manual(void)
 // Run the PID for 50 iterations and confirm it hits the setpoint
 static inline void assert_pid_complete(integerPID &pid, long *pInput, long *pOutput, long setpoint, uint8_t sampleTime)
 {
+    char szMsg[64];
+    snprintf(szMsg, _countof(szMsg)-1, "Start: %" PRId32 ", SetPoint: %" PRId32, (int32_t)*pInput, (int32_t)setpoint);
+    UnityPrint(szMsg); UNITY_PRINT_EOL();
+
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
 
-    char szMsg[64];
     for (uint16_t iteration=0; iteration<50U; ++iteration)
     {
         TEST_ASSERT_TRUE(pid.Compute(NOW+(iteration*sampleTime)));
@@ -463,7 +452,7 @@ static inline void assert_pid_complete(integerPID &pid, long *pInput, long *pOut
         UnityPrint(szMsg); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
-    TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);
+    TEST_ASSERT_INT32_WITHIN(abs(DIV_ROUND_CLOSEST(setpoint, 100, int32_t)), setpoint, *pInput);
 }
 
 static void test_end_to_end_positive_positive_up(void) 
@@ -496,21 +485,65 @@ static void test_end_to_end_positive_positive_down(void)
     assert_pid_complete(pid, &input, &output, setpoint, SAMPLE_TIME);
 }
 
+
 static void test_end_to_end_negative_negative_up(void) 
 {
-    TEST_IGNORE_MESSAGE("integerPID doesn't support negative inputs...yet");
+    constexpr uint8_t SAMPLE_TIME = 33;
+    long output = 0;
+    long input = -235;
+    long setpoint = -155;
+
+    integerPID pid(&input, &output, &setpoint, 15, 3, 2, DIRECT);
+    pid.SetSampleTime(SAMPLE_TIME);
+    pid.SetOutputLimits(-255, 255);
+    pid.SetMode(AUTOMATIC);
+
+    assert_pid_complete(pid, &input, &output, setpoint, SAMPLE_TIME);
 }
+
 static void test_end_to_end_negative_negative_down(void) 
 {
-    TEST_IGNORE_MESSAGE("integerPID doesn't support negative inputs...yet");
+    constexpr uint8_t SAMPLE_TIME = 33;
+    long output = 0;
+    long input = -155;
+    long setpoint = -235;
+
+    integerPID pid(&input, &output, &setpoint, 15, 3, 2, DIRECT);
+    pid.SetSampleTime(SAMPLE_TIME);
+    pid.SetOutputLimits(-255, 255);
+    pid.SetMode(AUTOMATIC);
+
+    assert_pid_complete(pid, &input, &output, setpoint, SAMPLE_TIME);
 }
-static void test_end_to_end_negative_positive(void) 
-{
-    TEST_IGNORE_MESSAGE("integerPID doesn't support negative inputs...yet");
-}
+
 static void test_end_to_end_positive_negative(void) 
 {
-    TEST_IGNORE_MESSAGE("integerPID doesn't support negative inputs...yet");
+    constexpr uint8_t SAMPLE_TIME = 33;
+    long output = 0;
+    long input = 63;
+    long setpoint = -55;
+
+    integerPID pid(&input, &output, &setpoint, 15, 1, 1, DIRECT);
+    pid.SetSampleTime(SAMPLE_TIME);
+    pid.SetOutputLimits(-255, 255);
+    pid.SetMode(AUTOMATIC);
+
+    assert_pid_complete(pid, &input, &output, setpoint, SAMPLE_TIME);
+}
+
+static void test_end_to_end_negative_positive(void) 
+{
+    constexpr uint8_t SAMPLE_TIME = 33;
+    long output = 0;
+    long input = -55;
+    long setpoint = 65;
+
+    integerPID pid(&input, &output, &setpoint, 15, 3, 2, DIRECT);
+    pid.SetSampleTime(SAMPLE_TIME);
+    pid.SetOutputLimits(-255, 255);
+    pid.SetMode(AUTOMATIC);
+
+    assert_pid_complete(pid, &input, &output, setpoint, SAMPLE_TIME);
 }
 
 void testIntegerPID(void)
@@ -522,7 +555,6 @@ void testIntegerPID(void)
         RUN_TEST_P(test_integerPID_output_limits_zero_range);
         RUN_TEST_P(test_integerPID_reverse_direction);
         RUN_TEST_P(test_integerPID_feedforward_term);
-        RUN_TEST_P(test_integerPID_input_zero_failsafe);
         RUN_TEST_P(test_integerPID_integral_with_feedforward);
         RUN_TEST_P(test_integerPID_output_limits_upper_clamp);
         RUN_TEST_P(test_integerPID_output_limits_lower_clamp);

--- a/test/test_pid/test_integerPID_ideal.cpp
+++ b/test/test_pid/test_integerPID_ideal.cpp
@@ -177,7 +177,7 @@ static void assert_pid_complete(integerPID_ideal &pid, long *pInput, uint16_t *p
         UnityPrint(szMsg); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
-    TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);
+    TEST_ASSERT_INT32_WITHIN(abs(DIV_ROUND_CLOSEST(setpoint, 100, int32_t)), setpoint, *pInput);
 }
 
 static void test_end_to_end_positive_positive_up(void) 

--- a/test/test_pid/test_pid.cpp
+++ b/test/test_pid/test_pid.cpp
@@ -211,9 +211,12 @@ static void test_pid_set_controller_direction_runtime_manual(void)
 // Run the PID for maxIterations and confirm it hits the setpoint
 static void assert_pid_complete(PID &pid, long *pInput, long *pOutput, long setpoint, uint16_t maxIterations)
 {
+    char szMsg[64];
+    snprintf(szMsg, _countof(szMsg)-1, "Start: %" PRId32 ", SetPoint: %" PRId32, (int32_t)*pInput, (int32_t)setpoint);
+    UnityPrint(szMsg); UNITY_PRINT_EOL();
+
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
 
-    char szMsg[64];
     for (uint16_t iteration=0; iteration<maxIterations; ++iteration)
     {
         TEST_ASSERT_TRUE(pid.Compute());
@@ -223,7 +226,7 @@ static void assert_pid_complete(PID &pid, long *pInput, long *pOutput, long setp
         UnityPrint(szMsg); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
-    TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);
+    TEST_ASSERT_INT32_WITHIN(abs(DIV_ROUND_CLOSEST(setpoint, 100, int32_t)), setpoint, *pInput);
 }
 
 static void test_end_to_end_positive_positive_up(void) 
@@ -260,8 +263,8 @@ static void test_end_to_end_negative_negative_up(void)
     long input = -1500;
     long setpoint = -900;
 
-    PID pid(&input, &output, &setpoint, 100, 30, 50, DIRECT);
-    pid.SetOutputLimits(-25, 25);
+    PID pid(&input, &output, &setpoint, 100, 25, 2, DIRECT);
+    pid.SetOutputLimits(-255, 255);
     pid.SetMode(AUTOMATIC);
     pid.Initialize();
 
@@ -289,7 +292,7 @@ static void test_end_to_end_negative_positive(void)
     long setpoint = 199;
 
     PID pid(&input, &output, &setpoint, 50, 1, 80, DIRECT);
-    pid.SetOutputLimits(-75, 75);
+    pid.SetOutputLimits(-255, 255);
     pid.SetMode(AUTOMATIC);
     pid.Initialize();
 
@@ -303,7 +306,7 @@ static void test_end_to_end_positive_to_negative(void)
     long setpoint = -1500;
 
     PID pid(&input, &output, &setpoint, 100, 30, 20, DIRECT);
-    pid.SetOutputLimits(-25, 25);
+    pid.SetOutputLimits(-255, 255);
     pid.SetMode(AUTOMATIC);
     pid.Initialize();
 


### PR DESCRIPTION
Remove the `>0` restriction on `integerPID::Compute()` input values and unit test.