### PR TITLE
Refactor scheduler IO

### DIFF
--- a/speeduino/TS_CommandButtonHandler.cpp
+++ b/speeduino/TS_CommandButtonHandler.cpp
@@ -82,211 +82,211 @@ bool TS_CommandButtonsHandler(uint16_t buttonCommand)
       break;
 
     case TS_CMD_INJ1_ON: // cmd group is for injector1 on actions
-      if( currentStatus.isTestModeActive ){ openInjector1(); }
+      if( currentStatus.isTestModeActive ){ openInjector(1); }
       break;
 
     case TS_CMD_INJ1_OFF: // cmd group is for injector1 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector1(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ1_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(1); BIT_CLEAR(HWTest_INJ_Pulsed, INJ1_CMD_BIT); }
       break;
 
     case TS_CMD_INJ1_PULSED: // cmd group is for injector1 50% dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ1_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ1_CMD_BIT)) { closeInjector1(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ1_CMD_BIT)) { closeInjector(1); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ2_ON: // cmd group is for injector2 on actions
-      if( currentStatus.isTestModeActive ){ openInjector2(); }
+      if( currentStatus.isTestModeActive ){ openInjector(2); }
       break;
 
     case TS_CMD_INJ2_OFF: // cmd group is for injector2 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector2(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ2_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(2); BIT_CLEAR(HWTest_INJ_Pulsed, INJ2_CMD_BIT); }
       break;
 
     case TS_CMD_INJ2_PULSED: // cmd group is for injector2 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ2_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ2_CMD_BIT)) { closeInjector2(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ2_CMD_BIT)) { closeInjector(2); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ3_ON: // cmd group is for injector3 on actions
-      if( currentStatus.isTestModeActive ){ openInjector3(); }
+      if( currentStatus.isTestModeActive ){ openInjector(3); }
       break;
 
     case TS_CMD_INJ3_OFF: // cmd group is for injector3 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector3(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ3_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(3); BIT_CLEAR(HWTest_INJ_Pulsed, INJ3_CMD_BIT); }
       break;
 
     case TS_CMD_INJ3_PULSED: // cmd group is for injector3 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ3_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ3_CMD_BIT)) { closeInjector3(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ3_CMD_BIT)) { closeInjector(3); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ4_ON: // cmd group is for injector4 on actions
-      if( currentStatus.isTestModeActive ){ openInjector4(); }
+      if( currentStatus.isTestModeActive ){ openInjector(4); }
       break;
 
     case TS_CMD_INJ4_OFF: // cmd group is for injector4 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector4(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ4_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(4); BIT_CLEAR(HWTest_INJ_Pulsed, INJ4_CMD_BIT); }
       break;
 
     case TS_CMD_INJ4_PULSED: // cmd group is for injector4 50% dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ4_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ4_CMD_BIT)) { closeInjector4(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ4_CMD_BIT)) { closeInjector(4); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ5_ON: // cmd group is for injector5 on actions
-      if( currentStatus.isTestModeActive ){ openInjector5(); }
+      if( currentStatus.isTestModeActive ){ openInjector(5); }
       break;
 
     case TS_CMD_INJ5_OFF: // cmd group is for injector5 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector5(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ5_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(5); BIT_CLEAR(HWTest_INJ_Pulsed, INJ5_CMD_BIT); }
       break;
 
     case TS_CMD_INJ5_PULSED: // cmd group is for injector5 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ5_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ5_CMD_BIT)) { closeInjector5(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ5_CMD_BIT)) { closeInjector(5); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ6_ON: // cmd group is for injector6 on actions
-      if( currentStatus.isTestModeActive ){ openInjector6(); }
+      if( currentStatus.isTestModeActive ){ openInjector(6); }
       break;
 
     case TS_CMD_INJ6_OFF: // cmd group is for injector6 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector6(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ6_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(6); BIT_CLEAR(HWTest_INJ_Pulsed, INJ6_CMD_BIT); }
       break;
 
     case TS_CMD_INJ6_PULSED: // cmd group is for injector6 50% dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ6_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ6_CMD_BIT)) { closeInjector6(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ6_CMD_BIT)) { closeInjector(6); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ7_ON: // cmd group is for injector7 on actions
-      if( currentStatus.isTestModeActive ){ openInjector7(); }
+      if( currentStatus.isTestModeActive ){ openInjector(7); }
       break;
 
     case TS_CMD_INJ7_OFF: // cmd group is for injector7 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector7(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ7_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(7); BIT_CLEAR(HWTest_INJ_Pulsed, INJ7_CMD_BIT); }
       break;
 
     case TS_CMD_INJ7_PULSED: // cmd group is for injector7 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ7_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ7_CMD_BIT)) { closeInjector7(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ7_CMD_BIT)) { closeInjector(7); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_INJ8_ON: // cmd group is for injector8 on actions
-      if( currentStatus.isTestModeActive ){ openInjector8(); }
+      if( currentStatus.isTestModeActive ){ openInjector(8); }
       break;
 
     case TS_CMD_INJ8_OFF: // cmd group is for injector8 off actions
-      if( currentStatus.isTestModeActive ){ closeInjector8(); BIT_CLEAR(HWTest_INJ_Pulsed, INJ8_CMD_BIT); }
+      if( currentStatus.isTestModeActive ){ closeInjector(8); BIT_CLEAR(HWTest_INJ_Pulsed, INJ8_CMD_BIT); }
       break;
 
     case TS_CMD_INJ8_PULSED: // cmd group is for injector8 50% dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_INJ_Pulsed, INJ8_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ8_CMD_BIT)) { closeInjector8(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_INJ_Pulsed, INJ8_CMD_BIT)) { closeInjector(8); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN1_ON: // cmd group is for spark1 on actions
-      if( currentStatus.isTestModeActive ){ beginCoil1Charge(); }
+      if( currentStatus.isTestModeActive ){ beginCoilCharge(1); }
       break;
 
     case TS_CMD_IGN1_OFF: // cmd group is for spark1 off actions
-        if( currentStatus.isTestModeActive ) { endCoil1Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN1_CMD_BIT); }
+        if( currentStatus.isTestModeActive ) { endCoilCharge(1); BIT_CLEAR(HWTest_IGN_Pulsed, IGN1_CMD_BIT); }
       break;
 
     case TS_CMD_IGN1_PULSED: // cmd group is for spark1 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN1_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN1_CMD_BIT)) { endCoil1Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN1_CMD_BIT)) { endCoilCharge(1); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN2_ON: // cmd group is for spark2 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil2Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(2); }
       break;
 
     case TS_CMD_IGN2_OFF: // cmd group is for spark2 off actions
-      if( currentStatus.isTestModeActive ) { endCoil2Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN2_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(2); BIT_CLEAR(HWTest_IGN_Pulsed, IGN2_CMD_BIT); }
       break;
 
     case TS_CMD_IGN2_PULSED: // cmd group is for spark2 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN2_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN2_CMD_BIT)) { endCoil2Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN2_CMD_BIT)) { endCoilCharge(2); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN3_ON: // cmd group is for spark3 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil3Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(3); }
       break;
 
     case TS_CMD_IGN3_OFF: // cmd group is for spark3 off actions
-      if( currentStatus.isTestModeActive ) { endCoil3Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN3_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(3); BIT_CLEAR(HWTest_IGN_Pulsed, IGN3_CMD_BIT); }
       break;
 
     case TS_CMD_IGN3_PULSED: // cmd group is for spark3 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN3_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN3_CMD_BIT)) { endCoil3Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN3_CMD_BIT)) { endCoilCharge(3); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN4_ON: // cmd group is for spark4 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil4Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(4); }
       break;
 
     case TS_CMD_IGN4_OFF: // cmd group is for spark4 off actions
-      if( currentStatus.isTestModeActive ) { endCoil4Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN4_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(4); BIT_CLEAR(HWTest_IGN_Pulsed, IGN4_CMD_BIT); }
       break;
 
     case TS_CMD_IGN4_PULSED: // cmd group is for spark4 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN4_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN4_CMD_BIT)) { endCoil4Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN4_CMD_BIT)) { endCoilCharge(4); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN5_ON: // cmd group is for spark5 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil5Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(5); }
       break;
 
     case TS_CMD_IGN5_OFF: // cmd group is for spark5 off actions
-      if( currentStatus.isTestModeActive ) { endCoil5Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN5_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(5); BIT_CLEAR(HWTest_IGN_Pulsed, IGN5_CMD_BIT); }
       break;
 
     case TS_CMD_IGN5_PULSED: // cmd group is for spark4 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN5_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN5_CMD_BIT)) { endCoil5Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN5_CMD_BIT)) { endCoilCharge(5); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN6_ON: // cmd group is for spark6 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil6Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(6); }
       break;
 
     case TS_CMD_IGN6_OFF: // cmd group is for spark6 off actions
-      if( currentStatus.isTestModeActive ) { endCoil6Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN6_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(6); BIT_CLEAR(HWTest_IGN_Pulsed, IGN6_CMD_BIT); }
       break;
 
     case TS_CMD_IGN6_PULSED: // cmd group is for spark6 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN6_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN6_CMD_BIT)) { endCoil6Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN6_CMD_BIT)) { endCoilCharge(6); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN7_ON: // cmd group is for spark7 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil7Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(7); }
       break;
 
     case TS_CMD_IGN7_OFF: // cmd group is for spark7 off actions
-      if( currentStatus.isTestModeActive ) { endCoil7Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN7_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(7); BIT_CLEAR(HWTest_IGN_Pulsed, IGN7_CMD_BIT); }
       break;
 
     case TS_CMD_IGN7_PULSED: // cmd group is for spark7 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN7_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN7_CMD_BIT)) { endCoil7Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN7_CMD_BIT)) { endCoilCharge(7); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     case TS_CMD_IGN8_ON: // cmd group is for spark8 on actions
-      if( currentStatus.isTestModeActive ) { beginCoil8Charge(); }
+      if( currentStatus.isTestModeActive ) { beginCoilCharge(8); }
       break;
 
     case TS_CMD_IGN8_OFF: // cmd group is for spark8 off actions
-      if( currentStatus.isTestModeActive ) { endCoil8Charge(); BIT_CLEAR(HWTest_IGN_Pulsed, IGN8_CMD_BIT); }
+      if( currentStatus.isTestModeActive ) { endCoilCharge(8); BIT_CLEAR(HWTest_IGN_Pulsed, IGN8_CMD_BIT); }
       break;
 
     case TS_CMD_IGN8_PULSED: // cmd group is for spark8 50%dc actions
       if( currentStatus.isTestModeActive ) { BIT_SET(HWTest_IGN_Pulsed, IGN8_CMD_BIT); }
-      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN8_CMD_BIT)) { endCoil8Charge(); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
+      if(!BIT_CHECK(HWTest_IGN_Pulsed, IGN8_CMD_BIT)) { endCoilCharge(8); } //Ensure this output is turned off (Otherwise the output may stay on permanently)
       break;
 
     //VSS Calibration routines

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -13,12 +13,24 @@ struct mc33810_t
     fastOutputPin_t pin;
     volatile uint8_t requestedState; //Current binary state of the 2nd ICs IGN and INJ values
     volatile uint8_t returnState; //Current binary state of the 1st ICs IGN and INJ values
+
+    void init(uint8_t pinNumber)
+    {
+        pin.setPin(pinNumber, OUTPUT);
+
+        //Set the output states to be off to fuel and ignition
+        requestedState = 0;
+        returnState = 0;
+    }
+
     uint8_t sendCommand(uint16_t command);
+    
     void setBit(uint8_t bit)
     {
         BIT_SET(requestedState, bit); 
         returnState = sendCommand(word(MC33810_ONOFF_CMD, requestedState));        
     }
+    
     void clearBit(uint8_t bit)
     {
         BIT_CLEAR(requestedState, bit); 
@@ -59,14 +71,8 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     memcpy(MC33810_BIT_IGN, ignBits, sizeof(MC33810_BIT_IGN));
 
     //Set pin port/masks
-    mc33810_1.pin.setPin(pinMC33810_1, OUTPUT);
-    mc33810_2.pin.setPin(pinMC33810_2, OUTPUT);
-
-    //Set the output states of both ICs to be off to fuel and ignition
-    mc33810_1.requestedState = 0;
-    mc33810_2.requestedState = 0;
-    mc33810_1.returnState = 0;
-    mc33810_2.returnState = 0;
+    mc33810_1.init(pinMC33810_1);
+    mc33810_2.init(pinMC33810_2);
 
     SPI.begin();
     //These are the SPI settings per the datasheet

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -95,55 +95,43 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     mc33810_2.sendCommand(loadDetectCmd);
 }
 
-void openInjector1_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[0]); }
-void openInjector2_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[1]); }
-void openInjector3_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[2]); }
-void openInjector4_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[3]); }
-void openInjector5_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[4]); }
-void openInjector6_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[5]); }
-void openInjector7_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[6]); }
-void openInjector8_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[7]); }
+static inline mc33810_t& getMC33810ForChannel(uint8_t channel)
+{ 
+    // Upper 4 channels (injection *and* ignition) are on the 2nd IC, lower 4 on the first IC
+    return channel>4U ? mc33810_2 : mc33810_1;
+}
 
-void closeInjector1_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[0]); }
-void closeInjector2_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[1]); }
-void closeInjector3_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[2]); }
-void closeInjector4_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[3]); }
-void closeInjector5_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[4]); }
-void closeInjector6_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[5]); }
-void closeInjector7_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[6]); }
-void closeInjector8_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[7]); }
+void openInjector_MC33810(uint8_t channel)
+{
+    if (channel<=_countof(MC33810_BIT_INJ))
+    {
+        getMC33810ForChannel(channel).setBit(MC33810_BIT_INJ[channel-1U]);
+    }
+}
 
-void coil1High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[0]); }
-void coil2High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[1]); }
-void coil3High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[2]); }
-void coil4High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[3]); }
-void coil5High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[4]); }
-void coil6High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[5]); }
-void coil7High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[6]); }
-void coil8High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[7]); }
+void closeInjector_MC33810(uint8_t channel)
+{ 
+    if (channel<=_countof(MC33810_BIT_INJ))
+    {
+        getMC33810ForChannel(channel).clearBit(MC33810_BIT_INJ[channel-1U]); 
+    }
+}
 
-void coil1Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[0]); }
-void coil2Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[1]); }
-void coil3Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[2]); }
-void coil4Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[3]); }
-void coil5Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[4]); }
-void coil6Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[5]); }
-void coil7Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[6]); }
-void coil8Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[7]); }
+void coilHigh_MC33810(uint8_t channel)
+{ 
+    if (channel<=_countof(MC33810_BIT_IGN))
+    {
+        getMC33810ForChannel(channel).setBit(MC33810_BIT_IGN[channel-1U]); 
+    }
+}
 
