### PR TITLE
Separate out boost control from auxiliaries.*

### DIFF
--- a/speeduino/auxiliaries.cpp
+++ b/speeduino/auxiliaries.cpp
@@ -27,7 +27,6 @@ TESTABLE_STATIC volatile bool vvt2_pwm_state;
 TESTABLE_STATIC volatile bool vvt1_max_pwm;
 TESTABLE_STATIC volatile bool vvt2_max_pwm;
 TESTABLE_STATIC volatile char nextVVT;
-TESTABLE_STATIC byte boostCounter;
 TESTABLE_STATIC byte vvtCounter;
 
 TESTABLE_STATIC fastInputPin_t n2o_arming_pin;
@@ -68,7 +67,6 @@ static __attribute__((optimize("Os"))) uint8_t getAirConRequestPinMode(const con
   }
 }
 
-TESTABLE_STATIC boardOutputPin_t boost_pin;
 TESTABLE_STATIC boardOutputPin_t n2o_stage1_pin;
 TESTABLE_STATIC boardOutputPin_t n2o_stage2_pin;
 TESTABLE_STATIC boardOutputPin_t aircon_comp_pin;
@@ -155,19 +153,11 @@ TESTABLE_STATIC uint8_t acRPMLockoutDelay;
 TESTABLE_STATIC uint8_t acAfterEngineStartDelay;
 TESTABLE_STATIC bool waitedAfterCranking; // This starts false and prevents the A/C from running until a few seconds after cranking
 
-TESTABLE_STATIC long boost_pwm_target_value;
-TESTABLE_STATIC volatile bool boost_pwm_state;
-TESTABLE_STATIC volatile unsigned int boost_pwm_cur_value = 0;
-
 static uint32_t vvtWarmTime;
 TESTABLE_STATIC bool vvtIsHot;
 TESTABLE_STATIC bool vvtTimeHold;
 TESTABLE_STATIC uint16_t vvt_pwm_max_count; //Used for variable PWM frequency
-static uint16_t boost_pwm_max_count; //Used for variable PWM frequency
-TESTABLE_CONSTEXPR table2D_u8_s16_6 flexBoostTable(&configPage10.flexBoostBins, &configPage10.flexBoostAdj);
 
-//Old PID method. Retained in case the new one has issues
-static integerPID_ideal boostPID; //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
 static integerPID vvtPID; //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
 static integerPID vvt2PID; //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
 
@@ -405,21 +395,6 @@ static __attribute__((optimize("Os"))) void initialiseVvtPins(uint8_t pin1, uint
   vvt2_pin.setPin(pin2, OUTPUT);
 }
 
