### PR TITLE
Fix boundary/overflow bugs in serial & CAN input parsing

### DIFF
--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -329,7 +329,7 @@ static void sendReturnCodeMsg(byte returnCode)
  */
 static bool updatePageValues(uint8_t pageNum, uint16_t offset, const byte *buffer, uint16_t length)
 {
-  if ( (offset + length) <= getPageSize(pageNum) )
+  if ( ((uint32_t)offset + (uint32_t)length) <= (uint32_t)getPageSize(pageNum) )
   {
     for(uint16_t i = 0; i < length; i++)
     {
@@ -747,10 +747,17 @@ void processSerialCommand(void)
       //2 - Length
       uint16_t length = word(serialPayload[6], serialPayload[5]);
 
-      //Setup the transmit buffer
-      serialPayload[0] = SERIAL_RC_OK;
-      loadPageValuesToBuffer(serialPayload[2], word(serialPayload[4], serialPayload[3]), &serialPayload[1], length);
-      sendSerialPayloadNonBlocking(length + 1U);
+      if (length <= (sizeof(serialPayload) - 1U))
+      {
+        //Setup the transmit buffer
+        serialPayload[0] = SERIAL_RC_OK;
+        loadPageValuesToBuffer(serialPayload[2], word(serialPayload[4], serialPayload[3]), &serialPayload[1], length);
+        sendSerialPayloadNonBlocking(length + 1U);
+      }
+      else
+      {
+        sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+      }
       break;
     }
 
@@ -771,8 +778,15 @@ void processSerialCommand(void)
 
       if(cmd == SEND_OUTPUT_CHANNELS) //Send output channels command 0x30 is 48dec
       {
-        generateLiveValues(offset, length);
-        sendSerialPayloadNonBlocking(length + 1U);
+        if (length <= (sizeof(serialPayload) - 1U))
+        {
+          generateLiveValues(offset, length);
+          sendSerialPayloadNonBlocking(length + 1U);
+        }
+        else
+        {
+          sendReturnCodeMsg(SERIAL_RC_RANGE_ERR);
+        }
       }
       else if(cmd == 0x0fU)
       {

--- a/speeduino/comms.cpp
+++ b/speeduino/comms.cpp
@@ -314,8 +314,19 @@ static void sendReturnCodeMsg(byte returnCode)
 
 // ====================================== Command/Action Support =============================
 
-// The functions in this section are abstracted out to prevent enlarging callers stack frame, 
+// The functions in this section are abstracted out to prevent enlarging callers stack frame,
 // which in turn throws off free ram reporting.
+
+/** @brief Add two 16-bit values in 32-bit arithmetic so the sum cannot wrap.
+ *
+ * On AVR `int` is 16-bit, so `a + b` for two uint16_t operands is evaluated at
+ * 16 bits and can overflow. Widening to uint32_t first guarantees an exact sum,
+ * which matters when the result is used in a bounds check against attacker-supplied
+ * offset/length values.
+ */
+static inline uint32_t addWithoutOverflow(uint16_t a, uint16_t b) {
+  return (uint32_t)a + (uint32_t)b;
+}
 
 /**
  * @brief Update a pages contents from a buffer
@@ -329,7 +340,7 @@ static void sendReturnCodeMsg(byte returnCode)
  */
 static bool updatePageValues(uint8_t pageNum, uint16_t offset, const byte *buffer, uint16_t length)
 {
-  if ( ((uint32_t)offset + (uint32_t)length) <= (uint32_t)getPageSize(pageNum) )
+  if ( addWithoutOverflow(offset, length) <= getPageSize(pageNum) )
   {
     for(uint16_t i = 0; i < length; i++)
     {
@@ -747,7 +758,7 @@ void processSerialCommand(void)
       //2 - Length
       uint16_t length = word(serialPayload[6], serialPayload[5]);
 
-      if (length <= (sizeof(serialPayload) - 1U))
+      if (length < _countof(serialPayload))
       {
         //Setup the transmit buffer
         serialPayload[0] = SERIAL_RC_OK;
@@ -778,7 +789,7 @@ void processSerialCommand(void)
 
       if(cmd == SEND_OUTPUT_CHANNELS) //Send output channels command 0x30 is 48dec
       {
-        if (length <= (sizeof(serialPayload) - 1U))
+        if (length < _countof(serialPayload))
         {
           generateLiveValues(offset, length);
           sendSerialPayloadNonBlocking(length + 1U);

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -789,7 +789,7 @@ void readAuxCanBus()
         // Gets the one-byte value from the Data Field.
         currentStatus.canin[i] = inMsg.buf[configPage9.caninput_source_start_byte[i]];
       }
-      else
+      else if (configPage9.caninput_source_start_byte[i] < 7U) // a 2-byte value can't start at the last byte of an 8-byte CAN payload
       {
         if (configPage9.caninputEndianess == 1)
         {
@@ -802,6 +802,7 @@ void readAuxCanBus()
           currentStatus.canin[i] = ((inMsg.buf[configPage9.caninput_source_start_byte[i]] << 8) | (inMsg.buf[configPage9.caninput_source_start_byte[i] + 1]));
         }
       }
+      else { /* Misconfigured: 2-byte value can't start at byte 7. Leave canin[i] unchanged. */ }
     }
   } 
 }

--- a/speeduino/comms_CAN.cpp
+++ b/speeduino/comms_CAN.cpp
@@ -789,7 +789,7 @@ void readAuxCanBus()
         // Gets the one-byte value from the Data Field.
         currentStatus.canin[i] = inMsg.buf[configPage9.caninput_source_start_byte[i]];
       }
-      else if (configPage9.caninput_source_start_byte[i] < 7U) // a 2-byte value can't start at the last byte of an 8-byte CAN payload
+      else if (configPage9.caninput_source_start_byte[i] < (_countof(inMsg.buf) - 1U)) // a 2-byte value can't start at the last byte of the CAN payload
       {
         if (configPage9.caninputEndianess == 1)
         {

--- a/speeduino/comms_secondary.cpp
+++ b/speeduino/comms_secondary.cpp
@@ -29,11 +29,45 @@ sendcancommand is called when a command is to be sent either to serial3
 uint8_t currentSecondaryCommand;
 SECONDARY_SERIAL_T* pSecondarySerial;
 
+// A classic CAN 2.0 data frame carries at most 8 data bytes.
+static constexpr uint8_t CAN_FRAME_DATA_BYTES = 8U;
+
 #if defined(CORE_AVR)
 #pragma GCC push_options
 // This minimizes RAM usage at no performance cost
-#pragma GCC optimize ("Os") 
+#pragma GCC optimize ("Os")
 #endif
+
+// Handle a 'G' reply from the CAN interface: <success><channel><8 data bytes>.
+// Assumes the caller has confirmed enough bytes are available to read.
+static void processSecondaryCanReply(void)
+{
+  const uint8_t cmdSuccessful = secondarySerial.read();      // 0 == fail, 1 == good
+  const uint8_t destcaninchannel = secondarySerial.read();   // the input channel that requested the data value
+
+  // Nothing further is sent for a failed request.
+  if (cmdSuccessful == 0U) { return; }
+
+  uint8_t Gdata[CAN_FRAME_DATA_BYTES + 1U] = { 0U };
+  for (uint8_t Gx = 0U; Gx < CAN_FRAME_DATA_BYTES; Gx++)
+  {
+    Gdata[Gx] = secondarySerial.read();
+  }
+
+  // Ignore out-of-range channels: destcaninchannel indexes both
+  // caninput_source_start_byte[] and canin[].
+  if (destcaninchannel >= _countof(currentStatus.canin)) { return; }
+
+  // Mask to a valid data-byte index (0..CAN_FRAME_DATA_BYTES-1)
+  const uint8_t startByte = configPage9.caninput_source_start_byte[destcaninchannel] & (CAN_FRAME_DATA_BYTES - 1U);
+  uint8_t Ghigh = 0U;
+  // A 2-byte value needs startByte and startByte+1, so it can't start at the last data byte.
+  if (BIT_CHECK(configPage9.caninput_source_num_bytes, destcaninchannel) && (startByte < (CAN_FRAME_DATA_BYTES - 1U)))
+  {
+    Ghigh = Gdata[startByte + 1U];
+  }
+  currentStatus.canin[destcaninchannel] = ((uint16_t)Ghigh << 8) | Gdata[startByte];
+}
 
 void secondserial_Command(void)
 {
@@ -72,43 +106,10 @@ void secondserial_Command(void)
 
     case 'G': // this is the reply command sent by the Can interface
       serialSecondaryStatusFlag = SERIAL_COMMAND_INPROGRESS_LEGACY;
-      byte destcaninchannel;
       if (secondarySerial.available() >= 9)
       {
         serialSecondaryStatusFlag = SERIAL_INACTIVE;
-        uint8_t cmdSuccessful = secondarySerial.read();        //0 == fail,  1 == good.
-        destcaninchannel = secondarySerial.read();  // the input channel that requested the data value
-        if (cmdSuccessful != 0)
-        {                                 // read all 8 bytes of data.
-          uint8_t Gdata[9];
-          uint8_t Glow, Ghigh;
-
-          for (byte Gx = 0; Gx < 8; Gx++) // first two are the can address the data is from. next two are the can address the data is for.then next 1 or two bytes of data
-          {
-            Gdata[Gx] = secondarySerial.read();
-          }
-        if (destcaninchannel < 16U) // destcaninchannel indexes caninput_source_start_byte[16] / canin[16]; discard out-of-range channels
-        {
-          Glow = Gdata[(configPage9.caninput_source_start_byte[destcaninchannel]&7)];
-          if ((BIT_CHECK(configPage9.caninput_source_num_bytes,destcaninchannel) > 0))  //if true then num bytes is 2
-          {
-            if ((configPage9.caninput_source_start_byte[destcaninchannel]&7) < 7)   //you can't have a 2 byte value starting at byte 7(8 on the list)
-            {
-              Ghigh = Gdata[((configPage9.caninput_source_start_byte[destcaninchannel]&7)+1)];
-            }
-            else { Ghigh = 0; }
-          }
-        else
-        {
-          Ghigh = 0;
-        }
-
-        currentStatus.canin[destcaninchannel] = (Ghigh<<8) | Glow;
-      }
-      }
-
-        else{}  //continue as command request failed and/or data/device was not available
-
+        processSecondaryCanReply();
       }
       break;
 

--- a/speeduino/comms_secondary.cpp
+++ b/speeduino/comms_secondary.cpp
@@ -87,10 +87,12 @@ void secondserial_Command(void)
           {
             Gdata[Gx] = secondarySerial.read();
           }
+        if (destcaninchannel < 16U) // destcaninchannel indexes caninput_source_start_byte[16] / canin[16]; discard out-of-range channels
+        {
           Glow = Gdata[(configPage9.caninput_source_start_byte[destcaninchannel]&7)];
           if ((BIT_CHECK(configPage9.caninput_source_num_bytes,destcaninchannel) > 0))  //if true then num bytes is 2
           {
-            if ((configPage9.caninput_source_start_byte[destcaninchannel]&7) < 8)   //you can't have a 2 byte value starting at byte 7(8 on the list)
+            if ((configPage9.caninput_source_start_byte[destcaninchannel]&7) < 7)   //you can't have a 2 byte value starting at byte 7(8 on the list)
             {
               Ghigh = Gdata[((configPage9.caninput_source_start_byte[destcaninchannel]&7)+1)];
             }
@@ -102,6 +104,7 @@ void secondserial_Command(void)
         }
 
         currentStatus.canin[destcaninchannel] = (Ghigh<<8) | Glow;
+      }
       }
 
         else{}  //continue as command request failed and/or data/device was not available


### PR DESCRIPTION
## Summary
Found while doing a static review of the core firmware. Fixes six related boundary/overflow bugs in the serial and CAN input parsing code:

- `comms_secondary.cpp`: the `'G'` handler's start-byte check was tautological (`(x&7)<8` is always true), letting a `start_byte==7` 2-byte read pull an uninitialized `Gdata[8]` byte into `currentStatus.canin`. Also, `destcaninchannel` came straight off the wire with no bounds check before indexing `caninput_source_start_byte[16]`/`canin[16]`.
- `comms_CAN.cpp`: `readAuxCanBus()` had the same off-by-one — a 2-byte CAN input configured with `start_byte==7` read `inMsg.buf[8]`, one past the 8-byte CAN payload.
- `comms.cpp`: `updatePageValues()` (`'M'` command) checked `(offset+length)<=getPageSize()` using 16-bit arithmetic, which can wrap and bypass the check; widened to 32-bit. `loadPageValuesToBuffer` (`'p'` command) and `generateLiveValues` (`SEND_OUTPUT_CHANNELS`) took a wire-controlled length with no check against `serialPayload`'s actual size, allowing a crafted length to overflow the global buffer; both now reject out-of-range lengths with `SERIAL_RC_RANGE_ERR`.

Each of these is filed as its own issue with full detail/repro reasoning.

Fixes #1555, Fixes #1556, Fixes #1557, Fixes #1558, Fixes #1559, Fixes #1560

## Test plan
- [ ] CI build/test suite
- Manually traced each fix against the current call sites; none of the changes alter behavior for well-formed/in-range input, only reject previously-unchecked out-of-range input.
- No local hardware available to me to test against a real TunerStudio/CAN session — would appreciate a maintainer sanity-check on the `'p'`/`'r'`/`'M'` serial protocol paths in particular.


---

### Note on `codecov/patch`

This check is red (0% patch coverage) and I don't think it can be reasonably satisfied here — flagging for maintainer discretion rather than leaving it unexplained:

- The changed lines are **defensive bounds-guards on serial/CAN input parsing** across `comms.cpp`, `comms_secondary.cpp` and `comms_CAN.cpp`. They are the fix itself, so (unlike a formatting-only change) they can't be reduced to a non-coverable diff.
- Exercising them requires driving `secondserial_Command()` / `readAuxCanBus()` / the `'p'`/`'r'`/`'M'` command handlers, which depend on `secondarySerial`, the CAN `inMsg` struct and the static `serialPayload` buffer. There is currently **no `test_comms` suite / serial+CAN mocking harness** in the repository, and codecov's 90% patch target would require covering ~all of these hardware-dependent branches, not just a subset.
- Every functional check on this PR (all-board compiles, unit tests, SonarCloud, `codecov/project`) is green; only the new-code `codecov/patch` gate is affected.

Happy to add a `test_comms` harness in a follow-up if the maintainers would like the coverage, or to adjust the approach.
