### PR TITLE
integerPID_ideal: use Derivative on Measurement

### DIFF
--- a/speeduino/src/PID/integerPID_ideal.cpp
+++ b/speeduino/src/PID/integerPID_ideal.cpp
@@ -28,7 +28,6 @@ integerPID_ideal::integerPID_ideal(long* Input, uint16_t* Output, uint16_t* Setp
     integerPID_ideal::SetTunings(Kp, Ki, Kd);
 
     lastTime = millis()- *mySampleTime;
-    lastError = 0;
 }
 
 
@@ -54,16 +53,16 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
       ITerm += error;
 
       /*Compute PID Output*/
-      long output = scaledFeedForward + (kp * error) + (ki * ITerm) + (kd * (error - lastError));
+      long output = scaledFeedForward + (kp * error) + (ki * ITerm) + (kd * (lastInput - *myInput));
       
       if(output > outMax)
       {
-         output  = outMax;
+         output = outMax;
          ITerm -= error;
       }
-      if(output < outMin)
+      else if(output < outMin)
       {
-         output  = outMin;
+         output = outMin;
          ITerm -= error;
       }
 
@@ -72,7 +71,7 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
 
       /*Remember some variables for next time*/
       lastTime = now;
-      lastError = error;
+      lastInput = *myInput;
 
       return true;
    }
@@ -135,7 +134,6 @@ void integerPID_ideal::Initialize()
 {
    ITerm = 0;
    lastInput = *myInput;
-   lastError = 0;
 }
 
 /* SetControllerDirection(...)*************************************************

--- a/speeduino/src/PID/integerPID_ideal.cpp
+++ b/speeduino/src/PID/integerPID_ideal.cpp
@@ -48,13 +48,14 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
       long unitless_setpoint = (((long)*mySetpoint - 0) * 10000L) / (sensitivity - 0);
       long unitless_input = (((long)*myInput - 0) * 10000L) / (sensitivity - 0);
       long error = unitless_setpoint - unitless_input;
+      // Bias is % in whole numbers. Multiply it by 10 to get it with 2 places.
+      uint32_t scaledFeedForward = FeedForward*10UL;
 
       ITerm += error;
 
       /*Compute PID Output*/
-      long output = (kp * error) + (ki * ITerm) + (kd * (error - lastError));
-      output = FeedForward + (output / 10); //output is % multiplied by 1000. To get % with 2 decimal places, divide it by 10. Likewise, bias is % in whole numbers. Multiply it by 100 to get it with 2 places.
-
+      long output = scaledFeedForward + (kp * error) + (ki * ITerm) + (kd * (error - lastError));
+      
       if(output > outMax)
       {
          output  = outMax;
@@ -66,7 +67,8 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
          ITerm -= error;
       }
 
-	    *myOutput = output;
+	   //output is % multiplied by 1000. To get % with 2 decimal places, divide it by 10. 
+      *myOutput = output/10;
 
       /*Remember some variables for next time*/
       lastTime = now;