-static void setBoostPidTunings(const config2 &page2, const config6 &page6, const config10 &page10)
-{
-  if(page6.boostMode == BOOST_MODE_SIMPLE)
-  {
-    boostPID.setTunings(PidTuningParameters());
-  }
-  else
-  {
-    boostPID.setTunings(PidTuningParameters(page6.boostKP, page6.boostKI, page6.boostKD));
-  }
-  boostPID.setOutputLimits(page2.boostMinDuty, page2.boostMaxDuty);
-  boostPID.setSampleTime(millis(), page10.boostIntv);
-  boostPID.setSensitivity(page10.boostSens);
-}
-
 static void setVvtPidTunings(integerPID &pid, const config10 &page10, bool isReverse)
 {
   int8_t multiplier = isReverse ? 1 : -1;
@@ -435,16 +410,12 @@ static void initialiseVvtPid(integerPID &pid, const config10 &page10, bool isRev
 
 void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
 {
-  boost_pin.setPin(pinNumbers.pinBoost, OUTPUT);
   initialiseVvtPins(pinNumbers.pinVVT_1, pinNumbers.pinVVT_2);
   initialiseN2oPins(configPage10);
 
   //This is a safety check that will be true if the board is uninitialised. This prevents hangs on a new board that could otherwise try to write to an invalid pin port/mask (Without this a new Teensy 4.x hangs on startup)
   //The n2o_minTPS variable is capped at 100 by TS, so 255 indicates a new board.
   if(configPage10.n2o_minTPS == 255) { configPage10.n2o_enable = 0; }
-
-  setBoostPidTunings(configPage2, configPage6, configPage10);
-  boost_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.boostFreq));
 
   if( configPage6.vvtEnabled > 0)
   {
@@ -481,253 +452,11 @@ void __attribute__((optimize("Os"))) initialiseAuxPWM(void)
     ENABLE_VVT_TIMER(); //Turn on the B compare unit (ie turn on the interrupt)
   }
 
-  currentStatus.boostDuty = 0;
-  boostCounter = 0;
   currentStatus.vvt1Duty = 0;
   currentStatus.vvt2Duty = 0;
   vvtCounter = 0;
 
   currentStatus.nitrous_status = NITROUS_OFF;
-}
-
-static void boostByGear(void)
-{
-  if(configPage4.boostType == OPEN_LOOP_BOOST)
-  {
-    if( configPage9.boostByGearEnabled == 1 )
-    {
-      uint16_t combinedBoost = 0;
-      switch (currentStatus.gear)
-      {
-        case 1:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear1 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        case 2:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear2 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        case 3:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear3 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        case 4:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear4 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        case 5:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear5 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        case 6:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear6 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
-          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
-          else{ currentStatus.boostDuty = 10000; }
-          break;
-        default:
-          break;
-      }
-    }
-    else if( configPage9.boostByGearEnabled == 2 ) 
-    {
-      switch (currentStatus.gear)
-      {
-        case 1:
-          currentStatus.boostDuty = configPage9.boostByGear1 * 2 * 100;
-          break;
-        case 2:
-          currentStatus.boostDuty = configPage9.boostByGear2 * 2 * 100;
-          break;
-        case 3:
-          currentStatus.boostDuty = configPage9.boostByGear3 * 2 * 100;
-          break;
-        case 4:
-          currentStatus.boostDuty = configPage9.boostByGear4 * 2 * 100;
-          break;
-        case 5:
-          currentStatus.boostDuty = configPage9.boostByGear5 * 2 * 100;
-          break;
-        case 6:
-          currentStatus.boostDuty = configPage9.boostByGear6 * 2 * 100;
-          break;
-        default:
-          break;
-      }
-    }
-  }
-  else if (configPage4.boostType == CLOSED_LOOP_BOOST)
-  {
-    if( configPage9.boostByGearEnabled == 1 )
-    {
-      uint16_t combinedBoost = 0;
-      switch (currentStatus.gear)
-      {
-        case 1:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear1 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        case 2:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear2 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        case 3:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear3 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        case 4:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear4 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        case 5:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear5 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        case 6:
-          combinedBoost = ( ((uint16_t)configPage9.boostByGear6 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
-          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
-          else{ currentStatus.boostTarget = 511; }
-          break;
-        default:
-          break;
-      }
-    }
-    else if( configPage9.boostByGearEnabled == 2 ) 
-    {
-      switch (currentStatus.gear)
-      {
-        case 1:
-          currentStatus.boostTarget = (configPage9.boostByGear1 << 1);
-          break;
-        case 2:
-          currentStatus.boostTarget = (configPage9.boostByGear2 << 1);
-          break;
-        case 3:
-          currentStatus.boostTarget = (configPage9.boostByGear3 << 1);
-          break;
-        case 4:
-          currentStatus.boostTarget = (configPage9.boostByGear4 << 1);
-          break;
-        case 5:
-          currentStatus.boostTarget = (configPage9.boostByGear5 << 1);
-          break;
-        case 6:
-          currentStatus.boostTarget = (configPage9.boostByGear6 << 1);
-          break;
-        default:
-          break;
-      }
-    }
-  }
-}
-
-void boostControl(void)
-{
-  if( configPage6.boostEnabled==1 )
-  {
-    if(configPage4.boostType == OPEN_LOOP_BOOST)
-    {
-      //Open loop
-      if ( (configPage9.boostByGearEnabled > 0) && isExternalVssMode(configPage2) ){ boostByGear(); }
-      else{ currentStatus.boostDuty = get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM) * 2 * 100; }
-
-      if(currentStatus.boostDuty > 10000) { currentStatus.boostDuty = 10000; } //Safety check
-      if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
-      else
-      {
-        boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
-      }
-    }
-    else if (configPage4.boostType == CLOSED_LOOP_BOOST)
-    {
-      if( (boostCounter & 7) == 1) 
-      { 
-        if ( (configPage9.boostByGearEnabled > 0) && isExternalVssMode(configPage2) ){ boostByGear(); }
-        else{ currentStatus.boostTarget = get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM) << 1; } //Boost target table is in kpa and divided by 2
-
-        //If flex fuel is enabled, there can be an adder to the boost target based on ethanol content
-        if( configPage2.flexEnabled == 1 )
-        {
-          currentStatus.flexBoostCorrection = table2D_getValue(&flexBoostTable, currentStatus.ethanolPct);
-          currentStatus.boostTarget += currentStatus.flexBoostCorrection;
-          currentStatus.boostTarget = min(currentStatus.boostTarget, (uint16_t)511U);
-        }
-        else
-        {
-          currentStatus.flexBoostCorrection = 0;
-        }
-      } 
-
-      if(((configPage15.boostControlEnable == EN_BOOST_CONTROL_BARO) && (currentStatus.MAP >= currentStatus.baro)) || ((configPage15.boostControlEnable == EN_BOOST_CONTROL_FIXED) && (currentStatus.MAP >= configPage15.boostControlEnableThreshold))) //Only enables boost control above baro pressure or above user defined threshold (User defined level is usually set to boost with wastegate actuator only boost level)
-      {
-        if(currentStatus.boostTarget > 0)
-        {
-          //This only needs to be run very infrequently, once every 16 calls to boostControl(). This is approx. once per second
-          if( (boostCounter & 15) == 1)
-          {
-            setBoostPidTunings(configPage2, configPage6, configPage10);
-          }
-
-          boostPID.setSetPoint(currentStatus.boostTarget);
-          boostPID.setFeedForwardTerm(get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100/2);
-          //Compute() returns false if the required interval has not yet passed.
-          bool PIDcomputed = boostPID.compute(millis(), 
-                                              currentStatus.MAP,
-                                              &currentStatus.boostDuty);
-          
-          if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
-          else
-          {
-            if(PIDcomputed == true)
-            {
-              boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
-            }
-          }
-        }
-        else
-        {
-          //If boost target is 0, turn everything off
-          boostDisable();
-        }
-      }
-      else
-      {
-        boostPID.initialize(currentStatus.MAP); //This resets the ITerm value to prevent rubber banding
-        //Boost control needs to have a high duty cycle if control is below threshold (baro or fixed value). This ensures the waste gate is closed as much as possible, this build boost as fast as possible.
-        currentStatus.boostDuty = configPage15.boostDCWhenDisabled*100;
-        boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
-        ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
-        if(currentStatus.boostDuty == 0) { boostDisable(); } //If boost control does nothing disable PWM completely
-      } //MAP above boost + hyster
-    } //Open / Cloosed loop
-
-    //Check for 100% duty cycle
-    if(currentStatus.boostDuty >= 10000)
-    {
-      DISABLE_BOOST_TIMER(); //Turn off the compare unit (ie turn off the interrupt) if boost duty is 100%
-      boost_pin.setPinHigh(); //Turn on boost pin if duty is 100%
-    }
-    else if(currentStatus.boostDuty > 0)
-    {
-      ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty is > 0
-    }
-    
-  }
-  else { // Disable timer channel and zero the flex boost correction status
-    DISABLE_BOOST_TIMER();
-    currentStatus.flexBoostCorrection = 0;
-  }
-
-  boostCounter++;
 }
 
 void vvt1On(void)