-void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
-void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }
-void coil2Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil2Low_MC33810();  } else { coil2High_MC33810(); } }
-void coil2StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil2High_MC33810(); } else { coil2Low_MC33810();  } }
-void coil3Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil3Low_MC33810();  } else { coil3High_MC33810(); } }
-void coil3StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil3High_MC33810(); } else { coil3Low_MC33810();  } }
-void coil4Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil4Low_MC33810();  } else { coil4High_MC33810(); } }
-void coil4StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil4High_MC33810(); } else { coil4Low_MC33810();  } }
-void coil5Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil5Low_MC33810();  } else { coil5High_MC33810(); } }
-void coil5StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil5High_MC33810(); } else { coil5Low_MC33810();  } }
-void coil6Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil6Low_MC33810();  } else { coil6High_MC33810(); } }
-void coil6StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil6High_MC33810(); } else { coil6Low_MC33810();  } }
-void coil7Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil7Low_MC33810();  } else { coil7High_MC33810(); } }
-void coil7StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil7High_MC33810(); } else { coil7Low_MC33810();  } }
-void coil8Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil8Low_MC33810();  } else { coil8High_MC33810(); } }
-void coil8StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil8High_MC33810(); } else { coil8Low_MC33810();  } }
+void coilLow_MC33810(uint8_t channel)
+{ 
+    if (channel<=_countof(MC33810_BIT_IGN))
+    {
+        getMC33810ForChannel(channel).clearBit(MC33810_BIT_IGN[channel-1U]); 
+    }
+}
+
+void coilCharging_MC33810(uint8_t channel) { if(configPage4.IgInv == GOING_HIGH) { coilLow_MC33810(channel);  } else { coilHigh_MC33810(channel); } }
+void coilStopCharging_MC33810(uint8_t channel) { if(configPage4.IgInv == GOING_HIGH) { coilHigh_MC33810(channel); } else { coilLow_MC33810(channel);  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -3,6 +3,8 @@
 #include "src/pins/fastOutputPin.h"
 #include "preprocessor.h"
 
+#if defined(MC33810_SUPPORT)
+
 static uint8_t MC33810_BIT_INJ[8] = {};
 static uint8_t MC33810_BIT_IGN[8] = {};
 
@@ -164,3 +166,4 @@ void coilStopCharging_MC33810(uint8_t channel)
 {
     coilDischargingFn(channel);
 }
+#endif

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -6,18 +6,22 @@
 static uint8_t MC33810_BIT_INJ[8] = {};
 static uint8_t MC33810_BIT_IGN[8] = {};
 
-static fastOutputPin_t mc33810_1_pin;
-static fastOutputPin_t mc33810_2_pin;
-static const uint8_t MC33810_ONOFF_CMD = 0x30; //48 in decimal
-static volatile uint8_t mc33810_1_requestedState; //Current binary state of the 1st ICs IGN and INJ values
-static volatile uint8_t mc33810_2_requestedState; //Current binary state of the 2nd ICs IGN and INJ values
-static volatile uint8_t mc33810_1_returnState; //Current binary state of the 1st ICs IGN and INJ values
-static volatile uint8_t mc33810_2_returnState; //Current binary state of the 2nd ICs IGN and INJ values
+static constexpr uint8_t MC33810_ONOFF_CMD = 0x30; //48 in decimal
 
-void setMC33810_1_ACTIVE(void) { mc33810_1_pin.setPinHigh(); }
-void setMC33810_1_INACTIVE(void) { mc33810_1_pin.setPinLow(); }
-void setMC33810_2_ACTIVE(void) { mc33810_2_pin.setPinHigh(); }
-void setMC33810_2_INACTIVE(void) { mc33810_2_pin.setPinLow(); }
+struct mc33810_t
+{
+    fastOutputPin_t pin;
+    volatile uint8_t requestedState; //Current binary state of the 2nd ICs IGN and INJ values
+    volatile uint8_t returnState; //Current binary state of the 1st ICs IGN and INJ values
+};
+
+static mc33810_t mc33810_1;
+static mc33810_t mc33810_2;
+
+void setMC33810_1_ACTIVE(void) { mc33810_1.pin.setPinHigh(); }
+void setMC33810_1_INACTIVE(void) { mc33810_1.pin.setPinLow(); }
+void setMC33810_2_ACTIVE(void) { mc33810_2.pin.setPinHigh(); }
+void setMC33810_2_INACTIVE(void) { mc33810_2.pin.setPinLow(); }
 
 void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                                                  const uint8_t (&injBits)[8], const uint8_t (&ignBits)[8])
@@ -28,14 +32,14 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     memcpy(MC33810_BIT_IGN, ignBits, sizeof(MC33810_BIT_IGN));
 
     //Set pin port/masks
-    mc33810_1_pin.setPin(pinMC33810_1, OUTPUT);
-    mc33810_2_pin.setPin(pinMC33810_2, OUTPUT);
+    mc33810_1.pin.setPin(pinMC33810_1, OUTPUT);
+    mc33810_2.pin.setPin(pinMC33810_2, OUTPUT);
 
     //Set the output states of both ICs to be off to fuel and ignition
-    mc33810_1_requestedState = 0;
-    mc33810_2_requestedState = 0;
-    mc33810_1_returnState = 0;
-    mc33810_2_returnState = 0;
+    mc33810_1.requestedState = 0;
+    mc33810_2.requestedState = 0;
+    mc33810_1.returnState = 0;
+    mc33810_2.returnState = 0;
 
     SPI.begin();
     //These are the SPI settings per the datasheet
@@ -76,41 +80,41 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     setMC33810_2_INACTIVE();
 }
 
-void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
 
-void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
 
-void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
 
-void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
+void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
 
 void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
 void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -1,7 +1,7 @@
 #include <SPI.h>
 #include "acc_mc33810.h"
 #include "src/pins/fastOutputPin.h"
-#include "globals.h"
+#include "preprocessor.h"
 
 static uint8_t MC33810_BIT_INJ[8] = {};
 static uint8_t MC33810_BIT_IGN[8] = {};
@@ -62,7 +62,34 @@ uint8_t mc33810_t::sendCommand(uint16_t command)
 static mc33810_t mc33810_1;
 static mc33810_t mc33810_2;
 
-void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2,
+static inline mc33810_t& getMC33810ForChannel(uint8_t channel)
+{ 
+    // Upper 4 channels (injection *and* ignition) are on the 2nd IC, lower 4 on the first IC
+    return channel>4U ? mc33810_2 : mc33810_1;
+}
+
+static void coilHigh(uint8_t channel)
+{ 
+    if (channel<=_countof(MC33810_BIT_IGN))
+    {
+        getMC33810ForChannel(channel).setBit(MC33810_BIT_IGN[channel-1U]); 
+    }
+}
+
+static void coilLow(uint8_t channel)
+{ 
+    if (channel<=_countof(MC33810_BIT_IGN))
+    {
+        getMC33810ForChannel(channel).clearBit(MC33810_BIT_IGN[channel-1U]); 
+    }
+}
+
+using channelFunc = void(*)(uint8_t);
+static channelFunc coilChargingFn = coilHigh;
+static channelFunc coilDischargingFn = coilLow;
+
+void __attribute__((optimize("Os"))) initMC33810(const config4 &page4,
+                                                 uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                                                  const uint8_t (&injBits)[8], const uint8_t (&ignBits)[8])
 {
     static_assert(sizeof(MC33810_BIT_INJ)==sizeof(injBits), "Mismatch!");
@@ -99,12 +126,17 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     constexpr uint16_t loadDetectCmd = 0b0010'1000'1111'0000;
     mc33810_1.sendCommand(loadDetectCmd);
     mc33810_2.sendCommand(loadDetectCmd);
-}
 
-static inline mc33810_t& getMC33810ForChannel(uint8_t channel)
-{ 
-    // Upper 4 channels (injection *and* ignition) are on the 2nd IC, lower 4 on the first IC
-    return channel>4U ? mc33810_2 : mc33810_1;
+    if (page4.IgInv == GOING_HIGH)
+    {
+        coilChargingFn = coilLow;
+        coilDischargingFn = coilHigh;
+    }
+    else
+    {
+        coilChargingFn = coilHigh;
+        coilDischargingFn = coilLow;
+    }
 }
 
 void openInjector_MC33810(uint8_t channel)
@@ -123,21 +155,12 @@ void closeInjector_MC33810(uint8_t channel)
     }
 }
 
-void coilHigh_MC33810(uint8_t channel)
+void coilCharging_MC33810(uint8_t channel) 
 { 
-    if (channel<=_countof(MC33810_BIT_IGN))
-    {
-        getMC33810ForChannel(channel).setBit(MC33810_BIT_IGN[channel-1U]); 
-    }
+    coilChargingFn(channel);
 }
 
-void coilLow_MC33810(uint8_t channel)
-{ 
-    if (channel<=_countof(MC33810_BIT_IGN))
-    {
-        getMC33810ForChannel(channel).clearBit(MC33810_BIT_IGN[channel-1U]); 
-    }
+void coilStopCharging_MC33810(uint8_t channel)
+{
+    coilDischargingFn(channel);
 }
-
-void coilCharging_MC33810(uint8_t channel) { if(configPage4.IgInv == GOING_HIGH) { coilLow_MC33810(channel);  } else { coilHigh_MC33810(channel); } }
-void coilStopCharging_MC33810(uint8_t channel) { if(configPage4.IgInv == GOING_HIGH) { coilHigh_MC33810(channel); } else { coilLow_MC33810(channel);  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -3,23 +3,8 @@
 #include "src/pins/fastOutputPin.h"
 #include "globals.h"
 
-uint8_t MC33810_BIT_INJ1 = 1;
-uint8_t MC33810_BIT_INJ2 = 2;
-uint8_t MC33810_BIT_INJ3 = 3;
-uint8_t MC33810_BIT_INJ4 = 4;
-uint8_t MC33810_BIT_INJ5 = 5;
-uint8_t MC33810_BIT_INJ6 = 6;
-uint8_t MC33810_BIT_INJ7 = 7;
-uint8_t MC33810_BIT_INJ8 = 8;
-
-uint8_t MC33810_BIT_IGN1 = 1;
-uint8_t MC33810_BIT_IGN2 = 2;
-uint8_t MC33810_BIT_IGN3 = 3;
-uint8_t MC33810_BIT_IGN4 = 4;
-uint8_t MC33810_BIT_IGN5 = 5;
-uint8_t MC33810_BIT_IGN6 = 6;
-uint8_t MC33810_BIT_IGN7 = 7;
-uint8_t MC33810_BIT_IGN8 = 8;
+uint8_t MC33810_BIT_INJ[8] = {};
+uint8_t MC33810_BIT_IGN[8] = {};
 
 static fastOutputPin_t mc33810_1_pin;
 static fastOutputPin_t mc33810_2_pin;
@@ -85,41 +70,41 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     setMC33810_2_INACTIVE();
 }
 
-void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
 
-void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
 
-void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
 
-void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
-void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
-void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[0]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[1]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[2]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN[3]); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[4]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[5]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[6]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN[7]); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
 
 void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
 void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -23,6 +23,11 @@ uint8_t MC33810_BIT_IGN8 = 8;
 
 static fastOutputPin_t mc33810_1_pin;
 static fastOutputPin_t mc33810_2_pin;
+static const uint8_t MC33810_ONOFF_CMD = 0x30; //48 in decimal
+static volatile uint8_t mc33810_1_requestedState; //Current binary state of the 1st ICs IGN and INJ values
+static volatile uint8_t mc33810_2_requestedState; //Current binary state of the 2nd ICs IGN and INJ values
+static volatile uint8_t mc33810_1_returnState; //Current binary state of the 1st ICs IGN and INJ values
+static volatile uint8_t mc33810_2_returnState; //Current binary state of the 2nd ICs IGN and INJ values
 
 void setMC33810_1_ACTIVE(void) { mc33810_1_pin.setPinHigh(); }
 void setMC33810_1_INACTIVE(void) { mc33810_1_pin.setPinLow(); }
@@ -81,5 +86,57 @@ void __attribute__((optimize("Os"))) initMC33810(void)
     setMC33810_2_ACTIVE();
     SPI.transfer16(cmd);
     setMC33810_2_INACTIVE();
-    
 }
+
+void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+
+void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+
+void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+
+void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE(); }
+void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE(); }
+
+void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
+void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }
+void coil2Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil2Low_MC33810();  } else { coil2High_MC33810(); } }
+void coil2StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil2High_MC33810(); } else { coil2Low_MC33810();  } }
+void coil3Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil3Low_MC33810();  } else { coil3High_MC33810(); } }
+void coil3StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil3High_MC33810(); } else { coil3Low_MC33810();  } }
+void coil4Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil4Low_MC33810();  } else { coil4High_MC33810(); } }
+void coil4StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil4High_MC33810(); } else { coil4Low_MC33810();  } }
+void coil5Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil5Low_MC33810();  } else { coil5High_MC33810(); } }
+void coil5StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil5High_MC33810(); } else { coil5Low_MC33810();  } }
+void coil6Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil6Low_MC33810();  } else { coil6High_MC33810(); } }
+void coil6StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil6High_MC33810(); } else { coil6Low_MC33810();  } }
+void coil7Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil7Low_MC33810();  } else { coil7High_MC33810(); } }
+void coil7StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil7High_MC33810(); } else { coil7Low_MC33810();  } }
+void coil8Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil8Low_MC33810();  } else { coil8High_MC33810(); } }
+void coil8StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil8High_MC33810(); } else { coil8Low_MC33810();  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -3,8 +3,8 @@
 #include "src/pins/fastOutputPin.h"
 #include "globals.h"
 
-uint8_t MC33810_BIT_INJ[8] = {};
-uint8_t MC33810_BIT_IGN[8] = {};
+static uint8_t MC33810_BIT_INJ[8] = {};
+static uint8_t MC33810_BIT_IGN[8] = {};
 
 static fastOutputPin_t mc33810_1_pin;
 static fastOutputPin_t mc33810_2_pin;
@@ -19,8 +19,14 @@ void setMC33810_1_INACTIVE(void) { mc33810_1_pin.setPinLow(); }
 void setMC33810_2_ACTIVE(void) { mc33810_2_pin.setPinHigh(); }
 void setMC33810_2_INACTIVE(void) { mc33810_2_pin.setPinLow(); }
 
-void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2)
+void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2,
+                                                 const uint8_t (&injBits)[8], const uint8_t (&ignBits)[8])
 {
+    static_assert(sizeof(MC33810_BIT_INJ)==sizeof(injBits), "Mismatch!");
+    memcpy(MC33810_BIT_INJ, injBits, sizeof(MC33810_BIT_INJ));
+    static_assert(sizeof(MC33810_BIT_IGN)==sizeof(ignBits), "Mismatch!");
+    memcpy(MC33810_BIT_IGN, ignBits, sizeof(MC33810_BIT_IGN));
+
     //Set pin port/masks
     mc33810_1_pin.setPin(pinMC33810_1, OUTPUT);
     mc33810_2_pin.setPin(pinMC33810_2, OUTPUT);

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -85,7 +85,7 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     00000000 = All remaining values are unused (For us)
     */
     //uint16_t cmd = 0b000111110000;
-    constexpr uint16_t modeCmd = 0b0001111100000000;
+    constexpr uint16_t modeCmd = 0b0001'1111'0000'0000;
     mc33810_1.sendCommand(modeCmd);
     mc33810_2.sendCommand(modeCmd);
 
@@ -96,7 +96,7 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     1111 = Open load detection fault when active (Default)
     0000 = Disable open load detection when off (Changed from 1111 to 0000)
     */
-    constexpr uint16_t loadDetectCmd = 0b0010100011110000;
+    constexpr uint16_t loadDetectCmd = 0b0010'1000'1111'0000;
     mc33810_1.sendCommand(loadDetectCmd);
     mc33810_2.sendCommand(loadDetectCmd);
 }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -34,20 +34,17 @@ void setMC33810_1_INACTIVE(void) { mc33810_1_pin.setPinLow(); }
 void setMC33810_2_ACTIVE(void) { mc33810_2_pin.setPinHigh(); }
 void setMC33810_2_INACTIVE(void) { mc33810_2_pin.setPinLow(); }
 
