### PR TITLE
Move power source change detection up the call stack to loop()

### DIFF
--- a/speeduino/sensors.cpp
+++ b/speeduino/sensors.cpp
@@ -30,7 +30,6 @@ A full copy of the license may be found in the projects root directory
 #include "src/pins/fastInputPin.h"
 #include "src/pins/inputPin.h"
 #include "src/pins/pinMapping.h"
-#include "src/controllers/fuelPump/fuelPumpController.h"
 
 uint8_t statusSensors = 0;
 
@@ -746,31 +745,14 @@ static inline void readO2(void)
 
 static inline void readBat(void)
 {
-  int16_t tempReading = fastMap10Bit(readAnalogSensor(pinBat), 0, 245); //Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
-
-  //Apply the offset calibration value to the reading
-  tempReading += configPage4.batVoltCorrect;
-  if(tempReading < 0){
-    tempReading=0;
-  }  //with negative overflow prevention
-
-
-  //The following is a check for if the voltage has jumped up from under 5.5v to over 7v.
-  //If this occurs, it's very likely that the system has gone from being powered by USB to being powered from the 12v power source.
-  //Should that happen, we re-trigger the fuel pump priming and idle homing (If using a stepper)
-  if( (currentStatus.battery10 < 55U) && (tempReading > 70) && (currentStatus.RPM == 0U) )
-  {
-    //Re-prime the fuel pump
-    startPumpPriming(currentStatus, configPage2);
-
-    //Redo the stepper homing
-    if( (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_CL) || (configPage6.iacAlgorithm == IAC_ALGORITHM_STEP_OL) )
-    {
-      initialiseIdle(true);
-    }
-  }
-
-  currentStatus.battery10 = LOW_PASS_FILTER(tempReading, configPage4.ADCFILTER_BAT, currentStatus.battery10);
+  // Get the current raw Battery value. Permissible values are from 0v to 24.5v (245)
+  currentStatus.battery10 =
+    clamp( 
+      LOW_PASS_FILTER((int16_t)fastMap10Bit( readAnalogSensor(pinBat), 0, 245) + configPage4.batVoltCorrect, 
+                      configPage4.ADCFILTER_BAT,
+                      (int16_t)currentStatus.battery10),
+      (int16_t)0,
+      (int16_t)UINT8_MAX);
 }
 
 #if defined(ANALOG_ISR)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -152,6 +152,32 @@ static inline void setFuelSchedules(const statuses &current, const uint16_t (&in
 #undef SET_FUEL_CHANNEL
 }
 
+static inline bool haveSwitchedToBatteryPower(uint8_t originalBatteryVoltage, const statuses &current)
+{
+  return (originalBatteryVoltage < 55U)
+      && (current.battery10 > 70)
+      && (current.RPM == 0U)
+      ;
+}
+
+// The following is a check for if the voltage has jumped up from under 5.5v to over 7v.
+// If this occurs, it's very likely that the system has gone from being powered by USB to being powered from the 12v power source.
+// Should that happen, we re-trigger the fuel pump priming and idle homing (If using a stepper)
+static void onPowerSourceSwitch(uint8_t originalBatteryVoltage, const statuses &current, const config2 &page2, const config6 &page6)
+{
+  if( haveSwitchedToBatteryPower(originalBatteryVoltage, current) )
+  {
+    //Re-prime the fuel pump
+    startPumpPriming(current, page2);
+
+    //Redo the stepper homing
+    if(isStepperIac(page6) )
+    {
+      initialiseIdle(true);
+    }
+  }
+}
+
 /** Speeduino main loop.
  * 
  * Main loop chores (roughly in the order that they are performed):
@@ -177,6 +203,8 @@ static inline void setFuelSchedules(const statuses &current, const uint16_t (&in
  */
 BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
 {
+  uint8_t originalBatteryVoltage = currentStatus.battery10;
+
       if(mainLoopCount < UINT16_MAX) { mainLoopCount++; }
       currentStatus.LOOP_TIMER = getAndClearTimerMask();
 
@@ -799,6 +827,7 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
 
     } //Has sync and RPM
     matchResetControlToEngineState(currentStatus);
+    onPowerSourceSwitch(originalBatteryVoltage, currentStatus, configPage2, configPage6);
 } //loop()
 END_LTO_INLINE()
 


### PR DESCRIPTION
By moving the power change detection into loop, we:
1. Break the dependency between sensors and the fuel pump controller
2. Place the coordination into our primary (only?) orchestration construct: `loop()`