### PR TITLE
Unit test reset control

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -28,6 +28,7 @@ A full copy of the license may be found in the projects root directory
 #endif
 #include "units.h"
 #include "sensors.h"
+#include "resetControl.h"
 
 /** @defgroup group-serial-comms-impl Serial comms implementation
  * @{
@@ -927,7 +928,7 @@ void processSerialCommand(void)
     }
 
     case 'U': //User wants to reset the Arduino (probably for FW update)
-      if (resetControl != RESET_CONTROL_DISABLED)
+      if (getResetControl() != RESET_CONTROL_DISABLED)
       {
       #ifndef SMALL_FLASH_MODE
         if (serialStatusFlag == SERIAL_INACTIVE) { primarySerial.println(F("Comms halted. Next byte will reset the Arduino.")); }

--- a/speeduino/comms_legacy.cpp
+++ b/speeduino/comms_legacy.cpp
@@ -24,6 +24,7 @@ A full copy of the license may be found in the projects root directory
 #endif
 #include "units.h"
 #include "sensors.h"
+#include "resetControl.h"
 
 static byte currentPage = 1;//Not the same as the speeduino config page numbers
 bool firstCommsRequest = true; /**< The number of times the A command has been issued. This is used to track whether a reset has recently been performed on the controller */
@@ -393,7 +394,7 @@ void legacySerialCommand(void)
       break;
 
     case 'U': //User wants to reset the Arduino (probably for FW update)
-      if (resetControl != RESET_CONTROL_DISABLED)
+      if (getResetControl() != RESET_CONTROL_DISABLED)
       {
       #ifndef SMALL_FLASH_MODE
         if (serialStatusFlag == SERIAL_INACTIVE) { primarySerial.println(F("Comms halted. Next byte will reset the Arduino.")); }

--- a/speeduino/config_pages.h
+++ b/speeduino/config_pages.h
@@ -117,11 +117,6 @@ constexpr uint8_t SPARK2_CONDITION_MAP = 1U;
 constexpr uint8_t SPARK2_CONDITION_TPS = 2U;
 constexpr uint8_t SPARK2_CONDITION_ETH = 3U;
 
-constexpr uint8_t RESET_CONTROL_DISABLED             = 0U;
-constexpr uint8_t RESET_CONTROL_PREVENT_WHEN_RUNNING = 1U;
-constexpr uint8_t RESET_CONTROL_PREVENT_ALWAYS       = 2U;
-constexpr uint8_t RESET_CONTROL_SERIAL_COMMAND       = 3U;
-
 constexpr uint8_t OPEN_LOOP_BOOST     = 0U;
 constexpr uint8_t CLOSED_LOOP_BOOST   = 1U;
 

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -48,9 +48,6 @@ volatile byte HWTest_INJ_Pulsed = 0; /**< Each bit in this variable represents o
 volatile byte HWTest_IGN = 0; /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 volatile byte HWTest_IGN_Pulsed = 0; 
 
-//This needs to be here because using the config page directly can prevent burning the setting
-byte resetControl = RESET_CONTROL_DISABLED;
-
 volatile byte TIMER_mask;
 volatile byte LOOP_TIMER;
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -157,7 +157,6 @@ extern volatile byte HWTest_INJ;      /**< Each bit in this variable represents 
 extern volatile byte HWTest_INJ_Pulsed; /**< Each bit in this variable represents one of the injector channels and it's 50% HW test status */
 extern volatile byte HWTest_IGN;      /**< Each bit in this variable represents one of the ignition channels and it's HW test status */
 extern volatile byte HWTest_IGN_Pulsed; /**< Each bit in this variable represents one of the ignition channels and it's 50% HW test status */
-extern byte resetControl; ///< resetControl needs to be here (as global) because using the config page (4) directly can prevent burning the setting
 extern volatile byte TIMER_mask;
 extern volatile byte LOOP_TIMER;
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2657,8 +2657,7 @@ void setPinMapping(byte boardID)
     if (configPage4.resetControlPin!=0U) {
       pinResetControl = pinTranslate(configPage4.resetControlPin);
     }
-    resetControl = configPage4.resetControlConfig;
-    setResetControlPinState();
+    setResetControlPinState(configPage4.resetControlConfig);
     pinMode(pinResetControl, OUTPUT);
   }
   

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -32,6 +32,7 @@
 #include "scheduledIO_direct_ign.h"
 #include "scheduledIO_direct_inj.h"
 #include "src/pins/pinMapping.h"