-void __attribute__((optimize("Os"))) initMC33810(void)
+void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2)
 {
     //Set pin port/masks
-    mc33810_1_pin.setPin(pinMC33810_1_CS, OUTPUT);
-    mc33810_2_pin.setPin(pinMC33810_2_CS, OUTPUT);
+    mc33810_1_pin.setPin(pinMC33810_1, OUTPUT);
+    mc33810_2_pin.setPin(pinMC33810_2, OUTPUT);
 
     //Set the output states of both ICs to be off to fuel and ignition
     mc33810_1_requestedState = 0;
     mc33810_2_requestedState = 0;
     mc33810_1_returnState = 0;
     mc33810_2_returnState = 0;
-
-    pinMode(pinMC33810_1_CS, OUTPUT);
-    pinMode(pinMC33810_2_CS, OUTPUT);
 
     SPI.begin();
     //These are the SPI settings per the datasheet

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -13,15 +13,32 @@ struct mc33810_t
     fastOutputPin_t pin;
     volatile uint8_t requestedState; //Current binary state of the 2nd ICs IGN and INJ values
     volatile uint8_t returnState; //Current binary state of the 1st ICs IGN and INJ values
+    uint8_t sendCommand(uint16_t command);
 };
+
+// RAII scope guard for MC33810 active/inactive
+struct mc33810_active_guard_t
+{
+    mc33810_t &_mc33810;
+    mc33810_active_guard_t(mc33810_t &mc33810)
+    : _mc33810(mc33810)
+    {
+        _mc33810.pin.setPinHigh();
+    }
+    ~mc33810_active_guard_t()
+    {
+        _mc33810.pin.setPinLow();
+    }
+};
+
+uint8_t mc33810_t::sendCommand(uint16_t command)
+{
+    mc33810_active_guard_t active(*this);
+    return SPI.transfer16(command);
+}
 
 static mc33810_t mc33810_1;
 static mc33810_t mc33810_2;
-
-void setMC33810_1_ACTIVE(void) { mc33810_1.pin.setPinHigh(); }
-void setMC33810_1_INACTIVE(void) { mc33810_1.pin.setPinLow(); }
-void setMC33810_2_ACTIVE(void) { mc33810_2.pin.setPinHigh(); }
-void setMC33810_2_INACTIVE(void) { mc33810_2.pin.setPinLow(); }
 
 void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                                                  const uint8_t (&injBits)[8], const uint8_t (&ignBits)[8])
@@ -52,15 +69,9 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     00000000 = All remaining values are unused (For us)
     */
     //uint16_t cmd = 0b000111110000;
-    uint16_t cmd = 0b0001111100000000;
-    //IC1
-    setMC33810_1_ACTIVE();
-    SPI.transfer16(cmd);
-    setMC33810_1_INACTIVE();
-    //IC2
-    setMC33810_2_ACTIVE();
-    SPI.transfer16(cmd);
-    setMC33810_2_INACTIVE();
+    constexpr uint16_t modeCmd = 0b0001111100000000;
+    mc33810_1.sendCommand(modeCmd);
+    mc33810_2.sendCommand(modeCmd);
 
     //Disable the Open Load pull-down current sync (See page 31 of MC33810 DS)
     /*
@@ -69,52 +80,46 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     1111 = Open load detection fault when active (Default)
     0000 = Disable open load detection when off (Changed from 1111 to 0000)
     */
-    cmd = 0b0010100011110000;
-    //IC1
-    setMC33810_1_ACTIVE();
-    SPI.transfer16(cmd);
-    setMC33810_1_INACTIVE();
-    //IC2
-    setMC33810_2_ACTIVE();
-    SPI.transfer16(cmd);
-    setMC33810_2_INACTIVE();
+    constexpr uint16_t loadDetectCmd = 0b0010100011110000;
+    mc33810_1.sendCommand(loadDetectCmd);
+    mc33810_2.sendCommand(loadDetectCmd);
 }
 
-void openInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void openInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void openInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void openInjector1_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void openInjector2_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void openInjector3_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void openInjector4_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void openInjector5_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void openInjector6_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void openInjector7_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void openInjector8_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
 
-void closeInjector1_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector2_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector3_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector4_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void closeInjector5_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector6_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector7_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void closeInjector8_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void closeInjector1_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void closeInjector2_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void closeInjector3_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void closeInjector4_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void closeInjector5_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void closeInjector6_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void closeInjector7_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void closeInjector8_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
 
-void coil1High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil2High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil3High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil4High_MC33810(void) { setMC33810_1_ACTIVE(); BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil5High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil6High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil7High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil8High_MC33810(void) { setMC33810_2_ACTIVE(); BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil1High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil2High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil3High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil4High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil5High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil6High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil7High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil8High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
 
-void coil1Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil2Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil3Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil4Low_MC33810(void) { setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); setMC33810_1_INACTIVE(); }
-void coil5Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil6Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil7Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
-void coil8Low_MC33810(void) { setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); setMC33810_2_INACTIVE(); }
+void coil1Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil2Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil3Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil4Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
+void coil5Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil6Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil7Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil8Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
 
 void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
 void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }

--- a/speeduino/acc_mc33810.cpp
+++ b/speeduino/acc_mc33810.cpp
@@ -14,6 +14,16 @@ struct mc33810_t
     volatile uint8_t requestedState; //Current binary state of the 2nd ICs IGN and INJ values
     volatile uint8_t returnState; //Current binary state of the 1st ICs IGN and INJ values
     uint8_t sendCommand(uint16_t command);
+    void setBit(uint8_t bit)
+    {
+        BIT_SET(requestedState, bit); 
+        returnState = sendCommand(word(MC33810_ONOFF_CMD, requestedState));        
+    }
+    void clearBit(uint8_t bit)
+    {
+        BIT_CLEAR(requestedState, bit); 
+        returnState = sendCommand(word(MC33810_ONOFF_CMD, requestedState));        
+    }
 };
 
 // RAII scope guard for MC33810 active/inactive
@@ -85,41 +95,41 @@ void __attribute__((optimize("Os"))) initMC33810(uint8_t pinMC33810_1, uint8_t p
     mc33810_2.sendCommand(loadDetectCmd);
 }
 
-void openInjector1_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void openInjector2_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void openInjector3_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void openInjector4_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void openInjector5_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void openInjector6_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void openInjector7_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void openInjector8_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void openInjector1_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[0]); }
+void openInjector2_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[1]); }
+void openInjector3_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[2]); }
+void openInjector4_MC33810(void) { mc33810_1.setBit(MC33810_BIT_INJ[3]); }
+void openInjector5_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[4]); }
+void openInjector6_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[5]); }
+void openInjector7_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[6]); }
+void openInjector8_MC33810(void) { mc33810_2.setBit(MC33810_BIT_INJ[7]); }
 
-void closeInjector1_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void closeInjector2_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void closeInjector3_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void closeInjector4_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_INJ[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void closeInjector5_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void closeInjector6_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void closeInjector7_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void closeInjector8_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_INJ[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void closeInjector1_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[0]); }
+void closeInjector2_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[1]); }
+void closeInjector3_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[2]); }
+void closeInjector4_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_INJ[3]); }
+void closeInjector5_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[4]); }
+void closeInjector6_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[5]); }
+void closeInjector7_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[6]); }
+void closeInjector8_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_INJ[7]); }
 
-void coil1High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil2High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil3High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil4High_MC33810(void) { BIT_SET(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil5High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil6High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil7High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil8High_MC33810(void) { BIT_SET(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil1High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[0]); }
+void coil2High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[1]); }
+void coil3High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[2]); }
+void coil4High_MC33810(void) { mc33810_1.setBit(MC33810_BIT_IGN[3]); }
+void coil5High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[4]); }
+void coil6High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[5]); }
+void coil7High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[6]); }
+void coil8High_MC33810(void) { mc33810_2.setBit(MC33810_BIT_IGN[7]); }
 
-void coil1Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[0]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil2Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[1]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil3Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[2]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil4Low_MC33810(void) { BIT_CLEAR(mc33810_1.requestedState, MC33810_BIT_IGN[3]); mc33810_1.returnState = mc33810_1.sendCommand(word(MC33810_ONOFF_CMD, mc33810_1.requestedState)); }
-void coil5Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[4]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil6Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[5]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil7Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[6]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
-void coil8Low_MC33810(void) { BIT_CLEAR(mc33810_2.requestedState, MC33810_BIT_IGN[7]); mc33810_2.returnState = mc33810_2.sendCommand(word(MC33810_ONOFF_CMD, mc33810_2.requestedState)); }
+void coil1Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[0]); }
+void coil2Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[1]); }
+void coil3Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[2]); }
+void coil4Low_MC33810(void) { mc33810_1.clearBit(MC33810_BIT_IGN[3]); }
+void coil5Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[4]); }
+void coil6Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[5]); }
+void coil7Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[6]); }
+void coil8Low_MC33810(void) { mc33810_2.clearBit(MC33810_BIT_IGN[7]); }
 
 void coil1Charging_MC33810(void)      { if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); } }
 void coil1StopCharging_MC33810(void)  { if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  } }

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -1,7 +1,10 @@
 #ifndef MC33810_H
 #define MC33810_H
 
-void initMC33810(   uint8_t pinMC33810_1, uint8_t pinMC33810_2,
+#include "config_pages.h"
+
+void initMC33810(   const config4 &page4,
+                    uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                     const uint8_t (&injBits)[8],
                     const uint8_t (&ignBits)[8]);
 

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -1,15 +1,9 @@
 #ifndef MC33810_H
 #define MC33810_H
 
-#include <SPI.h>
-#include "board_definition.h"
-
-void initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2);
-
-//These are default values for which injector is attached to which output on the IC. 
-//They may (Probably will) be changed during init by the board specific config in init.ino
-extern uint8_t MC33810_BIT_INJ[8];
-extern uint8_t MC33810_BIT_IGN[8];
+void initMC33810(   uint8_t pinMC33810_1, uint8_t pinMC33810_2,
+                    const uint8_t (&injBits)[8],
+                    const uint8_t (&ignBits)[8]);
 
 void openInjector1_MC33810(void);
 void openInjector2_MC33810(void);

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -4,18 +4,7 @@
 #include <SPI.h>
 #include "board_definition.h"
 
-static const uint8_t MC33810_ONOFF_CMD = 0x30; //48 in decimal
-static volatile uint8_t mc33810_1_requestedState; //Current binary state of the 1st ICs IGN and INJ values
-static volatile uint8_t mc33810_2_requestedState; //Current binary state of the 2nd ICs IGN and INJ values
-static volatile uint8_t mc33810_1_returnState; //Current binary state of the 1st ICs IGN and INJ values
-static volatile uint8_t mc33810_2_returnState; //Current binary state of the 2nd ICs IGN and INJ values
-
 void initMC33810(void);
-
-void setMC33810_1_ACTIVE(void);
-void setMC33810_1_INACTIVE(void);
-void setMC33810_2_ACTIVE(void);
-void setMC33810_2_INACTIVE(void);
 
 //These are default values for which injector is attached to which output on the IC. 
 //They may (Probably will) be changed during init by the board specific config in init.ino
@@ -37,57 +26,40 @@ extern uint8_t MC33810_BIT_IGN6;
 extern uint8_t MC33810_BIT_IGN7;
 extern uint8_t MC33810_BIT_IGN8;
 
-#define openInjector1_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define openInjector2_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define openInjector3_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define openInjector4_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define openInjector5_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define openInjector6_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define openInjector7_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define openInjector8_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
+void openInjector1_MC33810(void);
+void openInjector2_MC33810(void);
+void openInjector3_MC33810(void);
+void openInjector4_MC33810(void);
+void openInjector5_MC33810(void);
+void openInjector6_MC33810(void);
+void openInjector7_MC33810(void);
+void openInjector8_MC33810(void);
 
-#define closeInjector1_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define closeInjector2_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define closeInjector3_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define closeInjector4_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_INJ4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define closeInjector5_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define closeInjector6_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define closeInjector7_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define closeInjector8_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_INJ8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
+void closeInjector1_MC33810(void);
+void closeInjector2_MC33810(void);
+void closeInjector3_MC33810(void);
+void closeInjector4_MC33810(void);
+void closeInjector5_MC33810(void);
+void closeInjector6_MC33810(void);
+void closeInjector7_MC33810(void);
+void closeInjector8_MC33810(void);
 
-#define coil1High_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil2High_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil3High_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil4High_MC33810() setMC33810_1_ACTIVE(); BIT_SET(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil5High_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil6High_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil7High_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil8High_MC33810() setMC33810_2_ACTIVE(); BIT_SET(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
+void coil1Charging_MC33810(void);
+void coil1StopCharging_MC33810(void);
+void coil2Charging_MC33810(void);
+void coil2StopCharging_MC33810(void);
+void coil3Charging_MC33810(void);
+void coil3StopCharging_MC33810(void);
+void coil4Charging_MC33810(void);
+void coil4StopCharging_MC33810(void);
+void coil5Charging_MC33810(void);
+void coil5StopCharging_MC33810(void);
+void coil6Charging_MC33810(void);
+void coil6StopCharging_MC33810(void);
+void coil7Charging_MC33810(void);
+void coil7StopCharging_MC33810(void);
+void coil8Charging_MC33810(void);
+void coil8StopCharging_MC33810(void);
 