@@ -118,7 +120,7 @@ void integerPID_ideal::SetOutputLimits(long Min, long Max)
 {
    if(Min < Max)
    {
-     constexpr uint16_t LIMIT_FACTOR = 100; //How much outMin and OutMax must be multiplied by to get them in the same scale as the output
+     constexpr uint16_t LIMIT_FACTOR = 1000; //How much outMin and OutMax must be multiplied by to get them in the same scale as the output
 
      outMin = Min * LIMIT_FACTOR;
      outMax = Max * LIMIT_FACTOR;

--- a/speeduino/src/PID/integerPID_ideal.cpp
+++ b/speeduino/src/PID/integerPID_ideal.cpp
@@ -40,8 +40,6 @@ integerPID_ideal::integerPID_ideal(long* Input, uint16_t* Output, uint16_t* Setp
  **********************************************************************************/
 bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
 {
-   constexpr uint16_t limitMultiplier = 100; //How much outMin and OutMax must be multiplied by to get them in the same scale as the output
-
    unsigned long timeChange = (now - lastTime);
    if(timeChange >= *mySampleTime)
    {
@@ -58,14 +56,14 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
 
       if(ki != 0)
       {
-        output = ((outMax * limitMultiplier * 100) - FeedForward) / (long)ki;
+        output = ((outMax * 100) - FeedForward) / (long)ki;
         if (output < 0) { output = 0; }
       }
       if (ITerm > output) { ITerm = output; }
 
       if(ki != 0)
       {
-        output = (FeedForward - (-outMin * limitMultiplier * 100)) / (long)ki;
+        output = (FeedForward - (-outMin * 100)) / (long)ki;
         if (output < 0) { output = 0; }
       }
       else { output = 0; }
@@ -75,14 +73,14 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
       output = (kp * error) + (ki * ITerm) + (kd * (error - lastError));
       output = FeedForward + (output / 10); //output is % multiplied by 1000. To get % with 2 decimal places, divide it by 10. Likewise, bias is % in whole numbers. Multiply it by 100 to get it with 2 places.
 
-      if(output > (outMax * limitMultiplier))
+      if(output > outMax)
       {
-         output  = (outMax * limitMultiplier);
+         output  = outMax;
          ITerm -= error;
       }
-      if(output < (outMin * limitMultiplier))
+      if(output < outMin)
       {
-         output  = (outMin * limitMultiplier);
+         output  = outMin;
          ITerm -= error;
       }
 
@@ -138,8 +136,10 @@ void integerPID_ideal::SetOutputLimits(long Min, long Max)
 {
    if(Min < Max)
    {
-     outMin = Min;
-     outMax = Max;
+     constexpr uint16_t LIMIT_FACTOR = 100; //How much outMin and OutMax must be multiplied by to get them in the same scale as the output
+
+     outMin = Min * LIMIT_FACTOR;
+     outMax = Max * LIMIT_FACTOR;
    }
 }
 

--- a/speeduino/src/PID/integerPID_ideal.cpp
+++ b/speeduino/src/PID/integerPID_ideal.cpp
@@ -51,26 +51,8 @@ bool integerPID_ideal::Compute(unsigned long now, uint16_t FeedForward)
 
       ITerm += error;
 
-      // uint16_t bias = 50; //Base target DC%
-      long output = 0;
-
-      if(ki != 0)
-      {
-        output = ((outMax * 100) - FeedForward) / (long)ki;
-        if (output < 0) { output = 0; }
-      }
-      if (ITerm > output) { ITerm = output; }
-
-      if(ki != 0)
-      {
-        output = (FeedForward - (-outMin * 100)) / (long)ki;
-        if (output < 0) { output = 0; }
-      }
-      else { output = 0; }
-      if (ITerm < -output) { ITerm = -output; }
-
       /*Compute PID Output*/
-      output = (kp * error) + (ki * ITerm) + (kd * (error - lastError));
+      long output = (kp * error) + (ki * ITerm) + (kd * (error - lastError));
       output = FeedForward + (output / 10); //output is % multiplied by 1000. To get % with 2 decimal places, divide it by 10. Likewise, bias is % in whole numbers. Multiply it by 100 to get it with 2 places.
 
       if(output > outMax)

--- a/speeduino/src/PID/integerPID_ideal.h
+++ b/speeduino/src/PID/integerPID_ideal.h
@@ -62,7 +62,6 @@ public:
 
 
 	unsigned long lastTime;
-  long lastError;
 	long ITerm, lastInput;
 
 	long outMin, outMax;

--- a/test/test_pid/test_integerPID.cpp
+++ b/test/test_pid/test_integerPID.cpp
@@ -448,19 +448,24 @@ static void test_integerPID_set_controller_direction_runtime_manual(void)
     TEST_ASSERT_GREATER_THAN(0, output);
 }
 
+static String createIterationMsg(int16_t iteration, long input, long output)
+{
+    char szMsg[64];
+    snprintf(szMsg, _countof(szMsg)-1, "%" PRId16 ", %" PRId32 ", %" PRId32, iteration, (int32_t)input, (int32_t)output);
+    return szMsg;
+}
+
 // Run the PID for 50 iterations and confirm it hits the setpoint
 static inline void assert_pid_complete(integerPID &pid, long *pInput, long *pOutput, long setpoint, uint8_t sampleTime)
 {
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
+    UnityPrint(createIterationMsg(-1, *pInput, setpoint).c_str()); UNITY_PRINT_EOL();
 
-    char szMsg[64];
     for (uint16_t iteration=0; iteration<50U; ++iteration)
     {
         TEST_ASSERT_TRUE(pid.Compute(NOW+(iteration*sampleTime)));
         *pInput += *pOutput;
-
-        snprintf(szMsg, _countof(szMsg)-1, "%" PRIu16 ", %" PRId32 ", %" PRId32, iteration, (int32_t)*pInput, (int32_t)*pOutput);
-        UnityPrint(szMsg); UNITY_PRINT_EOL();
+        UnityPrint(createIterationMsg(iteration, *pInput, *pOutput).c_str()); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
     TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);

--- a/test/test_pid/test_integerPID_ideal.cpp
+++ b/test/test_pid/test_integerPID_ideal.cpp
@@ -170,14 +170,14 @@ static String createIterationMsg(int16_t iteration, uint16_t input, uint16_t out
 }
 
 // Run the PID for 50 and confirm it hits the setpoint
-static void assert_pid_complete(integerPID_ideal &pid, long *pInput, uint16_t *pOutput, uint16_t setpoint, uint8_t sampleTime)
+static void assert_pid_complete(integerPID_ideal &pid, long *pInput, uint16_t *pOutput, uint16_t setpoint, uint8_t sampleTime, uint16_t feedForwardTerm = 0U)
 {
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
     UnityPrint(createIterationMsg(-1, *pInput, setpoint).c_str()); UNITY_PRINT_EOL();
 
     for (uint16_t iteration=0; iteration<50U; ++iteration)
     {
-        TEST_ASSERT_TRUE(pid.Compute(NOW+(iteration*sampleTime), 0));
+        TEST_ASSERT_TRUE(pid.Compute(NOW+(iteration*sampleTime), feedForwardTerm));
         UnityPrint(createIterationMsg(iteration, *pInput, *pOutput).c_str()); UNITY_PRINT_EOL();
         *pInput = *pOutput;
     }
@@ -197,7 +197,7 @@ static void test_end_to_end_positive_positive_up(void)
     pid.SetOutputLimits(0, 255);
     pid.Initialize();
 
-    assert_pid_complete(pid, &input, &output, setpoint, sampleTime);
+    assert_pid_complete(pid, &input, &output, setpoint, sampleTime, 7);
 }
 
 static void test_end_to_end_positive_positive_down(void) 
@@ -212,7 +212,7 @@ static void test_end_to_end_positive_positive_down(void)
     pid.SetOutputLimits(0, 255);
     pid.Initialize();
 
-    assert_pid_complete(pid, &input, &output, setpoint, sampleTime);
+    assert_pid_complete(pid, &input, &output, setpoint, sampleTime, 11);
 }
 
 void testIntegerPID_ideal(void)

--- a/test/test_pid/test_integerPID_ideal.cpp
+++ b/test/test_pid/test_integerPID_ideal.cpp
@@ -162,19 +162,24 @@ static void test_derivative_term_changes_output_on_error_transition(void)
     TEST_ASSERT_NOT_EQUAL(firstOutput, output);
 }
 
+static String createIterationMsg(int16_t iteration, uint16_t input, uint16_t output)
+{
+    char szMsg[64];
+    snprintf(szMsg, _countof(szMsg)-1, "%" PRId16 ", %" PRIu16 ", %" PRIu16, iteration, input, output);
+    return szMsg;
+}
+
 // Run the PID for 50 and confirm it hits the setpoint
 static void assert_pid_complete(integerPID_ideal &pid, long *pInput, uint16_t *pOutput, uint16_t setpoint, uint8_t sampleTime)
 {
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
+    UnityPrint(createIterationMsg(-1, *pInput, setpoint).c_str()); UNITY_PRINT_EOL();
 
-    char szMsg[64];
     for (uint16_t iteration=0; iteration<50U; ++iteration)
     {
         TEST_ASSERT_TRUE(pid.Compute(NOW+(iteration*sampleTime), 0));
+        UnityPrint(createIterationMsg(iteration, *pInput, *pOutput).c_str()); UNITY_PRINT_EOL();
         *pInput = *pOutput;
-
-        snprintf(szMsg, _countof(szMsg)-1, "%" PRIu16 ", %" PRId32 ", %" PRId32, iteration, (int32_t)*pInput, (int32_t)*pOutput);
-        UnityPrint(szMsg); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
     TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);

--- a/test/test_pid/test_pid.cpp
+++ b/test/test_pid/test_pid.cpp
@@ -208,19 +208,25 @@ static void test_pid_set_controller_direction_runtime_manual(void)
     TEST_ASSERT_GREATER_THAN(0, output); // Reverse direction normally produces negative output
 }
 
+static String createIterationMsg(int16_t iteration, long input, long output)
+{
+    char szMsg[64];
+    snprintf(szMsg, _countof(szMsg)-1, "%" PRId16 ", %" PRId32 ", %" PRId32, iteration, (int32_t)input, (int32_t)output);
+    return szMsg;
+}
+
 // Run the PID for maxIterations and confirm it hits the setpoint
 static void assert_pid_complete(PID &pid, long *pInput, long *pOutput, long setpoint, uint16_t maxIterations)
 {
     UnityPrint("Iter,Input,Output"); UNITY_PRINT_EOL();
+    UnityPrint(createIterationMsg(-1, *pInput, setpoint).c_str()); UNITY_PRINT_EOL();
 
-    char szMsg[64];
     for (uint16_t iteration=0; iteration<maxIterations; ++iteration)
     {
         TEST_ASSERT_TRUE(pid.Compute());
         *pInput += *pOutput;
 
-        snprintf(szMsg, _countof(szMsg)-1, "%" PRIu16 ", %" PRId32 ", %" PRId32, iteration, (int32_t)*pInput, (int32_t)*pOutput);
-        UnityPrint(szMsg); UNITY_PRINT_EOL();
+        UnityPrint(createIterationMsg(iteration, *pInput, *pOutput).c_str()); UNITY_PRINT_EOL();
     }
     // Tolerance of 1%
     TEST_ASSERT_INT32_WITHIN(DIV_ROUND_CLOSEST(setpoint, 100, int32_t), setpoint, *pInput);


### PR DESCRIPTION
In `integerPID_ideal`:
1. Remove the pre-clamping of the integral term. It's not required **and** we are backing out the error from it anyway
2. Use Derivative on Measurement in place of Derivative on Error so the calculation matches the other PID classes.

Existing tests all pass. End to end tests show very, very close output:
<img width="776" height="432" alt="image" src="https://github.com/user-attachments/assets/d37b8300-c884-486a-9b2e-600184648af6" />

<img width="784" height="439" alt="image" src="https://github.com/user-attachments/assets/1f6d9f80-dba7-45d9-a69e-806c0b599e58" />
