### PR TITLE
Shared/common initialization of all PWM max counts

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -172,7 +172,7 @@ static uint32_t vvtWarmTime;
 TESTABLE_STATIC bool vvtIsHot;
 TESTABLE_STATIC bool vvtTimeHold;
 static uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
-uint16_t boost_pwm_max_count; //Used for variable PWM frequency
+static uint16_t boost_pwm_max_count; //Used for variable PWM frequency
 constexpr table2D_u8_s16_6 flexBoostTable(&configPage10.flexBoostBins, &configPage10.flexBoostAdj);
 
 //Old PID method. Retained in case the new one has issues
@@ -605,6 +605,7 @@ void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
   if(configPage10.n2o_minTPS == 255) { configPage10.n2o_enable = 0; }
 
   setBoostPidTunings(configPage2, configPage6, configPage10);
+  boost_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.boostFreq));
 
   if( configPage6.vvtEnabled > 0)
   {

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -171,7 +171,7 @@ static volatile unsigned int boost_pwm_cur_value = 0;
 static uint32_t vvtWarmTime;
 TESTABLE_STATIC bool vvtIsHot;
 TESTABLE_STATIC bool vvtTimeHold;
-uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
+static uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
 uint16_t boost_pwm_max_count; //Used for variable PWM frequency
 constexpr table2D_u8_s16_6 flexBoostTable(&configPage10.flexBoostBins, &configPage10.flexBoostAdj);
 
@@ -610,14 +610,7 @@ void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
   {
     currentStatus.vvt1Angle = 0;
     currentStatus.vvt2Angle = 0;
-
-    #if defined(CORE_AVR)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #elif defined(CORE_TEENSY35)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #elif defined(CORE_TEENSY41)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #endif
+    vvt_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.vvtFreq));
 
     if(configPage6.vvtMode == VVT_MODE_CLOSED_LOOP)
     {
@@ -640,14 +633,8 @@ void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
   if( (configPage6.vvtEnabled == 0) && (configPage10.wmiEnabled >= 1) )
   {
     // config wmi pwm output to use vvt output
-    #if defined(CORE_AVR)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #elif defined(CORE_TEENSY35)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #elif defined(CORE_TEENSY41)
-      vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    #endif
-   currentStatus.wmiTankEmpty = false;
+    vvt_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.vvtFreq));
+    currentStatus.wmiTankEmpty = false;
     currentStatus.wmiPW = 0;
     vvt1_pwm_value = 0;
     vvt2_pwm_value = 0;

--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -150,7 +150,7 @@ static bool isWmiTankEmpty(void)
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
 volatile bool fan_pwm_state;
-uint16_t fan_pwm_max_count; //Used for variable PWM frequency
+static uint16_t fan_pwm_max_count; //Used for variable PWM frequency
 volatile unsigned int fan_pwm_cur_value;
 TESTABLE_STATIC long fan_pwm_value;
 #endif
@@ -432,16 +432,14 @@ void __attribute__((optimize("Os"))) initialiseFan(uint8_t fanPin)
   currentStatus.fanOn = false;
   currentStatus.fanDuty = 0;
 
-  #if defined(PWM_FAN_AVAILABLE)
-    DISABLE_FAN_TIMER(); //disable FAN timer if available
-    if ( configPage2.fanEnable == 2 ) // PWM Fan control
-    {
-      #if defined(CORE_TEENSY)
-        fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.fanFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-      #endif
-      fan_pwm_value = 0;
-    }
-  #endif
+#if defined(PWM_FAN_AVAILABLE)
+  DISABLE_FAN_TIMER(); //disable FAN timer if available
+  if ( configPage2.fanEnable == 2 ) // PWM Fan control
+  {
+    fan_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.fanFreq));
+    fan_pwm_value = 0;
+  }
+#endif
 }
 
 void fanControl(void)

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -29,7 +29,6 @@ extern uint16_t fan_pwm_max_count; //Used for variable PWM frequency
 void fanInterrupt(void);
 #endif
 
-extern uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
 extern uint16_t boost_pwm_max_count; //Used for variable PWM frequency
 
 void boostInterrupt(void);

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -25,7 +25,6 @@ void fanOn(void);
 void fanOff(void);
 
 #if defined(PWM_FAN_AVAILABLE)//PWM fan not available on Arduino MEGA
-extern uint16_t fan_pwm_max_count; //Used for variable PWM frequency
 void fanInterrupt(void);
 #endif
 

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -29,8 +29,6 @@ extern uint16_t fan_pwm_max_count; //Used for variable PWM frequency
 void fanInterrupt(void);
 #endif
 