-#define coil1Low_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN1); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil2Low_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN2); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil3Low_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN3); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil4Low_MC33810() setMC33810_1_ACTIVE(); BIT_CLEAR(mc33810_1_requestedState, MC33810_BIT_IGN4); mc33810_1_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_1_requestedState)); setMC33810_1_INACTIVE();
-#define coil5Low_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN5); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil6Low_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN6); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil7Low_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN7); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-#define coil8Low_MC33810() setMC33810_2_ACTIVE(); BIT_CLEAR(mc33810_2_requestedState, MC33810_BIT_IGN8); mc33810_2_returnState = SPI.transfer16(word(MC33810_ONOFF_CMD, mc33810_2_requestedState)); setMC33810_2_INACTIVE();
-
-#define coil1Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil1Low_MC33810();  } else { coil1High_MC33810(); }
-#define coil1StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil1High_MC33810(); } else { coil1Low_MC33810();  }
-#define coil2Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil2Low_MC33810();  } else { coil2High_MC33810(); }
-#define coil2StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil2High_MC33810(); } else { coil2Low_MC33810();  }
-#define coil3Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil3Low_MC33810();  } else { coil3High_MC33810(); }
-#define coil3StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil3High_MC33810(); } else { coil3Low_MC33810();  }
-#define coil4Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil4Low_MC33810();  } else { coil4High_MC33810(); }
-#define coil4StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil4High_MC33810(); } else { coil4Low_MC33810();  }
-#define coil5Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil5Low_MC33810();  } else { coil5High_MC33810(); }
-#define coil5StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil5High_MC33810(); } else { coil5Low_MC33810();  }
-#define coil6Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil6Low_MC33810();  } else { coil6High_MC33810(); }
-#define coil6StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil6High_MC33810(); } else { coil6Low_MC33810();  }
-#define coil7Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil7Low_MC33810();  } else { coil7High_MC33810(); }
-#define coil7StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil7High_MC33810(); } else { coil7Low_MC33810();  }
-#define coil8Charging_MC33810()      if(configPage4.IgInv == GOING_HIGH) { coil8Low_MC33810();  } else { coil8High_MC33810(); }
-#define coil8StopCharging_MC33810()  if(configPage4.IgInv == GOING_HIGH) { coil8High_MC33810(); } else { coil8Low_MC33810();  }
 
 #endif

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -8,23 +8,8 @@ void initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2);
 
 //These are default values for which injector is attached to which output on the IC. 
 //They may (Probably will) be changed during init by the board specific config in init.ino
-extern uint8_t MC33810_BIT_INJ1;
-extern uint8_t MC33810_BIT_INJ2;
-extern uint8_t MC33810_BIT_INJ3;
-extern uint8_t MC33810_BIT_INJ4;
-extern uint8_t MC33810_BIT_INJ5;
-extern uint8_t MC33810_BIT_INJ6;
-extern uint8_t MC33810_BIT_INJ7;
-extern uint8_t MC33810_BIT_INJ8;
-
-extern uint8_t MC33810_BIT_IGN1;
-extern uint8_t MC33810_BIT_IGN2;
-extern uint8_t MC33810_BIT_IGN3;
-extern uint8_t MC33810_BIT_IGN4;
-extern uint8_t MC33810_BIT_IGN5;
-extern uint8_t MC33810_BIT_IGN6;
-extern uint8_t MC33810_BIT_IGN7;
-extern uint8_t MC33810_BIT_IGN8;
+extern uint8_t MC33810_BIT_INJ[8];
+extern uint8_t MC33810_BIT_IGN[8];
 
 void openInjector1_MC33810(void);
 void openInjector2_MC33810(void);

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -2,7 +2,9 @@
 #define MC33810_H
 
 #include "config_pages.h"
+#include "board_definition.h"
 
+#if defined(MC33810_SUPPORT)
 void initMC33810(   const config4 &page4,
                     uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                     const uint8_t (&injBits)[8],
@@ -13,5 +15,7 @@ void closeInjector_MC33810(uint8_t channel);
 
 void coilCharging_MC33810(uint8_t channel);
 void coilStopCharging_MC33810(uint8_t channel);
+
+#endif
 
 #endif

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -5,40 +5,10 @@ void initMC33810(   uint8_t pinMC33810_1, uint8_t pinMC33810_2,
                     const uint8_t (&injBits)[8],
                     const uint8_t (&ignBits)[8]);
 
-void openInjector1_MC33810(void);
-void openInjector2_MC33810(void);
-void openInjector3_MC33810(void);
-void openInjector4_MC33810(void);
-void openInjector5_MC33810(void);
-void openInjector6_MC33810(void);
-void openInjector7_MC33810(void);
-void openInjector8_MC33810(void);
+void openInjector_MC33810(uint8_t channel);
+void closeInjector_MC33810(uint8_t channel);
 
-void closeInjector1_MC33810(void);
-void closeInjector2_MC33810(void);
-void closeInjector3_MC33810(void);
-void closeInjector4_MC33810(void);
-void closeInjector5_MC33810(void);
-void closeInjector6_MC33810(void);
-void closeInjector7_MC33810(void);
-void closeInjector8_MC33810(void);
-
-void coil1Charging_MC33810(void);
-void coil1StopCharging_MC33810(void);
-void coil2Charging_MC33810(void);
-void coil2StopCharging_MC33810(void);
-void coil3Charging_MC33810(void);
-void coil3StopCharging_MC33810(void);
-void coil4Charging_MC33810(void);
-void coil4StopCharging_MC33810(void);
-void coil5Charging_MC33810(void);
-void coil5StopCharging_MC33810(void);
-void coil6Charging_MC33810(void);
-void coil6StopCharging_MC33810(void);
-void coil7Charging_MC33810(void);
-void coil7StopCharging_MC33810(void);
-void coil8Charging_MC33810(void);
-void coil8StopCharging_MC33810(void);
-
+void coilCharging_MC33810(uint8_t channel);
+void coilStopCharging_MC33810(uint8_t channel);
 
 #endif

--- a/speeduino/acc_mc33810.h
+++ b/speeduino/acc_mc33810.h
@@ -4,7 +4,7 @@
 #include <SPI.h>
 #include "board_definition.h"
 
-void initMC33810(void);
+void initMC33810(uint8_t pinMC33810_1, uint8_t pinMC33810_2);
 
 //These are default values for which injector is attached to which output on the IC. 
 //They may (Probably will) be changed during init by the board specific config in init.ino

--- a/speeduino/board_teensy35.h
+++ b/speeduino/board_teensy35.h
@@ -190,3 +190,5 @@ constexpr uint8_t ANALOG_PINS[] = { _ANALOG_PINS_A0_A14, A15, A16, A17, A18, A19
  * in order to avoid it overflowing. 
  */
 constexpr uint8_t SERIAL_BUFFER_THRESHOLD = 0U;
+
+#define MC33810_SUPPORT

--- a/speeduino/board_teensy41.h
+++ b/speeduino/board_teensy41.h
@@ -230,3 +230,5 @@ constexpr uint8_t ANALOG_PINS[] = { _ANALOG_PINS_A0_A14, A15, A16 };
  * in order to avoid it overflowing. 
  */
 constexpr uint8_t SERIAL_BUFFER_THRESHOLD = 0U;
+
+#define MC33810_SUPPORT

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -1180,10 +1180,10 @@ static void triggerPri_BasicDistributor(void)
 
     if ( configPage4.ignCranklock && currentStatus.engineIsCranking )
     {
-      endCoil1Charge();
-      endCoil2Charge();
-      endCoil3Charge();
-      endCoil4Charge();
+      endCoilCharge(1U);
+      endCoilCharge(2U);
+      endCoilCharge(3U);
+      endCoilCharge(4U);
     }
 
     if(configPage2.perToothIgn == true)
@@ -1531,14 +1531,14 @@ static void triggerPri_4G63(void)
         if(configPage2.nCylinders == 4)
         {
           //This operates in forced wasted spark mode during cranking to align with crank teeth
-          if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) { endCoil1Charge(); endCoil3Charge(); }
-          else if( (toothCurrentCount == 3) || (toothCurrentCount == 7) ) { endCoil2Charge(); endCoil4Charge(); }
+          if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) { endCoilCharge(1U); endCoilCharge(3U); }
+          else if( (toothCurrentCount == 3) || (toothCurrentCount == 7) ) { endCoilCharge(2U); endCoilCharge(4U); }
         }
         else if(configPage2.nCylinders == 6)
         {
-          if( (toothCurrentCount == 1) || (toothCurrentCount == 7) ) { endCoil1Charge(); }
-          else if( (toothCurrentCount == 3) || (toothCurrentCount == 9) ) { endCoil2Charge(); }
-          else if( (toothCurrentCount == 5) || (toothCurrentCount == 11) ) { endCoil3Charge(); }
+          if( (toothCurrentCount == 1) || (toothCurrentCount == 7) ) { endCoilCharge(1U); }
+          else if( (toothCurrentCount == 3) || (toothCurrentCount == 9) ) { endCoilCharge(2U); }
+          else if( (toothCurrentCount == 5) || (toothCurrentCount == 11) ) { endCoilCharge(3U); }
         }
       }
 
@@ -2629,8 +2629,8 @@ static void triggerPri_Miata9905(void)
     //if ( currentStatus.engineIsCranking && configPage4.ignCranklock)
     if ( (currentStatus.RPM < (currentStatus.crankRPM + 30)) && (configPage4.ignCranklock) ) //The +30 here is a safety margin. When switching from fixed timing to normal, there can be a situation where a pulse started when fixed and ending when in normal mode causes problems. This prevents that.
     {
-      if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) { endCoil1Charge(); endCoil3Charge(); }
-      else if( (toothCurrentCount == 3) || (toothCurrentCount == 7) ) { endCoil2Charge(); endCoil4Charge(); }
+      if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) { endCoilCharge(1U); endCoilCharge(3U); }
+      else if( (toothCurrentCount == 3) || (toothCurrentCount == 7) ) { endCoilCharge(2U); endCoilCharge(4U); }
     }
     secondaryToothCount = 0;
   } //Trigger filter
@@ -2856,8 +2856,8 @@ static void triggerPri_MazdaAU(void)
       // Locked cranking timing is available, fixed at 12* BTDC
       if ( currentStatus.engineIsCranking && configPage4.ignCranklock )
       {
-        if( toothCurrentCount == 1 ) { endCoil1Charge(); }
-        else if( toothCurrentCount == 3 ) { endCoil2Charge(); }
+        if( toothCurrentCount == 1 ) { endCoilCharge(1U); }
+        else if( toothCurrentCount == 3 ) { endCoilCharge(2U); }
       }
 
       //Whilst this is an uneven tooth pattern, if the specific angle between the last 2 teeth is specified, 1st deriv prediction can be used
@@ -3383,8 +3383,8 @@ static void triggerPri_Subaru67(void)
     //Locked timing during cranking. This is fixed at 10* BTDC.
     if ( currentStatus.engineIsCranking && configPage4.ignCranklock)
     {
-      if( (toothCurrentCount == 1) || (toothCurrentCount == 7) ) { endCoil1Charge(); endCoil3Charge(); }
-      else if( (toothCurrentCount == 4) || (toothCurrentCount == 10) ) { endCoil2Charge(); endCoil4Charge(); }
+      if( (toothCurrentCount == 1) || (toothCurrentCount == 7) ) { endCoilCharge(1U); endCoilCharge(3U); }
+      else if( (toothCurrentCount == 4) || (toothCurrentCount == 10) ) { endCoilCharge(2U); endCoilCharge(4U); }
     }
 
     if ( toothCurrentCount > 12 ) // done 720 degrees so increment rotation
@@ -3618,10 +3618,10 @@ static void triggerPri_Daihatsu(void)
       if ( configPage4.ignCranklock && currentStatus.engineIsCranking )
       {
         //This locks the cranking timing to 0 degrees BTDC (All the triggers allow for)
-        if(toothCurrentCount == 1) { endCoil1Charge(); }
-        else if(toothCurrentCount == 2) { endCoil2Charge(); }
-        else if(toothCurrentCount == 3) { endCoil3Charge(); }
-        else if(toothCurrentCount == 4) { endCoil4Charge(); }
+        if(toothCurrentCount == 1) { endCoilCharge(1U); }
+        else if(toothCurrentCount == 2) { endCoilCharge(2U); }
+        else if(toothCurrentCount == 3) { endCoilCharge(3U); }
+        else if(toothCurrentCount == 4) { endCoilCharge(4U); }
       }
     }
     else //NO SYNC

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -58,8 +58,6 @@ byte pinInjector5; ///< Output pin injector 5
 byte pinInjector6; ///< Output pin injector 6
 byte pinInjector7; ///< Output pin injector 7
 byte pinInjector8; ///< Output pin injector 8
-byte injectorOutputControl = OUTPUT_CONTROL_DIRECT; /**< Specifies whether the injectors are controlled directly (Via an IO pin)
-    or using something like the MC33810. 0 = Direct (OUTPUT_CONTROL_DIRECT), 10 = MC33810 (OUTPUT_CONTROL_MC33810) */
 byte pinCoil1; ///< Pin for coil 1
 byte pinCoil2; ///< Pin for coil 2
 byte pinCoil3; ///< Pin for coil 3

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -66,8 +66,6 @@ byte pinCoil5; ///< Pin for coil 5
 byte pinCoil6; ///< Pin for coil 6
 byte pinCoil7; ///< Pin for coil 7
 byte pinCoil8; ///< Pin for coil 8
-byte ignitionOutputControl = OUTPUT_CONTROL_DIRECT; /**< Specifies whether the coils are controlled directly (Via an IO pin)
-   or using something like the MC33810. 0 = Direct (OUTPUT_CONTROL_DIRECT), 10 = MC33810 (OUTPUT_CONTROL_MC33810) */
 byte pinTrigger;  ///< RPM1 (Typically CAS=crankshaft angle sensor) pin
 byte pinTrigger2; ///< RPM2 (Typically the Cam Sensor) pin
 byte pinTrigger3;	///< the 2nd cam sensor pin

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -38,9 +38,6 @@ constexpr uint8_t TOOTH_LOG_SIZE = 127U;
 constexpr uint8_t TOOTH_LOG_SIZE = 1U;
 #endif
 
-#define OUTPUT_CONTROL_DIRECT   0
-#define OUTPUT_CONTROL_MC33810  10
-
 #define INJ1_CMD_BIT      0
 #define INJ2_CMD_BIT      1
 #define INJ3_CMD_BIT      2
@@ -121,7 +118,6 @@ extern byte pinCoil5; //Pin for coil 5
 extern byte pinCoil6; //Pin for coil 6
 extern byte pinCoil7; //Pin for coil 7
 extern byte pinCoil8; //Pin for coil 8
-extern byte ignitionOutputControl; //Specifies whether the coils are controlled directly (Via an IO pin) or using something like the MC33810
 extern byte pinTrigger; //The CAS pin
 extern byte pinTrigger2; //The Cam Sensor pin known as secondary input
 extern byte pinTrigger3;	//the 2nd cam sensor pin known as tertiary input

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -113,7 +113,6 @@ extern byte pinInjector5; //Output pin injector 5
 extern byte pinInjector6; //Output pin injector 6
 extern byte pinInjector7; //Output pin injector 7
 extern byte pinInjector8; //Output pin injector 8
