### PR TITLE
Separate out fuel pump priming functionality

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -434,19 +434,26 @@ void fuelPumpOff(void)
   }
 }
 
-bool __attribute__((optimize("Os"))) initialiseFuelPump(const config2 &page2, uint8_t pumpPin)
+void __attribute__((optimize("Os"))) startPumpPriming(statuses &current, const config2 &page2)
+{
+  if(page2.fpPrime)
+  {
+    fpPrimeTime = current.secl;
+    fuelPumpOn();
+  }
+  else
+  {
+    fpPrimeTime = 0;
+  }
+  current.fpPrimed = !page2.fpPrime;
+}
+
+void __attribute__((optimize("Os"))) initialiseFuelPump(statuses &current, const config2 &page2, uint8_t pumpPin)
 {
   pump_pin.setPin(pumpPin, OUTPUT);
   fuelPumpOff();  //Initialise program with the fuel pump in the off state
 
-  //Begin priming the fuel pump. This is turned off in the low resolution, 1s interrupt in timers.ino
-  //First check that the priming time is not 0
-  if(page2.fpPrime>0U)
-  {
-    fuelPumpOn();
-    return false; // Priming not complete
-  }
-  return true; //If the user has set 0 for the pump priming, immediately mark the priming as being completed
+  startPumpPriming(current, page2);
 }
 
 

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -434,6 +434,8 @@ void fuelPumpOff(void)
   }
 }
 
