### PR TITLE
Remove #include "globals.h" from headers

### DIFF
--- a/speeduino/board_teensy35.cpp
+++ b/speeduino/board_teensy35.cpp
@@ -17,6 +17,7 @@
 #include "scheduler_fuel_controller.h"
 #include "src/controllers/fan/fanController.h"
 #include "src/controllers/boost/boostController.h"
+#include "globals.h"
 
  //These are declared locally in comms_CAN now due to this issue: https://github.com/tonton81/FlexCAN_T4/issues/67
 // #if defined(__MK64FX512__)         // use for Teensy 3.5 only 

--- a/speeduino/board_teensy41.cpp
+++ b/speeduino/board_teensy41.cpp
@@ -13,6 +13,7 @@
 #include "scheduler_fuel_controller.h"
 #include "src/pins/pinNumbers_t.h"
 #include "src/controllers/boost/boostController.h"
+#include "globals.h"
 
 static void PIT_isr();
 static void TMR1_isr(void);

--- a/speeduino/crankMaths.cpp
+++ b/speeduino/crankMaths.cpp
@@ -11,6 +11,9 @@ byte deltaToothCount = 0; //The last tooth that was used with the deltaV calc
 int rpmDelta;
 #endif
 
+int16_t CRANK_ANGLE_MAX_IGN = 360;
+int16_t CRANK_ANGLE_MAX_INJ = 360; 
+
 typedef uint32_t UQ24X8_t;
 static constexpr uint8_t UQ24X8_Shift = 8U;
 

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -42,6 +42,9 @@ static constexpr uint16_t MIN_REVOLUTION_TIME = MICROS_PER_MIN/MAX_RPM;
  */
 static constexpr uint32_t MAX_REVOLUTION_TIME = MICROS_PER_MIN/MIN_RPM;
 
+extern int16_t CRANK_ANGLE_MAX_IGN; ///< The number of crank degrees that the system tracks ignition over.
+extern int16_t CRANK_ANGLE_MAX_INJ; ///< The number of crank degrees that the system tracks fuel injection over.
+
 /**
  * @brief Makes one pass at nudging the angle to within [0,CRANK_ANGLE_MAX_IGN]
  * 

--- a/speeduino/crankMaths.h
+++ b/speeduino/crankMaths.h
@@ -2,7 +2,7 @@
 #define CRANKMATHS_H
 
 #include "maths.h"
-#include "globals.h"
+#include "board_definition.h"
 
 /**
  * @file

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -47,6 +47,8 @@ A full copy of the license may be found in the projects root directory
 #include "src/pins/boardInputPin.h"
 #include "scheduler_ignition_controller.h"
 
+#define CRANK_ANGLE_MAX (max(CRANK_ANGLE_MAX_IGN, CRANK_ANGLE_MAX_INJ))
+
 static void triggerRoverMEMSCommon(void);
 static inline void triggerRecordVVT1Angle (void);
 

--- a/speeduino/decoders.cpp
+++ b/speeduino/decoders.cpp
@@ -472,48 +472,48 @@ static inline void checkPerToothTiming(int16_t crankAngle, uint16_t currentTooth
   {
     if ( (currentTooth == ignitionEndTeeth[0]) )
     {
-      adjustCrankAngle(ignitionSchedule1, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule1, crankAngle);
     }
 #if IGN_CHANNELS >= 2
     else if ( (currentTooth == ignitionEndTeeth[1]) )
     {
-      adjustCrankAngle(ignitionSchedule2, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule2, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 3
     else if ( (currentTooth == ignitionEndTeeth[2]) )
     {
-      adjustCrankAngle(ignitionSchedule3, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule3, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 4
     else if ( (currentTooth == ignitionEndTeeth[3]) )
     {
-      adjustCrankAngle(ignitionSchedule4, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule4, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 5
     else if ( (currentTooth == ignitionEndTeeth[4]) )
     {
-      adjustCrankAngle(ignitionSchedule5, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule5, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 6
     else if ( (currentTooth == ignitionEndTeeth[5]) )
     {
-      adjustCrankAngle(ignitionSchedule6, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule6, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 7
     else if ( (currentTooth == ignitionEndTeeth[6]) )
     {
-      adjustCrankAngle(ignitionSchedule7, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule7, crankAngle);
     }
 #endif
 #if IGN_CHANNELS >= 8
     else if ( (currentTooth == ignitionEndTeeth[7]) )
     {
-      adjustCrankAngle(ignitionSchedule8, crankAngle);
+      adjustCrankAngle(currentStatus, ignitionSchedule8, crankAngle);
     }
 #endif
   }

--- a/speeduino/globals.cpp
+++ b/speeduino/globals.cpp
@@ -29,8 +29,7 @@ static_assert(_countof(toothHistory)<UINT8_MAX, "Check all uses of toothHistory/
 volatile unsigned int toothHistoryIndex = 0; ///< Current index to @ref toothHistory array
 unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-int16_t CRANK_ANGLE_MAX_IGN = 360;
-int16_t CRANK_ANGLE_MAX_INJ = 360; ///< The number of crank degrees that the system track over. Typically 720 divided by the number of squirts per cycle (Eg 360 for wasted 2 squirt and 720 for sequential single squirt)
+///< The number of crank degrees that the system track over. Typically 720 divided by the number of squirts per cycle (Eg 360 for wasted 2 squirt and 720 for sequential single squirt)
 volatile uint32_t runSecsX10;
 volatile uint32_t seclx10;
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -31,7 +31,6 @@
 #include "atomic.h"
 #include "src/pins/pinNumbers_t.h"
 
-#define CRANK_ANGLE_MAX (max(CRANK_ANGLE_MAX_IGN, CRANK_ANGLE_MAX_INJ))
 
 #ifndef UNIT_TEST 
 constexpr uint8_t TOOTH_LOG_SIZE = 127U;
@@ -66,8 +65,6 @@ extern volatile uint8_t compositeLogHistory[TOOTH_LOG_SIZE];
 extern volatile unsigned int toothHistoryIndex;
 extern unsigned long currentLoopTime; /**< The time (in uS) that the current mainloop started */
 extern volatile uint16_t ignitionCount; /**< The count of ignition events that have taken place since the engine started */