@@ -1070,40 +799,6 @@ void wmiControl(void)
         ENABLE_VVT_TIMER();
       }
     }
-  }
-}
-
-void boostDisable(void)
-{
-  boostPID.initialize(currentStatus.MAP); //This resets the ITerm value to prevent rubber banding
-  currentStatus.boostDuty = 0;
-  DISABLE_BOOST_TIMER(); //Turn off timer
-  boost_pin.setPinLow(); //Make sure solenoid is off (0% duty)
-}
-
-//The interrupt to control the Boost PWM
-void boostInterrupt(void)
-{
-  if (boost_pwm_state == true)
-  {
-    #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
-    boost_pin.setPinHigh();
-    #else
-    boost_pin.setPinLow();  // Switch pin to low
-    #endif
-    SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + (boost_pwm_max_count - boost_pwm_cur_value) );
-    boost_pwm_state = false;
-  }
-  else
-  {
-    #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
-    boost_pin.setPinLow();
-    #else
-    boost_pin.setPinHigh();  // Switch pin high
-    #endif
-    SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + boost_pwm_target_value);
-    boost_pwm_cur_value = boost_pwm_target_value;
-    boost_pwm_state = true;
   }
 }
 

--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -5,8 +5,6 @@
 #include "statuses.h"
 
 void initialiseAuxPWM(void);