+#include "resetControl.h"
 
 #if defined(CORE_AVR)
 #pragma GCC push_options

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2657,8 +2657,7 @@ void setPinMapping(byte boardID)
     if (configPage4.resetControlPin!=0U) {
       pinResetControl = pinTranslate(configPage4.resetControlPin);
     }
-    setResetControlPinState(configPage4.resetControlConfig);
-    pinMode(pinResetControl, OUTPUT);
+    initialiseResetControl(currentStatus, configPage4.resetControlConfig, pinResetControl);
   }
   
 

--- a/speeduino/resetControl.cpp
+++ b/speeduino/resetControl.cpp
@@ -2,6 +2,7 @@
 
 //This needs to be here because using the config page directly can prevent burning the setting
 static uint8_t _resetControl = RESET_CONTROL_DISABLED;
+static uint8_t _resetPin;
 
 uint8_t getResetControl(void)
 {
@@ -11,6 +12,7 @@ uint8_t getResetControl(void)
 void __attribute__((optimize("Os"))) initialiseResetControl(statuses &current, uint8_t resetControlMode, uint8_t resetPin)
 {
   _resetControl = resetControlMode;
+  _resetPin = resetPin;
   current.resetPreventActive = false;
 
   /* Setup reset control initial state */
@@ -41,4 +43,25 @@ void __attribute__((optimize("Os"))) initialiseResetControl(statuses &current, u
      If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
      because the control pin will go low as soon as the pinMode is set to OUTPUT. */
   pinMode(resetPin, OUTPUT);
+}
+
+void matchResetControlToEngineState(statuses &current)
+{
+  if ((current.decoder.getStatus().syncStatus!=SyncStatus::None) && (current.RPM > 0))
+  {
+    if ( (!current.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) ) 
+    {
+      //Reset prevention is supposed to be on while the engine is running but isn't. Fix that.
+      digitalWrite(_resetPin, HIGH);
+      current.resetPreventActive = true;
+    }
+  } 
+  else
+  {
+    if ( (current.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) )
+    {
+      digitalWrite(_resetPin, LOW);
+      current.resetPreventActive = false;
+    }
+  }
 }

--- a/speeduino/resetControl.cpp
+++ b/speeduino/resetControl.cpp
@@ -1,0 +1,30 @@
+#include "globals.h"
+
+void __attribute__((optimize("Os"))) setResetControlPinState(void)
+{
+  currentStatus.resetPreventActive = false;
+
+  /* Setup reset control initial state */
+  switch (resetControl)
+  {
+    case RESET_CONTROL_PREVENT_WHEN_RUNNING:
+      /* Set the reset control pin LOW and change it to HIGH later when we get sync. */
+      digitalWrite(pinResetControl, LOW);
+      currentStatus.resetPreventActive = false;
+      break;
+    case RESET_CONTROL_PREVENT_ALWAYS:
+      /* Set the reset control pin HIGH and never touch it again. */
+      digitalWrite(pinResetControl, HIGH);
+      currentStatus.resetPreventActive = true;
+      break;
+    case RESET_CONTROL_SERIAL_COMMAND:
+      /* Set the reset control pin HIGH. There currently isn't any practical difference
+         between this and PREVENT_ALWAYS but it doesn't hurt anything to have them separate. */
+      digitalWrite(pinResetControl, HIGH);
+      currentStatus.resetPreventActive = false;
+      break;
+    default:
+      // Do nothing - keep MISRA happy
+      break;
+  }
+}

--- a/speeduino/resetControl.cpp
+++ b/speeduino/resetControl.cpp
@@ -1,7 +1,16 @@
 #include "globals.h"
 
-void __attribute__((optimize("Os"))) setResetControlPinState(void)
+//This needs to be here because using the config page directly can prevent burning the setting
+static uint8_t _resetControl = RESET_CONTROL_DISABLED;
+
+uint8_t getResetControl(void)
 {
+    return _resetControl;
+}
+
+void __attribute__((optimize("Os"))) setResetControlPinState(uint8_t resetControl)
+{
+  _resetControl = resetControl;
   currentStatus.resetPreventActive = false;
 
   /* Setup reset control initial state */

--- a/speeduino/resetControl.cpp
+++ b/speeduino/resetControl.cpp
@@ -1,4 +1,4 @@
-#include "globals.h"
+#include "resetControl.h"
 
 //This needs to be here because using the config page directly can prevent burning the setting
 static uint8_t _resetControl = RESET_CONTROL_DISABLED;
@@ -8,32 +8,37 @@ uint8_t getResetControl(void)
     return _resetControl;
 }
 
-void __attribute__((optimize("Os"))) setResetControlPinState(uint8_t resetControl)
+void __attribute__((optimize("Os"))) initialiseResetControl(statuses &current, uint8_t resetControlMode, uint8_t resetPin)
 {
-  _resetControl = resetControl;
-  currentStatus.resetPreventActive = false;
+  _resetControl = resetControlMode;
+  current.resetPreventActive = false;
 
   /* Setup reset control initial state */
-  switch (resetControl)
+  switch (resetControlMode)
   {
     case RESET_CONTROL_PREVENT_WHEN_RUNNING:
       /* Set the reset control pin LOW and change it to HIGH later when we get sync. */
-      digitalWrite(pinResetControl, LOW);
-      currentStatus.resetPreventActive = false;
+      digitalWrite(resetPin, LOW);
+      current.resetPreventActive = false;
       break;
     case RESET_CONTROL_PREVENT_ALWAYS:
       /* Set the reset control pin HIGH and never touch it again. */
-      digitalWrite(pinResetControl, HIGH);
-      currentStatus.resetPreventActive = true;
+      digitalWrite(resetPin, HIGH);
+      current.resetPreventActive = true;
       break;
     case RESET_CONTROL_SERIAL_COMMAND:
       /* Set the reset control pin HIGH. There currently isn't any practical difference
          between this and PREVENT_ALWAYS but it doesn't hurt anything to have them separate. */
-      digitalWrite(pinResetControl, HIGH);
-      currentStatus.resetPreventActive = false;
+      digitalWrite(resetPin, HIGH);
+      current.resetPreventActive = false;
       break;
     default:
       // Do nothing - keep MISRA happy
       break;
   }
+
+  /* Reset control is a special case. If reset control is enabled, it needs its initial state set BEFORE its pinMode.
+     If that doesn't happen and reset control is in "Serial Command" mode, the Arduino will end up in a reset loop
+     because the control pin will go low as soon as the pinMode is set to OUTPUT. */
+  pinMode(resetPin, OUTPUT);
 }

--- a/speeduino/resetControl.h
+++ b/speeduino/resetControl.h
@@ -1,7 +1,12 @@
 #pragma once
 
-#include <stdint.h>
+#include "statuses.h"
 
-void setResetControlPinState(uint8_t resetControl);
+constexpr uint8_t RESET_CONTROL_DISABLED             = 0U;
+constexpr uint8_t RESET_CONTROL_PREVENT_WHEN_RUNNING = 1U;
+constexpr uint8_t RESET_CONTROL_PREVENT_ALWAYS       = 2U;
+constexpr uint8_t RESET_CONTROL_SERIAL_COMMAND       = 3U;
+
+void initialiseResetControl(statuses &current, uint8_t resetControlMode, uint8_t resetPin);
 
 uint8_t getResetControl(void);

--- a/speeduino/resetControl.h
+++ b/speeduino/resetControl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void setResetControlPinState(void);

--- a/speeduino/resetControl.h
+++ b/speeduino/resetControl.h
@@ -10,3 +10,5 @@ constexpr uint8_t RESET_CONTROL_SERIAL_COMMAND       = 3U;
 void initialiseResetControl(statuses &current, uint8_t resetControlMode, uint8_t resetPin);
 
 uint8_t getResetControl(void);
+
+void matchResetControlToEngineState(statuses &current);

--- a/speeduino/resetControl.h
+++ b/speeduino/resetControl.h
@@ -1,3 +1,7 @@
 #pragma once
 
-void setResetControlPinState(void);
+#include <stdint.h>
+
+void setResetControlPinState(uint8_t resetControl);
+
+uint8_t getResetControl(void);

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -53,6 +53,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "dwell.h"
 #include "decoder_init.h"
 #include "src/pins/pinMapping.h"
+#include "resetControl.h"
 
 #define CRANK_RUN_HYSTER    15
 
@@ -900,14 +901,14 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
 
       setIgnitionChannels(ignitionLimits(currentStatus.decoder.getCrankAngle()), currentStatus.dwell + fixedCrankingOverride, currentStatus.schedulerCutState.ignitionChannels);
 
-      if ( (!currentStatus.resetPreventActive) && (resetControl == RESET_CONTROL_PREVENT_WHEN_RUNNING) ) 
+      if ( (!currentStatus.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) ) 
       {
         //Reset prevention is supposed to be on while the engine is running but isn't. Fix that.
         digitalWrite(pinResetControl, HIGH);
         currentStatus.resetPreventActive = true;
       }
     } //Has sync and RPM
-    else if ( (currentStatus.resetPreventActive) && (resetControl == RESET_CONTROL_PREVENT_WHEN_RUNNING) )
+    else if ( (currentStatus.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) )
     {
       digitalWrite(pinResetControl, LOW);
       currentStatus.resetPreventActive = false;

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -901,18 +901,8 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
 
       setIgnitionChannels(ignitionLimits(currentStatus.decoder.getCrankAngle()), currentStatus.dwell + fixedCrankingOverride, currentStatus.schedulerCutState.ignitionChannels);
 
-      if ( (!currentStatus.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) ) 
-      {
-        //Reset prevention is supposed to be on while the engine is running but isn't. Fix that.
-        digitalWrite(pinResetControl, HIGH);
-        currentStatus.resetPreventActive = true;
-      }
     } //Has sync and RPM
-    else if ( (currentStatus.resetPreventActive) && (getResetControl() == RESET_CONTROL_PREVENT_WHEN_RUNNING) )
-    {
-      digitalWrite(pinResetControl, LOW);
-      currentStatus.resetPreventActive = false;
-    }
+    matchResetControlToEngineState(currentStatus);
 } //loop()
 END_LTO_INLINE()
 

