### PR TITLE
Replace statuses::engineIsRunning & engineIsCranking with rotationStatus

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -260,7 +260,7 @@ void airConControl(void)
     // ------------------------------------------------------------------------------------------------------
     // Check that the engine has been running past the post-start delay period before enabling the compressor
     // ------------------------------------------------------------------------------------------------------
-    if (currentStatus.engineIsRunning)
+    if (currentStatus.rotationStatus==EngineRotationStatus::Running)
     {
       if(acAfterEngineStartDelay >= configPage15.airConAfterStartDelay)
       {
@@ -462,7 +462,7 @@ void fanControl(void)
 
     
     if ( configPage2.fanWhenOff == true) { fanPermit = true; }
-    else { fanPermit = currentStatus.engineIsRunning; }
+    else { fanPermit = currentStatus.rotationStatus==EngineRotationStatus::Running; }
 
     if ( (fanPermit == true) &&
          ((currentStatus.coolant >= onTemp) || 
@@ -470,7 +470,7 @@ void fanControl(void)
            currentStatus.airconTurningOn == true)) )
     {
       //Fan needs to be turned on - either by high coolant temp, or from an A/C request (to ensure there is airflow over the A/C radiator).
-      if((currentStatus.engineIsCranking) && (configPage2.fanWhenCranking == 0))
+      if((currentStatus.rotationStatus==EngineRotationStatus::Cranking) && (configPage2.fanWhenCranking == 0))
       {
         //If the user has elected to disable the fan during cranking, make sure it's off 
         fanOff();
@@ -493,10 +493,10 @@ void fanControl(void)
   {
     bool fanPermit = false;
     if ( configPage2.fanWhenOff == true) { fanPermit = true; }
-    else { fanPermit = currentStatus.engineIsRunning; }
+    else { fanPermit = currentStatus.rotationStatus==EngineRotationStatus::Running; }
     if (fanPermit == true)
       {
-      if((currentStatus.engineIsCranking) && (configPage2.fanWhenCranking == 0))
+      if((currentStatus.rotationStatus==EngineRotationStatus::Cranking) && (configPage2.fanWhenCranking == 0))
       {
         currentStatus.fanDuty = 0; //If the user has elected to disable the fan during cranking, make sure it's off 
         currentStatus.fanOn = false;
@@ -907,7 +907,7 @@ void vvt2Off(void)
 
 void vvtControl(void)
 {
-  if( (configPage6.vvtEnabled == 1) && (currentStatus.coolant >= temperatureRemoveOffset(configPage4.vvtMinClt)) && (currentStatus.engineIsRunning))
+  if( (configPage6.vvtEnabled == 1) && (currentStatus.coolant >= temperatureRemoveOffset(configPage4.vvtMinClt)) && (currentStatus.rotationStatus==EngineRotationStatus::Running))
   {
     if(vvtTimeHold == false) 
     {

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -137,7 +137,7 @@ void receiveCANwbo()
     outMsg.flags.extended = 1;
     outMsg.len = 2;
     outMsg.buf[0] = currentStatus.battery10; // We don't do any conversion since factor is 0.1 and speeduino value is x10
-    outMsg.buf[1] = currentStatus.engineIsRunning ? 0x1 : 0x0; // Enable heater once engine is running (ie. above cranking rpm), this condition can be changed to CLT above certain temp and so on.
+    outMsg.buf[1] = currentStatus.rotationStatus==EngineRotationStatus::Running ? 0x1 : 0x0; // Enable heater once engine is running (ie. above cranking rpm), this condition can be changed to CLT above certain temp and so on.
     Can0.write(outMsg);
     outMsg.flags.extended = 0; //Make sure to set this back to standard to avoid future problems
     if ((inMsg.id == 0x190 || inMsg.id == 0x192))

--- a/speeduino/corrections.cpp
+++ b/speeduino/corrections.cpp
@@ -164,7 +164,7 @@ TESTABLE_INLINE_STATIC uint16_t correctionCranking(void)
   uint16_t crankingPercent = NO_FUEL_CORRECTION;
 
   //Check if we are actually cranking
-  if ( currentStatus.engineIsCranking )
+  if ( currentStatus.rotationStatus==EngineRotationStatus::Cranking )
   {
     crankingPercent = lookUpCrankingEnrichmentPct();
     crankingEnrichTaper = 0U;
@@ -201,7 +201,7 @@ TESTABLE_INLINE_STATIC uint8_t correctionASE(void)
 
   uint8_t ASEValue = NO_FUEL_CORRECTION;
 
-  if (currentStatus.engineIsCranking) {
+  if (currentStatus.rotationStatus==EngineRotationStatus::Cranking) {
     // Engine is cranking - mark ASE as inactive and ready to run 
     currentStatus.aseIsActive = false;
     aseTaper = 0U; 
@@ -515,7 +515,7 @@ TESTABLE_INLINE_STATIC uint16_t correctionAccel(void)
 // ============================= Flood Clear =============================
 
 static inline bool isFloodClearActive(const statuses &current, const config4 &page4) {
-  return current.engineIsCranking
+  return current.rotationStatus==EngineRotationStatus::Cranking
       && (current.TPS >= page4.floodClear);
 }
 
@@ -891,7 +891,7 @@ TESTABLE_INLINE_STATIC int8_t correctionCLTadvance(int8_t advance)
  */
 int8_t correctionCrankingFixedTiming(int8_t advance)
 {
-  if ( currentStatus.engineIsCranking )
+  if ( currentStatus.rotationStatus==EngineRotationStatus::Cranking )
   { 
     if ( configPage2.crkngAddCLTAdv == 0U ) { 
       advance = configPage4.CrankAng; //Use the fixed cranking ignition angle
@@ -976,7 +976,7 @@ static inline int8_t applyIdleAdvanceAdjust(int8_t advance, int8_t adjustment) {
 static inline bool isIdleAdvanceOn(void) {
   return (configPage2.idleAdvEnabled != IDLEADVANCE_MODE_OFF) 
       && (runSecsX10 >= TIME_TWENTY_MILLIS.toUser( configPage2.idleAdvDelay ))
-      && currentStatus.engineIsRunning
+      && currentStatus.rotationStatus==EngineRotationStatus::Running
       /* When Idle advance is the only idle speed control mechanism, activate as soon as not cranking. 
       When some other mechanism is also present, wait until the engine is no more than 200 RPM below idle target speed on first time
       */

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -658,7 +658,7 @@ static void triggerPri_missingTooth(void)
      
 
       //NEW IGNITION MODE
-      if( (configPage2.perToothIgn == true) && (!currentStatus.engineIsCranking) ) 
+      if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
       {
         int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) && (configPage2.strokes == FOUR_STROKE) )
@@ -965,7 +965,7 @@ static void triggerPri_DualWheel(void)
       }
 
       //NEW IGNITION MODE
-      if( (configPage2.perToothIgn == true) && (!currentStatus.engineIsCranking) ) 
+      if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
       {
         int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
         uint16_t currentTooth;
@@ -1178,7 +1178,7 @@ static void triggerPri_BasicDistributor(void)
 
     decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
 
-    if ( configPage4.ignCranklock && currentStatus.engineIsCranking )
+    if ( configPage4.ignCranklock && (currentStatus.rotationStatus==EngineRotationStatus::Cranking) )
     {
       endCoilCharge(1U);
       endCoilCharge(2U);
@@ -1526,7 +1526,7 @@ static void triggerPri_4G63(void)
 
     if (decoderStatus.syncStatus==SyncStatus::Full)
     {
-      if ( currentStatus.engineIsCranking && configPage4.ignCranklock && (currentStatus.startRevolutions >= configPage4.StgCycles))
+      if ( (currentStatus.rotationStatus==EngineRotationStatus::Cranking) && configPage4.ignCranklock && (currentStatus.startRevolutions >= configPage4.StgCycles))
       {
         if(configPage2.nCylinders == 4)
         {
@@ -2626,7 +2626,6 @@ static void triggerPri_Miata9905(void)
     toothLastMinusOneToothTime = toothLastToothTime;
     toothLastToothTime = curTime;
 
-    //if ( currentStatus.engineIsCranking && configPage4.ignCranklock)
     if ( (currentStatus.RPM < (currentStatus.crankRPM + 30)) && (configPage4.ignCranklock) ) //The +30 here is a safety margin. When switching from fixed timing to normal, there can be a situation where a pulse started when fixed and ending when in normal mode causes problems. This prevents that.
     {
       if( (toothCurrentCount == 1) || (toothCurrentCount == 5) ) { endCoilCharge(1U); endCoilCharge(3U); }
@@ -2642,7 +2641,7 @@ static void triggerSec_Miata9905(void)
   curTime2 = micros();
   curGap2 = curTime2 - toothLastSecToothTime;
 
-  if(currentStatus.engineIsCranking || (decoderStatus.syncStatus!=SyncStatus::Full) )
+  if((currentStatus.rotationStatus==EngineRotationStatus::Cranking) || (decoderStatus.syncStatus!=SyncStatus::Full) )
   {
     triggerFilterTime = 1500; //If this is removed, can have trouble getting sync again after the engine is turned off (but ECU not reset).
   }
@@ -2854,7 +2853,7 @@ static void triggerPri_MazdaAU(void)
     if (decoderStatus.syncStatus==SyncStatus::Full)
     {
       // Locked cranking timing is available, fixed at 12* BTDC
-      if ( currentStatus.engineIsCranking && configPage4.ignCranklock )
+      if ( (currentStatus.rotationStatus==EngineRotationStatus::Cranking) && configPage4.ignCranklock )
       {
         if( toothCurrentCount == 1 ) { endCoilCharge(1U); }
         else if( toothCurrentCount == 3 ) { endCoilCharge(2U); }
@@ -3381,7 +3380,7 @@ static void triggerPri_Subaru67(void)
   if ( decoderStatus.syncStatus==SyncStatus::Full )
   {
     //Locked timing during cranking. This is fixed at 10* BTDC.
-    if ( currentStatus.engineIsCranking && configPage4.ignCranklock)
+    if ( (currentStatus.rotationStatus==EngineRotationStatus::Cranking) && configPage4.ignCranklock)
     {
       if( (toothCurrentCount == 1) || (toothCurrentCount == 7) ) { endCoilCharge(1U); endCoilCharge(3U); }
       else if( (toothCurrentCount == 4) || (toothCurrentCount == 10) ) { endCoilCharge(2U); endCoilCharge(4U); }
@@ -3403,7 +3402,7 @@ static void triggerPri_Subaru67(void)
 
 
     //NEW IGNITION MODE
-    if( (configPage2.perToothIgn == true) && (!currentStatus.engineIsCranking) ) 
+    if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
     {
       int16_t crankAngle = toothAngles[(toothCurrentCount - 1)] + configPage4.triggerAngle;
       if( (configPage4.sparkMode != IGN_MODE_SEQUENTIAL) )
@@ -3615,7 +3614,7 @@ static void triggerPri_Daihatsu(void)
         setFilter(curGap); //Recalc the new filter value
       }
 
-      if ( configPage4.ignCranklock && currentStatus.engineIsCranking )
+      if ( configPage4.ignCranklock && (currentStatus.rotationStatus==EngineRotationStatus::Cranking) )
       {
         //This locks the cranking timing to 0 degrees BTDC (All the triggers allow for)
         if(toothCurrentCount == 1) { endCoilCharge(1U); }
@@ -4815,7 +4814,7 @@ static void triggerPri_NGC(void)
     toothLastToothTime = curTime;
 
     //NEW IGNITION MODE
-    if( (configPage2.perToothIgn == true) && (currentStatus.engineIsCranking == false) ) 
+    if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
     {
       int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
       if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) )
@@ -5326,7 +5325,7 @@ static void triggerPri_Renix(void)
 
 
       //NEW IGNITION MODE
-      if( (configPage2.perToothIgn == true) && (!currentStatus.engineIsCranking) ) 
+      if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
       {
         int16_t crankAngle = ( (toothCurrentCount - 1) * triggerToothAngle ) + configPage4.triggerAngle;
         if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true) && (configPage4.TrigSpeed == CRANK_SPEED) )
@@ -5555,7 +5554,7 @@ static void triggerPri_RoverMEMS(void)
     toothLastToothTime = curTime;
 
     //NEW IGNITION MODE
-    if( (configPage2.perToothIgn == true) && (!currentStatus.engineIsCranking) ) 
+    if( (configPage2.perToothIgn == true) && (currentStatus.rotationStatus!=EngineRotationStatus::Cranking) ) 
     {  
       int16_t crankAngle = ( (toothCurrentCount-1) * triggerToothAngle ) + configPage4.triggerAngle;
       if( (configPage4.sparkMode == IGN_MODE_SEQUENTIAL) && (revolutionOne == true))

--- a/speeduino/dwell.cpp
+++ b/speeduino/dwell.cpp
@@ -3,7 +3,7 @@
 uint16_t computeDwell(const statuses &current, const config2 &page2, const config4 &page4, const table3d4RpmLoad &dwellTable)
 {
     uint16_t dwell;
-    if ( current.engineIsCranking )
+    if ( current.rotationStatus==EngineRotationStatus::Cranking )
     {
         dwell = page4.dwellCrank; //use cranking dwell
     }

--- a/speeduino/fuel_calcs.cpp
+++ b/speeduino/fuel_calcs.cpp
@@ -156,7 +156,7 @@ TESTABLE_INLINE_STATIC uint16_t calcPrimaryPulseWidth(uint16_t injOpenTime, cons
 
 // Apply the pwLimit if staging is disabled and engine is not cranking
 TESTABLE_INLINE_STATIC uint16_t applyPwLimits(uint16_t pw, uint16_t pwLimit, const config10 &page10, const statuses &current) {
-  if( (!current.engineIsCranking) && (page10.stagingEnabled == false) ) { 
+  if( (current.rotationStatus!=EngineRotationStatus::Cranking) && (page10.stagingEnabled == false) ) { 
     return min(pw, pwLimit);
   }
   return pw;

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -381,13 +381,13 @@ void idleControl(void)
 
     case IAC_ALGORITHM_PWM_OL:      //Case 2 is PWM open loop
       //Check for cranking pulsewidth
-      if( currentStatus.engineIsCranking )
+      if( currentStatus.rotationStatus==EngineRotationStatus::Cranking )
       {
         //Currently cranking. Use the cranking table
         currentStatus.idleLoad = table2D_getValue(&iacCrankDutyTable, temperatureAddOffset(currentStatus.coolant)); //All temps are offset by 40 degrees
         idleTaper = 0;
       }
-      else if ( !currentStatus.engineIsRunning)
+      else if ( currentStatus.rotationStatus!=EngineRotationStatus::Running)
       {
         if( configPage6.iacPWMrun == true)
         {
@@ -424,7 +424,7 @@ void idleControl(void)
 
     case IAC_ALGORITHM_PWM_CL:    //Case 3 is PWM closed loop
         //No cranking specific value for closed loop (yet?)
-      if( currentStatus.engineIsCranking )
+      if( currentStatus.rotationStatus==EngineRotationStatus::Cranking )
       {
         //Currently cranking. Use the cranking table
         currentStatus.idleLoad = table2D_getValue(&iacCrankDutyTable, temperatureAddOffset(currentStatus.coolant)); //All temps are offset by 40 degrees
@@ -432,7 +432,7 @@ void idleControl(void)
         idle_pid_target_value = idle_pwm_target_value << 2; //Resolution increased
         idlePID.Initialize(); //Update output to smooth transition
       }
-      else if ( !currentStatus.engineIsRunning)
+      else if ( currentStatus.rotationStatus!=EngineRotationStatus::Running)
       {
         if( configPage6.iacPWMrun == true)
         {
@@ -482,7 +482,7 @@ void idleControl(void)
 
     case IAC_ALGORITHM_PWM_OLCL: //case 6 is PWM Open Loop table as feedforward term plus closed loop. 
       //No cranking specific value for closed loop (yet?)
-      if( currentStatus.engineIsCranking )
+      if( currentStatus.rotationStatus==EngineRotationStatus::Cranking )
       {
         //Currently cranking. Use the cranking table
         currentStatus.idleLoad = table2D_getValue(&iacCrankDutyTable, temperatureAddOffset(currentStatus.coolant)); //All temps are offset by 40 degrees
@@ -490,7 +490,7 @@ void idleControl(void)
         idle_pid_target_value = idle_pwm_target_value << 2; //Resolution increased
         idlePID.Initialize(); //Update output to smooth transition
       }
-      else if ( !currentStatus.engineIsRunning)
+      else if ( currentStatus.rotationStatus!=EngineRotationStatus::Running)
       {
         if( configPage6.iacPWMrun == true)
         {
@@ -548,7 +548,7 @@ void idleControl(void)
       if( (checkForStepping() == false) && (isStepperHomed() == true) ) //Check that homing is complete and that there's not currently a step already taking place. MUST BE IN THIS ORDER!
       {
         //Check for cranking pulsewidth
-        if( !currentStatus.engineIsRunning ) //If ain't running it means off or cranking
+        if( currentStatus.rotationStatus!=EngineRotationStatus::Running ) //If ain't running it means off or cranking
         {
           //Currently cranking. Use the cranking table
           idleStepper.targetIdleStep = table2D_getValue(&iacCrankStepsTable, temperatureAddOffset(currentStatus.coolant)) * 3; //All temps are offset by 40 degrees. Step counts are divided by 3 in TS. Multiply back out here
@@ -598,7 +598,7 @@ void idleControl(void)
       //First thing to check is whether there is currently a step going on and if so, whether it needs to be turned off
       if( (checkForStepping() == false) && (isStepperHomed() == true) ) //Check that homing is complete and that there's not currently a step already taking place. MUST BE IN THIS ORDER!
       {
-        if( !currentStatus.engineIsRunning ) //If ain't running it means off or cranking
+        if( currentStatus.rotationStatus!=EngineRotationStatus::Running ) //If ain't running it means off or cranking
         {
           //Currently cranking. Use the cranking table
           idleStepper.targetIdleStep = table2D_getValue(&iacCrankStepsTable, temperatureAddOffset(currentStatus.coolant)) * 3; //All temps are offset by 40 degrees. Step counts are divided by 3 in TS. Multiply back out here

--- a/speeduino/logger.cpp
+++ b/speeduino/logger.cpp
@@ -106,8 +106,8 @@ static byte buildStatus5(const statuses &current)
 byte buildEngineStatus(const statuses &current)
 {
   bool bits[] = {
-    current.engineIsRunning,
-    current.engineIsCranking,
+    current.rotationStatus==EngineRotationStatus::Running,
+    current.rotationStatus==EngineRotationStatus::Cranking,
     current.aseIsActive,
     current.wueIsActive,
     current.isAcceleratingTPS,

--- a/speeduino/secondaryTables.cpp
+++ b/speeduino/secondaryTables.cpp
@@ -132,7 +132,7 @@ static inline bool isFixedTimingOn(const config2 &page2, const statuses &current
             // Fixed timing is in effect
     return  (page2.fixAngEnable == 1U)
             // Cranking, so the cranking advance angle is in effect
-            || (current.engineIsCranking);
+            || (current.rotationStatus==EngineRotationStatus::Cranking);
 }
 
 void calculateSecondarySpark(const config2 &page2, const config10 &page10, const table3d16RpmLoad &sparkLookupTable, statuses &current)

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -243,9 +243,8 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
       ignitionCount = 0;
       stopPumpPriming(currentStatus, configPage2); //Turn off the fuel pump, but only if the priming is complete
       if (configPage6.iacPWMrun == false) { disableIdle(); } //Turn off the idle PWM
-      currentStatus.engineIsCranking = false; //Clear cranking bit (Can otherwise get stuck 'on' even with 0 rpm)
       currentStatus.wueIsActive = false; //Same as above except for WUE
-      currentStatus.engineIsRunning = false; //Same as above except for RUNNING status
+      currentStatus.rotationStatus = EngineRotationStatus::Stopped;
       currentStatus.aseIsActive = false; //Same as above except for ASE status
       currentStatus.isAcceleratingTPS = false; //Same as above but the accel enrich (If using MAP accel enrich a stall will cause this to trigger)
       currentStatus.isDeceleratingTPS = false; //Same as above but the decel enleanment
@@ -451,21 +450,21 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
         //Check whether running or cranking
         if(currentStatus.RPM > currentStatus.crankRPM) //Crank RPM in the config is stored as a x10. currentStatus.crankRPM is set in timers.ino and represents the true value
         {
-          currentStatus.engineIsRunning = true; //Sets the engine running bit
-          //Only need to do anything if we're transitioning from cranking to running
-          if( currentStatus.engineIsCranking )
+          bool crankToRun = currentStatus.rotationStatus==EngineRotationStatus::Cranking;
+          currentStatus.rotationStatus = EngineRotationStatus::Running;
+
+         //Only need to do anything if we're transitioning from cranking to running
+          if( crankToRun )
           {
-            currentStatus.engineIsCranking = false;
             if(configPage4.ignBypassEnabled > 0) { digitalWrite(pinIgnBypass, HIGH); }
           }
         }
         else
         {  
-          if( !currentStatus.engineIsRunning || (currentStatus.RPM < (currentStatus.crankRPM - CRANK_RUN_HYSTER)) )
+          if( (currentStatus.rotationStatus!=EngineRotationStatus::Running) || (currentStatus.RPM < (currentStatus.crankRPM - CRANK_RUN_HYSTER)) )
           {
             //Sets the engine cranking bit, clears the engine running bit
-            currentStatus.engineIsCranking = true;
-            currentStatus.engineIsRunning = false;
+            currentStatus.rotationStatus = EngineRotationStatus::Cranking;
             currentStatus.runSecs = 0; //We're cranking (hopefully), so reset the engine run time to prompt ASE.
             if(configPage4.ignBypassEnabled > 0) { digitalWrite(pinIgnBypass, LOW); }
 
@@ -769,7 +768,7 @@ BEGIN_LTO_ALWAYS_INLINE(void) loop(void)
       //Same as above, except for ignition
 
       //fixedCrankingOverride is used to extend the dwell during cranking so that the decoder can trigger the spark upon seeing a certain tooth. Currently only available on the basic distributor and 4g63 decoders.
-      if ( configPage4.ignCranklock && currentStatus.engineIsCranking && (currentStatus.decoder.getFeatures().hasFixedCrankingTiming) )
+      if ( configPage4.ignCranklock && (currentStatus.rotationStatus==EngineRotationStatus::Cranking) && (currentStatus.decoder.getFeatures().hasFixedCrankingTiming) )
       {
         fixedCrankingOverride = currentStatus.dwell * 3;
         //This is a safety step to prevent the ignition start time occurring AFTER the target tooth pulse has already occurred. It simply moves the start time forward a little, which is compensated for by the increase in the dwell time

--- a/speeduino/statuses.h
+++ b/speeduino/statuses.h
@@ -26,6 +26,17 @@ enum class SchedulerCutStatus : uint8_t
 };
 
 
+/** @brief The engine rotation status */
+enum class EngineRotationStatus : uint8_t
+{
+  /** Not rotating */
+  Stopped, 
+  /** Rotating below the cranking threshold. */
+  Cranking, 
+  /** Rotating above the cranking threshold. */
+  Running, 
+};
+
 /** @brief The status struct with current values for all 'live' variables.
 * 
 * Instantiated as global currentStatus.
@@ -167,12 +178,6 @@ struct statuses {
   // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
   bool clutchTriggerActive : 1; ///< Is the clutch trigger active (true) or not (false)
 
-  // Engine status fields as defined in the INI.  
-  // TODO: engine has 3 states: Off, Cranking, Running. Need to capture this better 
-  // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
-  bool engineIsRunning : 1; ///< Is engine running (true) or not (false) 
-  // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
-  bool engineIsCranking : 1; ///< Is engine cranking (true) or not (false) 
   // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
   bool aseIsActive : 1; ///< Is After Start Enrichment (ASE) active (true) or not (false) 
   // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
@@ -183,7 +188,8 @@ struct statuses {
   bool isAcceleratingTPS : 1;  ///< Are we accelerating (true) or not (false), based on TPS
   // cppcheck-suppress misra-c2012-6.1 ; False positive - MISRA C:2012 Rule (R 6.1) permits the use of boolean for bit fields.
   bool isDeceleratingTPS : 1; ///< Are we decelerating (true) or not (false), based on TPS
-  
+  EngineRotationStatus rotationStatus;
+
   // TODO: make all pulse widths uint16_t
   unsigned int PW1; ///< In uS
   unsigned int PW2; ///< In uS

--- a/speeduino/timers.cpp
+++ b/speeduino/timers.cpp
@@ -102,7 +102,7 @@ void oneMSInterval(void)
   // See if we're in power-on sweep mode
   if( currentStatus.tachoSweepEnabled )
   {
-    if( (currentStatus.engineIsRunning) || (currentStatus.engineIsCranking) || (ms_counter >= TACHO_SWEEP_TIME_MS) )  { currentStatus.tachoSweepEnabled = false; }  // Stop the sweep after SWEEP_TIME, or if real tach signals have started
+    if( (currentStatus.rotationStatus!=EngineRotationStatus::Stopped) || (ms_counter >= TACHO_SWEEP_TIME_MS) )  { currentStatus.tachoSweepEnabled = false; }  // Stop the sweep after SWEEP_TIME, or if real tach signals have started
     else 
     {
       // Ramp the needle smoothly to the max over the SWEEP_RAMP time
@@ -210,7 +210,7 @@ void oneMSInterval(void)
     currentStatus.rpmDOT = (currentStatus.RPM - lastRPM_100ms) * 10; //This is the RPM per second that the engine has accelerated/decelerated in the last loop
     lastRPM_100ms = currentStatus.RPM; //Record the current RPM for next calc
 
-    if ( currentStatus.engineIsRunning ) { runSecsX10++; }
+    if ( currentStatus.rotationStatus==EngineRotationStatus::Running ) { runSecsX10++; }
     else { runSecsX10 = 0; }
 
     if ( (currentStatus.injPrimed == false) && (seclx10 >= configPage2.primingDelay) && (currentStatus.RPM == 0) && (currentStatus.initialisationComplete == true) ) 
@@ -242,7 +242,7 @@ void oneMSInterval(void)
     //**************************************************************************************************************************************************
     //This updates the runSecs variable
     //If the engine is running or cranking, we need to update the run time counter.
-    if (currentStatus.engineIsRunning)
+    if (currentStatus.rotationStatus!=EngineRotationStatus::Stopped)
     { //NOTE - There is a potential for a ~1sec gap between engine crank starting and the runSec number being incremented. This may delay ASE!
       if (currentStatus.runSecs <= (UINT8_MAX-1U)) //Ensure we cap out at 255 and don't overflow. (which would reset ASE and cause problems with the closed loop fuelling (Which has to wait for the O2 to warmup))
         { currentStatus.runSecs++; } //Increment our run counter by 1 second.

--- a/test/test_fuel/test_corrections.cpp
+++ b/test/test_fuel/test_corrections.cpp
@@ -107,7 +107,7 @@ static void setup_correctionCranking(void) {
 static void test_corrections_cranking_inactive(void) {
   setup_correctionCranking();
   
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   currentStatus.aseIsActive = false;
   configPage10.crankingEnrichTaper = 0U;
 
@@ -117,7 +117,7 @@ static void test_corrections_cranking_inactive(void) {
 static void test_corrections_cranking_cranking(void) {
   setup_correctionCranking();
   
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   currentStatus.aseIsActive = false;
   configPage10.crankingEnrichTaper = 0U;
 
@@ -133,11 +133,11 @@ static void test_corrections_cranking_taper_noase(void) {
   currentStatus.ASEValue = 100U;
 
   // Reset taper
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   (void)correctionCranking();
 
   // Advance taper to halfway
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   for (uint8_t index=0; index<configPage10.crankingEnrichTaper/2U; ++index) {
     (void)correctionCranking();
   }
@@ -165,11 +165,11 @@ static void test_corrections_cranking_taper_withase(void) {
   currentStatus.ASEValue = 50U;
 
   // Reset taper
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   (void)correctionCranking();
 
   // Advance taper to halfway
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   for (uint8_t index=0; index<configPage10.crankingEnrichTaper/2U; ++index) {
     (void)correctionCranking();
   }
@@ -201,7 +201,7 @@ extern uint8_t correctionASE(void);
 static void test_corrections_ASE_inactive_cranking(void)
 {
   initialiseCorrections();
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
 
   // Taper finished
   TEST_ASSERT_EQUAL(100U, correctionASE());
@@ -214,7 +214,7 @@ extern table2D_u8_u8_4 ASECountTable; ///< 4 bin After Start duration map (2D)
 static inline void setup_correctionASE(void) {
   initialiseCorrections();
 
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   currentStatus.LOOP_TIMER = 0;
   BIT_SET(currentStatus.LOOP_TIMER, BIT_TIMER_10HZ) ;
   constexpr int16_t COOLANT_INITIAL = temperatureRemoveOffset(150); 
@@ -260,7 +260,7 @@ static void test_corrections_ASE_taper(void) {
   currentStatus.runSecs = 9;
 
   // Advance taper to halfway
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   for (uint8_t index=0; index<configPage2.aseTaperTime/2U; ++index) {
     (void)correctionASE();
   }
@@ -290,7 +290,7 @@ static void test_corrections_ASE(void)
 uint8_t correctionFloodClear(void);
 
 static void test_corrections_floodclear_no_crank_inactive(void) {
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;
 
@@ -298,7 +298,7 @@ static void test_corrections_floodclear_no_crank_inactive(void) {
 }
 
 static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear - 10;
 
@@ -306,7 +306,7 @@ static void test_corrections_floodclear_crank_below_threshold_inactive(void) {
 }
 
 static void test_corrections_floodclear_crank_above_threshold_active(void) {
-  currentStatus.engineIsCranking = true;
+  currentStatus.rotationStatus = EngineRotationStatus::Cranking;
   configPage4.floodClear = 90;
   currentStatus.TPS = configPage4.floodClear + 10;
 
@@ -1597,7 +1597,7 @@ static void test_corrections_correctionsFuel_ae_modes(void) {
   currentStatus.launchingHard = false;
   currentStatus.launchingSoft = false;
   currentStatus.isDFCOActive = false;
-  currentStatus.engineIsCranking = false;
+  currentStatus.rotationStatus = EngineRotationStatus::Running;
   currentStatus.ASEValue = 100U;
 
   configPage2.dfcoEnabled = 0;

--- a/test/test_fuel/test_pw_applyPwLimit.cpp
+++ b/test/test_fuel/test_pw_applyPwLimit.cpp
@@ -8,7 +8,7 @@ static void test_inactive_cranking(void) {
     config10 page10 = {};
     statuses current = {};
 
-    current.engineIsCranking = true;
+    current.rotationStatus = EngineRotationStatus::Cranking;
     TEST_ASSERT_EQUAL(1000, applyPwLimits(1000, 500, page10, current));
 }
 

--- a/test/test_ign/test_corrections.cpp
+++ b/test/test_ign/test_corrections.cpp
@@ -59,7 +59,7 @@ static void test_correctionCLTadvance(void) {
 
 static void test_correctionCrankingFixedTiming_nocrank_inactive(void) {
     setup_clt_advance_table();
-    currentStatus.engineIsCranking = false;
+    currentStatus.rotationStatus = EngineRotationStatus::Running;
     configPage2.crkngAddCLTAdv = 0;
     configPage4.CrankAng = 8;
 
@@ -68,7 +68,7 @@ static void test_correctionCrankingFixedTiming_nocrank_inactive(void) {
 
 static void test_correctionCrankingFixedTiming_crank_fixed(void) {
     setup_clt_advance_table();
-    currentStatus.engineIsCranking = true;
+    currentStatus.rotationStatus = EngineRotationStatus::Cranking;
     configPage2.crkngAddCLTAdv = 0;
 
     configPage4.CrankAng = 8;
@@ -80,7 +80,7 @@ static void test_correctionCrankingFixedTiming_crank_fixed(void) {
 
 static void test_correctionCrankingFixedTiming_crank_coolant(void) {
     setup_clt_advance_table();
-    currentStatus.engineIsCranking = true;
+    currentStatus.rotationStatus = EngineRotationStatus::Cranking;
     configPage2.crkngAddCLTAdv = 1;
     
     configPage4.CrankAng = 8;
@@ -292,7 +292,7 @@ static void setup_correctionIdleAdvance(void) {
     configPage9.idleAdvStartDelay = 0U;
 
     runSecsX10 = configPage2.idleAdvDelay * 5;
-    currentStatus.engineIsRunning = true;
+    currentStatus.rotationStatus = EngineRotationStatus::Running;
     // int idleRPMdelta = (currentStatus.CLIdleTarget - (currentStatus.RPM / 10) ) + 50;
     currentStatus.CLIdleTarget = 100;
     currentStatus.setRpm( (configPage2.idleAdvRPM * 100U) - 1U);
@@ -338,7 +338,7 @@ static void test_correctionIdleAdvance_inactive_notrunning(void) {
     setup_correctionIdleAdvance();
     
     TEST_ASSERT_EQUAL(23, correctionIdleAdvance(8));
-    currentStatus.engineIsRunning = false;
+    currentStatus.rotationStatus = EngineRotationStatus::Stopped;
     TEST_ASSERT_EQUAL(8, correctionIdleAdvance(8));
 }
 

--- a/test/test_ign/test_dwell.cpp
+++ b/test/test_ign/test_dwell.cpp
@@ -7,7 +7,7 @@ static void test_computeDwell_cranking(void) {
     config4 p4 = {};
     table3d4RpmLoad table = {};
 
-    cur.engineIsCranking = true;
+    cur.rotationStatus = EngineRotationStatus::Cranking;
     p4.dwellCrank = 43; // 4.3 ms stored as ms*10
 
     TEST_ASSERT_EQUAL_UINT16(4300U, computeDwell(cur, p2, p4, table));
@@ -19,7 +19,7 @@ static void test_computeDwell_map(void) {
     config4 p4 = {};
     table3d4RpmLoad table = {};
 
-    cur.engineIsCranking = false;
+    cur.rotationStatus = EngineRotationStatus::Running;
     p2.useDwellMap = true;
 
     // Fill the dwell table with a constant value of 55 (5.5 ms -> 5500 us)
@@ -34,7 +34,7 @@ static void test_computeDwell_running(void) {
     config4 p4 = {};
     table3d4RpmLoad table = {};
 
-    cur.engineIsCranking = false;
+    cur.rotationStatus = EngineRotationStatus::Running;
     p2.useDwellMap = false;
     p4.dwellRun = 60; // 6.0 ms -> 6000 us
 

--- a/test/test_secondary/test_secondary_spark.cpp
+++ b/test/test_secondary/test_secondary_spark.cpp
@@ -155,7 +155,7 @@ static void __attribute__((noinline)) test_cranking_no_secondary_spark(void) {
     table3d16RpmLoad lookupTable;
 
     setup_test_mode_simple(page2, page10, current, lookupTable, SPARK2_MODE_MULTIPLY);
-    current.engineIsCranking = true;// Should turn 2nd table off
+    current.rotationStatus = EngineRotationStatus::Cranking;// Should turn 2nd table off
     calculateSecondarySpark(page2, page10, lookupTable, current);
     assert_2nd_spark_is_off(current, SIMPLE_ADVANCE1);
 }


### PR DESCRIPTION
The engine can be stopped, cranking or running: this is currently captured in `statuses::engineIsRunning` & `engineIsCranking`.  However, taken together these allow a 4th invalid state:
| engineIsRunning | engineIsCranking | rotationStatus |
|-----------------|------------------|----------------|
| FALSE           | FALSE            | Stopped        |
| TRUE            | FALSE            | Running        |
| FALSE           | TRUE             | Cranking       |
| TRUE            | TRUE             | **Invalid**        |

So replace `statuses::engineIsRunning` & `engineIsCranking` with an enum (`rotationStatus`) that only has 3 possible values.