### PR TITLE
Streamline trigger pin initialization

### DIFF
--- a/speeduino/decoder_init.cpp
+++ b/speeduino/decoder_init.cpp
@@ -6,6 +6,8 @@
 #include "preprocessor.h"
 #include "unit_testing.h"
 
+#pragma GCC optimize("Os")
+
 static decoder_t defaultInitFunc(void)
 {
   return decoder_builder_t().build();
@@ -130,9 +132,10 @@ decoder_t buildDecoder(uint8_t decoderIndex)
 {
   decoder_t decoder = getDecoderInitFunc(decoderIndex)();
 
-  decoder.primary.attach(pinTrigger);
-  decoder.secondary.attach(pinTrigger2);
-  decoder.tertiary.attach(pinTrigger3);
+  // TODO: attach interrupts & init pins within the decoder init func
+  pinTrigger = decoder.primary.attach(pinTrigger);
+  pinTrigger2 = decoder.secondary.attach(pinTrigger2);
+  pinTrigger3 = decoder.tertiary.attach(pinTrigger3);
   
   initDecoderPins(pinTrigger, pinTrigger2, pinTrigger3);
 

--- a/speeduino/decoder_init.cpp
+++ b/speeduino/decoder_init.cpp
@@ -132,12 +132,9 @@ decoder_t buildDecoder(uint8_t decoderIndex)
 {
   decoder_t decoder = getDecoderInitFunc(decoderIndex)();
 
-  // TODO: attach interrupts & init pins within the decoder init func
   pinTrigger = decoder.primary.attach(pinTrigger);
   pinTrigger2 = decoder.secondary.attach(pinTrigger2);
   pinTrigger3 = decoder.tertiary.attach(pinTrigger3);
-  
-  initDecoderPins(pinTrigger, pinTrigger2, pinTrigger3);
 
   // Turn off per tooth ignition if the decoder doesn't support it
   configPage2.perToothIgn = configPage2.perToothIgn && decoder.getFeatures().supportsPerToothIgnition;

--- a/speeduino/decoder_t.cpp
+++ b/speeduino/decoder_t.cpp
@@ -1,0 +1,28 @@
+#include <Arduino.h>
+#include "decoder_t.h"
+
+#pragma GCC optimize("Os")
+
+// Just in case
+static_assert(TRIGGER_EDGE_NONE != LOW, "LOW edge value conflict");
+static_assert(TRIGGER_EDGE_NONE != HIGH, "HIGH edge value conflict");
+static_assert(TRIGGER_EDGE_NONE != RISING, "RISING edge value conflict");
+static_assert(TRIGGER_EDGE_NONE != FALLING, "FALLING edge value conflict");
+static_assert(TRIGGER_EDGE_NONE != CHANGE, "CHANGE edge value conflict");
+
+uint8_t interrupt_t::attach(uint8_t pin) const
+{
+    detach(pin);
+    if (isValid() && (pin!=NOT_A_PIN))
+    {
+        attachInterrupt(digitalPinToInterrupt(pin), callback, edge);
+        return pin;
+    }
+    return NOT_A_PIN;
+}  
+
+/** @brief Detach the interrupt from a pin */
+void interrupt_t::detach(uint8_t pin) const
+{
+    detachInterrupt( digitalPinToInterrupt(pin) );
+}  

--- a/speeduino/decoder_t.cpp
+++ b/speeduino/decoder_t.cpp
@@ -10,10 +10,12 @@ static_assert(TRIGGER_EDGE_NONE != RISING, "RISING edge value conflict");
 static_assert(TRIGGER_EDGE_NONE != FALLING, "FALLING edge value conflict");
 static_assert(TRIGGER_EDGE_NONE != CHANGE, "CHANGE edge value conflict");
 
-uint8_t interrupt_t::attach(uint8_t pin) const
+uint8_t interrupt_t::attach(uint8_t pin)
 {
     detach(pin);
-    if (isValid() && (pin!=NOT_A_PIN))
+
+    _pin.setPin(pin);
+    if (isValid())
     {
         attachInterrupt(digitalPinToInterrupt(pin), callback, edge);
         return pin;
@@ -22,7 +24,18 @@ uint8_t interrupt_t::attach(uint8_t pin) const
 }  
 
 /** @brief Detach the interrupt from a pin */
-void interrupt_t::detach(uint8_t pin) const
+void interrupt_t::detach(uint8_t pin)
 {
     detachInterrupt( digitalPinToInterrupt(pin) );
+    _pin.setPin(NOT_A_PIN);
 }  
+
+bool interrupt_t::isTriggered(void) const
+{
+    return isValid()
+    && (
+           (edge==CHANGE)
+        || (edge==FALLING && !isPinHigh())
+        || (edge==RISING && isPinHigh())
+    );
+}

--- a/speeduino/decoder_t.h
+++ b/speeduino/decoder_t.h
@@ -1,16 +1,9 @@
 #pragma once
 
 #include <stdint.h>
-#include <Arduino.h>
 
 /** @brief This constant represents no trigger edge */
 static constexpr uint8_t TRIGGER_EDGE_NONE = 99;
-// Just in case
-static_assert(TRIGGER_EDGE_NONE != LOW, "LOW edge value conflict");
-static_assert(TRIGGER_EDGE_NONE != HIGH, "HIGH edge value conflict");
-static_assert(TRIGGER_EDGE_NONE != RISING, "RISING edge value conflict");
-static_assert(TRIGGER_EDGE_NONE != FALLING, "FALLING edge value conflict");
-static_assert(TRIGGER_EDGE_NONE != CHANGE, "CHANGE edge value conflict");
 
 /** @brief This structure represents a trigger interrupt */
 struct interrupt_t
@@ -23,27 +16,16 @@ struct interrupt_t
   uint8_t edge = TRIGGER_EDGE_NONE;
 
   /** @brief Attach the interrupt to a pin */
-  void attach(uint8_t pin) const
-  {
-    detach(pin);
-    if (isValid())
-    {
-      attachInterrupt(digitalPinToInterrupt(pin), callback, edge);
-    }
-  }  
+  uint8_t attach(uint8_t pin) const;
 
   /** @brief Detach the interrupt from a pin */
-  void detach(uint8_t pin) const
-  {
-    detachInterrupt( digitalPinToInterrupt(pin) );
-  }  
+  void detach(uint8_t pin) const;
 
   bool isValid(void) const
   {
     return edge!=TRIGGER_EDGE_NONE && callback!=nullptr;
   }
 };
-
 
 /** \enum SyncStatus
  * @brief The decoder trigger status

--- a/speeduino/decoder_t.h
+++ b/speeduino/decoder_t.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "src/pins/boardInputPin.h"
 
 /** @brief This constant represents no trigger edge */
 static constexpr uint8_t TRIGGER_EDGE_NONE = 99;
@@ -15,16 +16,42 @@ struct interrupt_t
   /** @brief The edge type for the interrupt. E.g. RISING, FALLING, CHANGE */
   uint8_t edge = TRIGGER_EDGE_NONE;
 
+  interrupt_t() = default;
+  interrupt_t(callback_t _callback, uint8_t _edge)
+  : callback(_callback)
+  , edge(_edge)
+  {
+  }
+
   /** @brief Attach the interrupt to a pin */
-  uint8_t attach(uint8_t pin) const;
+  uint8_t attach(uint8_t pin);
 
   /** @brief Detach the interrupt from a pin */
-  void detach(uint8_t pin) const;
+  void detach(uint8_t pin);
 
+  /**
+   * @brief Does the pin state match the edge setting? 
+   * 
+   * @note Will always return true for the @ref CHANGE trigger edge
+  */
+  bool isTriggered(void) const;
+
+  /** @brief Is the interrupt configured correctly? */
   bool isValid(void) const
   {
-    return edge!=TRIGGER_EDGE_NONE && callback!=nullptr;
+    return edge!=TRIGGER_EDGE_NONE 
+        && callback!=nullptr
+        && _pin.isValid();
   }
+
+  bool isPinHigh(void) const {
+    return _pin.isPinHigh();
+  }
+
+#if !defined(UNIT_TEST)
+private:
+#endif
+  boardInputPin_t _pin;
 };
 
 /** \enum SyncStatus

--- a/speeduino/decoder_t.h
+++ b/speeduino/decoder_t.h
@@ -48,9 +48,6 @@ struct interrupt_t
     return _pin.isPinHigh();
   }
 
-#if !defined(UNIT_TEST)
-private:
-#endif
   boardInputPin_t _pin;
 };
 

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -104,10 +104,6 @@ TESTABLE_STATIC decoder_status_t decoderStatus;
 static libdivide::libdivide_s16_t divTriggerToothAngle;
 #endif
 
-TESTABLE_STATIC boardInputPin_t triggerPri_pin;
-TESTABLE_STATIC boardInputPin_t triggerSec_pin;
-TESTABLE_STATIC boardInputPin_t triggerThird_pin;
-
 #define TOOTH_CRANK 0
 #define TOOTH_CAM_SECONDARY 1
 #define TOOTH_CAM_TERTIARY  2
@@ -163,26 +159,26 @@ static inline void addToothLogEntry(unsigned long toothTime, byte whichTooth)
       if(currentStatus.compositeTriggerUsed == 4)
       {
         // we want to display both cams so swap the values round to display primary as cam1 and secondary as cam2, include the crank in the data as the third output
-        if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
-        if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); }
-        if(triggerPri_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
+        if(currentStatus.decoder.secondary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
+        if(currentStatus.decoder.tertiary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); }
+        if(currentStatus.decoder.primary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
         if(whichTooth > TOOTH_CAM_SECONDARY) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_TRIG); }
       }
       else
       {
         // we want to display crank and one of the cams
-        if(triggerPri_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
+        if(currentStatus.decoder.primary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_PRI); }
         if(currentStatus.compositeTriggerUsed == 3)
         { 
           // display cam2 and also log data for cam 1
-          if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } // only the COMPOSITE_LOG_SEC value is visualised hence the swapping of the data
-          if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); } 
+          if(currentStatus.decoder.tertiary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } // only the COMPOSITE_LOG_SEC value is visualised hence the swapping of the data
+          if(currentStatus.decoder.secondary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); } 
         } 
         else
         { 
           // display cam1 and also log data for cam 2 - this is the historic composite view
-          if(triggerSec_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } 
-          if(triggerThird_pin.isPinHigh() == true) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
+          if(currentStatus.decoder.secondary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_SEC); } 
+          if(currentStatus.decoder.tertiary.isPinHigh()) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_THIRD); }
         }
         if(whichTooth > TOOTH_CRANK) { BIT_SET(compositeLogHistory[toothHistoryIndex], COMPOSITE_LOG_TRIG); }
       }  
@@ -223,7 +219,7 @@ void loggerPrimaryISR(void)
   2) If the primary trigger is FALLING, then check whether the primary is currently LOW
   If either of these are true, the primary decoder function is called
   */
-  if( ( (currentStatus.decoder.primary.edge == RISING) && (triggerPri_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.primary.edge == FALLING) && (triggerPri_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.primary.edge == CHANGE) )
+  if(currentStatus.decoder.primary.isTriggered())
   {
     currentStatus.decoder.primary.callback();
     validEdge = true;
@@ -255,7 +251,7 @@ void loggerSecondaryISR(void)
   3) The secondary trigger is CHANGING
   If any of these are true, the primary decoder function is called
   */
-  if( ( (currentStatus.decoder.secondary.edge == RISING) && (triggerSec_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.secondary.edge == FALLING) && (triggerSec_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.secondary.edge == CHANGE) )
+  if (currentStatus.decoder.secondary.isTriggered())
   {
     currentStatus.decoder.secondary.callback();
   }
@@ -282,7 +278,7 @@ void loggerTertiaryISR(void)
   */
 
 
-  if( ( (currentStatus.decoder.tertiary.edge == RISING) && ( triggerThird_pin.isPinHigh() == HIGH) ) || ( (currentStatus.decoder.tertiary.edge == FALLING) && (triggerThird_pin.isPinHigh() == LOW) ) || (currentStatus.decoder.tertiary.edge == CHANGE) )
+  if(currentStatus.decoder.tertiary.isTriggered())
   {
     currentStatus.decoder.tertiary.callback();
   }
@@ -597,7 +593,7 @@ static void triggerPri_missingTooth(void)
                 toothCurrentCount = 1;
                 if (configPage4.trigPatternSec == SEC_TRIGGER_POLL) // at tooth one check if the cam sensor is high or low in poll level mode
                 {
-                  if (configPage4.PollLevelPolarity == triggerSec_pin.isPinHigh()) { revolutionOne = 1; }
+                  if (configPage4.PollLevelPolarity == currentStatus.decoder.secondary.isPinHigh()) { revolutionOne = 1; }
                   else { revolutionOne = 0; }
                 }
                 else {revolutionOne = !revolutionOne;} //Flip sequential revolution tracker if poll level is not used
@@ -1662,21 +1658,21 @@ static void triggerPri_4G63(void)
     {
       triggerSecFilterTime = 0;
       //New secondary method of determining sync
-      if(triggerPri_pin.isPinHigh() == true)
+      if(currentStatus.decoder.primary.isPinHigh())
       {
-        if(triggerSec_pin.isPinHigh() == true) { revolutionOne = true; }
+        if(currentStatus.decoder.secondary.isPinHigh()) { revolutionOne = true; }
         else { revolutionOne = false; }
       }
       else
       {
-        if( (triggerSec_pin.isPinHigh() == false) && (revolutionOne == true) ) 
+        if( (!currentStatus.decoder.secondary.isPinHigh()) && (revolutionOne == true) ) 
         { 
           //Crank is low, cam is low and the crank pulse STARTED when the cam was high. 
           if(configPage2.nCylinders == 4) { toothCurrentCount = 1; } //Means we're at 5* BTDC on a 4G63 4 cylinder
           //else if(configPage2.nCylinders == 6) { toothCurrentCount = 8; } 
         } 
         //If sequential is ever enabled, the below toothCurrentCount will need to change:
-        else if( (triggerSec_pin.isPinHigh() == true) && (revolutionOne == true) ) 
+        else if( (currentStatus.decoder.secondary.isPinHigh()) && (revolutionOne == true) ) 
         { 
           //Crank is low, cam is high and the crank pulse STARTED when the cam was high. 
           if(configPage2.nCylinders == 4) { toothCurrentCount = 5; } //Means we're at 5* BTDC on a 4G63 4 cylinder
@@ -1710,7 +1706,7 @@ static void triggerSec_4G63(void)
 
       triggerFilterTime = 1500; //If this is removed, can have trouble getting sync again after the engine is turned off (but ECU not reset).
       triggerSecFilterTime = triggerSecFilterTime >> 1; //Divide the secondary filter time by 2 again, making it 25%. Only needed when cranking
-      if(triggerPri_pin.isPinHigh() == true)
+      if(currentStatus.decoder.primary.isPinHigh())
       {
         if(configPage2.nCylinders == 4)
         { 
@@ -1738,7 +1734,7 @@ static void triggerSec_4G63(void)
       if( (decoderStatus.syncStatus==SyncStatus::Full) && (configPage2.nCylinders == 4) )
       {
         triggerSecFilterTime_duration = (micros() - secondaryLastToothTime1) >> 1;
-        if(triggerPri_pin.isPinHigh() == true)
+        if(currentStatus.decoder.primary.isPinHigh())
         {
           //Whilst we're cranking and have sync, we need to watch for noise pulses.
           if(toothCurrentCount != 8) 
@@ -3107,11 +3103,7 @@ static void triggerSec_Nissan360(void)
 
 
   //Calculate number of primary teeth that this window has been active for
-  byte trigEdge;
-  if(configPage4.TrigEdgeSec == 0) { trigEdge = LOW; }
-  else { trigEdge = HIGH; }
-
-  if( (secondaryToothCount == 0) || (triggerSec_pin.isPinHigh() == trigEdge) ) { secondaryToothCount = toothCurrentCount; } //This occurs on the first rotation upon powerup OR the start of a secondary window
+  if( (secondaryToothCount == 0) || (currentStatus.decoder.secondary.isTriggered()) ) { secondaryToothCount = toothCurrentCount; } //This occurs on the first rotation upon powerup OR the start of a secondary window
   else
   {
     //If we reach here, we are at the end of a secondary window
@@ -3764,7 +3756,7 @@ static void triggerPri_Harley(void)
   setFilter(curGap); // Filtering adjusted according to setting
   if (curGap > triggerFilterTime)
   {
-    if ( triggerPri_pin.isPinHigh() == HIGH) // Has to be the same as in main() trigger-attach, for readability we do it this way.
+    if (currentStatus.decoder.primary.isPinHigh()) // Has to be the same as in main() trigger-attach, for readability we do it this way.
     {
         decoderStatus.validTrigger = true; //Flag this pulse as being a valid trigger (ie that it passed filters)
         targetGap = lastGap ; //Gap is the Time to next toothtrigger, so we know where we are
@@ -4246,7 +4238,7 @@ static void triggerSec_420a(void)
 {
   //Secondary trigger is only on falling edge
 
-  if(triggerPri_pin.isPinHigh() == true)
+  if(currentStatus.decoder.primary.isPinHigh())
   {
     //Secondary signal is falling and primary signal is HIGH
     if( decoderStatus.syncStatus!=SyncStatus::Full )
@@ -4731,7 +4723,7 @@ static void triggerPri_NGC(void)
 {
   curTime = micros();
   // We need to know the polarity of the missing tooth to determine position
-  if (triggerPri_pin.isPinHigh() == HIGH) {
+  if (currentStatus.decoder.primary.isPinHigh()) {
     toothLastToothRisingTime = curTime;
     return;
   }
@@ -4846,7 +4838,7 @@ static void triggerSec_NGC4(void)
   curTime2 = micros();
 
   // We need to know the polarity of the missing tooth to determine position
-  if (triggerSec_pin.isPinHigh() == HIGH) {
+  if (currentStatus.decoder.secondary.isPinHigh()) {
     toothLastSecToothRisingTime = curTime2;
     return;
   }
@@ -5083,9 +5075,8 @@ Trigger is based on 'CHANGE' so we get a signal on the up and downward edges of 
 //We measure the width of a lobe so on the end of a lobe, but want to trigger on the beginning. Variable toothCurrentCount tracks the downward events, and secondaryToothCount updates on the upward events. Ideally, it should be the other way round but the engine stall routine resets secondaryToothCount, so it would not sync again after an engine stall.
 static void triggerPri_Vmax(void)
 {
-  bool primaryEdge = configPage4.TrigEdge == 0;
   curTime = micros();
-  if(triggerPri_pin.isPinHigh() == primaryEdge){// Forwarded from the config page to setup the primary trigger edge (rising or falling). Inverting VR-conditioners require FALLING, non-inverting VR-conditioners require RISING in the Trigger edge setup.
+  if(currentStatus.decoder.primary.isTriggered()){// Forwarded from the config page to setup the primary trigger edge (rising or falling). Inverting VR-conditioners require FALLING, non-inverting VR-conditioners require RISING in the Trigger edge setup.
     curGap2 = curTime;
     curGap = curTime - toothLastToothTime;
     if ( (curGap >= triggerFilterTime) ){
@@ -6432,10 +6423,3 @@ decoder_t  __attribute__((optimize("Os"))) triggerSetup_FordTFI(void)
                   .build();
 }
 /** @} */
-
-void initDecoderPins(uint8_t primaryPin, uint8_t secondaryPin, uint8_t tertiaryPin)
-{
-  triggerPri_pin.setPin(primaryPin);
-  triggerSec_pin.setPin(secondaryPin);
-  triggerThird_pin.setPin(tertiaryPin);
-}

--- a/speeduino/decoders.h
+++ b/speeduino/decoders.h
@@ -45,12 +45,4 @@ decoder_t triggerSetup_FordTFI(void);
 // TODO: use same VVT scheme as other decoders
 int getCamAngle_Miata9905(void);
 
-/** @brief Set the input pins for the decoders. Pin numbers are pulled from the tune
- * 
- * @param primaryPin Primary pin - usually the crank trigger
- * @param secondaryPin Secondary pin - optional, usually the cam trigger
- * @param tertiaryPin Tertiary pin - optional, for decoders that use a 3rd input. E.g. VVT
- */
-void initDecoderPins(uint8_t primaryPin, uint8_t secondaryPin, uint8_t tertiaryPin);
-
 #endif

--- a/speeduino/logger.cpp
+++ b/speeduino/logger.cpp
@@ -723,7 +723,7 @@ void startToothLogger(void)
   }
 }
 
-static inline void detachLoggerInterrupt(uint8_t pin, const interrupt_t &decoderInterrupt)
+static inline void detachLoggerInterrupt(uint8_t pin, interrupt_t &decoderInterrupt)
 {
   detachInterrupt( digitalPinToInterrupt(pin) );
   decoderInterrupt.attach(pin);

--- a/speeduino/logger.cpp
+++ b/speeduino/logger.cpp
@@ -726,7 +726,7 @@ void startToothLogger(void)
 static inline void detachLoggerInterrupt(uint8_t pin, interrupt_t &decoderInterrupt)
 {
   detachInterrupt( digitalPinToInterrupt(pin) );
-  decoderInterrupt.attach(pin);
+ (void)decoderInterrupt.attach(pin);
 }
 
 void stopToothLogger(void)

--- a/speeduino/resetControl.cpp
+++ b/speeduino/resetControl.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include "resetControl.h"
 #include "unit_testing.h"
 

--- a/test/test_decoders/general.cpp
+++ b/test/test_decoders/general.cpp
@@ -33,27 +33,9 @@ static void test_sharedEngineIsRunning(void)
     TEST_ASSERT_FALSE(sharedEngineIsRunning(600UL)); // 1101 uS elapsed
 }
 
-static void test_interrupt_isValid(void)
-{
-  interrupt_t subject;
-
-  TEST_ASSERT_FALSE(subject.isValid());
-  subject.edge = CHANGE;
-  TEST_ASSERT_FALSE(subject.isValid());
-  subject.callback = test_interrupt_isValid;
-  TEST_ASSERT_TRUE(subject.isValid());
-  subject.edge = RISING;
-  TEST_ASSERT_TRUE(subject.isValid());
-  subject.edge = FALLING;
-  TEST_ASSERT_TRUE(subject.isValid());
-  subject.edge = TRIGGER_EDGE_NONE;
-  TEST_ASSERT_FALSE(subject.isValid());
-}
-
 void testDecoder_General()
 {
   SET_UNITY_FILENAME() {
     RUN_TEST_P(test_sharedEngineIsRunning);
-    RUN_TEST_P(test_interrupt_isValid);
   }
 }

--- a/test/test_decoders/main.cpp
+++ b/test/test_decoders/main.cpp
@@ -25,6 +25,7 @@ void runAllDecoderTests(void)
     extern void testDecoderBuilder(void);
     extern void testDecoderInit(void);
     extern void testDecoderApiCoverage(void);
+    extern void testinterrupt_t(void);
     
     testMissingTooth();
     testDualWheel();
@@ -39,6 +40,7 @@ void runAllDecoderTests(void)
     testDecoderBuilder();
     testDecoderInit();
     testDecoderApiCoverage();
+    testinterrupt_t();
 }
 
 TEST_HARNESS(runAllDecoderTests)

--- a/test/test_decoders/test_api_coverage.cpp
+++ b/test/test_decoders/test_api_coverage.cpp
@@ -6,7 +6,6 @@
 #include "src/pins/boardInputPin.h"
 
 extern decoder_status_t decoderStatus;
-extern boardInputPin_t triggerPri_pin;
 extern volatile unsigned long toothOneTime;
 extern volatile unsigned long toothOneMinusOneTime;
 extern volatile unsigned long toothLastToothTime;
@@ -14,19 +13,18 @@ extern volatile unsigned long toothLastMinusOneToothTime;
 extern uint16_t toothCurrentCount;
 extern unsigned long MAX_STALL_TIME;
 
-static void test_primary_trigger(const decoder_t &decoder, uint8_t decoderNum)
+static void test_primary_trigger(decoder_t &decoder, uint8_t decoderNum)
 {
     char szMsg[64] = {};
     snprintf(szMsg, _countof(szMsg), "%" PRIu8, decoderNum);
 
-    configurePinState(triggerPri_pin, decoder.primary.edge);
     if (DECODER_NGC==decoderNum)
     {
-        configurePinState(triggerPri_pin, FALLING);
+        configurePinState(decoder.primary._pin, FALLING);
     }
     else
     {
-        configurePinState(triggerPri_pin, decoder.primary.edge);
+        configurePinState(decoder.primary._pin, decoder.primary.edge);
     }
 
     decoder.reset();

--- a/test/test_decoders/test_decoder_init.cpp
+++ b/test/test_decoders/test_decoder_init.cpp
@@ -15,20 +15,24 @@ static void assert_decoder(const decoder_t &decoder)
     if (decoder.secondary.edge!=TRIGGER_EDGE_NONE)
     {
         TEST_ASSERT_NOT_EQUAL_MESSAGE(decoder.secondary.callback, defaultDecoder.secondary.callback, "secondary");
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(NOT_A_PIN, pinTrigger2, "pinTrigger2");
     }
     else
     {
         TEST_ASSERT_EQUAL_MESSAGE(decoder.secondary.callback, defaultDecoder.secondary.callback, "secondary");
+        TEST_ASSERT_EQUAL_MESSAGE(NOT_A_PIN, pinTrigger2, "pinTrigger2");
     }
     
     // Tertiary is optional
     if (decoder.tertiary.edge!=TRIGGER_EDGE_NONE)
     {
         TEST_ASSERT_NOT_EQUAL_MESSAGE(decoder.tertiary.callback, defaultDecoder.tertiary.callback, "tertiary");
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(NOT_A_PIN, pinTrigger3, "pinTrigger3");
     }
     else
     {
         TEST_ASSERT_EQUAL_MESSAGE(decoder.tertiary.callback, defaultDecoder.tertiary.callback, "tertiary");
+        TEST_ASSERT_EQUAL_MESSAGE(NOT_A_PIN, pinTrigger3, "pinTrigger3");
     }
     
     // Mandatory
@@ -68,6 +72,9 @@ static uint8_t decoderIdentifier;
 static void test_buildDecoder(void)
 {
     configPage2.perToothIgn = true;
+    pinTrigger = 11;
+    pinTrigger2 = 12;
+    pinTrigger3 = 13;
     assert_decoder(buildDecoder(decoderIdentifier));
 }
 

--- a/test/test_decoders/test_interrupt_t.cpp
+++ b/test/test_decoders/test_interrupt_t.cpp
@@ -19,9 +19,60 @@ static void test_attach_return(void)
     TEST_ASSERT_EQUAL(33, subject.attach(33));
 }
 
+static void test_isValid(void)
+{
+  interrupt_t subject;
+
+  TEST_ASSERT_FALSE(subject.isValid());
+  subject.edge = CHANGE;
+  TEST_ASSERT_FALSE(subject.isValid());
+  subject.callback = test_isValid;
+  TEST_ASSERT_FALSE(subject.isValid());
+  subject.attach(19);
+  TEST_ASSERT_TRUE(subject.isValid());
+  subject.edge = RISING;
+  TEST_ASSERT_TRUE(subject.isValid());
+  subject.edge = FALLING;
+  TEST_ASSERT_TRUE(subject.isValid());
+  subject.edge = TRIGGER_EDGE_NONE;
+  TEST_ASSERT_FALSE(subject.isValid());
+}
+
+static void test_isTriggered(void)
+{
+  interrupt_t subject;
+
+  TEST_ASSERT_FALSE(subject.isTriggered());
+
+  subject.edge = CHANGE;
+  TEST_ASSERT_FALSE(subject.isTriggered());
+
+  subject.callback = test_isValid;
+  TEST_ASSERT_FALSE(subject.isTriggered());
+
+  subject.attach(19);
+  TEST_ASSERT_TRUE(subject.isTriggered());
+
+  subject.edge = RISING;
+  subject._pin._pin.setPinLow();
+  TEST_ASSERT_FALSE(subject.isTriggered());
+
+  subject._pin._pin.setPinHigh();
+  TEST_ASSERT_TRUE(subject.isTriggered());
+
+  subject.edge = FALLING;
+  TEST_ASSERT_FALSE(subject.isTriggered());
+
+  subject._pin._pin.setPinLow();
+  TEST_ASSERT_TRUE(subject.isTriggered());
+}
+
+
 void testinterrupt_t()
 {
   SET_UNITY_FILENAME() {
     RUN_TEST_P(test_attach_return);
+    RUN_TEST_P(test_isValid);
+    RUN_TEST_P(test_isTriggered);
   }
 }

--- a/test/test_decoders/test_interrupt_t.cpp
+++ b/test/test_decoders/test_interrupt_t.cpp
@@ -1,0 +1,27 @@
+#include <unity.h>
+#include "../test_utils.h"
+#include "decoder_t.h"
+
+static void nullCallback(void) { }
+
+static void test_attach_return(void)
+{
+    interrupt_t subject;
+    TEST_ASSERT_FALSE(subject.isValid());
+    TEST_ASSERT_EQUAL(NOT_A_PIN, subject.attach(33));
+
+    subject.callback = nullCallback;
+    TEST_ASSERT_FALSE(subject.isValid());
+    TEST_ASSERT_EQUAL(NOT_A_PIN, subject.attach(33));
+
+    subject.edge = CHANGE;
+    TEST_ASSERT_TRUE(subject.isValid());
+    TEST_ASSERT_EQUAL(33, subject.attach(33));
+}
+
+void testinterrupt_t()
+{
+  SET_UNITY_FILENAME() {
+    RUN_TEST_P(test_attach_return);
+  }
+}

--- a/test/test_decoders/test_toothloggers.cpp
+++ b/test/test_decoders/test_toothloggers.cpp
@@ -3,127 +3,113 @@
 #include "globals.h"
 #include "decoder_init.h"
 #include "../test_utils.h"
-#include "src/pins/boardInputPin.h"
 #include "decoder_name.h"
 #include "shared.h"
 
 extern decoder_status_t decoderStatus;
-extern boardInputPin_t triggerPri_pin;
-extern boardInputPin_t triggerSec_pin;
-extern boardInputPin_t triggerThird_pin;
+extern volatile unsigned long triggerFilterTime;
 
-static void assertTrigger(decoder_t decoder, uint8_t decoderNum, uint8_t edge, interrupt_t::callback_t isr)
+static const char* edgeName(uint8_t edge)
 {
-    char szMsg[64];
-    snprintf(szMsg, sizeof(szMsg), "Decoder %d, edge %d", decoderNum, edge);
-
-    currentStatus.decoder = decoder;
-    decoder.reset();
-    configureStateForPrimaryTrigger(decoderNum, decoderStatus);
-
-    configurePinState(triggerPri_pin, edge);
-    isr();
-    TEST_ASSERT_TRUE_MESSAGE(decoder.getStatus().validTrigger, szMsg);
+  if (edge==RISING)
+  {
+    static const char name[]="RISING";
+    return name;
+  }
+  if (edge==FALLING)
+  {
+    static const char name[]="FALLING";
+    return name;
+  }
+  if (edge==CHANGE)
+  {
+    static const char name[]="CHANGE";
+    return name;
+  }
+  static const char name[]="Unknown";
+  return name;
 }
 
-static void assertStartStopPrimaryTrigger(decoder_t decoder, uint8_t decoderNum, uint8_t edge)
+static void assertValidTrigger(const decoder_t &decoder, uint8_t decoderNum, uint8_t testEdge)
 {
-    currentStatus.decoder = decoder;
+  // We only expect a valid trigger when the decoder trigger conditions are met.
+  bool expected = currentStatus.decoder.primary.isTriggered();
+  // The NGC decoder triggers on change, but only sets 
+  // decoderStatus.validTrigger on falling interrupts.
+  if (DECODER_NGC==decoderNum)
+  {
+    expected = testEdge==FALLING;
+  }
 
-    // Test primary trigger function
-    assertTrigger(decoder, decoderNum, edge, decoder.primary.callback);
+  TEST_ASSERT_EQUAL(expected, decoder.getStatus().validTrigger);
+}
 
-    // Attach logger
-    startToothLogger();
+static void test_toothLogger(decoder_t &decoder, uint8_t decoderNum, uint8_t testEdge)
+{
+  currentStatus.decoder = decoder;
+    
+  // Attach logger
+  startToothLogger();
 
-    // Test primary trigger function
-    assertTrigger(decoder, decoderNum, edge, loggerPrimaryISR);
+  configurePinState(currentStatus.decoder.primary._pin, testEdge);
 
-    // Detach logger
-    stopToothLogger();
+  currentStatus.decoder.reset();
+  configureStateForPrimaryTrigger(decoderNum, decoderStatus);
 
-    // Test primary trigger function
-    assertTrigger(decoder, decoderNum, edge, decoder.primary.callback);
+  loggerPrimaryISR();
+  assertValidTrigger(currentStatus.decoder, decoderNum, testEdge);
+
+  // Detach logger
+  stopToothLogger();
+}
+
+static void test_toothLogger(uint8_t decoderNum, uint8_t configSetting, uint8_t testEdge)
+{
+#if !defined(SIMULATOR) && defined(CORE_AVR)
+  TEST_IGNORE_MESSAGE("Cannot run interrupt based tests on AVRboard");
+#endif
+
+  pinTrigger = 19; // Example pin number
+  configPage4.TrigEdge = configSetting;
+  currentStatus.initialisationComplete = false;
+  auto decoder = buildDecoder(decoderNum);
+
+  test_toothLogger(decoder, decoderNum, testEdge);
 }
 
 // Used as pseudo parameter to support dynamic test naming.
 static uint8_t decoderToTest;
-
-static void test_start_stop_rising(void)
+static uint8_t decoderConfigEdge;
+static uint8_t triggerEdge;
+static void test_toothLogger(void)
 {
-#if !defined(SIMULATOR) && defined(CORE_AVR)
-  TEST_IGNORE_MESSAGE("Cannot run interrupt based tests on AVRboard");
-#endif
-
-    pinTrigger = 19; // Example pin number
-    configPage4.TrigEdge = 0;
-    currentStatus.initialisationComplete = false;
-    auto decoder = buildDecoder(decoderToTest);
-
-    assertStartStopPrimaryTrigger(decoder, decoderToTest, decoder.primary.edge);
+  test_toothLogger(decoderToTest, decoderConfigEdge, triggerEdge);
 }
 
-static void test_start_stop_falling(void)
+static void test_start_stop_toothLogger(void)
 {
-#if !defined(SIMULATOR) && defined(CORE_AVR)
-  TEST_IGNORE_MESSAGE("Cannot run interrupt based tests on AVRboard");
-#endif
-
-    pinTrigger = 19; // Example pin number
-    configPage4.TrigEdge = 1;
-    auto decoder = buildDecoder(decoderToTest);
-
-    assertStartStopPrimaryTrigger(decoder, decoderToTest, decoder.primary.edge);
-}
-
-static void test_start_stop_all(void)
-{
-    for (uint8_t decoder = 0; decoder < DECODER_MAX; ++decoder)
+  for (decoderToTest = 0; decoderToTest < DECODER_MAX; ++decoderToTest)
+  {
+    auto decoderName = getDecoderName(decoderToTest);
+    if (DECODER_RENIX!=decoderToTest   // See issue #1347
+        && DECODER_ROVERMEMS!=decoderToTest) // See issue #1348
     {
-        if (   DECODER_NGC!=decoder     // See test_start_stop_ngc
-            && DECODER_RENIX!=decoder   // See issue #1347
-            && DECODER_ROVERMEMS!=decoder) { // See issue #1348
-
-          decoderToTest = decoder;
-          auto decoderName = getDecoderName(decoder);
-          RUN_TEST_POSTFIX_P(test_start_stop_rising, decoderName);
-          RUN_TEST_POSTFIX_P(test_start_stop_falling, decoderName);
+      for(decoderConfigEdge=0; decoderConfigEdge<2; ++decoderConfigEdge)
+      {
+        for (triggerEdge=CHANGE; triggerEdge<=RISING; ++triggerEdge)
+        {
+          char szPostfix[128] = {};
+          snprintf(szPostfix, _countof(szPostfix)-1, "%s_%" PRIu8 "_%s", decoderName, decoderConfigEdge, edgeName(triggerEdge));
+          RUN_TEST_POSTFIX_P(test_toothLogger, szPostfix);
         }
+      }
     }
-}
-
-static void test_start_stop_ngc(void)
-{
-#if !defined(SIMULATOR) && defined(CORE_AVR)
-  TEST_IGNORE_MESSAGE("Cannot run interrupt based tests on AVRboard");
-#endif
-  pinTrigger = 19; // Example pin number
-  auto decoder = buildDecoder(DECODER_NGC);
-
-  // The NGC decoder triggers on change, but only sets 
-  // BIT_DECODER_VALID_TRIGGER on falling interrupts.
-  configurePinState(triggerPri_pin, RISING);
-  assertTrigger(decoder, DECODER_NGC, decoder.primary.edge, decoder.primary.callback);
-  
-  // Attach logger
-  startToothLogger();
-
-  // Test primary trigger function
-  configurePinState(triggerPri_pin, RISING);
-  assertTrigger(decoder, DECODER_NGC, decoder.primary.edge, loggerPrimaryISR);
-
-  // Detach logger
-  stopToothLogger();
-
-  // Test primary trigger function
-  configurePinState(triggerPri_pin, RISING);
-  assertTrigger(decoder, DECODER_NGC, decoder.primary.edge, decoder.primary.callback);
+  }
 }
 
 void testToothLoggers(void)
 {
   SET_UNITY_FILENAME() {
-    test_start_stop_all();
-    RUN_TEST_P(test_start_stop_ngc);
+    test_start_stop_toothLogger();
   }
 }


### PR DESCRIPTION
* Add a `boardInputPin_t` instance to `interrupt_t`
* Trigger pins are now initialised in one operation, instead of split across cpp files
* Encapsulate and unit test the logic for checking if the pin state matches the trigger (see `isTriggered`)