### PR TITLE
Fix micros() rollover in stepper IAC step timing

### DIFF
--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -240,7 +240,7 @@ static inline uint8_t checkForStepping(void)
       timeCheck = iacCoolTime_uS;
     }
 
-    if(micros() > (idleStepper.stepStartTime + timeCheck) )
+    if( (micros() - idleStepper.stepStartTime) > timeCheck )
     {         
       if(idleStepper.stepperStatus == STEPPING)
       {


### PR DESCRIPTION
## Summary

In `checkForStepping()` the end of the STEP/COOLING phase was detected with:

```cpp
if(micros() > (idleStepper.stepStartTime + timeCheck) )
```

When a step starts within `timeCheck` microseconds of the 32-bit `micros()` wrap (every ~71.6 minutes), `stepStartTime + timeCheck` overflows to a small value and the condition becomes true immediately. This truncates the STEP pulse below the configured `iacStepTime`, which can cause the motor to miss the step and permanently desync `curIdleStep` from the real pintle position (never recovered until the next homing).

This PR replaces the comparison with the standard rollover-safe form:

```cpp
if( (micros() - idleStepper.stepStartTime) > timeCheck )
```

## Testing

- Compiled successfully for `megaatmega2560`.
- Unsigned-subtraction rollover behaviour verified by inspection: `micros() - stepStartTime` yields the correct elapsed time across the wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)