### PR TITLE
Move DropBear secondary serial assignment to HAL

### DIFF
--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -252,7 +252,7 @@ void boardInitRTC(void)
   // Do nothing
 }
 
-void boardInitPins(void)
+void boardInitPins(uint8_t)
 {
   // Do nothing
 }

--- a/speeduino/board_definition.h
+++ b/speeduino/board_definition.h
@@ -27,7 +27,7 @@ void initBoard(uint32_t baudRate);
  * 
  * This is called *after* the pins are assigned and therefore after initBoard()
  */
-void boardInitPins(void);
+void boardInitPins(uint8_t boardID);
 
 /** @brief Calculate free RAM for display in TunerStudio */
 uint16_t freeRam(void);

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -93,7 +93,7 @@ void boardInitRTC(void)
   // Do nothing
 }
 
-void boardInitPins(void)
+void boardInitPins(uint8_t)
 {
   // Do nothing
 }

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -417,7 +417,7 @@ void boardInitRTC(void)
 }
 
 
-void boardInitPins(void)
+void boardInitPins(uint8_t)
 {
   // Do nothing
 }

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -441,7 +441,7 @@ void boardInitRTC(void)
 }
 
 
-void boardInitPins(void)
+void boardInitPins(uint8_t)
 {
   // Do nothing
 }

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -441,9 +441,12 @@ void boardInitRTC(void)
 }
 
 
-void boardInitPins(uint8_t)
+void boardInitPins(uint8_t boardID)
 {
-  // Do nothing
+  if (boardID==55U)
+  {
+    pSecondarySerial = &Serial1; //Header that is broken out on Dropbear boards is attached to Serial1
+  }
 }
 
 static uint16_t getEepromWriteBlockSize(const statuses &current)

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -392,7 +392,7 @@ void boardInitRTC(void)
 }
 
 
-void boardInitPins(void)
+void boardInitPins(uint8_t)
 {
   //Primary trigger
   setPinHysteresis(pinTrigger);

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -2012,8 +2012,6 @@ void setPinMapping(byte boardID)
         pinCLT = A20; //CLS sensor pin
         pinO2 = A21; //O2 Sensor pin
         pinO2_2 = A18; //Spare 2
-
-        pSecondarySerial = &Serial1; //Header that is broken out on Dropbear boards is attached to Serial1
       #endif
 
       #if defined(CORE_TEENSY41)

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -165,9 +165,9 @@ void initialiseAll(void)
       //First time running on this board
       setTuneToEmpty();
       configPage4.triggerTeeth = 4; //Avoiddiv by 0 when start decoders
-      setPinMapping(3); //Force board to v0.4
+      configPage2.pinMapping = 3; //Force board to v0.4
     }
-    else { setPinMapping(configPage2.pinMapping); }
+    setPinMapping(configPage2.pinMapping);
 
     // Repeatedly initialising the CAN bus hangs the system when
     // running initialisation tests on Teensy 3.5
@@ -247,7 +247,7 @@ void initialiseAll(void)
     
     noInterrupts();
     currentStatus.decoder = buildDecoder(configPage4.TrigPattern);
-    boardInitPins();
+    boardInitPins(configPage2.pinMapping);
     // The schedulers are all configured & pins are mapped - so start the schedulers
     startIgnitionSchedulers();
     startFuelSchedulers();


### PR DESCRIPTION
Move the assignment of the DropBear secondary serial from `setPinMapping()` to `boardInitPins()`. This separates it from the pin mapping (SRP) and places it in the Hardware Abstraction Layer (`board*.cpp`) alongside all other existing secondary serial setup (code locality)