-extern int16_t CRANK_ANGLE_MAX_IGN;
-extern int16_t CRANK_ANGLE_MAX_INJ;       ///< The number of crank degrees that the system track over. 360 for wasted / timed batch and 720 for sequential
 extern volatile uint32_t runSecsX10;  /**< Counter of seconds since cranking commenced (similar to runSecs) but in increments of 0.1 seconds */
 extern volatile uint32_t seclx10;     /**< Counter of seconds since powered commenced (similar to secl) but in increments of 0.1 seconds */
 

--- a/speeduino/logger.cpp
+++ b/speeduino/logger.cpp
@@ -11,6 +11,7 @@
 #include "resetControl.h"
 #include "scheduler.h"
 #include "scheduler_fuel_controller.h"
+#include "globals.h"
 
 static byte setStatusBit(byte status, uint8_t index, bool bit)
 {

--- a/speeduino/logger.h
+++ b/speeduino/logger.h
@@ -9,15 +9,13 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include "globals.h" // Needed for FPU_MAX_SIZE
+#include "statuses.h"
 
 constexpr uint8_t LOG_ENTRY_SIZE = 138; /**< The size of the live data packet. This MUST match ochBlockSize setting in the ini file */
 
 byte getTSLogEntry(uint16_t byteNum);
 int16_t getReadableLogEntry(uint16_t logIndex);
-#if defined(FPU_MAX_SIZE) && FPU_MAX_SIZE >= 32 //cppcheck-suppress misra-c2012-20.9
-  float getReadableFloatLogEntry(uint16_t logIndex);
-#endif
+float getReadableFloatLogEntry(uint16_t logIndex);
 uint8_t getLegacySecondarySerialLogEntry(uint16_t byteNum);
 bool is2ByteEntry(uint8_t key);
 

--- a/speeduino/programmableIOControl.cpp
+++ b/speeduino/programmableIOControl.cpp
@@ -6,6 +6,7 @@
 #include "logger.h"
 #include "units.h"
 #include "unit_testing.h"
+#include "globals.h"
 
 TESTABLE_STATIC uint8_t ioDelay[_countof(config13::outputPin)];
 TESTABLE_STATIC uint8_t ioOutDelay[_countof(config13::outputPin)];

--- a/speeduino/schedule_calcs.hpp
+++ b/speeduino/schedule_calcs.hpp
@@ -149,7 +149,7 @@ static inline uint32_t _calculateIgnitionTimeout(const IgnitionSchedule &schedul
  * @param schedule The schedule to modify 
  * @param crankAngle The new crank angle in degrees
  */
-static inline void adjustCrankAngle(IgnitionSchedule &schedule, int16_t crankAngle) {
+static inline void adjustCrankAngle(const statuses &current, IgnitionSchedule &schedule, int16_t crankAngle) {
   constexpr uint8_t MIN_CYCLES_FOR_CORRECTION = 6U;
 
   crankAngle = ignitionLimits(crankAngle);
@@ -164,7 +164,7 @@ static inline void adjustCrankAngle(IgnitionSchedule &schedule, int16_t crankAng
       } 
     }
     else if( (schedule._status==PENDING) ) {
-      if ((currentStatus.startRevolutions > MIN_CYCLES_FOR_CORRECTION) && (schedule.chargeAngle>crankAngle)) {
+      if ((current.startRevolutions > MIN_CYCLES_FOR_CORRECTION) && (schedule.chargeAngle>crankAngle)) {
         // We are waiting for the timer to fire & start charging the coil.
         // Keep dwell (I.e. duration) constant (for better spark) - instead adjust the waiting period so 
         // the spark fires at the requested crank angle.

--- a/speeduino/schedule_calcs.hpp
+++ b/speeduino/schedule_calcs.hpp
@@ -6,6 +6,9 @@
 #include "crankMaths.h"
 #include "maths.h"
 #include "timers.h"
+#include "preprocessor.h"
+#include "atomic.h"
+#include "statuses.h"
 
 /**
  * @brief Compute the injector open angle for an injection channel

--- a/speeduino/scheduler.h
+++ b/speeduino/scheduler.h
@@ -41,9 +41,8 @@ See page 136 of the processors datasheet: http://www.atmel.com/Images/doc2549.pd
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
-#include "globals.h"
+#include "board_definition.h"
 #include "crankMaths.h"
-
 
 /** \enum ScheduleStatus
  * @brief The current state of a schedule

--- a/speeduino/scheduler_fuel_controller.cpp
+++ b/speeduino/scheduler_fuel_controller.cpp
@@ -1,6 +1,8 @@
 #include "scheduler_fuel_controller.h"
 #include "scheduledIO_inj.h"
 #include "units.h"
+#include "table2d.h"
+#include "globals.h"
 
 FuelSchedule fuelSchedule1(FUEL1_COUNTER, FUEL1_COMPARE); //cppcheck-suppress misra-c2012-8.4
 FuelSchedule fuelSchedule2(FUEL2_COUNTER, FUEL2_COMPARE); //cppcheck-suppress misra-c2012-8.4

--- a/test/test_loggers/test_getEntry.cpp
+++ b/test/test_loggers/test_getEntry.cpp
@@ -1,6 +1,7 @@
 #include <unity.h>
 #include "logger.h"
 #include "../test_utils.h"
+#include "globals.h"
 
 // Mirror of the static fsIntIndex[] table inside is2ByteEntry().
 // MUST be kept in sync with logger.cpp.

--- a/test/test_loggers/test_startstop.cpp
+++ b/test/test_loggers/test_startstop.cpp
@@ -2,6 +2,7 @@
 #include "logger.h"
 #include "decoder_init.h"
 #include "decoders.h"
+#include "globals.h"
 
 extern decoder_status_t decoderStatus;
 

--- a/test/test_schedule_calcs/test_adjust_crank_angle.cpp
+++ b/test/test_schedule_calcs/test_adjust_crank_angle.cpp
@@ -13,6 +13,7 @@ struct test_subject_t
   raw_counter_t counterReg = {101};
   raw_compare_t compareReg = {100};
   IgnitionSchedule schedule;
+  statuses current;
   test_subject_t() : schedule(counterReg, compareReg) { }
 #if defined(NATIVE_BOARD)
   test_subject_t(const test_subject_t &other) 
@@ -34,12 +35,12 @@ void test_adjust_crank_angle_pending_below_minrevolutions()
   auto subject = setupSubject();
 
   subject.schedule._status = PENDING;
-  currentStatus.startRevolutions = 0;
+  subject.current.startRevolutions = 0;
 
   subject.schedule.dischargeAngle = 359;
 
   // Should do nothing.
-  adjustCrankAngle(subject.schedule, 180);
+  adjustCrankAngle(subject.current, subject.schedule, 180);
   TEST_ASSERT_EQUAL(100, subject.schedule._compare);
   TEST_ASSERT_EQUAL(101, subject.schedule._counter);
 }
@@ -49,13 +50,13 @@ void test_adjust_crank_angle_pending_above_minrevolutions()
 {
   auto subject = setupSubject();
   subject.schedule._status = PENDING;  
-  currentStatus.startRevolutions = 2000;
+  subject.current.startRevolutions = 2000;
 
   constexpr uint16_t newCrankAngle = 180;
   constexpr uint16_t chargeAngle = 359;
   subject.schedule.chargeAngle = chargeAngle;
 
-  adjustCrankAngle(subject.schedule, newCrankAngle);
+  adjustCrankAngle(subject.current, subject.schedule, newCrankAngle);
   TEST_ASSERT_EQUAL(101, subject.schedule._counter);
   TEST_ASSERT_EQUAL(subject.schedule._counter+uS_TO_TIMER_COMPARE(angleToTime(chargeAngle-newCrankAngle)), subject.schedule._compare);
 }
@@ -64,13 +65,13 @@ void test_adjust_crank_angle_pending_above_minrevolutions_negative_angle()
 {
   auto subject = setupSubject();
   subject.schedule._status = PENDING;  
-  currentStatus.startRevolutions = 2000;
+  subject.current.startRevolutions = 2000;
 
   constexpr uint16_t newCrankAngle = 180;
   constexpr uint16_t chargeAngle = 100;
   subject.schedule.chargeAngle = chargeAngle;
 
-  adjustCrankAngle(subject.schedule, newCrankAngle);
+  adjustCrankAngle(subject.current, subject.schedule, newCrankAngle);
   TEST_ASSERT_EQUAL(101, subject.schedule._counter);
   TEST_ASSERT_EQUAL(100, subject.schedule._compare);
 }
@@ -84,7 +85,7 @@ void test_adjust_crank_angle_running()
   constexpr uint16_t chargeAngle = 359;
   subject.schedule.dischargeAngle = chargeAngle;
 
-  adjustCrankAngle(subject.schedule, newCrankAngle);
+  adjustCrankAngle(subject.current, subject.schedule, newCrankAngle);
   TEST_ASSERT_EQUAL(101, subject.schedule._counter);
   TEST_ASSERT_EQUAL(subject.schedule._counter+uS_TO_TIMER_COMPARE(angleToTime(chargeAngle-newCrankAngle)), subject.schedule._compare);
 }
@@ -98,7 +99,7 @@ void test_adjust_crank_angle_running_negative_angle()
   constexpr uint16_t chargeAngle = 179;
   subject.schedule.dischargeAngle = chargeAngle;
 
-  adjustCrankAngle(subject.schedule, newCrankAngle);
+  adjustCrankAngle(subject.current, subject.schedule, newCrankAngle);
   TEST_ASSERT_EQUAL(101, subject.schedule._counter);
   TEST_ASSERT_EQUAL(100, subject.schedule._compare);
 }

--- a/test/test_schedule_calcs/test_ign_calcs.cpp
+++ b/test/test_schedule_calcs/test_ign_calcs.cpp
@@ -5,6 +5,7 @@
 #include "crankMaths.h"
 #include "decoders.h"
 #include "../test_utils.h"
+#include "globals.h"
 
 #if !defined(_countof)
 #define _countof(x) (sizeof(x) / sizeof (x[0]))

--- a/test/test_schedules/test_overdwell.cpp
+++ b/test/test_schedules/test_overdwell.cpp
@@ -2,6 +2,7 @@
 #include "../test_utils.h"
 #include "scheduler.h"
 #include "src/stdlib/type_traits.h"
+#include "globals.h"
 
 using raw_counter_t = type_traits::remove_reference<IgnitionSchedule::counter_t>::type;
 using raw_compare_t = type_traits::remove_reference<IgnitionSchedule::compare_t>::type;

--- a/test/test_schedules/test_pw_applyPwToInjectorChannels.cpp
+++ b/test/test_schedules/test_pw_applyPwToInjectorChannels.cpp
@@ -3,6 +3,7 @@
 #include "fuel_calcs.h"
 #include "scheduler_fuel_controller.h"
 #include "units.h"
+#include "globals.h"
 
 static statuses getRandomPW(void) {
   statuses current = {};


### PR DESCRIPTION
This eliminates accidental coupling, making it easier to remove global dependencies.