-extern byte injectorOutputControl; //Specifies whether the injectors are controlled directly (Via an IO pin) or using something like the MC33810
 extern byte pinCoil1; //Pin for coil 1
 extern byte pinCoil2; //Pin for coil 2
 extern byte pinCoil3; //Pin for coil 3

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -904,8 +904,10 @@ void setPinMapping(byte boardID)
 
   if( configPage4.triggerTeeth == 0 ) { configPage4.triggerTeeth = 4; } //Avoid potential divide by 0 when starting decoders
 
+#if defined(MC33810_SUPPORT)
   uint8_t MC33810InjBits[8];
   uint8_t MC33810IgnBits[8];
+#endif
 
   switch (boardID)
   {
@@ -2577,11 +2579,13 @@ void setPinMapping(byte boardID)
     initInjDirectIO(injPins);
   }
   
+#if defined(MC33810_SUPPORT)
   if( (ignControlMode == IgnIoControlMode::MC33810) || (injControlMode == InjIoControlMode::MC33810) )
   {
     initMC33810(configPage4, pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
+#endif
   initInjIoControl(injControlMode);
   initIgnIoControl(ignControlMode);
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2576,7 +2576,7 @@ void setPinMapping(byte boardID)
   
   if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injectorOutputControl == OUTPUT_CONTROL_MC33810) )
   {
-    initMC33810();
+    initMC33810(pinMC33810_1_CS, pinMC33810_2_CS);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2579,7 +2579,7 @@ void setPinMapping(byte boardID)
   
   if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injectorOutputControl == OUTPUT_CONTROL_MC33810) )
   {
-    initMC33810(pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
+    initMC33810(configPage4, pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -899,7 +899,7 @@ void initialiseAll(void)
 void setPinMapping(byte boardID)
 {
   //Force set defaults. Will be overwritten below if needed.
-  injectorOutputControl = OUTPUT_CONTROL_DIRECT;
+  InjIoControlMode injControlMode = InjIoControlMode::Direct;
   ignitionOutputControl = OUTPUT_CONTROL_DIRECT;
 
   if( configPage4.triggerTeeth == 0 ) { configPage4.triggerTeeth = 4; } //Avoid potential divide by 0 when starting decoders
@@ -1958,7 +1958,7 @@ void setPinMapping(byte boardID)
     case 55:
       #if defined(CORE_TEENSY)
       //Pin mappings for the DropBear
-      injectorOutputControl = OUTPUT_CONTROL_MC33810;
+      injControlMode = InjIoControlMode::MC33810;
       ignitionOutputControl = OUTPUT_CONTROL_MC33810;
 
       //The injector pins below are not used directly as the control is via SPI through the MC33810s, however the pin numbers are set to be the SPI pins (SCLK, MOSI, MISO and CS) so that nothing else will set them as inputs
@@ -2548,7 +2548,7 @@ void setPinMapping(byte boardID)
     initIgnDirectIO(configPage4, ignPins);
   } 
 
-  if(injectorOutputControl == OUTPUT_CONTROL_DIRECT)
+  if(injControlMode == InjIoControlMode::Direct)
   {
     uint8_t injPins[INJ_CHANNELS] = {
       pinInjector1,
@@ -2577,11 +2577,12 @@ void setPinMapping(byte boardID)
     initInjDirectIO(injPins);
   }
   
-  if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injectorOutputControl == OUTPUT_CONTROL_MC33810) )
+  if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injControlMode == InjIoControlMode::MC33810) )
   {
     initMC33810(configPage4, pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
+  initInjIoControl(injControlMode);
 
 //CS pin number is now set in a compile flag. 
 // #ifdef USE_SPI_EEPROM

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2545,7 +2545,7 @@ void setPinMapping(byte boardID)
       pinCoil8,
       #endif
     };
-    initIgnDirectIO(ignPins);
+    initIgnDirectIO(configPage4, ignPins);
   } 
 
   if(injectorOutputControl == OUTPUT_CONTROL_DIRECT)

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -904,6 +904,9 @@ void setPinMapping(byte boardID)
 
   if( configPage4.triggerTeeth == 0 ) { configPage4.triggerTeeth = 4; } //Avoid potential divide by 0 when starting decoders
 
+  uint8_t MC33810InjBits[8];
+  uint8_t MC33810IgnBits[8];
+
   switch (boardID)
   {
     //Note: Case 0 (Speeduino v0.1) was removed in Nov 2020 to handle default case for blank FRAM modules
@@ -2057,23 +2060,23 @@ void setPinMapping(byte boardID)
         pinMC33810_2_CS = 9;
 
       //Pin alignment to the MC33810 outputs
-      MC33810_BIT_INJ[0] = 3;
-      MC33810_BIT_INJ[1] = 1;
-      MC33810_BIT_INJ[2] = 0;
-      MC33810_BIT_INJ[3] = 2;
-      MC33810_BIT_IGN[0] = 4;
-      MC33810_BIT_IGN[1] = 5;
-      MC33810_BIT_IGN[2] = 6;
-      MC33810_BIT_IGN[3] = 7;
+      MC33810InjBits[0] = 3;
+      MC33810InjBits[1] = 1;
+      MC33810InjBits[2] = 0;
+      MC33810InjBits[3] = 2;
+      MC33810IgnBits[0] = 4;
+      MC33810IgnBits[1] = 5;
+      MC33810IgnBits[2] = 6;
+      MC33810IgnBits[3] = 7;
 
-      MC33810_BIT_INJ[4] = 3;
-      MC33810_BIT_INJ[5] = 1;
-      MC33810_BIT_INJ[6] = 0;
-      MC33810_BIT_INJ[7] = 2;
-      MC33810_BIT_IGN[4] = 4;
-      MC33810_BIT_IGN[5] = 5;
-      MC33810_BIT_IGN[6] = 6;
-      MC33810_BIT_IGN[7] = 7;
+      MC33810InjBits[4] = 3;
+      MC33810InjBits[5] = 1;
+      MC33810InjBits[6] = 0;
+      MC33810InjBits[7] = 2;
+      MC33810IgnBits[4] = 4;
+      MC33810IgnBits[5] = 5;
+      MC33810IgnBits[6] = 6;
+      MC33810IgnBits[7] = 7;
 
 
 
@@ -2576,7 +2579,7 @@ void setPinMapping(byte boardID)
   
   if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injectorOutputControl == OUTPUT_CONTROL_MC33810) )
   {
-    initMC33810(pinMC33810_1_CS, pinMC33810_2_CS);
+    initMC33810(pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
 

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -42,6 +42,22 @@
 #pragma GCC optimize ("Os") 
 #endif
 
+static void __attribute__((optimize("Os"))) stopAllCoilsCharging(void)
+{
+  for (uint8_t index=1; index<=IGN_CHANNELS; ++index)
+  {
+    endCoilCharge(index);
+  }
+}
+
+static void __attribute__((optimize("Os"))) closeAllInjectors(void)
+{
+  for (uint8_t index=1; index<=INJ_CHANNELS; ++index)
+  {
+    closeInjector(index);
+  }
+}
+
 ///
 /// @brief Allow the user to reset the firmware storage (aka EPROM).
 ///
@@ -163,36 +179,10 @@ void initialiseAll(void)
     if (configPage9.enable_secondarySerial == 1) { secondarySerial.begin(115200); }
 
     //End all coil charges to ensure no stray sparks on startup
-    endCoil1Charge();
-    endCoil2Charge();
-    endCoil3Charge();
-    endCoil4Charge();
-    endCoil5Charge();
-    #if (IGN_CHANNELS >= 6)
-    endCoil6Charge();
-    #endif
-    #if (IGN_CHANNELS >= 7)
-    endCoil7Charge();
-    #endif
-    #if (IGN_CHANNELS >= 8)
-    endCoil8Charge();
-    #endif
+    stopAllCoilsCharging();
 
     //Similar for injectors, make sure they're turned off
-    closeInjector1();
-    closeInjector2();
-    closeInjector3();
-    closeInjector4();
-    closeInjector5();
-    #if (INJ_CHANNELS >= 6)
-    closeInjector6();
-    #endif
-    #if (INJ_CHANNELS >= 7)
-    closeInjector7();
-    #endif
-    #if (INJ_CHANNELS >= 8)
-    closeInjector8();
-    #endif
+    closeAllInjectors();
     
     //Set the tacho output default state
     digitalWrite(pinTachOut, HIGH);

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -900,7 +900,7 @@ void setPinMapping(byte boardID)
 {
   //Force set defaults. Will be overwritten below if needed.
   InjIoControlMode injControlMode = InjIoControlMode::Direct;
-  ignitionOutputControl = OUTPUT_CONTROL_DIRECT;
+  IgnIoControlMode ignControlMode = IgnIoControlMode::Direct;
 
   if( configPage4.triggerTeeth == 0 ) { configPage4.triggerTeeth = 4; } //Avoid potential divide by 0 when starting decoders
 
@@ -1959,7 +1959,7 @@ void setPinMapping(byte boardID)
       #if defined(CORE_TEENSY)
       //Pin mappings for the DropBear
       injControlMode = InjIoControlMode::MC33810;
-      ignitionOutputControl = OUTPUT_CONTROL_MC33810;
+      ignControlMode = IgnIoControlMode::MC33810;
 
       //The injector pins below are not used directly as the control is via SPI through the MC33810s, however the pin numbers are set to be the SPI pins (SCLK, MOSI, MISO and CS) so that nothing else will set them as inputs
       pinInjector1 = 13; //SCLK
@@ -2519,7 +2519,7 @@ void setPinMapping(byte boardID)
   //This is a legacy mode option to revert the MAP reading behaviour to match what was in place prior to the 201905 firmware
   if(configPage2.legacyMAP > 0) { digitalWrite(pinMAP, HIGH); }
 
-  if(ignitionOutputControl == OUTPUT_CONTROL_DIRECT)
+  if(ignControlMode == IgnIoControlMode::Direct)
   {
     uint8_t ignPins[IGN_CHANNELS] = {
       pinCoil1,
@@ -2577,12 +2577,13 @@ void setPinMapping(byte boardID)
     initInjDirectIO(injPins);
   }
   
-  if( (ignitionOutputControl == OUTPUT_CONTROL_MC33810) || (injControlMode == InjIoControlMode::MC33810) )
+  if( (ignControlMode == IgnIoControlMode::MC33810) || (injControlMode == InjIoControlMode::MC33810) )
   {
     initMC33810(configPage4, pinMC33810_1_CS, pinMC33810_2_CS, MC33810InjBits, MC33810IgnBits);
     if( (LED_BUILTIN != SCK) && (LED_BUILTIN != MOSI) && (LED_BUILTIN != MISO) ) pinMode(LED_BUILTIN, OUTPUT); //This is required on as the LED pin can otherwise be reset to an input
   }
   initInjIoControl(injControlMode);
+  initIgnIoControl(ignControlMode);
 
 //CS pin number is now set in a compile flag. 
 // #ifdef USE_SPI_EEPROM

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2057,23 +2057,23 @@ void setPinMapping(byte boardID)
         pinMC33810_2_CS = 9;
 
       //Pin alignment to the MC33810 outputs
-      MC33810_BIT_INJ1 = 3;
-      MC33810_BIT_INJ2 = 1;
-      MC33810_BIT_INJ3 = 0;
-      MC33810_BIT_INJ4 = 2;
-      MC33810_BIT_IGN1 = 4;
-      MC33810_BIT_IGN2 = 5;
-      MC33810_BIT_IGN3 = 6;
-      MC33810_BIT_IGN4 = 7;
+      MC33810_BIT_INJ[0] = 3;
+      MC33810_BIT_INJ[1] = 1;
+      MC33810_BIT_INJ[2] = 0;
+      MC33810_BIT_INJ[3] = 2;
+      MC33810_BIT_IGN[0] = 4;
+      MC33810_BIT_IGN[1] = 5;
+      MC33810_BIT_IGN[2] = 6;
+      MC33810_BIT_IGN[3] = 7;
 
-      MC33810_BIT_INJ5 = 3;
-      MC33810_BIT_INJ6 = 1;
-      MC33810_BIT_INJ7 = 0;
-      MC33810_BIT_INJ8 = 2;
-      MC33810_BIT_IGN5 = 4;
-      MC33810_BIT_IGN6 = 5;
-      MC33810_BIT_IGN7 = 6;
-      MC33810_BIT_IGN8 = 7;
+      MC33810_BIT_INJ[4] = 3;
+      MC33810_BIT_INJ[5] = 1;
+      MC33810_BIT_INJ[6] = 0;
+      MC33810_BIT_INJ[7] = 2;
+      MC33810_BIT_IGN[4] = 4;
+      MC33810_BIT_IGN[5] = 5;
+      MC33810_BIT_IGN[6] = 6;
+      MC33810_BIT_IGN[7] = 7;
 
 
 

--- a/speeduino/scheduledIO_direct_ign.cpp
+++ b/speeduino/scheduledIO_direct_ign.cpp
@@ -1,4 +1,4 @@
-#include "globals.h"
+#include "scheduledIO_direct_ign.h"
 #include "board_definition.h"
 #include "src/pins/fastOutputPin.h"
 #include "preprocessor.h"
@@ -7,14 +7,6 @@
 // Exclude from code coverage, since this is all board output control
  
 static fastOutputPin_t pins[IGN_CHANNELS];
-
-void initIgnDirectIO(const uint8_t (&pinNumbers)[IGN_CHANNELS])
-{
-    for (uint8_t i = 0; i < _countof(pins); i++)
-    {
-        pins[i].setPin(pinNumbers[i], OUTPUT);
-    }
-}
 
 static inline void coilLow(uint8_t channel)
 {
@@ -32,28 +24,36 @@ static inline void coilHigh(uint8_t channel)
     }
 }
 
-void coilCharging_DIRECT(uint8_t channel) 
-{ 
-    if (configPage4.IgInv == GOING_HIGH)
+using channelFunc = void(*)(uint8_t);
+static channelFunc coilChargingFn = coilHigh;
+static channelFunc coilDischargingFn = coilLow;
+
+void initIgnDirectIO(const config4 &page4, const uint8_t (&pinNumbers)[IGN_CHANNELS])
+{
+    for (uint8_t i = 0; i < _countof(pins); i++)
     {
-        coilLow(channel);
+        pins[i].setPin(pinNumbers[i], OUTPUT);
+    }
+    if (page4.IgInv == GOING_HIGH)
+    {
+        coilChargingFn = coilLow;
+        coilDischargingFn = coilHigh;
     }
     else
     {
-        coilHigh(channel);
+        coilChargingFn = coilHigh;
+        coilDischargingFn = coilLow;
     }
+}
+
+void coilCharging_DIRECT(uint8_t channel) 
+{ 
+    coilChargingFn(channel);
 }
 
 void coilStopCharging_DIRECT(uint8_t channel) 
 {
-    if (configPage4.IgInv == GOING_HIGH)
-    {
-        coilHigh(channel);
-     }
-     else 
-     {
-        coilLow(channel);
-     }
+    coilDischargingFn(channel);
 }
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_direct_ign.cpp
+++ b/speeduino/scheduledIO_direct_ign.cpp
@@ -10,25 +10,21 @@ static fastOutputPin_t pins[IGN_CHANNELS];
 
 static inline void coilLow(uint8_t channel)
 {
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinLow();
-    }
+    INTERNAL_TEST_ASSERT(channel>0 && channel<=_countof(pins));
+    pins[channel-1U].setPinLow();
 }
 
 static inline void coilHigh(uint8_t channel)
 {
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinHigh();
-    }
+    INTERNAL_TEST_ASSERT(channel>0 && channel<=_countof(pins));
+    pins[channel-1U].setPinHigh();
 }
 
 using channelFunc = void(*)(uint8_t);
 static channelFunc coilChargingFn = coilHigh;
 static channelFunc coilDischargingFn = coilLow;
 
-void initIgnDirectIO(const config4 &page4, const uint8_t (&pinNumbers)[IGN_CHANNELS])
+void initIgnDirectIO(const config4 &page4, const uint8_t (&pinNumbers)[_countof(pins)])
 {
     for (uint8_t i = 0; i < _countof(pins); i++)
     {

--- a/speeduino/scheduledIO_direct_ign.cpp
+++ b/speeduino/scheduledIO_direct_ign.cpp
@@ -1,3 +1,4 @@
+#include "globals.h"
 #include "board_definition.h"
 #include "src/pins/fastOutputPin.h"
 #include "preprocessor.h"
@@ -7,24 +8,6 @@
  
 static fastOutputPin_t pins[IGN_CHANNELS];
 
-template <uint8_t channel>
-static void channel_High(void)
-{
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinHigh();
-    }
-}
-
-template <uint8_t channel>
-static void channel_Low(void)
-{
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinLow();
-    }
-}
-
 void initIgnDirectIO(const uint8_t (&pinNumbers)[IGN_CHANNELS])
 {
     for (uint8_t i = 0; i < _countof(pins); i++)
@@ -33,21 +16,44 @@ void initIgnDirectIO(const uint8_t (&pinNumbers)[IGN_CHANNELS])
     }
 }
 
-void coil1Low_DIRECT(void)  { channel_Low<1U>(); }
-void coil1High_DIRECT(void) { channel_High<1U>(); }
-void coil2Low_DIRECT(void)  { channel_Low<2U>(); }
-void coil2High_DIRECT(void) { channel_High<2U>(); }
-void coil3Low_DIRECT(void)  { channel_Low<3U>(); }
-void coil3High_DIRECT(void) { channel_High<3U>(); }
-void coil4Low_DIRECT(void)  { channel_Low<4U>(); }
-void coil4High_DIRECT(void) { channel_High<4U>(); }
-void coil5Low_DIRECT(void)  { channel_Low<5U>(); }
-void coil5High_DIRECT(void) { channel_High<5U>(); }
-void coil6Low_DIRECT(void)  { channel_Low<6U>(); }
-void coil6High_DIRECT(void) { channel_High<6U>(); }
-void coil7Low_DIRECT(void)  { channel_Low<7U>(); }
-void coil7High_DIRECT(void) { channel_High<7U>(); }
-void coil8Low_DIRECT(void)  { channel_Low<8U>(); }
-void coil8High_DIRECT(void) { channel_High<8U>(); }
+static inline void coilLow(uint8_t channel)
+{
+    if (channel<=_countof(pins))
+    {
+        pins[channel-1U].setPinLow();
+    }
+}
+
+static inline void coilHigh(uint8_t channel)
+{
+    if (channel<=_countof(pins))
+    {
+        pins[channel-1U].setPinHigh();
+    }
+}
+
+void coilCharging_DIRECT(uint8_t channel) 
+{ 
+    if (configPage4.IgInv == GOING_HIGH)
+    {
+        coilLow(channel);
+    }
+    else
+    {
+        coilHigh(channel);
+    }
+}
+
+void coilStopCharging_DIRECT(uint8_t channel) 
+{
+    if (configPage4.IgInv == GOING_HIGH)
+    {
+        coilHigh(channel);
+     }
+     else 
+     {
+        coilLow(channel);
+     }
+}
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_direct_ign.h
+++ b/speeduino/scheduledIO_direct_ign.h
@@ -2,37 +2,5 @@
 
 void initIgnDirectIO(const uint8_t (&pins)[IGN_CHANNELS]);
 
-void coil1Low_DIRECT(void);
-void coil1High_DIRECT(void);
-void coil2Low_DIRECT(void);
-void coil2High_DIRECT(void);
-void coil3Low_DIRECT(void);
-void coil3High_DIRECT(void);
-void coil4Low_DIRECT(void);
-void coil4High_DIRECT(void);
-void coil5Low_DIRECT(void);
-void coil5High_DIRECT(void);
-void coil6Low_DIRECT(void);
-void coil6High_DIRECT(void);
-void coil7Low_DIRECT(void);
-void coil7High_DIRECT(void);
-void coil8Low_DIRECT(void);
-void coil8High_DIRECT(void);
-
-//Set the value of the coil pins to the coilHIGH or coilLOW state
-static inline void coil1Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil1Low_DIRECT() : coil1High_DIRECT()); }
-static inline void coil1StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil1High_DIRECT() : coil1Low_DIRECT()); }
-static inline void coil2Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil2Low_DIRECT() : coil2High_DIRECT()); }
-static inline void coil2StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil2High_DIRECT() : coil2Low_DIRECT()); }
-static inline void coil3Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil3Low_DIRECT() : coil3High_DIRECT()); }
-static inline void coil3StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil3High_DIRECT() : coil3Low_DIRECT()); }
-static inline void coil4Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil4Low_DIRECT() : coil4High_DIRECT()); }
-static inline void coil4StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil4High_DIRECT() : coil4Low_DIRECT()); }
-static inline void coil5Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil5Low_DIRECT() : coil5High_DIRECT()); }
-static inline void coil5StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil5High_DIRECT() : coil5Low_DIRECT()); }
-static inline void coil6Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil6Low_DIRECT() : coil6High_DIRECT()); }
-static inline void coil6StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil6High_DIRECT() : coil6Low_DIRECT()); }
-static inline void coil7Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil7Low_DIRECT() : coil7High_DIRECT()); }
-static inline void coil7StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil7High_DIRECT() : coil7Low_DIRECT()); }
-static inline void coil8Charging_DIRECT(void) {      (configPage4.IgInv == GOING_HIGH ? coil8Low_DIRECT() : coil8High_DIRECT()); }
-static inline void coil8StopCharging_DIRECT(void) {  (configPage4.IgInv == GOING_HIGH ? coil8High_DIRECT() : coil8Low_DIRECT()); }
+void coilCharging_DIRECT(uint8_t channel);
+void coilStopCharging_DIRECT(uint8_t channel);