+TESTABLE_STATIC uint8_t fpPrimeTime = 0; ///< The time (in seconds, based on @ref statuses.secl) that the fuel pump started priming
+
 void __attribute__((optimize("Os"))) startPumpPriming(statuses &current, const config2 &page2)
 {
   if(page2.fpPrime!=0U)

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -436,7 +436,7 @@ void fuelPumpOff(void)
 
 void __attribute__((optimize("Os"))) startPumpPriming(statuses &current, const config2 &page2)
 {
-  if(page2.fpPrime)
+  if(page2.fpPrime!=0U)
   {
     fpPrimeTime = current.secl;
     fuelPumpOn();
@@ -445,7 +445,25 @@ void __attribute__((optimize("Os"))) startPumpPriming(statuses &current, const c
   {
     fpPrimeTime = 0;
   }
-  current.fpPrimed = !page2.fpPrime;
+  current.fpPrimed = page2.fpPrime==0U;
+}
+
+void __attribute__((optimize("Os"))) stopPumpPriming(statuses &current, const config2 &page2)
+{
+  //Check whether fuel pump priming is complete
+  if(current.fpPrimed == false)
+  {
+    //fpPrimeTime is the time that the pump priming started. This is 0 on startup, but can be changed if the unit has been running on USB power and then had the ignition turned on (Which starts the priming again)
+    if( (current.secl - fpPrimeTime) >= page2.fpPrime)
+    {
+      current.fpPrimed = true; //Mark the priming as being completed
+      if(current.RPM == 0)
+      {
+        //If we reach here then the priming is complete, however only turn off the fuel pump if the engine isn't running
+        fuelPumpOff();
+      }
+    }
+  }
 }
 
 void __attribute__((optimize("Os"))) initialiseFuelPump(statuses &current, const config2 &page2, uint8_t pumpPin)

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -450,13 +450,18 @@ void __attribute__((optimize("Os"))) startPumpPriming(statuses &current, const c
   current.fpPrimed = page2.fpPrime==0U;
 }
 
+static inline bool primingTimeExpired(const statuses &current, const config2 &page2)
+{
+  return (current.secl>=fpPrimeTime) // Unlikely, but prevent unsigned overflow
+      && ((current.secl - fpPrimeTime) >= page2.fpPrime);
+}
+
 void __attribute__((optimize("Os"))) stopPumpPriming(statuses &current, const config2 &page2)
 {
   //Check whether fuel pump priming is complete
   if(current.fpPrimed == false)
   {
-    //fpPrimeTime is the time that the pump priming started. This is 0 on startup, but can be changed if the unit has been running on USB power and then had the ignition turned on (Which starts the priming again)
-    if( (current.secl - fpPrimeTime) >= page2.fpPrime)
+    if (primingTimeExpired(current, page2))
     {
       current.fpPrimed = true; //Mark the priming as being completed
       if(current.RPM == 0)

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -13,6 +13,7 @@ void initialiseAirCon(void);
 
 void initialiseFuelPump(statuses &current, const config2 &page2, uint8_t pumpPin);
 void startPumpPriming(statuses &current, const config2 &page2);
+void stopPumpPriming(statuses &current, const config2 &page2);
 
 void nitrousControl(void);
 void fanControl(void);

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -2,6 +2,7 @@
 #define AUX_H
 
 #include "config_pages.h"
+#include "statuses.h"
 
 void initialiseAuxPWM(void);
 void boostControl(void);
@@ -9,7 +10,10 @@ void boostDisable(void);
 void vvtControl(void);
 void initialiseFan(uint8_t fanPin);
 void initialiseAirCon(void);
-bool initialiseFuelPump(const config2 &page2, uint8_t pumpPin);
+
+void initialiseFuelPump(statuses &current, const config2 &page2, uint8_t pumpPin);
+void startPumpPriming(statuses &current, const config2 &page2);
+
 void nitrousControl(void);
 void fanControl(void);
 void airConControl(void);

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -25,7 +25,6 @@ trimTable3d trim8Table; ///< 6x6 Fuel trim 8 map
 struct table3d4RpmLoad dwellTable; ///< 4x4 Dwell map
 
 //These are variables used across multiple files
-byte fpPrimeTime = 0; ///< The time (in seconds, based on @ref statuses.secl) that the fuel pump started priming
 uint8_t softLimitTime = 0; //The time (in 0.1 seconds, based on seclx10) that the soft limiter started
 volatile uint16_t mainLoopCount; //Main loop counter (incremented at each main loop rev., used for maintaining currentStatus.loopsPerSecond)
 volatile unsigned long ms_counter = 0; //A counter that increments once per ms

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -81,7 +81,6 @@ extern trimTable3d trim8Table; //6x6 Fuel trim 8 map
 
 extern struct table3d4RpmLoad dwellTable; //4x4 Dwell map
 
-extern byte fpPrimeTime; //The time (in seconds, based on currentStatus.secl) that the fuel pump started priming
 extern uint8_t softLimitTime; //The time (in 0.1 seconds, based on seclx10) that the soft limiter started
 extern volatile uint16_t mainLoopCount;
 extern volatile unsigned long ms_counter; //A counter that increments once per ms

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -124,7 +124,6 @@ static void processResetStorageRequest(void) {
  */
 void initialiseAll(void)
 {   
-    currentStatus.fpPrimed = false;
     currentStatus.injPrimed = false;
 
     pinMode(LED_BUILTIN, OUTPUT);
@@ -240,7 +239,6 @@ void initialiseAll(void)
     currentStatus.crankRPM = ((unsigned int)configPage4.crankRPM * 10); //Crank RPM limit (Saves us calculating this over and over again. It's updated once per second in timers.ino)
     currentStatus.fuelPumpOn = false;
     currentStatus.engineProtect.reset();
-    fpPrimeTime = 0;
     ms_counter = 0;
     fixedCrankingOverride = 0;
     toothHistoryIndex = 0;
@@ -865,7 +863,7 @@ void initialiseAll(void)
         break;
     }
     
-    currentStatus.fpPrimed = initialiseFuelPump(configPage2, pinFuelPump);
+    initialiseFuelPump(currentStatus, configPage2, pinFuelPump);
 
     interrupts();
     initialiseCLT();

--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -757,9 +757,7 @@ static inline void readBat(void)
   if( (currentStatus.battery10 < 55U) && (tempReading > 70) && (currentStatus.RPM == 0U) )
   {
     //Re-prime the fuel pump
-    fpPrimeTime = currentStatus.secl;
-    currentStatus.fpPrimed = false;
-    fuelPumpOn();
+    startPumpPriming(currentStatus, configPage2);
 
     //Redo the stepper homing
     if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) )

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -261,19 +261,8 @@ void oneMSInterval(void)
     }
 
     //Check whether fuel pump priming is complete
-    if(currentStatus.fpPrimed == false)
-    {
-      //fpPrimeTime is the time that the pump priming started. This is 0 on startup, but can be changed if the unit has been running on USB power and then had the ignition turned on (Which starts the priming again)
-      if( (currentStatus.secl - fpPrimeTime) >= configPage2.fpPrime)
-      {
-        currentStatus.fpPrimed = true; //Mark the priming as being completed
-        if(currentStatus.RPM == 0)
-        {
-          //If we reach here then the priming is complete, however only turn off the fuel pump if the engine isn't running
-          fuelPumpOff();
-        }
-      }
-    }
+    stopPumpPriming(currentStatus, configPage2);
+    
     //**************************************************************************************************************************************************
     //Set the flex reading (if enabled). The flexCounter is updated with every pulse from the sensor. If cleared once per second, we get a frequency reading
     if(configPage2.flexEnabled == true)

--- a/test/test_fuel/main.cpp
+++ b/test/test_fuel/main.cpp
@@ -14,6 +14,7 @@ void runAllFuelTests(void)
     extern void testCalculateOpenTime(void);
     extern void testCalculatePWLimit(void);
     extern void testCalcPrimaryPulseWidth(void);
+    extern void testFuelPump(void);
 
     testCorrections();
     testComputePulseWidths();
@@ -25,6 +26,7 @@ void runAllFuelTests(void)
     testCalculateOpenTime();
     testCalculatePWLimit();
     testCalcPrimaryPulseWidth();
+    testFuelPump();
 }
 
 TEST_HARNESS(runAllFuelTests)

--- a/test/test_fuel/test_fuelpump.cpp
+++ b/test/test_fuel/test_fuelpump.cpp
@@ -1,0 +1,37 @@
+#include "../test_utils.h"
+#include "globals.h"
+#include "auxiliaries.h"
+
+static void test_startPumpPriming_prime(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    page2.fpPrime = true;
+    current.secl = 99;
+    startPumpPriming(current, page2);
+
+    TEST_ASSERT_FALSE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(current.secl, fpPrimeTime);
+}
+
+static void test_startPumpPriming_noprime(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    page2.fpPrime = false;
+    current.secl = 99;
+    startPumpPriming(current, page2);
+
+    TEST_ASSERT_TRUE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(0, fpPrimeTime);
+}
+
+void testFuelPump(void)
+{
+  SET_UNITY_FILENAME() {
+    RUN_TEST_P(test_startPumpPriming_prime);
+    RUN_TEST_P(test_startPumpPriming_noprime);
+  }
+}

--- a/test/test_fuel/test_fuelpump.cpp
+++ b/test/test_fuel/test_fuelpump.cpp
@@ -2,6 +2,8 @@
 #include "globals.h"
 #include "auxiliaries.h"
 
+extern uint8_t fpPrimeTime;
+
 static void test_startPumpPriming_prime(void)
 {
     statuses current = {};

--- a/test/test_fuel/test_fuelpump.cpp
+++ b/test/test_fuel/test_fuelpump.cpp
@@ -28,10 +28,70 @@ static void test_startPumpPriming_noprime(void)
     TEST_ASSERT_EQUAL(0, fpPrimeTime);
 }
 
+static void test_stopPumpPriming_delay_not_expired(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    current.secl = 99;
+    fpPrimeTime = 33;
+    page2.fpPrime = (current.secl - fpPrimeTime) + 1;
+    stopPumpPriming(current, page2);
+
+    TEST_ASSERT_FALSE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(33, fpPrimeTime);
+}
+
+static void test_stopPumpPriming_delay_expired(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    current.secl = 99;
+    fpPrimeTime = 33;
+    page2.fpPrime = (current.secl - fpPrimeTime) - 1;
+    stopPumpPriming(current, page2);
+
+    TEST_ASSERT_TRUE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(33, fpPrimeTime);
+}
+
+static void test_stopPumpPriming_delay_equaled(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    current.secl = 99;
+    current.setRpm(0); // Coverage: this excercises an additional code path
+    fpPrimeTime = 33;
+    page2.fpPrime = (current.secl - fpPrimeTime);
+    stopPumpPriming(current, page2);
+
+    TEST_ASSERT_TRUE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(33, fpPrimeTime);
+}
+
+static void test_stopPumpPriming_prime_true(void)
+{
+    statuses current = {};
+    config2 page2 = {};
+
+    current.fpPrimed = true;
+    fpPrimeTime = 0;
+    stopPumpPriming(current, page2);
+    // No effect
+    TEST_ASSERT_TRUE(current.fpPrimed);
+    TEST_ASSERT_EQUAL(0, fpPrimeTime);
+}
+
 void testFuelPump(void)
 {
   SET_UNITY_FILENAME() {
     RUN_TEST_P(test_startPumpPriming_prime);
     RUN_TEST_P(test_startPumpPriming_noprime);
+    RUN_TEST_P(test_stopPumpPriming_delay_expired);
+    RUN_TEST_P(test_stopPumpPriming_delay_equaled);
+    RUN_TEST_P(test_stopPumpPriming_delay_not_expired);
+    RUN_TEST_P(test_stopPumpPriming_prime_true);
   }
 }


### PR DESCRIPTION
1. Extract `startPumpPriming` since it's is called from a couple of places. 
2. Extract `stopPumpPriming` to mirror `startPumpPriming` and increase code locality