### PR TITLE
Fix idleUpAdder applied twice while cranking in stepper closed loop modes

### DIFF
--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -609,7 +609,7 @@ void idleControl(void)
         {
           //Currently cranking. Use the cranking table
           idleStepper.targetIdleStep = table2D_getValue(&iacCrankStepsTable, temperatureAddOffset(currentStatus.coolant)) * 3; //All temps are offset by 40 degrees. Step counts are divided by 3 in TS. Multiply back out here
-          if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } //Add Idle Up amount if active
+          //Note: Idle Up amount is added to targetIdleStep after this if/else block, common to all engine states. Adding it here as well would apply it twice.
 
           //limit to the configured max steps. This must include any idle up adder, to prevent over-opening.
           if (idleStepper.targetIdleStep > (configPage9.iacMaxSteps * 3) )


### PR DESCRIPTION
## Summary

In `idleControl()`, for `IAC_ALGORITHM_STEP_CL` / `IAC_ALGORITHM_STEP_OLCL`, the not-running (cranking) branch added `idleUpAdder` to `targetIdleStep`, and the unconditional add located after the if/else block then added it a **second** time:

```cpp
if( currentStatus.rotationStatus!=EngineRotationStatus::Running )
{
  idleStepper.targetIdleStep = table2D_getValue(&iacCrankStepsTable, ...) * 3;
  if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } // 1st add
  ...
}
...
if(currentStatus.idleUpActive == true) { idleStepper.targetIdleStep += configPage2.idleUpAdder; } // 2nd add
```

With idle-up active while cranking/stalled, the valve target was inflated by 2x the configured adder (bounded only by the `iacMaxSteps` clamp), and the doubled value also seeded `idle_pid_target_value` / `FeedForwardTerm` used by the post-start taper.

This PR removes the add inside the cranking branch and keeps the common one, so the adder is applied exactly once in all engine states, matching the running-branch behaviour (the STEP_OL algorithm is already correct in this regard).

## Testing

- Compiled successfully for `megaatmega2560`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)