--- a/speeduino/utilities.cpp
+++ b/speeduino/utilities.cpp
@@ -21,35 +21,6 @@ uint8_t ioOutDelay[sizeof(configPage13.outputPin)];
 uint8_t pinIsValid = 0;
 uint8_t currentRuleStatus = 0;
 
-void setResetControlPinState(void)
-{
-  currentStatus.resetPreventActive = false;
-
-  /* Setup reset control initial state */
-  switch (resetControl)
-  {
-    case RESET_CONTROL_PREVENT_WHEN_RUNNING:
-      /* Set the reset control pin LOW and change it to HIGH later when we get sync. */
-      digitalWrite(pinResetControl, LOW);
-      currentStatus.resetPreventActive = false;
-      break;
-    case RESET_CONTROL_PREVENT_ALWAYS:
-      /* Set the reset control pin HIGH and never touch it again. */
-      digitalWrite(pinResetControl, HIGH);
-      currentStatus.resetPreventActive = true;
-      break;
-    case RESET_CONTROL_SERIAL_COMMAND:
-      /* Set the reset control pin HIGH. There currently isn't any practical difference
-         between this and PREVENT_ALWAYS but it doesn't hurt anything to have them separate. */
-      digitalWrite(pinResetControl, HIGH);
-      currentStatus.resetPreventActive = false;
-      break;
-    default:
-      // Do nothing - keep MISRA happy
-      break;
-  }
-}
-
 //*********************************************************************************************************************************************************************************
 void initialiseProgrammableIO(void)
 {

--- a/speeduino/utilities.h
+++ b/speeduino/utilities.h
@@ -28,7 +28,6 @@ extern uint8_t pinIsValid;
 extern uint8_t currentRuleStatus;
 //uint8_t outputPin[sizeof(configPage13.outputPin)];
 
-void setResetControlPinState(void);
 void initialiseProgrammableIO(void);
 void checkProgrammableIO(void);
 int16_t ProgrammableIOGetData(uint16_t index);

--- a/test/test_general/main.cpp
+++ b/test/test_general/main.cpp
@@ -5,8 +5,10 @@
 void runAllTests(void)
 {
     extern void testPinMapping(void);
+    extern void testResetControl(void);
 
     testPinMapping();
+    testResetControl();
 }
 
 TEST_HARNESS(runAllTests)

--- a/test/test_general/test_resetcontrol.cpp
+++ b/test/test_general/test_resetcontrol.cpp
@@ -1,0 +1,45 @@
+#include "../test_utils.h"
+#include "resetControl.h"
+
+static decoder_status_t fakeDecoderStatus = {};
+static decoder_status_t fakeGetStatus(void)
+{
+    return fakeDecoderStatus;
+}
+
+static void test_matchResetControlToEngineState(void)
+{
+    constexpr uint8_t resetPin = 42;
+    statuses current{};
+
+    current.decoder.getStatus = fakeGetStatus;
+    current.RPM = 0;
+    fakeDecoderStatus.syncStatus = SyncStatus::None;
+
+    initialiseResetControl(current, RESET_CONTROL_PREVENT_WHEN_RUNNING, resetPin);
+
+    TEST_ASSERT_EQUAL(RESET_CONTROL_PREVENT_WHEN_RUNNING, getResetControl());
+    TEST_ASSERT_EQUAL(LOW, digitalRead(resetPin));
+    TEST_ASSERT_FALSE(current.resetPreventActive);
+
+    current.RPM = 900;
+    fakeDecoderStatus.syncStatus = SyncStatus::Full;
+    matchResetControlToEngineState(current);
+
+    TEST_ASSERT_EQUAL(HIGH, digitalRead(resetPin));
+    TEST_ASSERT_TRUE(current.resetPreventActive);
+
+    current.RPM = 0;
+    fakeDecoderStatus.syncStatus = SyncStatus::None;
+    matchResetControlToEngineState(current);
+
+    TEST_ASSERT_EQUAL(LOW, digitalRead(resetPin));
+    TEST_ASSERT_FALSE(current.resetPreventActive);
+}
+
+void testResetControl(void) 
+{
+    SET_UNITY_FILENAME() {
+        RUN_TEST_P(test_matchResetControlToEngineState);
+    }
+}

--- a/test/test_general/test_resetcontrol.cpp
+++ b/test/test_general/test_resetcontrol.cpp
@@ -7,14 +7,48 @@ static decoder_status_t fakeGetStatus(void)
     return fakeDecoderStatus;
 }
 