-void boostControl(void);
-void boostDisable(void);
 void vvtControl(void);
 void initialiseAirCon(void);
 
@@ -19,7 +17,6 @@ void vvt1Off(void);
 void vvt2On(void);
 void vvt2Off(void);
 
-void boostInterrupt(void);
 void vvtInterrupt(void);
 
 #endif

--- a/speeduino/board_avr2560.cpp
+++ b/speeduino/board_avr2560.cpp
@@ -14,6 +14,7 @@
 #include "board_eeprom_adapter.hpp"
 #include "scheduler_ignition_controller.h"
 #include "scheduler_fuel_controller.h"
+#include "src/controllers/boost/boostController.h"
 
 // Prescaler values for timers 1-3-4-5. Refer to www.instructables.com/files/orig/F3T/TIKL/H3WSA4V7/F3TTIKLH3WSA4V7.jpg
 #define TIMER_PRESCALER_OFF  ((0<<CS12)|(0<<CS11)|(0<<CS10))

--- a/speeduino/board_native.cpp
+++ b/speeduino/board_native.cpp
@@ -10,6 +10,7 @@
 #include "scheduler_ignition_controller.h"
 #include "scheduler_fuel_controller.h"
 #include "src/controllers/fan/fanController.h"
+#include "src/controllers/boost/boostController.h"
 
 #define IGNITION_INTERRUPT_NAME(index) CONCAT(CONCAT(ignitionSchedule, index), Interrupt)
 #define FUEL_INTERRUPT_NAME(index) CONCAT(CONCAT(fuelSchedule, index), Interrupt)

--- a/speeduino/board_stm32_official.cpp
+++ b/speeduino/board_stm32_official.cpp
@@ -9,6 +9,7 @@
 #include "scheduler_ignition_controller.h"
 #include "scheduler_fuel_controller.h"
 #include "src/controllers/fan/fanController.h"
+#include "src/controllers/boost/boostController.h"
 
 #if defined(BOARD_FCR_MICRO_F4)
 extern "C" void __real_pinMode(uint8_t pin, uint8_t mode);

--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -16,6 +16,7 @@
 #include "scheduler_ignition_controller.h"
 #include "scheduler_fuel_controller.h"
 #include "src/controllers/fan/fanController.h"
+#include "src/controllers/boost/boostController.h"
 
  //These are declared locally in comms_CAN now due to this issue: https://github.com/tonton81/FlexCAN_T4/issues/67
 // #if defined(__MK64FX512__)         // use for Teensy 3.5 only 

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -12,6 +12,7 @@
 #include "scheduler_ignition_controller.h"
 #include "scheduler_fuel_controller.h"
 #include "src/pins/pinNumbers_t.h"
+#include "src/controllers/boost/boostController.h"
 
 static void PIT_isr();
 static void TMR1_isr(void);

--- a/speeduino/init.cpp
+++ b/speeduino/init.cpp
@@ -37,6 +37,7 @@
 #include "elapsed_time.h"
 #include "src/controllers/fuelPump/fuelPumpController.h"
 #include "src/controllers/fan/fanController.h"
+#include "src/controllers/boost/boostController.h"
 
 #if defined(CORE_AVR)
 #pragma GCC push_options