-extern uint16_t boost_pwm_max_count; //Used for variable PWM frequency
-
 void boostInterrupt(void);
 void vvtInterrupt(void);
 

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -159,11 +159,6 @@ void initBoard(uint32_t baudRate)
     TCCR1B = TIMER_PRESCALER_256;   //Timer1 Control Reg B: Timer Prescaler set to 256. 1 tick = 16uS.
     TIFR1 = (1 << OCF1A) | (1<<OCF1B) | (1<<OCF1C) | (1<<TOV1) | (1<<ICF1); //Clear the compare flags, overflow flag and external input flag bits
 
-    if (isPwmIac(configPage6))
-    {
-      idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-    }
-
     /*
     ***********************************************************************************************************
     * Timers

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -159,7 +159,6 @@ void initBoard(uint32_t baudRate)
     TCCR1B = TIMER_PRESCALER_256;   //Timer1 Control Reg B: Timer Prescaler set to 256. 1 tick = 16uS.
     TIFR1 = (1 << OCF1A) | (1<<OCF1B) | (1<<OCF1C) | (1<<TOV1) | (1<<ICF1); //Clear the compare flags, overflow flag and external input flag bits
 
-    boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
     if (isPwmIac(configPage6))
     {
       idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -292,4 +292,10 @@ storage_api_t getBoardStorageApi(void)
   return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void)
+{
+  return 16;
+}
+
 #endif //CORE_AVR

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -160,7 +160,6 @@ void initBoard(uint32_t baudRate)
     TIFR1 = (1 << OCF1A) | (1<<OCF1B) | (1<<OCF1C) | (1<<TOV1) | (1<<ICF1); //Clear the compare flags, overflow flag and external input flag bits
 
     boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
-    vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle
     if (isPwmIac(configPage6))
     {
       idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz

--- a/speeduino/board_definition.h
+++ b/speeduino/board_definition.h
@@ -44,6 +44,9 @@ uint8_t getSystemTemp(void);
 /** @brief Get the storage API for the board */
 storage_api_t getBoardStorageApi(void);
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void);
+
 ///@cond 
 // Shared building blocks for the board headers
 #define _ANALOG_PINS_A0_A8  A0, A1, A2, A3, A4, A5, A6, A7, A8

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -166,4 +166,10 @@ storage_api_t getBoardStorageApi(void)
   return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void)
+{
+  return 2;
+}
+
 #endif

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -230,11 +230,6 @@ STM32RTC& rtc = STM32RTC::getInstance();
     ***********************************************************************************************************
     * Idle
     */
-    if (isPwmIac(configPage6))
-    {
-        idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 5KHz
-    } 
-
     //This must happen at the end of the idle init
     #if ( STM32_CORE_VERSION_MAJOR < 2 )
     Timer1.setMode(4, TIMER_OUTPUT_COMPARE);

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -273,9 +273,6 @@ STM32RTC& rtc = STM32RTC::getInstance();
     ***********************************************************************************************************
     * Auxiliaries
     */
-    //2uS resolution Min 8Hz, Max 5KHz
-    fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.fanFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle
-
     //Need to be initialised last due to instant interrupt
     #if ( STM32_CORE_VERSION_MAJOR < 2 )
     Timer1.setMode(1, TIMER_OUTPUT_COMPARE);

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -274,7 +274,6 @@ STM32RTC& rtc = STM32RTC::getInstance();
     * Auxiliaries
     */
     //2uS resolution Min 8Hz, Max 5KHz
-    boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
     fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.fanFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle
 
     //Need to be initialised last due to instant interrupt

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -275,7 +275,6 @@ STM32RTC& rtc = STM32RTC::getInstance();
     */
     //2uS resolution Min 8Hz, Max 5KHz
     boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
-    vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle
     fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (TIMER_RESOLUTION * configPage6.fanFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 4uS) it takes to complete 1 cycle
 
     //Need to be initialised last due to instant interrupt

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -517,4 +517,10 @@ storage_api_t getBoardStorageApi(void)
   return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void)
+{
+  return TIMER_RESOLUTION;
+}
+
 #endif

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -472,4 +472,10 @@ storage_api_t getBoardStorageApi(void)
   return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void)
+{
+  return 32;
+}
+
 #endif

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -97,8 +97,6 @@ void initBoard(uint32_t baudRate)
 
         //Enable IRQ Interrupt
         NVIC_ENABLE_IRQ(IRQ_FTM2);