-static void test_matchResetControlToEngineState(void)
+static void assert_matchResetControlToEngineState_On(statuses &current,uint16_t rpm, SyncStatus syncStatus, uint8_t resetPin)
+{
+    setRpm(current, rpm);
+
+    current.decoder.getStatus = fakeGetStatus;
+    fakeDecoderStatus.syncStatus = syncStatus;
+
+    matchResetControlToEngineState(current);
+    TEST_ASSERT_EQUAL(HIGH, digitalRead(resetPin));
+    TEST_ASSERT_TRUE(current.resetPreventActive);
+}
+
+static void assert_matchResetControlToEngineState_Off(statuses &current, uint16_t rpm, SyncStatus syncStatus, uint8_t resetPin)
+{
+    setRpm(current, rpm);
+
+    current.decoder.getStatus = fakeGetStatus;
+    fakeDecoderStatus.syncStatus = syncStatus;
+
+    matchResetControlToEngineState(current);
+    TEST_ASSERT_EQUAL(LOW, digitalRead(resetPin));
+    TEST_ASSERT_FALSE(current.resetPreventActive);
+}
+
+static void assert_matchResetControlToEngineState_NoChange(statuses &current, uint16_t rpm, SyncStatus syncStatus, uint8_t resetPin, uint8_t expectedState)
+{
+    bool oldState = current.resetPreventActive;
+    setRpm(current, rpm);
+
+    current.decoder.getStatus = fakeGetStatus;
+    fakeDecoderStatus.syncStatus = syncStatus;
+
+    matchResetControlToEngineState(current);
+    TEST_ASSERT_EQUAL(expectedState, digitalRead(resetPin));
+    TEST_ASSERT_EQUAL(oldState, current.resetPreventActive);
+}
+
+
+static void test_matchResetControlToEngineState_PreventWhenRunning(void)
 {
     constexpr uint8_t resetPin = 42;
     statuses current{};
-
-    current.decoder.getStatus = fakeGetStatus;
-    current.RPM = 0;
-    fakeDecoderStatus.syncStatus = SyncStatus::None;
 
     initialiseResetControl(current, RESET_CONTROL_PREVENT_WHEN_RUNNING, resetPin);
 
@@ -22,24 +56,62 @@ static void test_matchResetControlToEngineState(void)
     TEST_ASSERT_EQUAL(LOW, digitalRead(resetPin));
     TEST_ASSERT_FALSE(current.resetPreventActive);
 
-    current.RPM = 900;
-    fakeDecoderStatus.syncStatus = SyncStatus::Full;
-    matchResetControlToEngineState(current);
+    assert_matchResetControlToEngineState_On(current, 900, SyncStatus::Full, resetPin);
+    current.resetPreventActive = true; // Simulate that the reset prevention is now active
+    assert_matchResetControlToEngineState_Off(current, 0, SyncStatus::Full, resetPin);
+    current.resetPreventActive = true; // Simulate that the reset prevention is now active
+    assert_matchResetControlToEngineState_Off(current, 900, SyncStatus::None, resetPin);
+    current.resetPreventActive = true; // Simulate that the reset prevention is now active
+    assert_matchResetControlToEngineState_Off(current, 0, SyncStatus::None, resetPin);
+    current.resetPreventActive = false; // Simulate that the reset prevention is off
+    assert_matchResetControlToEngineState_On(current, 900, SyncStatus::Partial, resetPin);
+    current.resetPreventActive = true; // Simulate that the reset prevention is now active
+    assert_matchResetControlToEngineState_Off(current, 0, SyncStatus::Partial, resetPin);
+}
 