@@ -197,6 +198,7 @@ void initialiseAll(void)
     initialiseFuelSchedules(currentStatus, configPage2, configPage4);
     initialiseIdle(true);
     initialiseFan(pinNumbers.pinFan);
+    initialiseBoost(pinNumbers.pinBoost);
     initialiseAirCon();
     initialiseAuxPWM();
     initialiseCorrections();

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -59,6 +59,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "scheduler_fuel_controller.h"
 #include "src/controllers/tsCommand/tsCommandController.h"
 #include "src/controllers/fan/fanController.h"
+#include "src/controllers/boost/boostController.h"
 
 #define CRANK_RUN_HYSTER    15
 

--- a/speeduino/src/controllers/boost/boostController.cpp
+++ b/speeduino/src/controllers/boost/boostController.cpp
@@ -1,0 +1,314 @@
+#include "../../pins/boardOutputPin.h"
+#include "../../../globals.h"
+#include "../../../unit_testing.h"
+#include "../../../units.h"
+#include "../../PID/integerPID_ideal.h"
+
+TESTABLE_STATIC byte boostCounter;
+TESTABLE_STATIC boardOutputPin_t boost_pin;
+TESTABLE_STATIC long boost_pwm_target_value;
+TESTABLE_STATIC volatile bool boost_pwm_state;
+TESTABLE_STATIC volatile unsigned int boost_pwm_cur_value = 0;
+static uint16_t boost_pwm_max_count; //Used for variable PWM frequency
+static integerPID_ideal boostPID; //This is the PID object if that algorithm is used. Needs to be global as it maintains state outside of each function call
+
+TESTABLE_CONSTEXPR table2D_u8_s16_6 flexBoostTable(&configPage10.flexBoostBins, &configPage10.flexBoostAdj);
+
+static __attribute__((optimize("Os"))) void setBoostPidTunings(const config2 &page2, const config6 &page6, const config10 &page10)
+{
+  if(page6.boostMode == BOOST_MODE_SIMPLE)
+  {
+    boostPID.setTunings(PidTuningParameters());
+  }
+  else
+  {
+    boostPID.setTunings(PidTuningParameters(page6.boostKP, page6.boostKI, page6.boostKD));
+  }
+  boostPID.setOutputLimits(page2.boostMinDuty, page2.boostMaxDuty);
+  boostPID.setSampleTime(millis(), page10.boostIntv);
+  boostPID.setSensitivity(page10.boostSens);
+}
+
+__attribute__((optimize("Os"))) void initialiseBoost(uint8_t boostPin)
+{
+  boost_pin.setPin(boostPin, OUTPUT);
+
+  setBoostPidTunings(configPage2, configPage6, configPage10);
+  boost_pwm_max_count = pwmFreqToTicks(FREQUENCY.toUser(configPage6.boostFreq));
+  currentStatus.boostDuty = 0;
+  boostCounter = 0;
+}
+
+void boostDisable(void)
+{
+  boostPID.initialize(currentStatus.MAP); //This resets the ITerm value to prevent rubber banding
+  currentStatus.boostDuty = 0;
+  DISABLE_BOOST_TIMER(); //Turn off timer
+  boost_pin.setPinLow(); //Make sure solenoid is off (0% duty)
+}
+
+static void boostByGear(void)
+{
+  if(configPage4.boostType == OPEN_LOOP_BOOST)
+  {
+    if( configPage9.boostByGearEnabled == 1 )
+    {
+      uint16_t combinedBoost = 0;
+      switch (currentStatus.gear)
+      {
+        case 1:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear1 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        case 2:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear2 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        case 3:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear3 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        case 4:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear4 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        case 5:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear5 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        case 6:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear6 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM))  ) << 2;
+          if( combinedBoost <= 10000 ){ currentStatus.boostDuty = combinedBoost; }
+          else{ currentStatus.boostDuty = 10000; }
+          break;
+        default:
+          break;
+      }
+    }
+    else if( configPage9.boostByGearEnabled == 2 ) 
+    {
+      switch (currentStatus.gear)
+      {
+        case 1:
+          currentStatus.boostDuty = configPage9.boostByGear1 * 2 * 100;
+          break;
+        case 2:
+          currentStatus.boostDuty = configPage9.boostByGear2 * 2 * 100;
+          break;
+        case 3:
+          currentStatus.boostDuty = configPage9.boostByGear3 * 2 * 100;
+          break;
+        case 4:
+          currentStatus.boostDuty = configPage9.boostByGear4 * 2 * 100;
+          break;
+        case 5:
+          currentStatus.boostDuty = configPage9.boostByGear5 * 2 * 100;
+          break;
+        case 6:
+          currentStatus.boostDuty = configPage9.boostByGear6 * 2 * 100;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  else if (configPage4.boostType == CLOSED_LOOP_BOOST)
+  {
+    if( configPage9.boostByGearEnabled == 1 )
+    {
+      uint16_t combinedBoost = 0;
+      switch (currentStatus.gear)
+      {
+        case 1:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear1 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        case 2:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear2 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        case 3:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear3 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        case 4:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear4 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        case 5:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear5 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        case 6:
+          combinedBoost = ( ((uint16_t)configPage9.boostByGear6 * (uint16_t)get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM)) / 100 ) << 2;
+          if( combinedBoost <= 511 ){ currentStatus.boostTarget = combinedBoost; }
+          else{ currentStatus.boostTarget = 511; }
+          break;
+        default:
+          break;
+      }
+    }
+    else if( configPage9.boostByGearEnabled == 2 ) 
+    {
+      switch (currentStatus.gear)
+      {
+        case 1:
+          currentStatus.boostTarget = (configPage9.boostByGear1 << 1);
+          break;
+        case 2:
+          currentStatus.boostTarget = (configPage9.boostByGear2 << 1);
+          break;
+        case 3:
+          currentStatus.boostTarget = (configPage9.boostByGear3 << 1);
+          break;
+        case 4:
+          currentStatus.boostTarget = (configPage9.boostByGear4 << 1);
+          break;
+        case 5:
+          currentStatus.boostTarget = (configPage9.boostByGear5 << 1);
+          break;
+        case 6:
+          currentStatus.boostTarget = (configPage9.boostByGear6 << 1);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
+void boostControl(void)
+{
+  if( configPage6.boostEnabled==1 )
+  {
+    if(configPage4.boostType == OPEN_LOOP_BOOST)
+    {
+      //Open loop
+      if ( (configPage9.boostByGearEnabled > 0) && isExternalVssMode(configPage2) ){ boostByGear(); }
+      else{ currentStatus.boostDuty = get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM) * 2 * 100; }
+
+      if(currentStatus.boostDuty > 10000) { currentStatus.boostDuty = 10000; } //Safety check
+      if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
+      else
+      {
+        boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
+      }
+    }
+    else if (configPage4.boostType == CLOSED_LOOP_BOOST)
+    {
+      if( (boostCounter & 7) == 1) 
+      { 
+        if ( (configPage9.boostByGearEnabled > 0) && isExternalVssMode(configPage2) ){ boostByGear(); }
+        else{ currentStatus.boostTarget = get3DTableValue(&boostTable, (currentStatus.TPS * 2U), currentStatus.RPM) << 1; } //Boost target table is in kpa and divided by 2
+
+        //If flex fuel is enabled, there can be an adder to the boost target based on ethanol content
+        if( configPage2.flexEnabled == 1 )
+        {
+          currentStatus.flexBoostCorrection = table2D_getValue(&flexBoostTable, currentStatus.ethanolPct);
+          currentStatus.boostTarget += currentStatus.flexBoostCorrection;
+          currentStatus.boostTarget = min(currentStatus.boostTarget, (uint16_t)511U);
+        }
+        else
+        {
+          currentStatus.flexBoostCorrection = 0;
+        }
+      } 
+
+      if(((configPage15.boostControlEnable == EN_BOOST_CONTROL_BARO) && (currentStatus.MAP >= currentStatus.baro)) || ((configPage15.boostControlEnable == EN_BOOST_CONTROL_FIXED) && (currentStatus.MAP >= configPage15.boostControlEnableThreshold))) //Only enables boost control above baro pressure or above user defined threshold (User defined level is usually set to boost with wastegate actuator only boost level)
+      {
+        if(currentStatus.boostTarget > 0)
+        {
+          //This only needs to be run very infrequently, once every 16 calls to boostControl(). This is approx. once per second
+          if( (boostCounter & 15) == 1)
+          {
+            setBoostPidTunings(configPage2, configPage6, configPage10);
+          }
+
+          boostPID.setSetPoint(currentStatus.boostTarget);
+          boostPID.setFeedForwardTerm(get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100/2);
+          //Compute() returns false if the required interval has not yet passed.
+          bool PIDcomputed = boostPID.compute(millis(), 
+                                              currentStatus.MAP,
+                                              &currentStatus.boostDuty);
+          
+          if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); boost_pin.setPinLow(); } //If boost duty is 0, shut everything down
+          else
+          {
+            if(PIDcomputed == true)
+            {
+              boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
+            }
+          }
+        }
+        else
+        {
+          //If boost target is 0, turn everything off
+          boostDisable();
+        }
+      }
+      else
+      {
+        boostPID.initialize(currentStatus.MAP); //This resets the ITerm value to prevent rubber banding
+        //Boost control needs to have a high duty cycle if control is below threshold (baro or fixed value). This ensures the waste gate is closed as much as possible, this build boost as fast as possible.
+        currentStatus.boostDuty = configPage15.boostDCWhenDisabled*100;
+        boost_pwm_target_value = ((unsigned long)(currentStatus.boostDuty) * boost_pwm_max_count) / 10000; //Convert boost duty (Which is a % multiplied by 100) to a pwm count
+        ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty >0
+        if(currentStatus.boostDuty == 0) { boostDisable(); } //If boost control does nothing disable PWM completely
+      } //MAP above boost + hyster
+    } //Open / Cloosed loop
+
+    //Check for 100% duty cycle
+    if(currentStatus.boostDuty >= 10000)
+    {
+      DISABLE_BOOST_TIMER(); //Turn off the compare unit (ie turn off the interrupt) if boost duty is 100%
+      boost_pin.setPinHigh(); //Turn on boost pin if duty is 100%
+    }
+    else if(currentStatus.boostDuty > 0)
+    {
+      ENABLE_BOOST_TIMER(); //Turn on the compare unit (ie turn on the interrupt) if boost duty is > 0
+    }
+    
+  }
+  else { // Disable timer channel and zero the flex boost correction status
+    DISABLE_BOOST_TIMER();
+    currentStatus.flexBoostCorrection = 0;
+  }
+
+  boostCounter++;
+}
+
+//The interrupt to control the Boost PWM
+void boostInterrupt(void)
+{
+  if (boost_pwm_state == true)
+  {
+    #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
+    boost_pin.setPinHigh();
+    #else
+    boost_pin.setPinLow();  // Switch pin to low
+    #endif
+    SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + (boost_pwm_max_count - boost_pwm_cur_value) );
+    boost_pwm_state = false;
+  }
+  else
+  {
+    #if defined(CORE_TEENSY41) //PIT TIMERS count down and have opposite effect on PWM
+    boost_pin.setPinLow();
+    #else
+    boost_pin.setPinHigh();  // Switch pin high
+    #endif
+    SET_COMPARE(BOOST_TIMER_COMPARE, BOOST_TIMER_COUNTER + boost_pwm_target_value);
+    boost_pwm_cur_value = boost_pwm_target_value;
+    boost_pwm_state = true;
+  }
+}