-
-        idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 32uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
     }
 
     /*

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -173,8 +173,6 @@ void initBoard(uint32_t baudRate)
 
         //Enable IRQ Interrupt
         NVIC_ENABLE_IRQ(IRQ_FTM1);
-
-        fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.fanFreq * 2U));     //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
     }
 
     /*

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -175,7 +175,6 @@ void initBoard(uint32_t baudRate)
         NVIC_ENABLE_IRQ(IRQ_FTM1);
 
         boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
-        vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.vvtFreq * 2U));     //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
         fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.fanFreq * 2U));     //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
     }
 

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -174,7 +174,6 @@ void initBoard(uint32_t baudRate)
         //Enable IRQ Interrupt
         NVIC_ENABLE_IRQ(IRQ_FTM1);
 
-        boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
         fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (32U * configPage6.fanFreq * 2U));     //Converts the frequency in Hz to the number of ticks (at 16uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
     }
 

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -425,4 +425,10 @@ storage_api_t getBoardStorageApi(void)
   return getEEPROMStorageApi(getEepromWriteBlockSize);
 }
 
+/** @brief Get the PWM timer resolution in uS */
+uint8_t getPwmTimerResolution(void)
+{
+  return 2;
+}
+
 #endif

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -68,8 +68,6 @@ void initBoard(uint32_t /*baudRate*/)
       PIT_TCTRL0 |= PIT_TCTRL_TIE; // enable Timer 1 interrupts
       PIT_TCTRL0 |= PIT_TCTRL_TEN; // start Timer 1
       PIT_LDVAL0 = 1; //1 * 2uS = 2uS
-
-      idle_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.idleFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. Note that the frequency is divided by 2 coming from TS to allow for up to 512hz
     }
 
     /*

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -104,7 +104,6 @@ void initBoard(uint32_t /*baudRate*/)
     }
 
     //2uS resolution Min 8Hz, Max 5KHz
-    boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
     #if defined(PWM_FAN_AVAILABLE)
       fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle
     #endif

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -105,7 +105,6 @@ void initBoard(uint32_t /*baudRate*/)
 
     //2uS resolution Min 8Hz, Max 5KHz
     boost_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.boostFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle. The x2 is there because the frequency is stored at half value (in a byte) to allow frequencies up to 511Hz
-    vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle
     #if defined(PWM_FAN_AVAILABLE)
       fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle
     #endif

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -103,11 +103,6 @@ void initBoard(uint32_t /*baudRate*/)
       PIT_LDVAL2 = 1; //1 * 2uS = 2uS
     }
 
-    //2uS resolution Min 8Hz, Max 5KHz
-    #if defined(PWM_FAN_AVAILABLE)
-      fan_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (2U * configPage6.vvtFreq * 2U)); //Converts the frequency in Hz to the number of ticks (at 2uS) it takes to complete 1 cycle
-    #endif
-
     //TODO: Configure timers here
 
     /*

--- a/speeduino/idle.cpp
+++ b/speeduino/idle.cpp
@@ -44,7 +44,7 @@ static unsigned int completedHomeSteps;
 
 static volatile bool idle_pwm_state;
 static bool lastDFCOValue;
-uint16_t idle_pwm_max_count; //Used for variable PWM frequency
+static uint16_t idle_pwm_max_count; //Used for variable PWM frequency
 static volatile unsigned int idle_pwm_cur_value;
 static int32_t idle_pid_target_value;
 static int32_t FeedForwardTerm;
@@ -112,6 +112,8 @@ void initialiseIdle(bool forcehoming)
   idle_pin.setPin(pinIdle1, OUTPUT);
   idle2_pin.setPin(pinIdle2, OUTPUT);
 
+  idle_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.idleFreq));
+  
   //Initialising comprises of setting the 2D tables with the relevant values from the config pages
   switch(configPage6.iacAlgorithm)
   {

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -3,8 +3,6 @@
 
 #include <stdint.h>
 
-extern uint16_t idle_pwm_max_count; //Used for variable PWM frequency
-
 void initialiseIdle(bool forcehoming);
 void idleControl(void);
 void disableIdle(void);

--- a/speeduino/maths.cpp
+++ b/speeduino/maths.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include "maths.h"
+#include "board_definition.h"
 
 //Generates a random number from 1 to 100 (inclusive).
 //The initial seed used is always based on micros(), though this is unlikely to cause an issue as the first run is nearly random itself
@@ -26,4 +27,10 @@ uint8_t random1to100(void) noexcept
   }
   while(a >= 100U);
   return (a+1U);
+}
+
+uint16_t pwmFreqToTicks(uint16_t frequency)
+{
+  frequency = max(frequency, (uint16_t)1); // Prevent division by zero
+  return (uint16_t)(MICROS_PER_SEC / (getPwmTimerResolution() * frequency));
 }

--- a/speeduino/maths.h
+++ b/speeduino/maths.h
@@ -27,6 +27,9 @@ static constexpr uint32_t MICROS_PER_HOUR = MICROS_PER_MIN*60U;
 /** @brief Self-explanatory */
 static constexpr uint32_t MILLI_PER_SEC = MICROS_PER_SEC/1000;
 