+static void test_matchResetControlToEngineState_PreventAlways(void)
+{
+    constexpr uint8_t resetPin = 42;
+    statuses current{};
+
+    initialiseResetControl(current, RESET_CONTROL_PREVENT_ALWAYS, resetPin);
+
+    TEST_ASSERT_EQUAL(RESET_CONTROL_PREVENT_ALWAYS, getResetControl());
     TEST_ASSERT_EQUAL(HIGH, digitalRead(resetPin));
     TEST_ASSERT_TRUE(current.resetPreventActive);
 
-    current.RPM = 0;
-    fakeDecoderStatus.syncStatus = SyncStatus::None;
-    matchResetControlToEngineState(current);
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::None, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::None, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::Full, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::Full, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::Partial, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::Partial, resetPin, HIGH);
+}
 
-    TEST_ASSERT_EQUAL(LOW, digitalRead(resetPin));
+static void test_matchResetControlToEngineState_SerialCommand(void)
+{
+    constexpr uint8_t resetPin = 42;
+    statuses current{};
+
+    initialiseResetControl(current, RESET_CONTROL_SERIAL_COMMAND, resetPin);
+
+    TEST_ASSERT_EQUAL(RESET_CONTROL_SERIAL_COMMAND, getResetControl());
+    TEST_ASSERT_EQUAL(HIGH, digitalRead(resetPin));
     TEST_ASSERT_FALSE(current.resetPreventActive);
+
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::None, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::None, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::Full, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::Full, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 0, SyncStatus::Partial, resetPin, HIGH);
+    assert_matchResetControlToEngineState_NoChange(current, 900, SyncStatus::Partial, resetPin, HIGH);
 }
 
 void testResetControl(void) 
 {
     SET_UNITY_FILENAME() {
-        RUN_TEST_P(test_matchResetControlToEngineState);
+        RUN_TEST_P(test_matchResetControlToEngineState_PreventWhenRunning);
+        RUN_TEST_P(test_matchResetControlToEngineState_PreventAlways);
+        RUN_TEST_P(test_matchResetControlToEngineState_SerialCommand);
     }
 }

