### PR TITLE
Fix off-by-one bounds checks in Programmable I/O rule-reuse indexing

### DIFF
--- a/speeduino/programmableIOControl.cpp
+++ b/speeduino/programmableIOControl.cpp
@@ -61,7 +61,7 @@ TESTABLE_STATIC void checkProgrammableIO(statuses& current, const config13& page
       if ( dataRequested > 239U ) //Somehow using 239 uses 9 bytes of RAM, why??
       {
         dataRequested -= REUSE_RULES;
-        if ( dataRequested <= sizeof(page13.outputPin) ) { data = BIT_CHECK(currentRuleStatus, dataRequested); }
+        if ( dataRequested < sizeof(page13.outputPin) ) { data = BIT_CHECK(currentRuleStatus, dataRequested); }
         else { data = 0; }
       }
       else { data = getData(dataRequested); }
@@ -79,7 +79,7 @@ TESTABLE_STATIC void checkProgrammableIO(statuses& current, const config13& page
       if (page13.operation[y].bitwise != BITWISE_DISABLED)
       {
         dataRequested = page13.secondDataIn[y];
-        if ( dataRequested <= (REUSE_RULES + sizeof(page13.outputPin)) ) //Failsafe check
+        if ( dataRequested < (REUSE_RULES + sizeof(page13.outputPin)) ) //Failsafe check
         {
           if ( dataRequested > 239U ) //Somehow using 239 uses 9 bytes of RAM, why??
           {


### PR DESCRIPTION
## Summary
`checkProgrammableIO()` used `<=` where `<` was needed when validating a reused-rule index against `page13.outputPin`'s 8 elements / the 8-bit `currentRuleStatus` bitfield, admitting index 8 (one past the valid 0-7 range). The second check (`secondDataIn` path) has an observable effect: comparator/target combinations at the boundary value (`secondDataIn[y] == 248`) produce different results depending on whether the invalid index is let through or rejected.

No existing test in `test_programmableio` exercises this exact boundary (tests use rule indices 0, 2-4, and an out-of-bounds value of 10; not 8), so this shouldn't affect existing coverage.

Fixes #1561

## Test plan
- [ ] CI build/test suite
- Manually traced both call sites against `test/test_programmableio/test_programmableIOControl.cpp` to confirm no existing test asserts on the old (buggy) boundary behavior.