--- a/speeduino/scheduledIO_direct_ign.h
+++ b/speeduino/scheduledIO_direct_ign.h
@@ -1,6 +1,8 @@
 #pragma once
 
-void initIgnDirectIO(const uint8_t (&pins)[IGN_CHANNELS]);
+#include "config_pages.h"
+
+void initIgnDirectIO(const config4 &page4, const uint8_t (&pins)[IGN_CHANNELS]);
 
 void coilCharging_DIRECT(uint8_t channel);
 void coilStopCharging_DIRECT(uint8_t channel);

--- a/speeduino/scheduledIO_direct_inj.cpp
+++ b/speeduino/scheduledIO_direct_inj.cpp
@@ -1,4 +1,3 @@
-#include "globals.h"
 #include "board_definition.h"
 #include "src/pins/fastOutputPin.h"
 #include "preprocessor.h"
@@ -8,24 +7,6 @@
 
 static fastOutputPin_t pins[INJ_CHANNELS];
 
-template <uint8_t channel>
-static void channel_High(void)
-{
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinHigh();
-    }
-}
-
-template <uint8_t channel>
-static void channel_Low(void)
-{
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinLow();
-    }
-}
-
 void initInjDirectIO(const uint8_t (&pinNumbers)[INJ_CHANNELS])
 {
     for (uint8_t i = 0; i < _countof(pins); i++)
@@ -34,23 +15,19 @@ void initInjDirectIO(const uint8_t (&pinNumbers)[INJ_CHANNELS])
     }
 }
 
-//Macros are used to define how each injector control system functions. These are then called by the master openInjectx() function.
-//The DIRECT macros (ie individual pins) are defined below. Others should be defined in their relevant acc_x.h file
-void openInjector1_DIRECT(void)  { channel_High<1>(); }
-void closeInjector1_DIRECT(void) { channel_Low<1>(); }
-void openInjector2_DIRECT(void)  { channel_High<2>(); }
-void closeInjector2_DIRECT(void) { channel_Low<2>(); }
-void openInjector3_DIRECT(void)  { channel_High<3>(); }
-void closeInjector3_DIRECT(void) { channel_Low<3>(); }
-void openInjector4_DIRECT(void)  { channel_High<4>(); }
-void closeInjector4_DIRECT(void) { channel_Low<4>(); }
-void openInjector5_DIRECT(void)  { channel_High<5>(); }
-void closeInjector5_DIRECT(void) { channel_Low<5>(); }
-void openInjector6_DIRECT(void)  { channel_High<6>(); }
-void closeInjector6_DIRECT(void) { channel_Low<6>(); }
-void openInjector7_DIRECT(void)  { channel_High<7>(); }
-void closeInjector7_DIRECT(void) { channel_Low<7>(); }
-void openInjector8_DIRECT(void)  { channel_High<8>(); }
-void closeInjector8_DIRECT(void) { channel_Low<8>(); }
+void openInjector_DIRECT(uint8_t channel)
+{
+    if (channel<=_countof(pins))
+    {
+        pins[channel-1U].setPinHigh();
+    }
+}
+void closeInjector_DIRECT(uint8_t channel)
+{
+    if (channel<=_countof(pins))
+    {
+        pins[channel-1U].setPinLow();
+    }
+}
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_direct_inj.cpp
+++ b/speeduino/scheduledIO_direct_inj.cpp
@@ -7,7 +7,7 @@
 
 static fastOutputPin_t pins[INJ_CHANNELS];
 
-void initInjDirectIO(const uint8_t (&pinNumbers)[INJ_CHANNELS])
+void initInjDirectIO(const uint8_t (&pinNumbers)[_countof(pins)])
 {
     for (uint8_t i = 0; i < _countof(pins); i++)
     {
@@ -17,17 +17,13 @@ void initInjDirectIO(const uint8_t (&pinNumbers)[INJ_CHANNELS])
 
 void openInjector_DIRECT(uint8_t channel)
 {
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinHigh();
-    }
+    INTERNAL_TEST_ASSERT(channel>0 && channel<=_countof(pins));
+    pins[channel-1U].setPinHigh();
 }
 void closeInjector_DIRECT(uint8_t channel)
 {
-    if (channel<=_countof(pins))
-    {
-        pins[channel-1U].setPinLow();
-    }
+    INTERNAL_TEST_ASSERT(channel>0 && channel<=_countof(pins));
+    pins[channel-1U].setPinLow();
 }
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_direct_inj.h
+++ b/speeduino/scheduledIO_direct_inj.h
@@ -2,21 +2,5 @@
 
 void initInjDirectIO(const uint8_t (&pins)[INJ_CHANNELS]);
 
-//Macros are used to define how each injector control system functions. These are then called by the master openInjectx() function.
-//The DIRECT macros (ie individual pins) are defined below. Others should be defined in their relevant acc_x.h file
-void openInjector1_DIRECT(void);
-void closeInjector1_DIRECT(void);
-void openInjector2_DIRECT(void);
-void closeInjector2_DIRECT(void);
-void openInjector3_DIRECT(void);
-void closeInjector3_DIRECT(void);
-void openInjector4_DIRECT(void);
-void closeInjector4_DIRECT(void);
-void openInjector5_DIRECT(void);
-void closeInjector5_DIRECT(void);
-void openInjector6_DIRECT(void);
-void closeInjector6_DIRECT(void);
-void openInjector7_DIRECT(void);
-void closeInjector7_DIRECT(void);
-void openInjector8_DIRECT(void);
-void closeInjector8_DIRECT(void);
+void openInjector_DIRECT(uint8_t channel);
+void closeInjector_DIRECT(uint8_t channel);

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -17,7 +17,7 @@ void initIgnIoControl(IgnIoControlMode controlMode)
 static void tachoOutputOn(void) { if(configPage6.tachoMode) { tachoPulseLow(); } else { tachoOutputFlag = READY; } }
 static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh(); } }
 
-static void beginCoilCharge(uint8_t channel) 
+void beginCoilCharge(uint8_t channel) 
 { 
 #if defined(MC33810_SUPPORT)
     if(_controlMode==IgnIoControlMode::Direct) 
@@ -34,7 +34,7 @@ static void beginCoilCharge(uint8_t channel)
     tachoOutputOn(); 
 }
 
-static void endCoilCharge(uint8_t channel)
+void endCoilCharge(uint8_t channel)
 {
 #if defined(MC33810_SUPPORT)
     if(_controlMode==IgnIoControlMode::Direct) 
@@ -50,7 +50,6 @@ static void endCoilCharge(uint8_t channel)
 #endif
     tachoOutputOff();
 }
-
 
 void beginCoil1Charge(void) { beginCoilCharge(1U); }
 void endCoil1Charge(void) { endCoilCharge(1U); }
@@ -77,32 +76,32 @@ void beginCoil8Charge(void) { beginCoilCharge(8U); }
 void endCoil8Charge(void) { endCoilCharge(8U); }
 
 //The below 3 calls are all part of the rotary ignition mode
-void beginTrailingCoilCharge(void) { beginCoil2Charge(); }
-void endTrailingCoilCharge1(void) { endCoil2Charge(); beginCoil3Charge(); } //Sets ign3 (Trailing select) high
-void endTrailingCoilCharge2(void) { endCoil2Charge(); endCoil3Charge(); } //sets ign3 (Trailing select) low
+void beginTrailingCoilCharge(void) { beginCoilCharge(2U); }
+void endTrailingCoilCharge1(void) { endCoilCharge(2U); beginCoilCharge(3U); } //Sets ign3 (Trailing select) high
+void endTrailingCoilCharge2(void) { endCoilCharge(2U); endCoilCharge(3U); } //sets ign3 (Trailing select) low
 
 //As above but for ignition (Wasted COP mode)