+/** @brief Convert a frequency in Hz to the equivalent number of PWM timer ticks */
+uint16_t pwmFreqToTicks(uint16_t frequency);
+
 /**
  * @defgroup group-rounded-div Rounding integer division
  * 

--- a/speeduino/units.h
+++ b/speeduino/units.h
@@ -140,6 +140,9 @@ static constexpr conversionFactor<int16_t, uint8_t> TEMPERATURE = { .scale=1U, .
 /** @brief The fuel trim tables are offset by 128 to allow for -50% to +50% values */
 static constexpr conversionFactor<int8_t, uint8_t> FUEL_TRIM = { .scale=1U, .translate=-127 };
 
+/** @brief Frequency range from 0 to 512 */
+static constexpr conversionFactor<uint16_t, uint8_t> FREQUENCY = { .scale=2U, .translate=0U };
+
 ///@}
 
 /**

--- a/test/test_fancontrol/shared.cpp
+++ b/test/test_fancontrol/shared.cpp
@@ -35,4 +35,5 @@ void setup_pwm_tune(void)
     const uint8_t values[] = {0, 0, 200, 200};
     populate_2dtable(&fanPWMTable, values, bins);
     configPage2.fanEnable = 2U;
+    configPage6.fanFreq = 55;
 }

--- a/test/test_math/test_other.cpp
+++ b/test/test_math/test_other.cpp
@@ -2,6 +2,7 @@
 #include "test_fp_support.h"
 #include "maths.h"
 #include "../test_utils.h"
+#include "board_definition.h"
 
 static void test_nudge_i16(void)
 {
@@ -58,9 +59,19 @@ static void test_clamp(void)
   TEST_ASSERT_EQUAL_UINT32(200, clamp((uint32_t)250, (uint32_t)10, (uint32_t)200));
 }
 
+static void test_pwmFreqToTicks(void)
+{
+  auto resolution = getPwmTimerResolution();
+  TEST_ASSERT_EQUAL_UINT16(MICROS_PER_SEC/resolution, pwmFreqToTicks(0));
+  TEST_ASSERT_EQUAL_UINT16(MICROS_PER_SEC/resolution, pwmFreqToTicks(1));
+  TEST_ASSERT_NOT_EQUAL_UINT16(1, pwmFreqToTicks(512));
+  TEST_ASSERT_NOT_EQUAL_UINT16(1, pwmFreqToTicks(UINT16_MAX));
+}
+
 void testOther(void) {
   SET_UNITY_FILENAME() {
     RUN_TEST(test_nudge_i16);
     RUN_TEST(test_clamp);
+    RUN_TEST(test_pwmFreqToTicks);
   }
 }

--- a/test/test_vvtcontrol/test_vvtcontrol.cpp
+++ b/test/test_vvtcontrol/test_vvtcontrol.cpp
@@ -63,8 +63,6 @@ static void setup_vvt_basic_tune(uint8_t mode)
   configPage10.vvtCLMinAng = INT8_MIN+5;
   configPage10.vvtCLMaxAng = UINT8_MAX-5;
   configPage10.vvtCLholdDuty = 100U;
-
-  vvt_pwm_max_count = (uint16_t)(MICROS_PER_SEC / (16U * configPage6.vvtFreq * 2U));
 }
 
 static void setup_vvt_onconditions(void)


### PR DESCRIPTION
Currently, PWM max counts (E.g. `boost_pwm_max_count`) are initialized inconsistently: 
* In board `.cpp` file; or...
* In the controller; or...
* Both places; or...
* Not initialized at (depending on the board & which PWM controller)
  * This is a silent error - it will compile, then fail at runtime

At best, this makes for flaky PWM related unit tests.

This PR makes PWM max count initialization consistent and explicit:
1. The PWM timer resolution is the same for all timers *per board*: this exposed by `getPwmTimerResolution()`
2. Using `getPwmTimerResolution()`, the frequency to timer ticks is a simple calculation: `pwmFreqToTicks()`
3. Using `pwmFreqToTicks()` each controller can compute a PWM max count however is required.

Bonus: the max counts can now be given internal linkage (I.e. `static`) 