--- a/test/test_init/tests_init.cpp
+++ b/test/test_init/tests_init.cpp
@@ -3,6 +3,7 @@
 #include "init.h"
 #include "../test_utils.h"
 #include "storage.h"
+#include "resetControl.h"
 
 void prepareForInitialiseAll(uint8_t boardId);
 
@@ -250,7 +251,7 @@ void test_initialisation_outputs_reset_control_use_board_default(void)
   initialiseAll(); //Run the main initialise function
 
   TEST_ASSERT_NOT_EQUAL(0, pinResetControl); 
-  TEST_ASSERT_EQUAL(resetControl, RESET_CONTROL_PREVENT_WHEN_RUNNING);
+  TEST_ASSERT_EQUAL(getResetControl(), RESET_CONTROL_PREVENT_WHEN_RUNNING);
   TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinResetControl));  
 #endif
 }
@@ -266,7 +267,7 @@ void test_initialisation_outputs_reset_control_override_board_default(void)
   initialiseAll(); //Run the main initialise function
 
   TEST_ASSERT_EQUAL(45, pinResetControl);  
-  TEST_ASSERT_EQUAL(resetControl, RESET_CONTROL_PREVENT_WHEN_RUNNING);
+  TEST_ASSERT_EQUAL(getResetControl(), RESET_CONTROL_PREVENT_WHEN_RUNNING);
   TEST_ASSERT_EQUAL(OUTPUT, getPinMode(pinResetControl));
 #endif
 }


### PR DESCRIPTION
1. Move `setResetControlPinState` to `resetControl.cpp` and rename to `initialiseResetControl`
2. Move reset control logic from `loop` to `matchResetControlToEngineState`
3. Comprehensive unit tests