### PR TITLE
Fix incorrect comparison causing only one tooth to be logged

### DIFF
--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -193,7 +193,7 @@ static inline void addToothLogEntry(unsigned long toothTime, byte whichTooth)
     //If there has been a value logged above, update the indexes
     if(valueLogged == true)
     {
-      currentStatus.isToothLog1Full = toothHistoryIndex < (TOOTH_LOG_SIZE-1);
+      currentStatus.isToothLog1Full = toothHistoryIndex >= (TOOTH_LOG_SIZE-1);
       if (!currentStatus.isToothLog1Full) { ++toothHistoryIndex; }
     }
 


### PR DESCRIPTION
Fixes #1469 

Simple comparison change to allow full use of the tooth log buffer