-void beginCoil1and3Charge(void) { beginCoil1Charge(); beginCoil3Charge(); }
-void endCoil1and3Charge(void)   { endCoil1Charge();  endCoil3Charge(); }
-void beginCoil2and4Charge(void) { beginCoil2Charge(); beginCoil4Charge(); }
-void endCoil2and4Charge(void)   { endCoil2Charge();  endCoil4Charge(); }
+void beginCoil1and3Charge(void) { beginCoilCharge(1U); beginCoilCharge(3U); }
+void endCoil1and3Charge(void)   { endCoilCharge(1U);  endCoilCharge(3U); }
+void beginCoil2and4Charge(void) { beginCoilCharge(2U); beginCoilCharge(4U); }
+void endCoil2and4Charge(void)   { endCoilCharge(2U);  endCoilCharge(4U); }
 
 //For 6cyl wasted COP mode)
-void beginCoil1and4Charge(void) { beginCoil1Charge(); beginCoil4Charge(); }
-void endCoil1and4Charge(void)   { endCoil1Charge();  endCoil4Charge(); }
-void beginCoil2and5Charge(void) { beginCoil2Charge(); beginCoil5Charge(); }
-void endCoil2and5Charge(void)   { endCoil2Charge();  endCoil5Charge(); }
-void beginCoil3and6Charge(void) { beginCoil3Charge(); beginCoil6Charge(); }
-void endCoil3and6Charge(void)   { endCoil3Charge(); endCoil6Charge(); }
+void beginCoil1and4Charge(void) { beginCoilCharge(1U); beginCoilCharge(4U); }
+void endCoil1and4Charge(void)   { endCoilCharge(1U);  endCoilCharge(4U); }
+void beginCoil2and5Charge(void) { beginCoilCharge(2U); beginCoilCharge(5U); }
+void endCoil2and5Charge(void)   { endCoilCharge(2U);  endCoilCharge(5U); }
+void beginCoil3and6Charge(void) { beginCoilCharge(3U); beginCoilCharge(6U); }
+void endCoil3and6Charge(void)   { endCoilCharge(3U); endCoilCharge(6U); }
 
 //For 8cyl wasted COP mode)
-void beginCoil1and5Charge(void) { beginCoil1Charge(); beginCoil5Charge(); }
-void endCoil1and5Charge(void)   { endCoil1Charge();  endCoil5Charge(); }
-void beginCoil2and6Charge(void) { beginCoil2Charge(); beginCoil6Charge(); }
-void endCoil2and6Charge(void)   { endCoil2Charge();  endCoil6Charge(); }
-void beginCoil3and7Charge(void) { beginCoil3Charge(); beginCoil7Charge();  }
-void endCoil3and7Charge(void)   { endCoil3Charge(); endCoil7Charge(); }
-void beginCoil4and8Charge(void) { beginCoil4Charge(); beginCoil8Charge(); }
-void endCoil4and8Charge(void)   { endCoil4Charge();  endCoil8Charge(); }
+void beginCoil1and5Charge(void) { beginCoilCharge(1U); beginCoilCharge(5U); }
+void endCoil1and5Charge(void)   { endCoilCharge(1U);  endCoilCharge(5U); }
+void beginCoil2and6Charge(void) { beginCoilCharge(2U); beginCoilCharge(6U); }
+void endCoil2and6Charge(void)   { endCoilCharge(2U);  endCoilCharge(6U); }
+void beginCoil3and7Charge(void) { beginCoilCharge(3U); beginCoilCharge(7U);  }
+void endCoil3and7Charge(void)   { endCoilCharge(3U); endCoilCharge(7U); }
+void beginCoil4and8Charge(void) { beginCoilCharge(4U); beginCoilCharge(8U); }
+void endCoil4and8Charge(void)   { endCoilCharge(4U);  endCoilCharge(8U); }
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -9,29 +9,29 @@
 static void tachoOutputOn(void) { if(configPage6.tachoMode) { tachoPulseLow(); } else { tachoOutputFlag = READY; } }
 static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh(); } }
 
-void beginCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1Charging_DIRECT(); } else { coil1Charging_MC33810(); } tachoOutputOn(); }
-void endCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil1StopCharging_DIRECT(); } else { coil1StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(1); } else { coil1Charging_MC33810(); } tachoOutputOn(); }
+void endCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(1); } else { coil1StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2Charging_DIRECT(); } else { coil2Charging_MC33810(); } tachoOutputOn(); }
-void endCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil2StopCharging_DIRECT(); } else { coil2StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(2); } else { coil2Charging_MC33810(); } tachoOutputOn(); }
+void endCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(2); } else { coil2StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3Charging_DIRECT(); } else { coil3Charging_MC33810(); } tachoOutputOn(); }
-void endCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil3StopCharging_DIRECT(); } else { coil3StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(3); } else { coil3Charging_MC33810(); } tachoOutputOn(); }
+void endCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(3); } else { coil3StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4Charging_DIRECT(); } else { coil4Charging_MC33810(); } tachoOutputOn(); }
-void endCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil4StopCharging_DIRECT(); } else { coil4StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(4); } else { coil4Charging_MC33810(); } tachoOutputOn(); }
+void endCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(4); } else { coil4StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5Charging_DIRECT(); } else { coil5Charging_MC33810(); } tachoOutputOn(); }
-void endCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil5StopCharging_DIRECT(); } else { coil5StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(5); } else { coil5Charging_MC33810(); } tachoOutputOn(); }
+void endCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(5); } else { coil5StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6Charging_DIRECT(); } else { coil6Charging_MC33810(); } tachoOutputOn(); }
-void endCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil6StopCharging_DIRECT(); } else { coil6StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(6); } else { coil6Charging_MC33810(); } tachoOutputOn(); }
+void endCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(6); } else { coil6StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7Charging_DIRECT(); } else { coil7Charging_MC33810(); } tachoOutputOn(); }
-void endCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil7StopCharging_DIRECT(); } else { coil7StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(7); } else { coil7Charging_MC33810(); } tachoOutputOn(); }
+void endCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(7); } else { coil7StopCharging_MC33810(); } tachoOutputOff(); }
 
-void beginCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8Charging_DIRECT(); } else { coil8Charging_MC33810(); } tachoOutputOn(); }
-void endCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coil8StopCharging_DIRECT(); } else { coil8StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(8); } else { coil8Charging_MC33810(); } tachoOutputOn(); }
+void endCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(8); } else { coil8StopCharging_MC33810(); } tachoOutputOff(); }
 
 //The below 3 calls are all part of the rotary ignition mode
 void beginTrailingCoilCharge(void) { beginCoil2Charge(); }

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -9,29 +9,56 @@
 static void tachoOutputOn(void) { if(configPage6.tachoMode) { tachoPulseLow(); } else { tachoOutputFlag = READY; } }
 static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh(); } }
 
-void beginCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(1); } else { coilCharging_MC33810(1); } tachoOutputOn(); }
-void endCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(1); } else { coilStopCharging_MC33810(1); } tachoOutputOff(); }
+static void beginCoilCharge(uint8_t channel) 
+{ 
+    if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) 
+    {
+        coilCharging_DIRECT(channel);
+    }
+    else
+    {
+        coilCharging_MC33810(channel);
+    }
+    tachoOutputOn(); 
+}
 
-void beginCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(2); } else { coilCharging_MC33810(2); } tachoOutputOn(); }
-void endCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(2); } else { coilStopCharging_MC33810(2); } tachoOutputOff(); }
+static void endCoilCharge(uint8_t channel)
+{
+    if(ignitionOutputControl != OUTPUT_CONTROL_MC33810)
+    {
+        coilStopCharging_DIRECT(channel);
+    }
+    else
+    {
+        coilStopCharging_MC33810(channel);
+    }
+    tachoOutputOff();
+}
 
-void beginCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(3); } else { coilCharging_MC33810(3); } tachoOutputOn(); }
-void endCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(3); } else { coilStopCharging_MC33810(3); } tachoOutputOff(); }
 
-void beginCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(4); } else { coilCharging_MC33810(4); } tachoOutputOn(); }
-void endCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(4); } else { coilStopCharging_MC33810(4); } tachoOutputOff(); }
+void beginCoil1Charge(void) { beginCoilCharge(1U); }
+void endCoil1Charge(void) { endCoilCharge(1U); }
 
-void beginCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(5); } else { coilCharging_MC33810(5); } tachoOutputOn(); }
-void endCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(5); } else { coilStopCharging_MC33810(5); } tachoOutputOff(); }
+void beginCoil2Charge(void) { beginCoilCharge(2U); }
+void endCoil2Charge(void) { endCoilCharge(2U); }
 
-void beginCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(6); } else { coilCharging_MC33810(6); } tachoOutputOn(); }
-void endCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(6); } else { coilStopCharging_MC33810(6); } tachoOutputOff(); }
+void beginCoil3Charge(void) { beginCoilCharge(3U); }
+void endCoil3Charge(void) { endCoilCharge(3U); }
 
-void beginCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(7); } else { coilCharging_MC33810(7); } tachoOutputOn(); }
-void endCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(7); } else { coilStopCharging_MC33810(7); } tachoOutputOff(); }
+void beginCoil4Charge(void) { beginCoilCharge(4U); }
+void endCoil4Charge(void) { endCoilCharge(4U); }
 
-void beginCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(8); } else { coilCharging_MC33810(8); } tachoOutputOn(); }
-void endCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(8); } else { coilStopCharging_MC33810(8); } tachoOutputOff(); }
+void beginCoil5Charge(void) { beginCoilCharge(5U); }
+void endCoil5Charge(void) { endCoilCharge(5U); }
+
+void beginCoil6Charge(void) { beginCoilCharge(6U); }
+void endCoil6Charge(void) { endCoilCharge(6U); }
+
+void beginCoil7Charge(void) { beginCoilCharge(7U); }
+void endCoil7Charge(void) { endCoilCharge(7U); }
+
+void beginCoil8Charge(void) { beginCoilCharge(8U); }
+void endCoil8Charge(void) { endCoilCharge(8U); }
 
 //The below 3 calls are all part of the rotary ignition mode
 void beginTrailingCoilCharge(void) { beginCoil2Charge(); }

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -9,29 +9,29 @@
 static void tachoOutputOn(void) { if(configPage6.tachoMode) { tachoPulseLow(); } else { tachoOutputFlag = READY; } }
 static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh(); } }
 
-void beginCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(1); } else { coil1Charging_MC33810(); } tachoOutputOn(); }
-void endCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(1); } else { coil1StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(1); } else { coilCharging_MC33810(1); } tachoOutputOn(); }
+void endCoil1Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(1); } else { coilStopCharging_MC33810(1); } tachoOutputOff(); }
 
-void beginCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(2); } else { coil2Charging_MC33810(); } tachoOutputOn(); }
-void endCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(2); } else { coil2StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(2); } else { coilCharging_MC33810(2); } tachoOutputOn(); }
+void endCoil2Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(2); } else { coilStopCharging_MC33810(2); } tachoOutputOff(); }
 
-void beginCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(3); } else { coil3Charging_MC33810(); } tachoOutputOn(); }
-void endCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(3); } else { coil3StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(3); } else { coilCharging_MC33810(3); } tachoOutputOn(); }
+void endCoil3Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(3); } else { coilStopCharging_MC33810(3); } tachoOutputOff(); }
 
-void beginCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(4); } else { coil4Charging_MC33810(); } tachoOutputOn(); }
-void endCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(4); } else { coil4StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(4); } else { coilCharging_MC33810(4); } tachoOutputOn(); }
+void endCoil4Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(4); } else { coilStopCharging_MC33810(4); } tachoOutputOff(); }
 
-void beginCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(5); } else { coil5Charging_MC33810(); } tachoOutputOn(); }
-void endCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(5); } else { coil5StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(5); } else { coilCharging_MC33810(5); } tachoOutputOn(); }
+void endCoil5Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(5); } else { coilStopCharging_MC33810(5); } tachoOutputOff(); }
 
-void beginCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(6); } else { coil6Charging_MC33810(); } tachoOutputOn(); }
-void endCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(6); } else { coil6StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(6); } else { coilCharging_MC33810(6); } tachoOutputOn(); }
+void endCoil6Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(6); } else { coilStopCharging_MC33810(6); } tachoOutputOff(); }
 
-void beginCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(7); } else { coil7Charging_MC33810(); } tachoOutputOn(); }
-void endCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(7); } else { coil7StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(7); } else { coilCharging_MC33810(7); } tachoOutputOn(); }
+void endCoil7Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(7); } else { coilStopCharging_MC33810(7); } tachoOutputOff(); }
 