--- a/speeduino/src/controllers/boost/boostController.h
+++ b/speeduino/src/controllers/boost/boostController.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+
+void initialiseBoost(uint8_t boostPin);
+void boostControl(void);
+void boostDisable(void);
+
+void boostInterrupt(void);
+

--- a/test/test_boostcontrol/test_boostcontrol.cpp
+++ b/test/test_boostcontrol/test_boostcontrol.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.h"
 #include "globals.h"
-#include "auxiliaries.h"
+#include "src/controllers/boost/boostController.h"
 #include "units.h"
 #include "shared.h"
 #include "src/pins/boardOutputPin.h"
@@ -15,7 +15,7 @@ extern table2D_u8_s16_6 flexBoostTable;
 static void test_boost_disabled(void)
 {
     setup_simplepid_tune();
-    initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
 
     currentStatus.flexBoostCorrection = 99;
     configPage6.boostEnabled = false;
@@ -99,7 +99,7 @@ static void test_ol_zero_duty(void)
 {
   setup_boost_tune(false, VSS_MODE_EXTERNAL_MI, OPEN_LOOP_BOOST, BOOST_BY_GEAR_OFF);
   fill_table_values(boostTable, 0);
-  initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
   currentStatus.boostDuty = 99;
 
   boostControl();
@@ -168,7 +168,7 @@ static void test_cl_flexcorrection(void)
   populate_2dtable(&flexBoostTable, (int16_t)77, (uint8_t)50);
   fill_table_values(boostTable, 55);
 
-  initialiseAuxPWM();
+  initialiseBoost(TEST_BOOST_PIN);
 
   boostCounter = 1;
   currentStatus.flexBoostCorrection = 99;

--- a/test/test_boostcontrol/test_boostdisable.cpp
+++ b/test/test_boostcontrol/test_boostdisable.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.h"
 #include "globals.h"
-#include "auxiliaries.h"
+#include "src/controllers/boost/boostController.h"
 #include "shared.h"
 #include "src/pins/boardOutputPin.h"
 
@@ -9,7 +9,7 @@ extern boardOutputPin_t boost_pin;
 static void test_disable(void)
 {
     setup_simplepid_tune();
-    initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
     currentStatus.boostDuty = 99;
 
     boostDisable();

--- a/test/test_boostcontrol/test_boostinterrupt.cpp
+++ b/test/test_boostcontrol/test_boostinterrupt.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.h"
 #include "globals.h"
-#include "auxiliaries.h"
+#include "src/controllers/boost/boostController.h"
 #include "shared.h"
 #include "src/pins/boardOutputPin.h"
 
@@ -10,7 +10,7 @@ extern boardOutputPin_t boost_pin;
 static void test_on_to_off(void)
 {
     pinNumbers.pinBoost = TEST_BOOST_PIN;
-    initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
 
     boost_pwm_state = true;
     boostInterrupt();
@@ -22,7 +22,7 @@ static void test_on_to_off(void)
 static void test_off_to_on(void)
 {
     pinNumbers.pinBoost = TEST_BOOST_PIN;
-    initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
 
     boost_pwm_state = false;
     boostInterrupt();

--- a/test/test_boostcontrol/test_init.cpp
+++ b/test/test_boostcontrol/test_init.cpp
@@ -1,9 +1,11 @@
 #include "../test_utils.h"
 #include "globals.h"
-#include "auxiliaries.h"
+#include "src/controllers/boost/boostController.h"
 #include "shared.h"
+#include "src/pins/boardOutputPin.h"
 
 extern uint8_t boostCounter;
+extern boardOutputPin_t boost_pin;
 
 static void test_initialise(void)
 {
@@ -11,11 +13,11 @@ static void test_initialise(void)
     currentStatus.boostDuty = 99;
     boostCounter = 101;
 
-    initialiseAuxPWM();
+    initialiseBoost(TEST_BOOST_PIN);
 
     TEST_ASSERT_EQUAL(0, currentStatus.boostDuty);
     TEST_ASSERT_EQUAL(0, boostCounter);
-    // TEST_ASSERT_EQUAL(LOW, digitalRead(TEST_BOOST_PIN));
+    TEST_ASSERT_TRUE(boost_pin._pin.isPinLow());
 }
 
 void testBoostInit(void)


### PR DESCRIPTION
Move the boost control code out of auxilliaries.* into src/controllers/boost/*

1. SRP: there is no reason to mix together code for multiple pieces of functionality
2. Clearer unit test coverage numbers. E.g. 22% of auxilliaries.cpp tellls us nothing.
3. Conforms to our target architecture.

**No changes to any code, other than cut & paste**