-void beginCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(8); } else { coil8Charging_MC33810(); } tachoOutputOn(); }
-void endCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(8); } else { coil8StopCharging_MC33810(); } tachoOutputOff(); }
+void beginCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilCharging_DIRECT(8); } else { coilCharging_MC33810(8); } tachoOutputOn(); }
+void endCoil8Charge(void) { if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) { coilStopCharging_DIRECT(8); } else { coilStopCharging_MC33810(8); } tachoOutputOff(); }
 
 //The below 3 calls are all part of the rotary ignition mode
 void beginTrailingCoilCharge(void) { beginCoil2Charge(); }

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -19,6 +19,7 @@ static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh();
 
 static void beginCoilCharge(uint8_t channel) 
 { 
+#if defined(MC33810_SUPPORT)
     if(_controlMode==IgnIoControlMode::Direct) 
     {
         coilCharging_DIRECT(channel);
@@ -27,11 +28,15 @@ static void beginCoilCharge(uint8_t channel)
     {
         coilCharging_MC33810(channel);
     }
+#else
+    coilCharging_DIRECT(channel);
+#endif
     tachoOutputOn(); 
 }
 
 static void endCoilCharge(uint8_t channel)
 {
+#if defined(MC33810_SUPPORT)
     if(_controlMode==IgnIoControlMode::Direct) 
     {
         coilStopCharging_DIRECT(channel);
@@ -40,6 +45,9 @@ static void endCoilCharge(uint8_t channel)
     {
         coilStopCharging_MC33810(channel);
     }
+#else
+    coilStopCharging_DIRECT(channel);
+#endif
     tachoOutputOff();
 }
 

--- a/speeduino/scheduledIO_ign.cpp
+++ b/speeduino/scheduledIO_ign.cpp
@@ -1,7 +1,15 @@
-#include "globals.h"
+#include "scheduledIO_ign.h"
 #include "scheduledIO_direct_ign.h"
 #include "acc_mc33810.h"
 #include "timers.h"
+#include "globals.h"
+
+static IgnIoControlMode _controlMode = IgnIoControlMode::Direct;
+
+void initIgnIoControl(IgnIoControlMode controlMode)
+{
+    _controlMode = controlMode;
+}
 
 // LCOV_EXCL_START
 // Exclude from code coverage, since this is all board output control
@@ -11,7 +19,7 @@ static void tachoOutputOff(void) { if(configPage6.tachoMode) { tachoPulseHigh();
 
 static void beginCoilCharge(uint8_t channel) 
 { 
-    if(ignitionOutputControl != OUTPUT_CONTROL_MC33810) 
+    if(_controlMode==IgnIoControlMode::Direct) 
     {
         coilCharging_DIRECT(channel);
     }
@@ -24,7 +32,7 @@ static void beginCoilCharge(uint8_t channel)
 
 static void endCoilCharge(uint8_t channel)
 {
-    if(ignitionOutputControl != OUTPUT_CONTROL_MC33810)
+    if(_controlMode==IgnIoControlMode::Direct) 
     {
         coilStopCharging_DIRECT(channel);
     }

--- a/speeduino/scheduledIO_ign.h
+++ b/speeduino/scheduledIO_ign.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <stdint.h>
+
+enum class IgnIoControlMode : uint8_t
+{
+    Direct,
+    MC33810
+};
+void initIgnIoControl(IgnIoControlMode controlMode);
+
 void beginCoil1Charge(void);
 void endCoil1Charge(void);
 

--- a/speeduino/scheduledIO_ign.h
+++ b/speeduino/scheduledIO_ign.h
@@ -9,6 +9,9 @@ enum class IgnIoControlMode : uint8_t
 };
 void initIgnIoControl(IgnIoControlMode controlMode);
 
+void beginCoilCharge(uint8_t channel);
+void endCoilCharge(uint8_t channel);
+
 void beginCoil1Charge(void);
 void endCoil1Charge(void);
 

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -24,7 +24,7 @@ char getInjectorStatus(void)
     if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
         openInjector_DIRECT(channel); \
     } else { \
-        openInjector ## channel ## _MC33810(); \
+        openInjector_MC33810(channel); \
     }; \
     BIT_SET(injStatusMask, (channel)-1U);
 
@@ -32,7 +32,7 @@ char getInjectorStatus(void)
     if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
         closeInjector_DIRECT(channel); \
     } else { \
-        closeInjector ## channel ## _MC33810(); \
+        closeInjector_MC33810(channel); \
     }; \
     BIT_CLEAR(injStatusMask, (channel)-1U); 
 

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -22,7 +22,7 @@ char getInjectorStatus(void)
 
 #define OPEN_INJECTOR(channel) \
     if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
-        openInjector ## channel ## _DIRECT(); \
+        openInjector_DIRECT(channel); \
     } else { \
         openInjector ## channel ## _MC33810(); \
     }; \
@@ -30,7 +30,7 @@ char getInjectorStatus(void)
 
 #define CLOSE_INJECTOR(channel) \
     if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
-        closeInjector ## channel ## _DIRECT(); \
+        closeInjector_DIRECT(channel); \
     } else { \
         closeInjector ## channel ## _MC33810(); \
     }; \

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -26,7 +26,7 @@ char getInjectorStatus(void)
 // LCOV_EXCL_START
 // Exclude from code coverage, since this is all board output control
 
-static void openInjector(uint8_t channel)
+void openInjector(uint8_t channel)
 {
 #if defined(MC33810_SUPPORT)
     if(_controlMode==InjIoControlMode::Direct) {
@@ -40,7 +40,7 @@ static void openInjector(uint8_t channel)
     BIT_SET(injStatusMask, (channel)-1U);
 }
 
-static void closeInjector(uint8_t channel)
+void closeInjector(uint8_t channel)
 {
 #if defined(MC33810_SUPPORT)
     if(_controlMode==InjIoControlMode::Direct) {
@@ -73,31 +73,31 @@ void closeInjector8(void)  { closeInjector(8); }
 
 // These are for Semi-Sequential and 5 Cylinder injection
 //Standard 4 cylinder pairings
-void openInjector1and3(void) { openInjector1(); openInjector3(); }
-void closeInjector1and3(void) { closeInjector1(); closeInjector3(); }
-void openInjector2and4(void) { openInjector2(); openInjector4(); }
-void closeInjector2and4(void) { closeInjector2(); closeInjector4(); }
+void openInjector1and3(void) { openInjector(1U); openInjector(3U); }
+void closeInjector1and3(void) { closeInjector(1U); closeInjector(3U); }
+void openInjector2and4(void) { openInjector(2U); openInjector(4U); }
+void closeInjector2and4(void) { closeInjector(2U); closeInjector(4U); }
 //Alternative output pairings
-void openInjector1and4(void) { openInjector1(); openInjector4(); }
-void closeInjector1and4(void) { closeInjector1(); closeInjector4(); }
-void openInjector2and3(void) { openInjector2(); openInjector3(); }
-void closeInjector2and3(void) { closeInjector2(); closeInjector3(); }
+void openInjector1and4(void) { openInjector(1U); openInjector(4U); }
+void closeInjector1and4(void) { closeInjector(1U); closeInjector(4U); }
+void openInjector2and3(void) { openInjector(2U); openInjector(3U); }
+void closeInjector2and3(void) { closeInjector(2U); closeInjector(3U); }
 
-void openInjector3and5(void) { openInjector3(); openInjector5(); }
-void closeInjector3and5(void) { closeInjector3(); closeInjector5(); }
+void openInjector3and5(void) { openInjector(3U); openInjector(5U); }
+void closeInjector3and5(void) { closeInjector(3U); closeInjector(5U); }
 
-void openInjector2and5(void) { openInjector2(); openInjector5(); }
-void closeInjector2and5(void) { closeInjector2(); closeInjector5(); }
-void openInjector3and6(void) { openInjector3(); openInjector6(); }
-void closeInjector3and6(void) { closeInjector3(); closeInjector6(); }
+void openInjector2and5(void) { openInjector(2U); openInjector(5U); }
+void closeInjector2and5(void) { closeInjector(2U); closeInjector(5U); }
+void openInjector3and6(void) { openInjector(3U); openInjector(6U); }
+void closeInjector3and6(void) { closeInjector(3U); closeInjector(6U); }
 
-void openInjector1and5(void) { openInjector1(); openInjector5(); }
-void closeInjector1and5(void) { closeInjector1(); closeInjector5(); }
-void openInjector2and6(void) { openInjector2(); openInjector6(); }
-void closeInjector2and6(void) { closeInjector2(); closeInjector6(); }
-void openInjector3and7(void) { openInjector3(); openInjector7(); }
-void closeInjector3and7(void) { closeInjector3(); closeInjector7(); }
-void openInjector4and8(void) { openInjector4(); openInjector8(); }
-void closeInjector4and8(void) { closeInjector4(); closeInjector8(); }
+void openInjector1and5(void) { openInjector(1U); openInjector(5U); }
+void closeInjector1and5(void) { closeInjector(1U); closeInjector(5U); }
+void openInjector2and6(void) { openInjector(2U); openInjector(6U); }
+void closeInjector2and6(void) { closeInjector(2U); closeInjector(6U); }
+void openInjector3and7(void) { openInjector(3U); openInjector(7U); }
+void closeInjector3and7(void) { closeInjector(3U); closeInjector(7U); }
+void openInjector4and8(void) { openInjector(4U); openInjector(8U); }
+void closeInjector4and8(void) { closeInjector(4U); closeInjector(8U); }
 
 // LCOV_EXCL_STOP

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -1,4 +1,4 @@
-#include "globals.h"
+#include "scheduledIO_inj.h"
 #include "acc_mc33810.h"
 #include "scheduledIO_direct_inj.h"
 
@@ -9,9 +9,15 @@
  * form where they are called (by scheduler.ino).
  */
 
- volatile byte injStatusMask = 0;
+static volatile byte injStatusMask = 0;
+static InjIoControlMode _controlMode = InjIoControlMode::Direct;
 
- /** @brief Injector open/close status bits */
+void initInjIoControl(InjIoControlMode controlMode)
+{
+    _controlMode = controlMode;
+}
+
+/** @brief Injector open/close status bits */
 char getInjectorStatus(void)
 {
     return injStatusMask;
@@ -22,7 +28,7 @@ char getInjectorStatus(void)
 
 static void openInjector(uint8_t channel)
 {
-    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) {
+    if(_controlMode==InjIoControlMode::Direct) {
         openInjector_DIRECT(channel);
     } else {
         openInjector_MC33810(channel);
@@ -32,7 +38,7 @@ static void openInjector(uint8_t channel)
 
 static void closeInjector(uint8_t channel)
 {
-    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) {
+    if(_controlMode==InjIoControlMode::Direct) {
         closeInjector_DIRECT(channel);
     } else {
         closeInjector_MC33810(channel);

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -28,21 +28,29 @@ char getInjectorStatus(void)
 
 static void openInjector(uint8_t channel)
 {
+#if defined(MC33810_SUPPORT)
     if(_controlMode==InjIoControlMode::Direct) {
         openInjector_DIRECT(channel);
     } else {
         openInjector_MC33810(channel);
     };
+#else
+    openInjector_DIRECT(channel);
+#endif
     BIT_SET(injStatusMask, (channel)-1U);
 }
 
 static void closeInjector(uint8_t channel)
 {
+#if defined(MC33810_SUPPORT)
     if(_controlMode==InjIoControlMode::Direct) {
         closeInjector_DIRECT(channel);
     } else {
         closeInjector_MC33810(channel);
     };
+#else
+    closeInjector_DIRECT(channel);
+#endif
     BIT_CLEAR(injStatusMask, (channel)-1U); 
 }
 

--- a/speeduino/scheduledIO_inj.cpp
+++ b/speeduino/scheduledIO_inj.cpp
@@ -20,38 +20,42 @@ char getInjectorStatus(void)
 // LCOV_EXCL_START
 // Exclude from code coverage, since this is all board output control
 
-#define OPEN_INJECTOR(channel) \
-    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
-        openInjector_DIRECT(channel); \
-    } else { \
-        openInjector_MC33810(channel); \
-    }; \
+static void openInjector(uint8_t channel)
+{
+    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) {
+        openInjector_DIRECT(channel);
+    } else {
+        openInjector_MC33810(channel);
+    };
     BIT_SET(injStatusMask, (channel)-1U);
+}
 
-#define CLOSE_INJECTOR(channel) \
-    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) { \
-        closeInjector_DIRECT(channel); \
-    } else { \
-        closeInjector_MC33810(channel); \
-    }; \
+static void closeInjector(uint8_t channel)
+{
+    if(injectorOutputControl != OUTPUT_CONTROL_MC33810) {
+        closeInjector_DIRECT(channel);
+    } else {
+        closeInjector_MC33810(channel);
+    };
     BIT_CLEAR(injStatusMask, (channel)-1U); 
+}
 
-void openInjector1(void)   { OPEN_INJECTOR(1); }
-void closeInjector1(void)  { CLOSE_INJECTOR(1); }
-void openInjector2(void)   { OPEN_INJECTOR(2); }
-void closeInjector2(void)  { CLOSE_INJECTOR(2); }
-void openInjector3(void)   { OPEN_INJECTOR(3); }
-void closeInjector3(void)  { CLOSE_INJECTOR(3); }
-void openInjector4(void)   { OPEN_INJECTOR(4); }
-void closeInjector4(void)  { CLOSE_INJECTOR(4); }
-void openInjector5(void)   { OPEN_INJECTOR(5); }
-void closeInjector5(void)  { CLOSE_INJECTOR(5); }
-void openInjector6(void)   { OPEN_INJECTOR(6); }
-void closeInjector6(void)  { CLOSE_INJECTOR(6); }
-void openInjector7(void)   { OPEN_INJECTOR(7); }
-void closeInjector7(void)  { CLOSE_INJECTOR(7); }
-void openInjector8(void)   { OPEN_INJECTOR(8); }
-void closeInjector8(void)  { CLOSE_INJECTOR(8); }
+void openInjector1(void)   { openInjector(1); }
+void closeInjector1(void)  { closeInjector(1); }
+void openInjector2(void)   { openInjector(2); }
+void closeInjector2(void)  { closeInjector(2); }
+void openInjector3(void)   { openInjector(3); }
+void closeInjector3(void)  { closeInjector(3); }
+void openInjector4(void)   { openInjector(4); }
+void closeInjector4(void)  { closeInjector(4); }
+void openInjector5(void)   { openInjector(5); }
+void closeInjector5(void)  { closeInjector(5); }
+void openInjector6(void)   { openInjector(6); }
+void closeInjector6(void)  { closeInjector(6); }
+void openInjector7(void)   { openInjector(7); }
+void closeInjector7(void)  { closeInjector(7); }
+void openInjector8(void)   { openInjector(8); }
+void closeInjector8(void)  { closeInjector(8); }
 
 // These are for Semi-Sequential and 5 Cylinder injection
 //Standard 4 cylinder pairings

--- a/speeduino/scheduledIO_inj.h
+++ b/speeduino/scheduledIO_inj.h
@@ -12,6 +12,9 @@ void initInjIoControl(InjIoControlMode controlMode);
 /** @brief Injector open/close status bits */
 char getInjectorStatus(void);
 
+void openInjector(uint8_t channel);
+void closeInjector(uint8_t channel);
+
 void openInjector1(void);
 void closeInjector1(void);
 

--- a/speeduino/scheduledIO_inj.h
+++ b/speeduino/scheduledIO_inj.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <stdint.h>
+
+enum class InjIoControlMode : uint8_t
+{
+    Direct,
+    MC33810
+};
+void initInjIoControl(InjIoControlMode controlMode);
+
 /** @brief Injector open/close status bits */
 char getInjectorStatus(void);
 

--- a/speeduino/unit_testing.h
+++ b/speeduino/unit_testing.h
@@ -57,3 +57,16 @@
 #else
 #define TESTABLE_STATIC_CONSTEXPR static inline
 #endif
+
+#if !defined(UNIT_TEST) 
+/** 
+ * @brief A unit test only assert
+ * 
+ * Useful for asserting non-unit test code during unit tests
+ * 
+ */
+#define INTERNAL_TEST_ASSERT(expression) 
+#else
+#include <assert.h>
+#define INTERNAL_TEST_ASSERT(expression) assert(expression)
+#endif

--- a/speeduino/unit_testing.h
+++ b/speeduino/unit_testing.h
@@ -62,11 +62,12 @@
 /** 
  * @brief A unit test only assert
  * 
- * Useful for asserting non-unit test code during unit tests
+ * Useful for asserting non-unit test code during unit tests. A regular assert
+ * will exit(1) on AVR, which is not useful
  * 
  */
 #define INTERNAL_TEST_ASSERT(expression) 
 #else
-#include <assert.h>
-#define INTERNAL_TEST_ASSERT(expression) assert(expression)
+#include <unity.h>
+#define INTERNAL_TEST_ASSERT(expression) TEST_ASSERT_TRUE((expression))
 #endif


### PR DESCRIPTION
Save RAM and Flash by:
1. Use channel parameters (1 to 8) to open/close/charge/discharge (this removed per-channel copy/pasted code)
2. Conditional compile of MC33810 support.

No reduction in speed/